### PR TITLE
Update translations for 0.37 and add Bulgarian (BG)

### DIFF
--- a/locales/bg.po
+++ b/locales/bg.po
@@ -5,28 +5,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: it\n"
+"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "Il database è stato aggiunto!"
+msgstr "Успешно добавихте базата данни!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "Stiamo dando uno sguardo ai tuoi dati e abbiamo alcune esplorazioni automatiche che possiamo mostrarti!"
+msgstr "Желаете ли да видите автоматично изследване и анализ на Вашите данни?"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "A posto così, grazie"
+msgstr "Не, благодаря!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "Analizza questi dati"
+msgstr "Изследвай данните!"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
-msgstr "Selezionare il tipo di database"
+msgstr "Избери вида база данни"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
@@ -44,95 +44,95 @@ msgstr "Selezionare il tipo di database"
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:30
 msgid "Save"
-msgstr "Salva"
+msgstr "Запази"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Per fare qualcosa di magico, Metabase ha bisogno di esplorare il tuo database. L'esplorazione viene periodicamente rieseguita. Di seguito puoi controllare quando avverrà la prossima esplorazione."
+msgstr "Metabase има нужда да сканира вашата база данни. Това ще се случва периодично, за да можем да поддържаме мета данните актуални. Можете да изберете периодичността на сканиранията по-долу."
 
 #: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
-msgstr "Database sincronizzato"
+msgstr "Базата данни се синхронизира"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Questo è un processo leggero che controlla aggiornamenti allo schema del database. Nella maggior parte dei casi, andrá bene impostarlo ad ogni ora."
+msgstr "Това е процес, който не заема много ресурси. Той проверява за промени в схемата на базата данни. В повечето случай синхронизация на всеки час е достатъчна."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
-msgstr "Scansione"
+msgstr "Сканирай"
 
 #: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
-msgstr "Ricerca di Valori Filtro"
+msgstr "Сканира за стойности на филтъра"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase può cercare i valori presenti in ogni campo di questo database per abilitare i checkbox dei filtri nelle dashboard e questions. Questo processo puó essere intensivo, in particolare se hai un database molto grande."
+msgstr "Metabase може да сканира стойностите във всяко поле от базата данни за да активира чекбокс филтри в дашборди и въпроси. Това може да отнеме значителни системни ресурси, особено при по-големи бази данни. "
 
 #: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "Quando Metabase dovrebbe automaticamente scansionare e fare cache dei valori?"
+msgstr "Кога желаете Metabase автоматично да сканира и кешира стойности от полетата в базата данни?"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:25
 msgid "Regularly, on a schedule"
-msgstr "Regolarmente secondo schedulazione"
+msgstr "Периодично, според зададен предварително план"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:50
 msgid "Only when adding a new filter widget"
-msgstr "Solo quando si aggiunge un nuovo filtro nel widget"
+msgstr "Само когато се добавя нов филтър widget"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Quando un utente aggiunge un nuovo filtro a una Dashboard o Question, Metabase cercherá nei campi mappati dal filtro per mostrare la lista dei valori selezionabili."
+msgstr "Когато потребител добавя нов филтър към дашборд или SQL върпос, Metabase ще сканира полетата видещи до този филтър за да покаже списък с възможни стойности."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
-msgstr "Mai, lo farò manualmente se necessario"
+msgstr "Никога, ще го направя ръчно когато се налага"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
-msgstr "Salvataggio..."
+msgstr "Записва..."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 msgid "Server error encountered"
-msgstr "Errore nel server"
+msgstr "Сървърна грешка"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "Cancellare il database?"
+msgstr "Изтрий тази база данни?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Tutte le Questions, Metriche e segmenti salvati per questo database andranno persi."
+msgstr "Всички запазени въпроси, метрични показатели и сегменти, които се основават на тази база данни ще бъдат изгубени."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "Questo non può essere ripristinato"
+msgstr "Тази операция е необратима."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "Se sei sicuro digita"
+msgstr "Ако сте сигурни, моля попълнете"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "CANCELLA"
+msgstr "ИЗТРИЙ"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "in questa casella:"
+msgstr "в това поле:"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
@@ -170,14 +170,14 @@ msgstr "in questa casella:"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "Annulla"
+msgstr "Откажи"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Elimina"
+msgstr "Изтрий"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -189,19 +189,19 @@ msgstr "Elimina"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "Database"
+msgstr "Бази данни"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:148
 msgid "Add Database"
-msgstr "Aggiungi un Database"
+msgstr "Добави база данни"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:73
 msgid "Connection"
-msgstr "Connessione"
+msgstr "Връзка"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:77
 msgid "Scheduling"
-msgstr "Schedulazione"
+msgstr "Планиране"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
@@ -213,17 +213,17 @@ msgstr "Schedulazione"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "Salva i cambiamenti"
+msgstr "Запази промените"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
-msgstr "Azioni"
+msgstr "Действия"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 msgid "Sync database schema now"
-msgstr "Sincronizza lo schema database ora"
+msgstr "Синхронизирай схемата на базата данни сега"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:212
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
@@ -232,49 +232,49 @@ msgstr "Sincronizza lo schema database ora"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
-msgstr "Avvio..."
+msgstr "Започва се..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:213
 msgid "Failed to sync"
-msgstr "Sync fallito"
+msgstr "Неуспешна синхронизация"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:214
 msgid "Sync triggered!"
-msgstr "Sync azionato!"
+msgstr "Синхронизацията е стартирана!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:223
 msgid "Re-scan field values now"
-msgstr "Ri-scansiona i valori dei campi adesso"
+msgstr "Сканирай отново стойностите сега"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
-msgstr "Inizio della scansione fallito"
+msgstr "Неуспешно стартиране на порцеса по сканиране"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
-msgstr "Scan azionato!"
+msgstr "Сканирането започна!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:233
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "Zona Pericolosa"
+msgstr "Опасна Зона"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Discard saved field values"
-msgstr "Scarta valori campo salvati"
+msgstr "Отхвърли запазените стойности"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:257
 msgid "Remove this database"
-msgstr "Rimuovere questo database"
+msgstr "Премахни тази база данни"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "Aggiungi un database"
+msgstr "Добави база данни"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
@@ -291,99 +291,99 @@ msgstr "Aggiungi un database"
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
-msgstr "Nome"
+msgstr "Име"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "Motore"
+msgstr "Софтуер"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "In cancellazione..."
+msgstr "Изтрива..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Caricamento..."
+msgstr "Зарежда..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "Ripristinare i dati d'esempio"
+msgstr "Върни примерните данни"
 
 #: frontend/src/metabase/admin/databases/database.js:167
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "Impossibile collegarsi al database. Controlla i parametri connessione"
+msgstr "Неуспешен опит за свързване с базата данни. Моля, проверете връзката."
 
 #: frontend/src/metabase/admin/databases/database.js:384
 msgid "Successfully created!"
-msgstr "Creazione riuscita!"
+msgstr "Успешно създаване!"
 
 #: frontend/src/metabase/admin/databases/database.js:394
 msgid "Successfully saved!"
-msgstr "Salvataggio riuscito!"
+msgstr "Успешно запазване!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
-msgstr "Edita"
+msgstr "Редактирай"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "Storico Revisioni"
+msgstr "История на промените"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "Rimuovere questo {0}?"
+msgstr "Премахни този {0}?"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Le domande salvate e altre cose che dipendono da questo {0} continueranno a funzionare, ma questo {1} non sarà più selezionabile dal generatore di query."
+msgstr "Запазените въпроси и други неща, които зависят от този {0} ще продължат да работят, но този {1} няма да може да бъде избиран от инструмента за създаване на заявки."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "Se sei sicuro di voler rimuovere questo {0}, ti preghiamo di scrivere una rapida spiegazione del motivo per cui è stato rimosso:"
+msgstr "Ако сте сигурни, че искате да премахнете този {0}, моля, опишете накратко причината: "
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "Questo verrà visualizzato nel feed di attività e in un'email che verrà inviata a chiunque nel tuo team che ha creato qualcosa che utilizza questo {0}."
+msgstr "Тази информация ще се появи в полето с активността на потребителите и отделно ще бъде изпратено в имейл до всеки потребител от Вашия екип, който е използвал този {0}."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "Rimuovi"
+msgstr "Премахни"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "Rimozione..."
+msgstr "Премахване..."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 #: frontend/src/metabase/components/form/CustomForm.jsx:188
 msgid "Failed"
-msgstr "Fallito"
+msgstr "Неуспех"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 #: frontend/src/metabase/components/form/CustomForm.jsx:189
 msgid "Success"
-msgstr "Riuscito"
+msgstr "Успех"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
-msgstr "Anteprima"
+msgstr "Преглед"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
-msgstr "Ancora nessuna descrizione della colonna"
+msgstr "Все още няма описание на колоната"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
-msgstr "Selezionare la visibilità del campo"
+msgstr "Изберете ниво на видимост на полето "
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
-msgstr "Nessun tipo speciale"
+msgstr "Без специален вид"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
@@ -391,16 +391,16 @@ msgstr "Nessun tipo speciale"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
-msgstr "Altri"
+msgstr "Друго"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "Seleziona uno speciale tipo"
+msgstr "Изберете специален вид"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
-msgstr "Seleziona una destinazione"
+msgstr "Изберете цел"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
@@ -410,97 +410,97 @@ msgstr "Seleziona una destinazione"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
-msgstr "Colonne"
+msgstr "Колони"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "Colonna"
+msgstr "Колона"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
-msgstr "Visibilità"
+msgstr "Видимост"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
-msgstr "Tipo"
+msgstr "Вид"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "Database corrente:"
+msgstr "Текуща база данни:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
-msgstr "Mostra lo schema originale"
+msgstr "Покажи оригиналната схема"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "Tipo dei dati"
+msgstr "Вид данни"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "Informazioni addizionali"
+msgstr "Допълнителна информация"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "Trova uno schema"
+msgstr "Намери схема"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "{0} schema"
-msgstr[1] "{0} schemi"
+msgstr[0] "{0} схема"
+msgstr[1] "{0} схеми"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
-msgstr "Perché nasconderlo?"
+msgstr "Защо да скрием?"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
-msgstr "Dati Tecnici"
+msgstr "Технически данни"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
-msgstr "Irrilevante/Mal progettato"
+msgstr "Неуместен/Излишен"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
-msgstr "Interrogabile"
+msgstr "С възможност за заявка за търсене "
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
-msgstr "Nascosto"
+msgstr "Скрит"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
-msgstr "Nessuna descrizione della tabella ancora"
+msgstr "Все още няма описание на таблицата"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "Forza del metadata"
+msgstr "Сила на метаданните"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "Tabella interrogabile"
-msgstr[1] "Tabelle interrogabili"
+msgstr[0] "{0} Таблица с възможност за заявка за търсене "
+msgstr[1] "{0} Таблици с възможност за заявка за търсене"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "Tabella nascosta"
-msgstr[1] "Tabelle nascoste"
+msgstr[0] "{0} Скрита таблица"
+msgstr[1] "{0} Скрити таблици"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
-msgstr "Trova una tabella"
+msgstr "Намери таблица"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
-msgstr "Schemi"
+msgstr "Схеми"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
@@ -511,21 +511,21 @@ msgstr "Schemi"
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
-msgstr "Metriche"
+msgstr "Метрични показатели"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:27
 msgid "Add a Metric"
-msgstr "Aggiungi una metrica"
+msgstr "Добави метричен показател"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
-msgstr "Definizione"
+msgstr "Дефиниция"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:51
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "Crea metriche per aggiungerle al menu a discesa dela Vista nel generatore di query"
+msgstr "Създай метрични показатели за да могат да бъдат добавени в изглед с падащо меню към инструмента за създаване на заявки."
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
@@ -535,294 +535,294 @@ msgstr "Crea metriche per aggiungerle al menu a discesa dela Vista nel generator
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "Segmenti"
+msgstr "Сегменти"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:27
 msgid "Add a Segment"
-msgstr "Aggiungi un segmento"
+msgstr "Добави сегмент"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "Crea segmenti per aggiungerle nel menu a discesa dei Filtri nel generatore di query"
+msgstr "Създай сегменти за да могат да бъдат добавени към филтъра с падащо меню към инструмента за създаване на заявки."
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
-msgstr "creato"
+msgstr "създаден"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
-msgstr "ritornare alla versione precedente"
+msgstr "върнат към предишна версия"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
-msgstr "titolo modificato"
+msgstr "редактира заглавието"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
-msgstr "Modificato la descrizione"
+msgstr "редактира описанието"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
-msgstr "Modificato il␣"
+msgstr "редактира"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
-msgstr "fatte alcune modifiche"
+msgstr "направи промени"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "Tu"
+msgstr "Ти"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "Modello dei dati"
+msgstr "Модел на данни"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
-msgstr "Storico"
+msgstr "История"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
-msgstr "Cronologia delle revisioni per"
+msgstr "История на промените за"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
-msgstr "{0} – Impostazioni dei campi"
+msgstr "{0} - Настройки на полето"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
-msgstr "Dove questo campo apparirà in tutto Metabase"
+msgstr "На кои места в Метабейс ще се появява това поле"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
-msgstr "Filtra per questo campo"
+msgstr "Филтриране по това поле"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "Quando questo campo é usato in un filtro, cosa dovrebbero usare le persone per inserire il valore per il quale vogliono filtrare?"
+msgstr "Какви стойности за филтриране ще трябва да въведат потребителите, когато това поле се използва в даден филтър"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
-msgstr "Nessuna descrizione per questo campo fino ad ora"
+msgstr "Все още няма описание на това поле"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
-msgstr "Valore originale"
+msgstr "Първоначална стойност"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
-msgstr "Valore mappato"
+msgstr "Съответстваща стойност"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
-msgstr "Inserire valore"
+msgstr "Въведете стойност"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
-msgstr "Usa il valore originale"
+msgstr "Използвай първоначалната стойност"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
-msgstr "Usa la chiave esterna"
+msgstr "Използвай външен ключ"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
-msgstr "Mapping personalizzato"
+msgstr "Персонализирано съответствие"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
-msgstr "Tipo mapping non riconosciuto"
+msgstr "Неразпознат вид на съответствие"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "Il campo corrente non é una Foreign Key o il metadata della tabella target della FK é mancante"
+msgstr "Текущото поле не е външен ключ или липсва външен ключ в избраната таблица с метаданни"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
-msgstr "Il campo selezionato non é una foreign key"
+msgstr "Избраното поле не е външен ключ"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
-msgstr "Visualizza valori"
+msgstr "Покажи стойности"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "Scegli se mostrare il valore originale dal database o se visualizzare questo campo associato o informazioni personalizzate."
+msgstr "Изберете показване на първоначалната стойност в базата данни или покажете в това поле друга свързана или персонализирана информация."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
-msgstr "Scegli un campo"
+msgstr "Изберете поле"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
-msgstr "Prego selezionare una colonna da usare per visualizzazione"
+msgstr "Моля изберете коя колона да се показва."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "Suggerimento:"
+msgstr "Съвет:"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "Potresti voler aggiornare il nome del campo per assicurarti che abbia ancora senso in base alle tue scelte di rimappatura."
+msgstr "Може би желаете да осъвремените името на полето за да сте сигурни, че е все още смислено след промяна на съответствията (mapping)."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
-msgstr "Valori del campo memorizzato nella cache"
+msgstr "Кеширани стойности"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabase può analizzare i valori per questo campo in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'."
+msgstr "Метабейс може да сканира стойностите на това поле за да направи възможни филтри тип поле за отметка в табла или въпроси."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "Ri-scansiona questo campo"
+msgstr "Сканирай отново това поле"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
-msgstr "Scarta la cache dei valori"
+msgstr "Отмени кешираните стойности"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
-msgstr "Errore durante la cancellazione del valore"
+msgstr "Неуспех при отмяна на стойностите"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
-msgstr "Cancellazione avviata"
+msgstr "Отмяна инициирана!"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "Seleziona una qualsiasi tabella per vederne lo schema o cambiarne i metadati"
+msgstr "Изберете таблица за да разгледате нейната схема и да добавите или редактирате метаданни."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 #: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
-msgstr "Nome è obbligatorio"
+msgstr "Име е задължително"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
-msgstr "Descrizione è obbligatorio"
+msgstr "Описание е задължително"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
-msgstr "Sono richieste le informazioni di revisione"
+msgstr "Бележка за промените е задължителна"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
-msgstr "E' richiesta un' aggregazione"
+msgstr "Сумирането е задължително"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
-msgstr "Modifica la tua Metrica"
+msgstr "Редактирайте Вашите метрични показатели"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
-msgstr "Crea la tua metrica"
+msgstr "Създайте Вашите метрични показатели"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "Cambia le tue metriche e aggiungi una nota esplicativa"
+msgstr "Направете промени по метричните показатели и оставете обяснителна бележка."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:145
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "È possibile creare metriche salvate per aggiungere un'opzione metrica con nome a questa tabella. Le metriche salvate includono il tipo di aggregazione, il campo aggregato e, facoltativamente, qualsiasi filtro aggiunto. Ad esempio, è possibile utilizzarlo per creare qualcosa come il modo ufficiale di calcolare 'Prezzo medio' per una tabella Ordini."
+msgstr "Можете да запазвате вее запазени метрични показатели, които да добавите като опция към тази таблица. Запазените показатели включват вида на сбора от параметри, съвкупността от полета и различни филтри, които можете да добавите. Например: можете да използвате този подход за да изчислите \"Средна Цена\" на таблица Поръчки."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
-msgstr "Risultato:"
+msgstr "Резултат:"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
-msgstr "Dai un nome alla tua Metrica"
+msgstr "Дайте име на метричния показател"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
-msgstr "Dai un nome alla tua Metrica per aiutare gli altri a trovarla."
+msgstr "Дайте име на метричния показател за да помогнете на други потребители да го намерят по-лесно."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
-msgstr "Qualcosa di descrittivo ma non troppo dettagliato"
+msgstr "Нещо описателно, но не прекалено дълго"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
-msgstr "Descrivi la tua Metrica"
+msgstr "Опишете Вашия метричен показател"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "Dai alla tua Metrica una descrizione per aiutare gli altri a capire di cosa tratta"
+msgstr "Опишете метричния показател за да помогнете на други потребители да разберат какво точно представлява той."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "Questo é un buon posto per essere piú specifici riguardo le metriche meno ovvie"
+msgstr "Тук е добро място да бъдете по-конкретен относно по-малко очевидни правила за метрични показатели"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
-msgstr "Motivo per le modifiche"
+msgstr "Причина за промените"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "Lascia un commento per spiegare quali cambiamenti hai fatto e perché li ritenevi necessari."
+msgstr "Оставете бележка, за да обясните какви промени сте направили и защо са необходими."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "Questo verrá mostrato nello storico revisioni di questa metrica per aiutare tutti a ricordarsi perché le cose sono cambiate"
+msgstr "Това ще се покаже в историята на промените за този показател, за да помогне на всички да си припомнят защо нещата са се променили"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
-msgstr "Al meno uno filtro è obbligatorio"
+msgstr "Задължителен е поне един филтър"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
-msgstr "Modifica il tuo Segmento"
+msgstr "Променете Вашия сегмент"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
-msgstr "Crea il tuo Segmento"
+msgstr "Създайте сегмент"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "Cambia il tuo segmento e aggiungi una nota esplicativa"
+msgstr "Направете промени по Вашия сегмент и оставете обяснителна бележка."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "Seleziona un filtro da aggiungere per creare un nuovo segmento sulla tabella {0}"
+msgstr "Изберете и добавете филтри за да създадете нов сегмент за таблица {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
-msgstr "Dai un nome al tuo Segmento"
+msgstr "Дайте име на Вашия сегмент"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
-msgstr "Dai un nome al tuo segmento per aiutare gli altri a trovarlo"
+msgstr "Дайте име на сегмента си, за да помогнете на другите да го намерят."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
-msgstr "Discrivi il tuo segmento"
+msgstr "Опишете сегмента си"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "Dai una descrizione al tuo segmento per aiutare gli altri a capire di cosa si tratta."
+msgstr "Дайте описание на вашия сегмент, за да помогнете на другите да разберат за какво става въпрос."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "questo e' un buon posto per essere precisi nel descrivere le regole di segmento meno ovvie"
+msgstr "Това е добро място да бъдете по-конкретни относно по-малко очевидните правила за сегменти"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "Questo verrà visualizzato nella cronologia delle revisioni di questo segmento per aiutare tutti a ricordare perché le cose sono cambiate"
+msgstr "Това ще се появи в историята на редакциите за този сегмент, за подсещане на потребителите защо нещата са се променили"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
 #: frontend/src/metabase/admin/routes.jsx:137
@@ -833,67 +833,65 @@ msgstr "Questo verrà visualizzato nella cronologia delle revisioni di questo se
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
-msgstr "Impostazioni"
+msgstr "Настройки"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabase può analizzare i valori per questa tabella in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'. "
+msgstr "Метабейс може да сканира стойностите в тази таблица, за да активира филтрите за отметки в таблата и въпросите."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
-msgstr "Riscansiona questa tabella"
+msgstr "Сканирай тази таблица наново"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
-msgstr "Aggiungi"
+msgstr "Добави"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 msgid "Not a valid formatted email address"
-msgstr "Indirizzo email formattato non correttamente"
+msgstr "Невлидно форматиран имейл адрес"
 
 #: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
-msgstr "Nome"
+msgstr "Име"
 
 #: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
-msgstr "Cognome"
+msgstr "Фамилия"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
-msgstr "Indirizzo email"
+msgstr "Имейл"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "Gruppi di Sicurezza"
+msgstr "Права на групи"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
-msgstr "Rendi admin questo user"
+msgstr "Направете този потребител администратор"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "Tutti gli utenti appartengono al gruppo {0} e non possono essere rimossi da esso. L'impostazione dei permessi per questo gruppo è un ottimo modo per \n"
-"assicurarti di sapere quali nuovi utenti di Metabase saranno in grado di vedere."
+msgstr "Всички потребители принадлежат към група {0} и не могат да бъдат премахнати от нея. Задаването на разрешения за тази група е добър начин да сте сигурни какво ще могат да виждат новите потребители в Метабейс."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "Questo è un gruppo speciale i cui membri possono vedere tutto dell'istanza di Metabase e chi vi accede può apportare modifiche alle\n"
-"impostazioni nel Pannello di amministrazione, compresi i permessi di modifica! Quindi, aggiungi le persone a questo gruppo con cura."
+msgstr "Това е специална група, чиито членове могат да виждат всичко в Метабейс и които имат достъп и могат да правят промени в настройките в Административния Панел, включително промяна на разрешенията! Добавяйте хора към тази група с повишено внимание."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Per essere sicuro di non restare bloccato da Metabase, deve sempre esserci almeno un utente in questo gruppo."
+msgstr "За да сте сигурни, че ще имате достъп до Метабейс, винаги трябва да има поне един потребител в тази група."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "Utenti"
+msgstr "Членове"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -902,66 +900,66 @@ msgstr "Utenti"
 #: frontend/src/metabase/lib/core.js:146
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
-msgstr "Email"
+msgstr "Имейл"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "Un gruppo é tanto buono quanto lo sono i suoi membri."
+msgstr "Една група е толкова добра, колкото са нейните членове."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
-msgstr "Admin"
+msgstr "Администратор"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
-msgstr "e"
+msgstr "и"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} altro gruppo"
-msgstr[1] "{0} altri gruppi"
+msgstr[0] "{0} друга група"
+msgstr[1] "{0} други групи"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "Default"
+msgstr "Настройка по подразбиране"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "Qualcosa simile a \"marketing\""
+msgstr "Нещо като \"Маркетинг\""
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "Rimuovere questo gruppo?"
+msgstr "Премахнете групата?"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "Sei sicuro? Tutti i membri di questo gruppo perderanno tutti i permessi basati su di esso. Operazione irreversibile."
+msgstr "Сигурни ли сте? Всички членове на тази група ще загубят всички  разрешения и настройки, базирани на тази група. Няма връщане назад."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "Sì"
+msgstr "Да"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "No"
+msgstr "Не"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "Modifica nome"
+msgstr "Промени името"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "Rimuovi gruppo"
+msgstr "Премахнете групата"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -977,11 +975,11 @@ msgstr "Rimuovi gruppo"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
-msgstr "Fatto"
+msgstr "Готово"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "Nome del gruppo"
+msgstr "Име на групата"
 
 #: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
@@ -991,386 +989,386 @@ msgstr "Nome del gruppo"
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
-msgstr "Gruppi"
+msgstr "Групи"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "Crea un gruppo"
+msgstr "Създайте група"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "Puoi utilizzare i gruppi per controllare l'accesso dei tuoi utenti ai tuoi dati. Metti gli utenti in gruppi e poi vai alla sezione Permessi per controllare l'accesso di ciascun gruppo. I gruppi 'Amministratori' (Administrators) e 'Tutti gli utenti' (All Uses) sono gruppi predefiniti speciali che non possono essere rimossi."
+msgstr "Можете да използвате групи, за да контролирате достъпа на Вашите потребители до Вашите данни. Поставете потребителите в групи и след това отидете в раздела Разрешения, за да контролирате достъпа на всяка група. Групите \"Администратори\" и \"Всички потребители\" са специални групи по подразбиране, които не могат да бъдат премахнати."
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "Modifica dettagli"
+msgstr "Редактирайте Детайли"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "Rimanda invito"
+msgstr "Изпратете поканата наново"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "Password dimenticata"
+msgstr "Нулиране на паролата"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "Disattiva"
+msgstr "Деактивирайте"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
-msgstr "Persone"
+msgstr "Хора"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "Chi vuoi aggiungere?"
+msgstr "Кого искате да добавите?"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "Modifica i dettagli di  {0}"
+msgstr "Променете детайлите на {0}"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "{0} è stato aggiunto"
+msgstr "{0} беше добавен"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "Aggiungi un'altra persona"
+msgstr "Добавете друг човек"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "Non è stato possibile inviare agli utenti un invito via email, \n"
-"assicurati di comunicare di accedere utilizzando {0} \n"
-"e questa password che abbiamo generato:"
+msgstr "Не можахме да им изпратим покана по имейл,\n"
+"така че бедете сигурни да им кажете да влязат с помощта на {0}\n"
+"и тази парола, която сме генерирали за тях:"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "Se vuoi essere in grado di inviare inviti e-mail, vai alla pagina {0}."
+msgstr "Ако искате да можете да изпращате покани по имейл, просто отидете на страницата {0}."
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "Abbiamo inviato un invito a {0} con le istruzioni per impostare la password."
+msgstr "Изпратихме покана до {0} с инструкции за задаване на паролата им."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "Sono stati inviati gli inviti di {0}"
+msgstr "Изпратихме повторно поканата на {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:24
 msgid "Okay"
-msgstr "Ok"
+msgstr "Окей"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr " Qualsiasi email precedente inviti non funzionerà più."
+msgstr "Всички предишни покани по имейл няма да работят повече."
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "Disattiva {0}?"
+msgstr "Деактивирай {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0} non sarà più in grado di accedere."
+msgstr "{0} вече няма да може да влезе в системата."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "Vuoi riattivare l'account di {0}?"
+msgstr "Искате ли да активирате отново акаунта на {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "Riattivare"
+msgstr "Активирайте отново"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "Saranno in grado di accedere di nuovo e verranno reinseriti nei gruppi in cui si trovavano prima che il loro account fosse disattivato."
+msgstr "Те ще могат да влязат отново и ще бъдат поставени обратно в групите, в които са били преди деактивирането на акаунта им."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "Reimposta la password di {0}?"
+msgstr "Нулиране на паролата на {0}?"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:76
 msgid "Reset"
-msgstr "Reset"
+msgstr "Нулиране"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
-msgstr "Sei sicuro di volerlo fare?"
+msgstr "Сигурни ли сте?"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "La password di {0} è stata ripristinata"
+msgstr "Паролата на {0} беше нулирана"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "Ecco una password temporanea si può utilizzare per accedere ,sucessivamente modificare la password"
+msgstr "Това е временна парола, която могат да използват, за да влязат и след това да променят паролата си."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "Abbiamo spedito una email con le istruzioni per creare una nuova password"
+msgstr "Изпратихме имейл с инструкции за създаване на нова парола."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:15
 msgid "Active"
-msgstr "Attivo"
+msgstr "Активен"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "Deattivato"
+msgstr "Деактивиран"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "Aggiungi qualcuno"
+msgstr "Добавете потребител"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "Ultimo Login"
+msgstr "Последно влизане"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:154
 msgid "Signed up via Google"
-msgstr "Iscritto  tramite  Google"
+msgstr "Регистриран чрез Google"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:159
 msgid "Signed up via LDAP"
-msgstr "Accesso con LDAP"
+msgstr "Регистриран чрез LDAP"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:171
 msgid "Reactivate this account"
-msgstr "Riattivare questo account"
+msgstr "Активирайте наново този акаунт"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:195
 msgid "Never"
-msgstr "Mai"
+msgstr "Никога"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0} tabella"
-msgstr[1] "{0} tabelle"
+msgstr[0] "{0} Таблица"
+msgstr[1] "{0} Таблици"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr " sarà "
+msgstr " ще бъде "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "Accesso permesso a"
+msgstr "даден достъп до"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr " e "
+msgstr " и "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "Accesso proibito a"
+msgstr "отказан достъп до"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr " non sarà più in grado di "
+msgstr " повече няма да може да "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr " non sarà in grado di "
+msgstr " вече ще може да "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr " query native per "
+msgstr " сурови запитвания за "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:14
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Permissions"
-msgstr "Permessi"
+msgstr "Разрешения"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "Salvare i permessi?"
+msgstr "Запазете разрешенията?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 msgid "Save Changes"
-msgstr "Salva le modifiche"
+msgstr "Запазете промените"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "Scartare le modifiche?"
+msgstr "Отмени промените?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "Nessun cambiamento ai permessi sará fatto"
+msgstr "Промени в разрешенията няма да бъдат направени."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "Hai cambiato i permessi"
+msgstr "Направихте промени в резрешенията."
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
-msgstr "Permessi per questa collection"
+msgstr "Разрешения за тази колекция"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:81
 msgid "You have unsaved changes"
-msgstr "Hai modifiche non salvate"
+msgstr "Има незапазени промени"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:82
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "Vuoi lasciare questa pagina e scartare le tue modifiche?"
+msgstr "Искате ли да напуснете тази страница и да отхвърлите промените си?"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:129
 msgid "Sorry, an error occurred."
-msgstr "Spiacenti, si é verificato un errore"
+msgstr "За съжаление възникна грешка."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:71
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "Gli amministratori hanno sempre il più alto livello di accesso a tutto Metabase."
+msgstr "Администраторите винаги имат най-високо ниво на достъп до всичко в Метабейс."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:73
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "Ogni utente di Metabase appartiene al gruppo 'Tutti gli utenti' (All Users). Se si desidera limitare o limitare l'accesso di un gruppo a qualcosa, assicurarsi che il gruppo 'Tutti gli utenti' abbia un livello di accesso uguale o inferiore."
+msgstr "Всеки потребител на Метабейс принадлежи към групата Всички потребители. Ако искате да ограничите достъпа на групата до нещо, уверете се, че групата Всички потребители има равно или по-ниско ниво на достъп."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:75
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBot è il bot Slack di Metabase. Puoi scegliere a cosa può accedere qui."
+msgstr "Метабот е Слак бота на Метабейс. Тук можете да изберете до какво има достъп."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:128
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "Il \"{0}\" gruppo può avere accesso a un diverso insieme di {1} rispetto a questo gruppo, che può dare a questo gruppo ulteriore accesso ad alcune {2}."
+msgstr "Групата „{0}“ може да има достъп до различен набор от {1} от тази група, което може да даде на тази група допълнителен достъп до някои {2}."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:131
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "Il gruppo \"{0}\" ha un livello di accesso superiore a questo, per cui sarà sostutuita questa impostazione. Devi limitare o revocare l'accesso del gruppo \"{1}\" a questo elemento."
+msgstr "Групата „{0}“ има по-високо ниво на достъп от това, което ще замени тази настройка. Трябва да ограничите или отнемете достъпа на групата „{1}“ до този елемент."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "Limita"
+msgstr "Ограничи"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "Revoca"
+msgstr "Отмени"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "accesso anche se \"{0}\" ha un accesso maggiore?"
+msgstr "достъп, въпреки че „{0}“ има по-голям достъп?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "Limita l'accesso"
+msgstr "Ограничи достъпа"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 #: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
-msgstr "Revoca L'accesso"
+msgstr "Отмени достъпа"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "Modificare l'accesso a questo database a limitato?"
+msgstr "Да се промени ли достъпът до тази база данни на ограничен?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "Cambia"
+msgstr "Промени"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "Consenti scrittura di query?"
+msgstr "Да се разреши ли писане на сурови заявки?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "Questo cambierà anche l'accesso ai dati di questo gruppo a 'Non ristretto' (Unrestricted) per questo database."
+msgstr "Това също ще промени достъпа на данните на тази група до неограничен за тази база данни."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "Permetto"
+msgstr "Позволи"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "Revocare l'accesso a tutte le tabelle?"
+msgstr "Отмени достъпът до всички таблици?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "Questo revocherà anche l'accesso di questo gruppo alle query per questo database."
+msgstr "Това също ще отмени достъпа на тази група до сурови заявки за тази база данни."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "Concedere l'accesso illimitato"
+msgstr "Предоставете неограничен достъп"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "Accesso Illimitato"
+msgstr "Неограничен достъп"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "Acceso limitato"
+msgstr "Ограничен достъп"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "Accesso Negato"
+msgstr "Няма достъп"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "Scrivi Query"
+msgstr "Напишете сурови заявки"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "Puoi scrivere query brutali"
+msgstr "Може да пише сурови заявки"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "Cura la collezione"
+msgstr "Организирайте колекцията"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "Vedi collezione"
+msgstr "Преглед на колекцията"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:352
 #: frontend/src/metabase/admin/permissions/selectors.js:463
 #: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
-msgstr "Accesso ai dati"
+msgstr "Достъп до данни"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:528
 #: frontend/src/metabase/admin/permissions/selectors.js:683
 #: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
-msgstr "Vedi tabelle"
+msgstr "Преглед на таблици"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
-msgstr "SQL query"
+msgstr "SQL заявки"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
-msgstr "Vedi schemi"
+msgstr "Преглед на схеми"
 
 #: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
-msgstr "Modello dei dati"
+msgstr "Модел на данни"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 #: frontend/src/metabase/plugins/builtin/auth/google.js:31
 msgid "Sign in with Google"
-msgstr "Accesso con Google"
+msgstr "Влезте с Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 #: frontend/src/metabase/plugins/builtin/auth/google.js:32
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Consente agli utenti con account Metabase esistenti di accedere con un account Google che corrisponda al loro indirizzo email oltre al nome utente e alla password di Metabase."
+msgstr "Позволява на потребителите със съществуващи акаунти в Метабейс да влизат с акаунт в Google, който съответства на техния имейл адрес в допълнение към тяхното потребителско име и парола за Метабейс."
 
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:24
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "Configurare"
+msgstr "Конфигурирайте"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:20
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:15
@@ -1379,45 +1377,45 @@ msgstr "LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:16
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "Consente agli utenti all'interno della directory LDAP di accedere a Metabase con le proprie credenziali LDAP e consente la mappatura automatica dei gruppi LDAP ai gruppi di metabase."
+msgstr "Позволява на потребителите във вашата LDAP директория да влизат в Метабейс със своите LDAP идентификационни данни и позволява автоматично картографиране на LDAP групи в Метабейс групи."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
 #: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
-msgstr "Email non valida"
+msgstr "Това не е валиден имейл адрес"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
-msgstr "Intero non valido"
+msgstr "Това не е валидно цяло число"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
-msgstr "Modifiche Salvate!"
+msgstr "Промените са запазени!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
-msgstr "Mi"
+msgstr "Изглежда, че се сблъскахме с някои проблеми"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:19
 msgid "Send test email"
-msgstr "Spedisci email di test"
+msgstr "Изпратете тестов имейл"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:20
 msgid "Sending..."
-msgstr "Invio..."
+msgstr "Изпращане..."
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:21
 msgid "Sent!"
-msgstr "Inviato!"
+msgstr "Изпратено!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:93
 msgid "Clear"
-msgstr "Pulisci"
+msgstr "Изчисти"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
@@ -1425,91 +1423,91 @@ msgstr "Pulisci"
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
-msgstr "Autenticazione"
+msgstr "Удостоверяване"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
-msgstr "Parametri Server"
+msgstr "Настройки на сървъра"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:36
 msgid "User Schema"
-msgstr "Schema Utente"
+msgstr "Потребителска схема"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:40
 msgid "Attributes"
-msgstr "Attributi"
+msgstr "Атрибути"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
-msgstr "Schema Gruppo"
+msgstr "Групова схема"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:33
 msgid "Using "
-msgstr "Usando "
+msgstr "Използвайки "
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "Prepararsi"
+msgstr "Настройка"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Alcune cose che puoi fare per ottenere il massimo da Metabase."
+msgstr "Няколко неща, които можете да направите, за да извлечете максимума от Метабейс."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "Prossimo passo (raccomandato)"
+msgstr "Препоръчителна следваща стъпка"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "Google Sign-In"
+msgstr "Вход с Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "Per consentire agli utenti di accedere con Google, devi fornire a Metabase un ID client dell'applicazione Google Developers Console. Ci vogliono solo pochi passi e le istruzioni su come creare una chiave possono essere trovate {0}"
+msgstr "За да позволите на потребителите да влизат с Google, ще трябва да дадете на Метабейс клиентски идентификационен номер на приложение за конзола на Google Developers. Необходими са само няколко стъпки и могат да бъдат намерени инструкции как да създадете ключ {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:140
 msgid "Your Google client ID"
-msgstr "il tuo Google ID"
+msgstr "Вашият клиентски идентификационен номер на Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:145
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Consenti agli utenti di registrarsi da soli se il loro indirizzo email dell'account Google proviene da:"
+msgstr "Позволете на потребителите да се регистрират сами, ако имейл адресът на акаунта им в Google е от:"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
-msgstr "Le risposte vengono inviate direttamente ai tuoi #channels di Slack"
+msgstr "Отговори, изпратени директно до вашите Slack #channels"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "Crea un Utente Bot Slack per MetaBot"
+msgstr "Създайте потребител на Slack Bot за MetaBot"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "Una volta che sei lì, dagli un nome e fai clicca {0}. Quindi copia e incolla il token API Bot nel campo sottostante. Una volta terminato, crea un canale \"metabase_files\" in Slack. Metabase ha bisogno di questo per caricare grafici."
+msgstr "След като сте там, дайте му име и кликнете върху {0}. След това копирайте и поставете маркера за API на бота в полето по-долу. След като приключите, създайте канал „metabase_files“ в Slack. Метабейс се нуждае от това, за да прикачва графики."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:17
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "Stai usando Metabase {0} che é l'ultimo e il migliore!"
+msgstr "Използвате най-новата и най-добрата Метабейс {0}!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "É disponibile Metabase {0}. La versione in uso é la {1}."
+msgstr "Налична е метабаза {0}. Изпълнявате {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
-msgstr "Aggiornare"
+msgstr "Актуализиране"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:46
 msgid "What's Changed:"
-msgstr "Cos'è cambiato:"
+msgstr "Какво е променено:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "Aggiungi una mappa"
+msgstr "Добавете карта"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
@@ -1521,7 +1519,7 @@ msgstr "URL"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "Cancellare mappa personalizzata"
+msgstr "Изтриване на персонализирана карта"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
@@ -1532,7 +1530,7 @@ msgstr "Cancellare mappa personalizzata"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
-msgstr "Rimuovere"
+msgstr "Премахване"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
@@ -1540,300 +1538,300 @@ msgstr "Rimuovere"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
-msgstr "Seleziona..."
+msgstr "Изберете ..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "Valori di esempio:"
+msgstr "Примерни стойности:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "Aggiungi una nuova mappa"
+msgstr "Добавете нова карта"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "Modifica mappa"
+msgstr "Редактиране на картата"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "Come vuoi chiamare questa mappa?"
+msgstr "Как искате да наречете тази карта?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "p.es. United Kingdom, Brazil, Mars"
+msgstr "напр. Обединено кралство, Бразилия, Марс"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "URL per il file GeoJSON che vuoi usare"
+msgstr "URL за файла GeoJSON, който искате да използвате"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "Come https://my-mb-server.com/maps/my-map.json"
+msgstr "Като https://my-mb-server.com/maps/my-map.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "Aggiorna"
+msgstr "Обнови"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "Carica"
+msgstr "Зареди"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "Quale proprietà specifica l'identificativo della regione?"
+msgstr "Кое свойство посочва идентификатора на региона?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "Quale proprietà specifica il nome da mostrare della regione?"
+msgstr "Кое свойство посочва показваното име на региона?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "Carica un file GeoJSON per vedere l'anteprima"
+msgstr "Заредете файл GeoJSON, за да видите визуализация"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "Salva mappa"
+msgstr "Запазване на картата"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "Aggiungi mappa"
+msgstr "Добавяне на карта"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "Usa la modalità \"embedded\""
+msgstr "Използване на вграждане"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "Abilitando l'incorporamento accetti la licenza di incorporamento situata in"
+msgstr "Активирайки вграждането, вие се съгласявате с лиценза за вграждане, намиращ се на адрес"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "In italiano semplice, quando si incorporano grafici o 'dashboard' da Metabase nella propria applicazione, tale applicazione non è soggetta alla 'Affero General Public License' che copre il resto di Metabase, purché si mantenga visibile il logo della metabase e il \"Powered by Metabase\" su quegli elementi inclusi. Tuttavia, dovresti leggere il testo della licenza linkato in alto, poiché questa è la licenza effettiva a cui dovrai accettare abilitando questa funzione."
+msgstr "На чист български език, когато вграждате диаграми или табла за управление от Метабейс във вашето собствено приложение, това приложение не е обект на Общия публичен лиценз Affero, който покрива останалата част от Метабейс, при условие че запазите видимото лого на Метабейс и „Powered by Metabase“ върху тези вграждания. Трябва обаче да прочетете текста на лиценза, свързан по-горе, тъй като това е действителният лиценз, с който ще се съгласите, като активирате тази функция."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "Abilita"
+msgstr "Активирайте"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "Abilitazione Premium \"embedding \" attivata"
+msgstr "Премиум вграждането е активирано"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Inserisci il token che hai comprato dal negozio Metabase"
+msgstr "Въведете токена, който сте закупили от Metabase Store"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "il Premium ti consente di disattivare 'Powered by Metabase' nelle dashboard e domande embeddate"
+msgstr "Премиум вграждането ви позволява да деактивирате „Powered by Metabase“ на вашите вградени табла и въпроси."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "Acquista un token"
+msgstr "Купете токен"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "Inserisci un Token"
+msgstr "Въведете токен"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
-msgstr "Modifica Mapping"
+msgstr "Редактирайте съпоставянния"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
-msgstr "Raggruppa Mapping"
+msgstr "Групирайте съпоставяния"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
-msgstr "Crea Mapping"
+msgstr "Създайте картографиране"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "I mapping consentono a Metabase di aggiungere e rimuovere automaticamente utenti dai gruppi in base alle informazioni sull'appartenenza fornite dal server di directory \n"
-". L'appartenenza al gruppo di amministrazione può essere concessa tramite associazioni, ma non verrà automaticamente rimossa come misura \n"
-"failsafe."
+msgstr "Съпоставянето позволява на Metabase автоматично да добавя и премахва потребители от групи въз основа на информацията за членство, предоставена от\n"
+"сървъра на директориите. Членството в административната група може да бъде предоставено чрез картографиране, но няма да бъде премахнато автоматично като\n"
+"мярка за безопасност"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:107
 msgid "Distinguished Name"
-msgstr "Nome distinto"
+msgstr "Уважаемо име"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "Link Pubblico"
+msgstr "Обществена връзка"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "Revoca Link"
+msgstr "Отмени връзката"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "Vuoi disabilitare questo link"
+msgstr "Да се ​​деактивира ли тази връзка?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "Non funzioneranno più e non possono essere ripristinati, ma puoi creare nuovi collegamenti."
+msgstr "Те вече няма да работят и не могат да бъдат възстановени, но можете да създадете нови връзки."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
-msgstr "Lista delle 'dashboard' pubbliche"
+msgstr "Публично табло за управление"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "Nessuna dashboard è stato ancora pubblicamente condivisa."
+msgstr "Все още няма публични табла за управление."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "Lista delle card pubbliche"
+msgstr "Обява за публична карта"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "Nessuna domanda è stato ancora pubblicamente condivisa."
+msgstr "Все още няма публично споделени въпроси."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "Lista delle  'dashboard'  inserite"
+msgstr "Списък с вградено табло"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "Nessuna 'dashboard' è stata ancora inserita"
+msgstr "Все още няма вградени табла за управление."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "Lista delle card incorporate"
+msgstr "Списък с вградени карти"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "Nessuna domanda è stata ancora incorporata."
+msgstr "Все още няма вградени въпроси."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "Rigenerare la chiave incorporata?"
+msgstr "Регенериране на ключа за вграждане?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "Ciò causerà l'interruzione del funzionamento delle parti incorporate esistenti finché non vengono aggiornati con la nuova chiave"
+msgstr "Това ще доведе до спиране на работата на съществуващите вграждания, докато не бъдат актуализирани с новия ключ."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "Chiave rigenerata"
+msgstr "Регенериране на ключ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "Chiave generata"
+msgstr "Генериране на ключ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
-msgstr "Abilitata"
+msgstr "Активирано"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "Disabilitato"
+msgstr "хора с увреждания"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
-msgstr "Impostazione sconosciuta {0}"
+msgstr "Неизвестна настройка {0}"
 
 #: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
-msgstr "Imposta"
+msgstr "Настройвам"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
 #: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
-msgstr "Generale"
+msgstr "Общ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
-msgstr "Nome del Sito"
+msgstr "Име на сайта"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
-msgstr "URL del sito"
+msgstr "URL адрес на сайта"
 
 #: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
-msgstr "Indirizzo email per richieste di assistenza"
+msgstr "Имейл адрес за заявки за помощ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
-msgstr "Segnala fuso orario"
+msgstr "Отчетете Часова зона"
 
 #: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
-msgstr "Database predefinito"
+msgstr "База данни по подразбиране"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "Seleziona una timezone"
+msgstr "Изберете часова зона"
 
 #: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "Non tutti i database supportano i fusi orari, nel qual caso questa impostazione non avrà effetto."
+msgstr "Не всички бази данни поддържат часови зони, като в този случай тази настройка няма да влезе в сила."
 
 #: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
-msgstr "Lingua"
+msgstr "Език"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "Seleziona una lingua"
+msgstr "Изберете език"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
-msgstr "Tracciamento Anonimo"
+msgstr "Анонимно проследяване"
 
 #: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
-msgstr "Nomi tabelle e campi amichevoli"
+msgstr "Приятелски имена на таблици и полета"
 
 #: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
-msgstr "Sostituisci solo caratteri di sottolineatura e trattini con spazi"
+msgstr "Заменяйте само подчертаванията и тиретата с интервали"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
-msgstr "Abilita le query annidate"
+msgstr "Активиране на вложени заявки"
 
 #: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
-msgstr "Aggiornamenti"
+msgstr "Актуализации"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
-msgstr "Controlla Aggiornamenti"
+msgstr "Провери за актуализации"
 
 #: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
-msgstr "Host SMTP"
+msgstr "SMTP хост"
 
 #: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
-msgstr "Porta SMTP"
+msgstr "SMTP порт"
 
 #: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
-msgstr "Questo non e' un numero diporta valido"
+msgstr "Това не е валиден номер на порт"
 
 #: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
-msgstr "Tipo sicurezza SMTP"
+msgstr "SMTP сигурност"
 
 #: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
-msgstr "SMTP Username"
+msgstr "SMTP потребителско име"
 
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
-msgstr "SMTP Password"
+msgstr "SMTP парола"
 
 #: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
-msgstr "\"Da\" Indirizzo"
+msgstr "От Адрес"
 
 #: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
@@ -1841,31 +1839,31 @@ msgstr "Slack API Token"
 
 #: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
-msgstr "Inserisci il token di slack"
+msgstr "Въведете токена, който сте получили от Slack"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "Single Sign-On"
+msgstr "Единично влизане"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:30
 msgid "LDAP Authentication"
-msgstr "Autenticazione LDAP"
+msgstr "LDAP удостоверяване"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:36
 msgid "LDAP Host"
-msgstr "LDAP Host"
+msgstr "LDAP домакин"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:44
 msgid "LDAP Port"
-msgstr "Porta LDAP"
+msgstr "LDAP порт"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:51
 msgid "LDAP Security"
-msgstr "Sicurezza LDAP"
+msgstr "LDAP сигурност"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:59
 msgid "Username or DN"
-msgstr "Username o DN"
+msgstr "Потребителско име или DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
 #: frontend/src/metabase/entities/databases/forms.js:61
@@ -1873,259 +1871,259 @@ msgstr "Username o DN"
 #: frontend/src/metabase/user/components/UserSettings.jsx:66
 #: src/metabase/driver/common.clj
 msgid "Password"
-msgstr "Password"
+msgstr "Парола"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:69
 msgid "User search base"
-msgstr "Base di ricerca degli utenti"
+msgstr "Потребителска база за търсене"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:75
 msgid "User filter"
-msgstr "Filtro utente"
+msgstr "Потребителски филтър"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:81
 msgid "Check your parentheses"
-msgstr "Controlla le tue parentesi"
+msgstr "Проверете скобите си"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
-msgstr "Attributo email"
+msgstr "Атрибут на имейл"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
-msgstr "Attributo nome"
+msgstr "Атрибут за собствено име"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
-msgstr "Attributo cognome"
+msgstr "Атрибут на фамилното име"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
-msgstr "Sincronizza le appartenenze ai gruppi"
+msgstr "Синхронизирайте членството в група"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:113
 msgid "Group search base"
-msgstr "Ricerca base gruppo"
+msgstr "Групова база за търсене"
 
 #: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
-msgstr "Mappe"
+msgstr "Карти"
 
 #: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
-msgstr "URL del MAP TILE SERVER"
+msgstr "URL адрес на сървъра за плочки на картата"
 
 #: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabase utilizza OpenStreetMaps per impostazione predefinita."
+msgstr "Metabase използва OpenStreetMaps по подразбиране."
 
 #: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
-msgstr "Mappe personalizzate"
+msgstr "Персонализирани карти"
 
 #: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "Aggiungi i tuoi file GeoJSON per abilitare visualizzazioni di mappe di regioni diverse"
+msgstr "Добавете свои собствени GeoJSON файлове, за да активирате различни визуализации на регионални карти"
 
 #: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
-msgstr "Condivisione pubblica"
+msgstr "Публично споделяне"
 
 #: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
-msgstr "Abilita la condivisione pubblica"
+msgstr "Активирайте публичното споделяне"
 
 #: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
-msgstr "'Dashboard' condivise"
+msgstr "Споделени табла за управление"
 
 #: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
-msgstr "Question condivise"
+msgstr "Споделени въпроси"
 
 #: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
-msgstr "Incorporamento in altre applicazioni"
+msgstr "Вграждане в други приложения"
 
 #: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "Abilita incorporamento di Metabase in altre applicazioni"
+msgstr "Активирайте вграждането на Metabase в други приложения"
 
 #: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
-msgstr "Chiave segreta incorporata"
+msgstr "Вграждане на таен ключ"
 
 #: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
-msgstr "'Dashboard' incorporate"
+msgstr "Вградени табла за управление"
 
 #: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
-msgstr "Question incorporate"
+msgstr "Вградени въпроси"
 
 #: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
-msgstr "Caching"
+msgstr "Кеширане"
 
 #: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
-msgstr "Abilita caching"
+msgstr "Активиране на кеширането"
 
 #: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
-msgstr "Durata minima Query"
+msgstr "Минимална продължителност на заявката"
 
 #: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "Moltiplicatore Time-To-Live (TTL) della cache"
+msgstr "Умножител на времето за изживяване в кеша (TTL)"
 
 #: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
-msgstr "Dimensione massima della cache"
+msgstr "Максимален размер на записа в кеша"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "Il tuo avviso è tutto configurato."
+msgstr "Вашият сигнал е настроен."
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "L'avviso è stato aggiornato."
+msgstr "Вашият сигнал е актуализиран."
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "L'avviso è stato cancellato con successo."
+msgstr "Сигналът беше успешно изтрит."
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "Per piacere inserisci un indirizzo email valido"
+msgstr "Моля, въведете валиден форматиран имейл адрес."
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "La password non corrisponde"
+msgstr "Паролите не съвпадат"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "Torna alla login"
+msgstr "Обратно към вход"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "Nessun account Metabase esiste per questo account Google."
+msgstr "Не съществува акаунт в Metabase за този акаунт в Google."
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Avrai bisogno di un amministratore per creare un account Metabase prima di poter utilizzare Google per accedere."
+msgstr "Ще ви е необходим администратор, за да създадете акаунт в Metabase, преди да можете да използвате Google за влизане."
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 msgid "Sign in with {0}"
-msgstr "Accedi con {0}"
+msgstr "Влезте с {0}"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
-msgstr "Contatta un amministratore per fare in modo che reimposti la password"
+msgstr "Моля, свържете се с администратор, за да им нулира паролата"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
-msgstr "Password dimenticata"
+msgstr "Забравена парола"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
-msgstr "L'email che usi per il tuo account Metabase"
+msgstr "Имейлът, който използвате за вашия акаунт в Metabase"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
-msgstr "Invia email di reimpostazione della password"
+msgstr "Изпратете имейл за нулиране на паролата"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
-msgstr "Controlla la tua e-mail per le istruzioni su come reimpostare la password."
+msgstr "Проверете вашия имейл за инструкции как да нулирате паролата си."
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
-msgstr "Accedi a Metabase"
+msgstr "Влезте в Metabase"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:165
 msgid "OR"
-msgstr "O"
+msgstr "ИЛИ"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 msgid "Username or email address"
-msgstr "Username e indirizzo email"
+msgstr "Потребителско име или имейл адрес"
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:56
 msgid "Sign in"
-msgstr "Accedi"
+msgstr "Впиши се"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:79
 msgid "I seem to have forgotten my password"
-msgstr "Mi sembra di aver dimenticato la mia password"
+msgstr "Изглежда съм забравил паролата си"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
-msgstr "richiedi una nuova email di ripristino"
+msgstr "заявете нов имейл за нулиране"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
-msgstr "Ops, questo è un link scaduto"
+msgstr "Ами сега, това е изтекла връзка"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "Per motivi di sicurezza, i link di reimpostazione password scadono dopo un po 'di tempo. Se hai ancora bisogno\n"
-"per resettare la tua password, puoi {0}."
+msgstr "От съображения за сигурност връзките за нулиране на паролата изтичат след малко. Ако все пак трябва\n"
+"да зададете нова парола, можете да {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
-msgstr "Nuova password"
+msgstr "Нова парола"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
-msgstr "Per proteggere i dati, password {0}"
+msgstr "За да защитите данните си, пароли {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "Crea una nuova password"
+msgstr "Създайте нова парола"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:135
 msgid "Make sure its secure like the instructions above"
-msgstr "Assicurati che sia sicuro come le istruzioni sopra"
+msgstr "Уверете се, че е сигурен, както е описано по-горе"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:186
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:143
 msgid "Confirm new password"
-msgstr "Conferma la nuova password"
+msgstr "Потвърждение на новата парола"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:193
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:152
 msgid "Make sure it matches the one you just entered"
-msgstr "Assicurati che corrisponda a quello che hai appena inserito"
+msgstr "Уверете се, че съвпада с този, който току-що сте въвели"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
-msgstr "La tua password è stata appena reimpostata"
+msgstr "Паролата ви е нулирана."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
-msgstr "Accedi con la tua nuova password"
+msgstr "Влезте с новата си парола"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "salvataggio fallito"
+msgstr "Запазването не бе успешно"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2133,19 +2131,19 @@ msgstr "salvataggio fallito"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "Salvato"
+msgstr "Запазено"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
-msgstr "Ok"
+msgstr "Добре"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
-msgstr "Archiviare questa collezione"
+msgstr "Да се ​​архивира ли тази колекция?"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "Anche le 'dashboard', le collezioni, e i 'pulse' in questa collezione saranno archiviati"
+msgstr "Таблата, колекциите и импулсите в тази колекция също ще бъдат архивирани."
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
 #: frontend/src/metabase/components/ArchiveModal.jsx:40
@@ -2160,19 +2158,19 @@ msgstr "Anche le 'dashboard', le collezioni, e i 'pulse' in questa collezione sa
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
 #: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
-msgstr "Archivia"
+msgstr "Архив"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:65
 msgid "This {0} has been archived"
-msgstr "Questo {0} è stato archiviato"
+msgstr "Това {0} е архивирано"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:710
 msgid "View the archive"
-msgstr "Vedi l'archivio"
+msgstr "Преглед на архива"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "Annulla questo {0}"
+msgstr "Деархивиране на това {0}"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:46
 #: frontend/src/metabase/components/BrowseApp.jsx:112
@@ -2181,54 +2179,54 @@ msgstr "Annulla questo {0}"
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
-msgstr "I tuoi dati"
+msgstr "Нашите данни"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
-msgstr "Verifica questa tabella"
+msgstr "Рентгеново тази таблица"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
-msgstr "Ulteriori informazioni su questa tabella"
+msgstr "Научете повече за тази таблица"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "click ripetuti"
+msgstr "Clickity щракване"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "salvato!"
+msgstr "Запазено!"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "Salvataggio fallito."
+msgstr "Запазването не бе успешно."
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Su"
-msgstr "Do"
+msgstr "Су"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Mo"
-msgstr "Lu"
+msgstr "Mo"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Tu"
-msgstr "Ma"
+msgstr "Вт"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "We"
-msgstr "Me"
+msgstr "Ние"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Th"
-msgstr "Gio"
+msgstr "Th"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Fr"
-msgstr "Ve"
+msgstr "О"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Sa"
@@ -2236,77 +2234,77 @@ msgstr "Sa"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "La tua email d'amministratore"
+msgstr "Имейл адресът на вашия администратор"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "Per inviare {0},  devi {1} integrare."
+msgstr "За да изпратите {0}, ще трябва да настроите {1} интеграция."
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr " oppure "
+msgstr "или"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "Per inviare {0}, un amministratore deve impostare l'integrazione {1}."
+msgstr "За да изпрати {0}, администраторът трябва да настрои {1} интеграция."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "Questa collezione è vuota, come una tela bianca"
+msgstr "Тази колекция е празна, като празно платно"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "Puoi utilizzare le raccolte per organizzare e raggruppare dashboard, domande e spunti per la tua squadra o per te stesso"
+msgstr "Можете да използвате колекции, за да организирате и групирате табла за управление, въпроси и импулси за вашия екип или за себе си"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "Crea una nuova collezione"
+msgstr "Създайте друга колекция"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "Le dashboard ti consentono di raccogliere e condividere i dati in un'unica posizione."
+msgstr "Таблата за управление ви позволяват да събирате и споделяте данни на едно място."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "Le pulsazioni ti consentono di inviare gli ultimi dati al tuo team in base a una temporizzazione via email o slack."
+msgstr "Импулсите ви позволяват да изпращате най-новите данни на вашия екип по график по имейл или в несигурност."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
-msgstr "Le richieste (question) sono una vista salvata dei tuoi dati."
+msgstr "Въпросите са запазен поглед върху вашите данни."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
-msgstr "Fissa"
+msgstr "Щифтове"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "Trascina qualcosa qui per fissarlo in cima"
+msgstr "Плъзнете нещо тук, за да го закачите в горната част"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
-msgstr "Collezioni"
+msgstr "Колекции"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:452
 msgid "Drag here to un-pin"
-msgstr "Trascian qui per sbloccare"
+msgstr "Плъзнете тук, за да откачите"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:487
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0} elemento selezionato"
-msgstr[1] "{0} elementi selezionati"
+msgstr[0] "Избран е {0} елемент"
+msgstr[1] "Избрани са {0} елемента"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:517
 msgid "Move {0} items?"
-msgstr "Vuoi spostare {0} elementi"
+msgstr "Преместване на {0} елемента?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:518
 msgid "Move \"{0}\"?"
-msgstr "Vuoi spostare \"{0}\"?"
+msgstr "Да се ​​премести ли „{0}“?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:623
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2315,84 +2313,84 @@ msgstr "Vuoi spostare \"{0}\"?"
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
-msgstr "Sposta"
+msgstr "Ход"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:687
 msgid "Edit this collection"
-msgstr "Modifica la collezione"
+msgstr "Редактирайте тази колекция"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:695
 msgid "Archive this collection"
-msgstr "Archivia questa collezione"
+msgstr "Архивирайте тази колекция"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "La mia collezione personale"
+msgstr "Моята лична колекция"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "Nuova collezione"
+msgstr "Нова колекция"
 
 #: frontend/src/metabase/components/CopyButton.jsx:36
 msgid "Copied!"
-msgstr "Copiato!"
+msgstr "Копирано!"
 
 #: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
-msgstr "Usa un tunnel-SSH per le connessioni col database"
+msgstr "Използвайте SSH-тунел за връзки с база данни"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "È possibile accedere ad alcune installazioni di database solo collegandosi tramite un host protetto SSH.\n"
-"Questa opzione fornisce anche un ulteriore livello di sicurezza quando una VPN non è disponibile.\n"
-"Abilitare ciò è di solito più lento rispetto ad una connessione diretta."
+msgstr "До някои инсталации на база данни може да се осъществи достъп само чрез свързване чрез SSH бастион хост.\n"
+"Тази опция също така осигурява допълнителен слой сигурност, когато VPN не е налице.\n"
+"Активирането на това обикновено е по-бавно от директната връзка."
 
 #: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "Questo è un database grande, quindi lasciami scegliere quando Metabase deve sincronizzare e scansionare"
+msgstr "Това е голяма база данни, така че нека да избера кога Metabase се синхронизира и сканира"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "Come impostazione predefinita, Metabase esegue una sincronizzazione oraria leggera e un'analisi giornaliera intensiva dei valori dei campi.\n"
-"Se si dispone di un database di grandi dimensioni, si consiglia di attivarlo e rivedere quando e con quale frequenza si verificano le scansioni dei valori di campo."
+msgstr "По подразбиране Metabase извършва лека почасова синхронизация и интензивно ежедневно сканиране на стойностите на полетата.\n"
+"Ако имате голяма база данни, препоръчваме да я включите и да прегледате кога и колко често се случват сканиранията на стойността на полето."
 
 #: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "{0} per generare un ID client e un client segreto per il progetto."
+msgstr "{0} за генериране на клиентски идентификатор и клиентска тайна за вашия проект."
 
 #: frontend/src/metabase/entities/databases/forms.js:115
 #: frontend/src/metabase/entities/databases/forms.js:130
 #: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
-msgstr "Clicca qui"
+msgstr "Натисни тук"
 
 #: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "Scegli \"Altro\" come tipo di applicazione. Chiamalo come preferisci."
+msgstr "Изберете „Друго“ като тип на приложението. Назовете го, както искате."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:357
 msgid "{0} to get an auth code"
-msgstr "{0} per prendere un codice di autenticazione"
+msgstr "{0}, за да получите код за удостоверяване"
 
 #: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
-msgstr "con i permessi di Google Drive"
+msgstr "с разрешения на Google Диск"
 
 #: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "Per usare Metabase con questi dati, devi abilitare l'accesso API nella console degli sviluppatori Google (Google Developers Console)."
+msgstr "За да използвате Metabase с тези данни, трябва да активирате достъпа до API в конзолата за разработчици на Google."
 
 #: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "{0} per andare alla console se non lo hai già fatto"
+msgstr "{0}, за да отидете на конзолата, ако още не сте го направили."
 
 #: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
-msgstr "Come vorresti fare riferimento a questo database?"
+msgstr "Как бихте искали да се обърнете към тази база данни?"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:187
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2403,148 +2401,148 @@ msgstr "Come vorresti fare riferimento a questo database?"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
-msgstr "Successivo"
+msgstr "Следващия"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "Cancella questo {0}"
+msgstr "Изтриване на това {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "Blocca questo elemento"
+msgstr "Закачете този елемент"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "Sposta questo elemento"
+msgstr "Преместете този елемент"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:21
 msgid "Edit this question"
-msgstr "Modifica questa domanda (question)"
+msgstr "Редактирайте този въпрос"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "Tipo di azione"
+msgstr "Тип действие"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:26
 msgid "View revision history"
-msgstr "Vedi storia di revisione"
+msgstr "Преглед на историята на редакциите"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "Sposta l'azione"
+msgstr "Преместване на действие"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "Archivia azione"
+msgstr "Действие в архива"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:31
 msgid "Add to dashboard"
-msgstr "Aggiungi alla 'dashboard'"
+msgstr "Добавяне към таблото за управление"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "Scarica i risultati"
+msgstr "Изтеглете резултатите"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/dashboard/containers/DashboardEmbedWidget.jsx:53
 msgid "Sharing and embedding"
-msgstr "Condividi e incorpora"
+msgstr "Споделяне и вграждане"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "Un altro tipo di azione"
+msgstr "Друг тип действие"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "Ricevi avvisi su questo"
+msgstr "Получавайте сигнали за това"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "Mostra SQL"
+msgstr "Вижте SQL"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "Segmenti per questo"
+msgstr "Сегменти за това"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "Mostra dettagli di errore"
+msgstr "Показване на подробности за грешка"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "Qui c'è un messaggio completo di errore"
+msgstr "Ето пълното съобщение за грешка"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "Ciao, sono Metabot"
+msgstr "Здравей, Metabot тук."
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "Basato sullo schema"
+msgstr "Въз основа на схемата"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
-msgstr "Uno sguardo alla tua"
+msgstr "Поглед към вашия"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
-msgstr "Cerca la lista"
+msgstr "Търсене в списъка"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
-msgstr "Cercato da {0}"
+msgstr "Търсене по {0}"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
-msgstr " o inserisci un ID"
+msgstr "или въведете идентификационен номер"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
-msgstr "Inserisci un ID"
+msgstr "Въведете идентификационен номер"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
-msgstr "Inserisci un numero"
+msgstr "Въведете номер"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
-msgstr "Inserisci del testo"
+msgstr "Въведете малко текст"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
-msgstr "Nessun {0} corrispondente trovato"
+msgstr "Не е намерено съвпадение {0}."
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "Includendo tutte le opzioni nel tuo filtro probabilmente non farai molto..."
+msgstr "Включването на всяка опция във вашия филтър вероятно няма да направи много ..."
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:26
 msgid "Something's gone wrong"
-msgstr "Qualcosa è andato storto"
+msgstr "Нещо се обърка"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:27
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "Ci siamo imbattuti in un errore. Puoi provare ad aggiornare la pagina, o semplicemente tornare indietro."
+msgstr "Срещнахме грешка. Можете да опитате да опресните страницата или просто да се върнете назад."
 
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
@@ -2554,32 +2552,32 @@ msgstr "Ci siamo imbattuti in un errore. Puoi provare ad aggiornare la pagina, o
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:238
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:213
 msgid "No description yet"
-msgstr "Ancora nessuna descrizione"
+msgstr "Все още няма описание"
 
 #: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
-msgstr "Nuovo {0}"
+msgstr "Ново {0}"
 
 #: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
-msgstr "Chiesto da {0}"
+msgstr "Попитан от {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "Oggi, "
+msgstr "Днес,"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "Ieri, "
+msgstr "Вчера,"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "Prima revisione."
+msgstr "Първа ревизия."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "Ripristinato a una revisione precedente e {0}"
+msgstr "Върнато към по-ранна версия и {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
@@ -2587,313 +2585,313 @@ msgstr "Ripristinato a una revisione precedente e {0}"
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
-msgstr "Storia di revisione"
+msgstr "История на редакциите"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "Quando"
+msgstr "Кога"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "Chi"
+msgstr "СЗО"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "Cosa"
+msgstr "Какво"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "Ripristina"
+msgstr "Връщане"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "Ripristino..."
+msgstr "Връща се ..."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "Ripristino fallito"
+msgstr "Възстановяването не бе успешно"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "Ripristinato"
+msgstr "Възстановено"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "Ogni cosa"
+msgstr "Всичко"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "Dashboard"
+msgstr "Табла за управление"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "Domande"
+msgstr "Въпроси"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
-msgstr "Pulse"
+msgstr "Импулси"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "Indietro"
+msgstr "обратно"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "Trova..."
+msgstr "Намирам..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "Si è verificato un errore"
+msgstr "Възникна грешка"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "Caricamento..."
+msgstr "Зареждане..."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Newsletter di Metabase"
+msgstr "Бюлетин на Metabase"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "Ricevi e-mail non frequenti su nuove versioni e aggiornamenti delle funzionalità."
+msgstr "Получавайте редки имейли за нови версии и актуализации на функции."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "Iscriviti"
+msgstr "Абонирай се"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "Sei iscritto. Grazie per aver usato Metabase"
+msgstr "Абонирани сте. Благодаря, че използвате Metabase!"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:46
 msgid "We're a little lost..."
-msgstr "Siamo un po' persi..."
+msgstr "Малко сме се изгубили ..."
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "Password temporanea"
+msgstr "Временна парола"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:455
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
-msgstr "Nascondi"
+msgstr "Крия"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:456
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
-msgstr "Mostra"
+msgstr "Покажи"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "Salvato! Aggiungo alla 'dashboard'?"
+msgstr "Запазено! Да се ​​добави ли това към таблото за управление?"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "Si grazie!"
+msgstr "Да моля!"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "Non ora"
+msgstr "Не сега"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "Errore:"
+msgstr "Грешка:"
 
 #: frontend/src/metabase/admin/settings/selectors.js:241
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
-msgstr "Domenica"
+msgstr "Неделя"
 
 #: frontend/src/metabase/admin/settings/selectors.js:242
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
-msgstr "Lunedì"
+msgstr "Понеделник"
 
 #: frontend/src/metabase/admin/settings/selectors.js:243
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
-msgstr "Martedì"
+msgstr "Вторник"
 
 #: frontend/src/metabase/admin/settings/selectors.js:244
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
-msgstr "Mercoledì"
+msgstr "Сряда"
 
 #: frontend/src/metabase/admin/settings/selectors.js:245
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
-msgstr "Giovedì"
+msgstr "Четвъртък"
 
 #: frontend/src/metabase/admin/settings/selectors.js:246
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
-msgstr "Venerdì"
+msgstr "Петък"
 
 #: frontend/src/metabase/admin/settings/selectors.js:247
 #: frontend/src/metabase/components/SchedulePicker.jsx:30
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
-msgstr "Sabato"
+msgstr "Събота"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
-msgstr "Primo"
+msgstr "Първо"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
-msgstr "Ultimo"
+msgstr "Последно"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:36
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
-msgstr "15mo (Medio)"
+msgstr "15-ти (Midpoint)"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
-msgstr "Giorno di calendario"
+msgstr "Календарен ден"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
-msgstr "il tuo timezone di Metabase"
+msgstr "вашата метабаза часовата зона"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "Filtra questa lista..."
+msgstr "Филтрирайте този списък ..."
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "Blu"
+msgstr "Син"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "Verde"
+msgstr "Зелено"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "Rosso"
+msgstr "червен"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "Giallo"
+msgstr "Жълто"
 
 #: frontend/src/metabase/components/Select.info.js:7
 msgid "A component used to make a selection"
-msgstr "Un componente utilizzato per fare una selezione"
+msgstr "Компонент, използван за извършване на селекция"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "Selezionato"
+msgstr "Избрано"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "Niente da selezionare"
+msgstr "Нищо за избор"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:56
 msgid "Sorry, you don’t have permission to see that."
-msgstr "Mi spiace, non hai i permessi per vederlo."
+msgstr "За съжаление нямате разрешение да го видите."
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "C'è stato un errore sconosciuto"
+msgstr "Възникна неизвестна грешка"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
-msgstr "Crea"
+msgstr "Създайте"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "Crea una dashboard"
+msgstr "Създайте табло за управление"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
-msgstr "Tabella"
+msgstr "Таблица"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
-msgstr "Database"
+msgstr "База данни"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "Creatore"
+msgstr "Създател"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "Nessun risultto trovato"
+msgstr "Няма намерени резултати"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "Prova ad aggiustare il tuo filtro per trovare ciò che stai cercando."
+msgstr "Опитайте да коригирате филтъра си, за да намерите това, което търсите."
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "Visto da"
+msgstr "Преглед от"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
-msgstr "di"
+msgstr "на"
 
 #: frontend/src/metabase/containers/Overworld.jsx:91
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "Non dirlo a nessuno, ma tu sei il mio preferito."
+msgstr "Не казвай на никого, но ти си ми любим."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "Una volta che hai collegato i tuoi dati, posso mostrarti alcune esplorazioni automatiche chiamate raggi X. Ecco alcuni esempi con dati di esempio."
+msgstr "След като свържете собствените си данни, мога да ви покажа някои автоматични изследвания, наречени рентгенови лъчи. Ето няколко примера с примерни данни."
 
 #: frontend/src/metabase/containers/Overworld.jsx:180
 #: frontend/src/metabase/containers/Overworld.jsx:384
 msgid "Start here"
-msgstr "Inizia qui"
+msgstr "Започни тук"
 
 #: frontend/src/metabase/containers/Overworld.jsx:379
 #: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
-msgstr "La nostra analisi"
+msgstr "Нашите анализи"
 
 #: frontend/src/metabase/containers/Overworld.jsx:248
 msgid "Browse all items"
-msgstr "Sfoglia tutti gli elementi"
+msgstr "Прегледайте всички елементи"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
-msgstr "Sostituisci o salva come nuovo?"
+msgstr "Да се ​​замени или запази като нова?"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
-msgstr "Sostituisci la richiesta (`question`) originaria, {0}"
+msgstr "Заменете оригиналния въпрос „{0}“"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
-msgstr "Salva come nuova richiesta (`question`)"
+msgstr "Запазване като нов въпрос"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
-msgstr "Prima, salva la tua richiesta (`question`)"
+msgstr "Първо запазете въпроса си"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
-msgstr "Salva la richiesta (`question`)"
+msgstr "Запазете въпроса"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
-msgstr "Quale è il nome della tua card?"
+msgstr "Какво е името на вашата карта?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2911,7 +2909,7 @@ msgstr "Quale è il nome della tua card?"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:211
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:26
 msgid "Description"
-msgstr "Descrizione"
+msgstr "Описание"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
@@ -2921,472 +2919,472 @@ msgstr "Descrizione"
 #: frontend/src/metabase/entities/snippet-collections.js:82
 #: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
-msgstr "E' opzionale ma oh, così utile"
+msgstr "Не е задължително, но о, толкова полезно"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
-msgstr "In quale raccolta dovrebbe andare?"
+msgstr "В коя колекция трябва да влезе това?"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "modificato"
+msgstr "модифициран"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "elemento"
+msgstr "вещ"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "Annulla"
+msgstr "Отмяна"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
-msgstr "Inoltrando Richiesta (`Question`)"
+msgstr "Прилагане на въпрос"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
-msgstr "Questa richiesta non è compatibile"
+msgstr "Този въпрос не е съвместим"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
-msgstr "Cercando la richiesta"
+msgstr "Потърсете въпрос"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
-msgstr "Non siamo sicuri che questa richiesta sia compatibile"
+msgstr "Не сме сигурни дали този въпрос е съвместим"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "Archivia la 'dashboard'"
+msgstr "Табло за архивиране"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "Assicurati di fare una selezione per ogni serie, altrimenti il filtro non funzionerà su questa card."
+msgstr "Уверете се, че сте направили избор за всяка серия, иначе филтърът няма да работи на тази карта."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
-msgstr "Questa dashboard sembra vuota"
+msgstr "Това табло за управление изглежда празно."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
-msgstr "Aggiungi una richiesta(Question) per iniziare a renderla utile!"
+msgstr "Добавете въпрос, за да започнете да го правите полезен!"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "Modalità giorno"
+msgstr "Дневен режим"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "Modalità notte"
+msgstr "Нощен режим"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "Esci dallo schermo intero"
+msgstr "Излезте от цял ​​екран"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "Porta a tutto schermo"
+msgstr "Въведете цял екран"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "Salvataggio...."
+msgstr "Запазва се ..."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:220
 msgid "Add a question"
-msgstr "Aggiungi una richiesta (question)"
+msgstr "Добавете въпрос"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:223
 msgid "Add a question to this dashboard"
-msgstr "Aggiungi una richiesta (question) alla dashboard"
+msgstr "Добавете въпрос към това табло за управление"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
-msgstr "Aggiungi un filtro"
+msgstr "Добавете филтър"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "Parametri"
+msgstr "Параметри"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
-msgstr "Aggiungi un campo di testo"
+msgstr "Добавете текстово поле"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
-msgstr "Sposta la Dashboard"
+msgstr "Преместване на таблото за управление"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
-msgstr "Modifica la dashboard"
+msgstr "Редактиране на таблото за управление"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:307
 msgid "Edit Dashboard Layout"
-msgstr "Modifica il layout della dashboard"
+msgstr "Редактиране на оформлението на таблото"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
-msgstr "Stai modificando una dashboard"
+msgstr "Редактирате табло за управление"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
-msgstr "Seleziona il campo che vorresti fosse filtrato per ogni card"
+msgstr "Изберете полето, което трябва да се филтрира за всяка карта"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "Sposta la dasboard in..."
+msgstr "Преместване на таблото за управление в ..."
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "Dashboard spostata in {0}"
+msgstr "Таблото за управление е преместено в {0}"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
-msgstr "Cosa vuoi filtrare?"
+msgstr "Какво искате да филтрирате?"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
-msgstr "Che tipo di filtro?"
+msgstr "Какъв филтър?"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:242
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:250
 msgid "Off"
-msgstr "Spegni"
+msgstr "Изключено"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1 minuto"
+msgstr "1 минута"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5 minuti"
+msgstr "5 минути"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10 minuti"
+msgstr "10 минути"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15 minuti"
+msgstr "15 минути"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30 minuti"
+msgstr "30 минути"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60 minuti"
+msgstr "60 минути"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:51
 msgid "Auto-refresh"
-msgstr "Auto-aggiorna"
+msgstr "Автоматично опресняване"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:57
 msgid "Refreshing in"
-msgstr "Aggiornando in"
+msgstr "Освежаващо в"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:30
 msgid "Remove this question?"
-msgstr "Eliminare la richiesta (Question)?"
+msgstr "Да се ​​премахне ли този въпрос?"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "La tua dashboard è stata salvata"
+msgstr "Таблото ви за управление бе запазено"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:740
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "Guardalo"
+msgstr "Виж го"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "Salvalo"
+msgstr "Запазете това"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "Mostra di più su questo"
+msgstr "Покажете повече за това"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "Questa scheda non ha campi o parametri che possono essere associati a questo tipo di parametro."
+msgstr "Тази карта няма никакви полета или параметри, които могат да бъдат съпоставени с този тип параметри."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "I valori in questo campo non si sovrappongono ai valori di altri campi che hai scelto."
+msgstr "Стойностите в това поле не се припокриват със стойностите на други полета, които сте избрали."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
-msgstr "Nessun campo valido."
+msgstr "Няма валидни полета"
 
 #: frontend/src/metabase/entities/collections.js:98
 #: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
-msgstr "Il nome deve avere 100 caratteri o meno"
+msgstr "Името трябва да е 100 знака или по-малко"
 
 #: frontend/src/metabase/entities/collections.js:112
 #: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
-msgstr "Colore richiesto"
+msgstr "Изисква се цвят"
 
 #: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
-msgstr "Quale è il nome della tua dashboard?"
+msgstr "Какво е името на таблото ви за управление?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:95
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "ha fatto delle cose fantastiche che è difficile da descrivere"
+msgstr "направи някои страхотни неща, които е трудно да се опишат"
 
 #: frontend/src/metabase/home/components/Activity.jsx:104
 #: frontend/src/metabase/home/components/Activity.jsx:119
 msgid "created an alert about - "
-msgstr "creata una alert su - "
+msgstr "създаде сигнал за -"
 
 #: frontend/src/metabase/home/components/Activity.jsx:129
 #: frontend/src/metabase/home/components/Activity.jsx:144
 msgid "deleted an alert about - "
-msgstr "cancellata una alert su - "
+msgstr "изтри известие за -"
 
 #: frontend/src/metabase/home/components/Activity.jsx:155
 msgid "saved a question about "
-msgstr "salvata una richiesta (Question) su "
+msgstr "запази въпрос за"
 
 #: frontend/src/metabase/home/components/Activity.jsx:168
 msgid "saved a question"
-msgstr "salvata una richiesta"
+msgstr "запази въпрос"
 
 #: frontend/src/metabase/home/components/Activity.jsx:172
 msgid "deleted a question"
-msgstr "cancellata una richiesta"
+msgstr "изтри въпроса"
 
 #: frontend/src/metabase/home/components/Activity.jsx:175
 msgid "created a dashboard"
-msgstr "creata una dashboard"
+msgstr "създаде табло за управление"
 
 #: frontend/src/metabase/home/components/Activity.jsx:178
 msgid "deleted a dashboard"
-msgstr "cancellata una dashboard"
+msgstr "изтри таблото за управление"
 
 #: frontend/src/metabase/home/components/Activity.jsx:184
 #: frontend/src/metabase/home/components/Activity.jsx:199
 msgid "added a question to the dashboard - "
-msgstr "aggiunta una richiesta (Question) alla dashboard"
+msgstr "добави въпрос към таблото за управление -"
 
 #: frontend/src/metabase/home/components/Activity.jsx:209
 #: frontend/src/metabase/home/components/Activity.jsx:224
 msgid "removed a question from the dashboard - "
-msgstr "eliminata una richiesta dalla dashboard - "
+msgstr "премахна въпрос от таблото за управление -"
 
 #: frontend/src/metabase/home/components/Activity.jsx:234
 #: frontend/src/metabase/home/components/Activity.jsx:241
 msgid "received the latest data from"
-msgstr "ricevuti gli ultimi dati da"
+msgstr "получи последните данни от"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
-msgstr "Sconosciuto"
+msgstr "Неизвестно"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Hello World!"
-msgstr "Ciao Mondo!"
+msgstr "Здравей свят!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:255
 msgid "Metabase is up and running."
-msgstr "Metabase è su ed è in funzione"
+msgstr "Metabase работи и работи."
 
 #: frontend/src/metabase/home/components/Activity.jsx:261
 #: frontend/src/metabase/home/components/Activity.jsx:291
 msgid "added the metric "
-msgstr "aggiunta la metrica "
+msgstr "добави метриката"
 
 #: frontend/src/metabase/home/components/Activity.jsx:275
 #: frontend/src/metabase/home/components/Activity.jsx:365
 msgid " to the "
-msgstr " al "
+msgstr "към"
 
 #: frontend/src/metabase/home/components/Activity.jsx:285
 #: frontend/src/metabase/home/components/Activity.jsx:325
 #: frontend/src/metabase/home/components/Activity.jsx:375
 #: frontend/src/metabase/home/components/Activity.jsx:416
 msgid " table"
-msgstr " tabella"
+msgstr "маса"
 
 #: frontend/src/metabase/home/components/Activity.jsx:301
 #: frontend/src/metabase/home/components/Activity.jsx:331
 msgid "made changes to the metric "
-msgstr "fatti cambiamenti alla metrica "
+msgstr "направи промени в показателя"
 
 #: frontend/src/metabase/home/components/Activity.jsx:315
 #: frontend/src/metabase/home/components/Activity.jsx:406
 msgid " in the "
-msgstr " nel "
+msgstr "в"
 
 #: frontend/src/metabase/home/components/Activity.jsx:338
 msgid "removed the metric "
-msgstr "cancellata la metrica "
+msgstr "премахна метриката"
 
 #: frontend/src/metabase/home/components/Activity.jsx:341
 msgid "created a pulse"
-msgstr "creato un pulse"
+msgstr "създаде пулс"
 
 #: frontend/src/metabase/home/components/Activity.jsx:344
 msgid "deleted a pulse"
-msgstr "cancellato un pulse"
+msgstr "изтри пулс"
 
 #: frontend/src/metabase/home/components/Activity.jsx:350
 #: frontend/src/metabase/home/components/Activity.jsx:381
 msgid "added the filter"
-msgstr "aggiunto un filtro"
+msgstr "добави филтъра"
 
 #: frontend/src/metabase/home/components/Activity.jsx:391
 #: frontend/src/metabase/home/components/Activity.jsx:422
 msgid "made changes to the filter"
-msgstr "fatti cambiamenti al filtro"
+msgstr "направи промени във филтъра"
 
 #: frontend/src/metabase/home/components/Activity.jsx:429
 msgid "removed the filter {0}"
-msgstr "cancellato il filtro {0}"
+msgstr "премахна филтъра {0}"
 
 #: frontend/src/metabase/home/components/Activity.jsx:432
 msgid "joined!"
-msgstr "iscritto!"
+msgstr "присъединиха!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:532
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "mmm, sembra che non sia ancora successo nulla."
+msgstr "Хммм, изглежда все още нищо не се е случило."
 
 #: frontend/src/metabase/home/components/Activity.jsx:535
 msgid "Save a question and get this baby going!"
-msgstr "Salva una richiesta e fai andare questa bambina!"
+msgstr "Запазете въпрос и задвижете това бебе!"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "Poni una richiesta e esplora"
+msgstr "Задавайте въпроси и изследвайте"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "Fai clic su grafici o tabelle per esplorare o fare una nuova richiesta utilizzando l'interfaccia facile o il potente editor SQL."
+msgstr "Кликнете върху диаграми или таблици, за да изследвате, или задайте нов въпрос, като използвате лесния интерфейс или мощния SQL редактор."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "Crea il tuo grafico"
+msgstr "Направете свои собствени диаграми"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "Crea grafici a linee, grafici a dispersione, mappe e altro."
+msgstr "Създавайте линейни диаграми, разпръсквайте парцели, карти и др."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "Condividi ciò che trovi"
+msgstr "Споделете това, което намерите"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "Crea dashboard potenti e flessibili e invia aggiornamenti regolari via e-mail o Slack."
+msgstr "Създавайте мощни и гъвкави табла за управление и изпращайте редовни актуализации по имейл или Slack."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "Andiamo"
+msgstr "Да тръгваме"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "Suggerimento di installazione"
+msgstr "Съвет за настройка"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "Vedi tutto"
+msgstr "Виж всички"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "Recentemente visualizzato"
+msgstr "наскоро разгледани"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:77
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "Di recente non hai guardato dashboard o domande"
+msgstr "Наскоро не сте разглеждали табла или въпроси"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0} elementi selezionati"
+msgstr "Избрани са {0} елемента"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 #: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
-msgstr "Non archiviare"
+msgstr "Разархивиране"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:59
 msgid "Activity"
-msgstr "Attività"
+msgstr "Дейност"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:31
 msgid "Results for \"{0}\""
-msgstr "Risultati per \"{0}\""
+msgstr "Резултати за „{0}“"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
-msgstr "Pulse"
+msgstr "Пулс"
 
 #: frontend/src/metabase/lib/core.js:8
 msgid "Entity Key"
-msgstr "Chiave di entità"
+msgstr "Ключ на обекта"
 
 #: frontend/src/metabase/lib/core.js:9 frontend/src/metabase/lib/core.js:15
 #: frontend/src/metabase/lib/core.js:21
 msgid "Overall Row"
-msgstr "Riga generale"
+msgstr "Общ ред"
 
 #: frontend/src/metabase/lib/core.js:10
 msgid "The primary key for this table."
-msgstr "La chiave primaria per questa tabella"
+msgstr "Първичният ключ за тази таблица."
 
 #: frontend/src/metabase/lib/core.js:14
 msgid "Entity Name"
-msgstr "Nome Entità"
+msgstr "Име на обекта"
 
 #: frontend/src/metabase/lib/core.js:16
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "il \"nome\" di ogni record. Normalmente una colonna chiamata \"nome\", \"titolo\", ecc."
+msgstr "„Името“ на всеки запис. Обикновено колона, наречена \"име\", \"заглавие\" и т.н."
 
 #: frontend/src/metabase/lib/core.js:20
 msgid "Foreign Key"
-msgstr "Chiave esterna"
+msgstr "Външен ключ"
 
 #: frontend/src/metabase/lib/core.js:22
 msgid "Points to another table to make a connection."
-msgstr "Punta a un'altra tabella per stabilire una connessione."
+msgstr "Посочва друга таблица, за да осъществи връзка."
 
 #: frontend/src/metabase/lib/core.js:257
 msgid "Avatar Image URL"
-msgstr "URL dell'immagine di avatar"
+msgstr "URL адрес на изображението на аватар"
 
 #: frontend/src/metabase/lib/core.js:29 frontend/src/metabase/lib/core.js:34
 #: frontend/src/metabase/lib/core.js:39 frontend/src/metabase/lib/core.js:44
 #: frontend/src/metabase/lib/core.js:49
 msgid "Common"
-msgstr "Comune"
+msgstr "често срещани"
 
 #: frontend/src/metabase/lib/core.js:28
 #: frontend/src/metabase/meta/Dashboard.js:86
 #: frontend/src/metabase/modes/components/drill/PivotByCategoryDrill.jsx:10
 msgid "Category"
-msgstr "Categoria"
+msgstr "Категория"
 
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/meta/Dashboard.js:66
 msgid "City"
-msgstr "Città"
+msgstr "Град"
 
 #: frontend/src/metabase/lib/core.js:60
 #: frontend/src/metabase/meta/Dashboard.js:78
 msgid "Country"
-msgstr "Paese"
+msgstr "Държава"
 
 #: frontend/src/metabase/lib/core.js:240
 msgid "Enum"
@@ -3394,120 +3392,120 @@ msgstr "Enum"
 
 #: frontend/src/metabase/lib/core.js:262
 msgid "Image URL"
-msgstr "URL immagine"
+msgstr "URL адрес на изображението"
 
 #: frontend/src/metabase/lib/core.js:274
 msgid "Field containing JSON"
-msgstr "Campo contenente il JSON"
+msgstr "Поле, съдържащо JSON"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Latitude"
-msgstr "Latitudine"
+msgstr "Географска ширина"
 
 #: frontend/src/metabase/lib/core.js:70
 msgid "Longitude"
-msgstr "Longitudine"
+msgstr "Географска дължина"
 
 #: frontend/src/metabase/lib/core.js:43
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
-msgstr "Numero"
+msgstr "Брой"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:75
 #: frontend/src/metabase/meta/Dashboard.js:70
 msgid "State"
-msgstr "Stato"
+msgstr "Щат"
 
 #: frontend/src/metabase/lib/core.js:233
 msgid "UNIX Timestamp (Seconds)"
-msgstr "UNIX timestamp (secondi)"
+msgstr "UNIX Timestamp (секунди)"
 
 #: frontend/src/metabase/lib/core.js:228
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "UNIX timestamp (millisecondi)"
+msgstr "UNIX Timestamp (милисекунди)"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Zip Code"
-msgstr "Codice Postale"
+msgstr "Пощенски код"
 
 #: frontend/src/metabase/lib/core.js:119
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
-msgstr "Quantità"
+msgstr "Количество"
 
 #: frontend/src/metabase/lib/core.js:107
 msgid "Income"
-msgstr "Ingresso"
+msgstr "Доход"
 
 #: frontend/src/metabase/lib/core.js:97
 msgid "Discount"
-msgstr "Sconto"
+msgstr "Отстъпка"
 
 #: frontend/src/metabase/lib/core.js:193
 msgid "Creation timestamp"
-msgstr "Data e ora della creazione"
+msgstr "Клеймо за време на създаване"
 
 #: frontend/src/metabase/lib/core.js:188
 msgid "Creation time"
-msgstr "ora di creazione "
+msgstr "Време за създаване"
 
 #: frontend/src/metabase/lib/core.js:183
 msgid "Creation date"
-msgstr "Data creazione "
+msgstr "Дата на създаване"
 
 #: frontend/src/metabase/lib/core.js:245
 msgid "Product"
-msgstr "Prodotto"
+msgstr "Продукт"
 
 #: frontend/src/metabase/lib/core.js:161
 msgid "User"
-msgstr "Utente"
+msgstr "Потребител"
 
 #: frontend/src/metabase/lib/core.js:250
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
-msgstr "Sorgente"
+msgstr "Източник"
 
 #: frontend/src/metabase/lib/core.js:112
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
-msgstr "Prezzo"
+msgstr "Цена"
 
 #: frontend/src/metabase/lib/core.js:223
 msgid "Join timestamp"
-msgstr "Timestamp di iscrizione"
+msgstr "Присъединете се към клеймото за време"
 
 #: frontend/src/metabase/lib/core.js:218
 msgid "Join time"
-msgstr "Orario di iscrizione"
+msgstr "Присъединете се към времето"
 
 #: frontend/src/metabase/lib/core.js:213
 msgid "Join date"
-msgstr "Data di iscrizione"
+msgstr "Дата на присъединяване"
 
 #: frontend/src/metabase/lib/core.js:129
 msgid "Share"
-msgstr "Condividi"
+msgstr "Дял"
 
 #: frontend/src/metabase/lib/core.js:151
 msgid "Owner"
-msgstr "Proprietario"
+msgstr "Собственик"
 
 #: frontend/src/metabase/lib/core.js:141
 msgid "Company"
-msgstr "Società"
+msgstr "Компания"
 
 #: frontend/src/metabase/lib/core.js:156
 msgid "Subscription"
-msgstr "Sottoscrizione"
+msgstr "Абонамент"
 
 #: frontend/src/metabase/lib/core.js:124
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
-msgstr "Punteggio"
+msgstr "Резултат"
 
 #: frontend/src/metabase/lib/core.js:48
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
@@ -3515,7 +3513,7 @@ msgstr "Punteggio"
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
-msgstr "Titolo"
+msgstr "Заглавие"
 
 #: frontend/src/metabase/lib/core.js:33
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
@@ -3523,55 +3521,55 @@ msgstr "Titolo"
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
-msgstr "Commento"
+msgstr "Коментирайте"
 
 #: frontend/src/metabase/lib/core.js:87
 msgid "Cost"
-msgstr "Costo"
+msgstr "Разходи"
 
 #: frontend/src/metabase/lib/core.js:102
 msgid "Gross margin"
-msgstr "Margine lordo"
+msgstr "Брутна печалба"
 
 #: frontend/src/metabase/lib/core.js:136
 msgid "Birthday"
-msgstr "Compleanno"
+msgstr "Рожден ден"
 
 #: frontend/src/metabase/lib/core.js:285
 msgid "Search box"
-msgstr "Casella di ricerca"
+msgstr "Поле за търсене"
 
 #: frontend/src/metabase/lib/core.js:286
 msgid "A list of all values"
-msgstr "Una lista di tutti i valori"
+msgstr "Списък на всички стойности"
 
 #: frontend/src/metabase/lib/core.js:287
 msgid "Plain input box"
-msgstr "Casella di input normale"
+msgstr "Обикновено поле за въвеждане"
 
 #: frontend/src/metabase/lib/core.js:293
 msgid "Everywhere"
-msgstr "Ovunque"
+msgstr "Навсякъде"
 
 #: frontend/src/metabase/lib/core.js:294
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "L'impostazione predefinita Questo campo verrà visualizzato normalmente in tabelle e grafici."
+msgstr "Настройката по подразбиране. Това поле ще се показва нормално в таблици и диаграми."
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "Solo nelle viste di dettaglio"
+msgstr "Само в подробни изгледи"
 
 #: frontend/src/metabase/lib/core.js:299
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "Questo campo verrà visualizzato solo quando si visualizzano i dettagli di un singolo record. Usalo per informazioni lunghe o inutili in una tabella o in un grafico."
+msgstr "Това поле ще се покаже само при преглед на подробностите за един запис. Използвайте това за информация, която е дълга или не е полезна в таблица или диаграма."
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "Non include"
+msgstr "Не включвайте"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabase non recupererà mai questo campo. Utilizzare questo per informazioni sensibili o irrilevanti."
+msgstr "Metabase никога няма да извлече това поле. Използвайте това за чувствителна или неподходяща информация."
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
@@ -3584,97 +3582,97 @@ msgstr "Metabase non recupererà mai questo campo. Utilizzare questo per informa
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
-msgstr "Conteggio"
+msgstr "Броя"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "Conteggio cumulativo"
+msgstr "CumulativeCount"
 
 #: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
-msgstr "Somma"
+msgstr "Сума"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "Somma cumulativa"
+msgstr "CumulativeSum"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
-msgstr "Distinto"
+msgstr "Различен"
 
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "DeviazioneStandard"
+msgstr "Стандартно отклонение"
 
 #: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
-msgstr "Media"
+msgstr "Средно аритметично"
 
 #: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
-msgstr "Min"
+msgstr "Мин"
 
 #: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
-msgstr "Max"
+msgstr "Макс"
 
 #: frontend/src/metabase/lib/expressions/parser.js:373
 msgid "sad sad panda, lexing errors detected"
-msgstr "rilevati errori di lessico"
+msgstr "тъжна тъжна панда, открити грешки при лексинг"
 
 #: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
-msgstr[0] "{0} secondo"
-msgstr[1] "{0} secondi"
+msgstr[0] "{0} секунда"
+msgstr[1] "{0} секунди"
 
 #: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0} minuto"
-msgstr[1] "{0} minuti"
+msgstr[0] "{0} минута"
+msgstr[1] "{0} минути"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "Ehilà"
+msgstr "Ей там"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "Come va"
+msgstr "Как върви"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "Salve"
+msgstr "Здрасти"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "Saluti"
+msgstr "Поздравления"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "E' bello rivederti"
+msgstr "Радвам се да те видя"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "Cosa vuoi sapere?"
+msgstr "Какво искаш да знаеш?"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "Cosa hai in mente?"
+msgstr "Какво мислиш?"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "Cosa vuoi scoprire?"
+msgstr "Какво искате да разберете?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
@@ -3682,91 +3680,91 @@ msgstr "Cosa vuoi scoprire?"
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
-msgstr "Dati grezzi"
+msgstr "Необработени данни"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
 #: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
-msgstr "Conto cumulativo"
+msgstr "Кумулативен брой"
 
 #: frontend/src/metabase/lib/query/description.js:82
 #: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
-msgstr "Media di "
+msgstr "Средно от"
 
 #: frontend/src/metabase/lib/query/description.js:87
 #: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
-msgstr "Valori distinti di "
+msgstr "Различни стойности на"
 
 #: frontend/src/metabase/lib/query/description.js:92
 #: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
-msgstr "Deviazione standard di "
+msgstr "Стандартно отклонение на"
 
 #: frontend/src/metabase/lib/query/description.js:97
 #: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
-msgstr "Somma di "
+msgstr "Сбор"
 
 #: frontend/src/metabase/lib/query/description.js:102
 #: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
-msgstr "Somma cumulativa di "
+msgstr "Кумулативна сума от"
 
 #: frontend/src/metabase/lib/query/description.js:107
 #: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
-msgstr "Massimo di "
+msgstr "Максимум"
 
 #: frontend/src/metabase/lib/query/description.js:112
 #: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
-msgstr "Minimo di "
+msgstr "Минимум от"
 
 #: frontend/src/metabase/lib/query/description.js:126
 #: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
-msgstr "Raggruppato per "
+msgstr "Групирани по"
 
 #: frontend/src/metabase/lib/query/description.js:140
 #: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
-msgstr "Filtrato per "
+msgstr "Филтрирано от"
 
 #: frontend/src/metabase/lib/query/description.js:169
 #: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
-msgstr "Ordinato per "
+msgstr "Сортирано по"
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "True"
-msgstr "Vero"
+msgstr "Вярно"
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "False"
-msgstr "Falso"
+msgstr "Грешно"
 
 #: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
-msgstr "Seleziona il campo longitudine"
+msgstr "Изберете поле за географска дължина"
 
 #: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
-msgstr "Inserisci la latituine superiore"
+msgstr "Въведете горната ширина"
 
 #: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
-msgstr "inserisci la longitudine a sinistra"
+msgstr "Въведете лявата дължина"
 
 #: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
-msgstr "Inserisci la latitudine inferiore"
+msgstr "Въведете по-ниска географска ширина"
 
 #: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
-msgstr "Inserisci la longitudine a destra"
+msgstr "Въведете дясната дължина"
 
 #: frontend/src/metabase/lib/schema_metadata.js:368
 #: frontend/src/metabase/lib/schema_metadata.js:388
@@ -3776,7 +3774,7 @@ msgstr "Inserisci la longitudine a destra"
 #: frontend/src/metabase/lib/schema_metadata.js:422
 #: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
-msgstr "E'"
+msgstr "Е"
 
 #: frontend/src/metabase/lib/schema_metadata.js:369
 #: frontend/src/metabase/lib/schema_metadata.js:389
@@ -3784,7 +3782,7 @@ msgstr "E'"
 #: frontend/src/metabase/lib/schema_metadata.js:417
 #: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
-msgstr "Non è"
+msgstr "Не е"
 
 #: frontend/src/metabase/lib/schema_metadata.js:370
 #: frontend/src/metabase/lib/schema_metadata.js:384
@@ -3794,7 +3792,7 @@ msgstr "Non è"
 #: frontend/src/metabase/lib/schema_metadata.js:418
 #: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
-msgstr "E' vuoto"
+msgstr "Празно е"
 
 #: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:385
@@ -3804,295 +3802,295 @@ msgstr "E' vuoto"
 #: frontend/src/metabase/lib/schema_metadata.js:419
 #: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
-msgstr "Non vuoto"
+msgstr "Не е празно"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
-msgstr "Uguale a"
+msgstr "Равна на"
 
 #: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
-msgstr "Non uguale a "
+msgstr "Не е равно на"
 
 #: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
-msgstr "Più grande di"
+msgstr "По-голям от"
 
 #: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
-msgstr "Meno di"
+msgstr "По-малко от"
 
 #: frontend/src/metabase/lib/schema_metadata.js:381
 #: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "Tra"
+msgstr "Между"
 
 #: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
-msgstr "Più grande o uguale a"
+msgstr "По-голямо или равно на"
 
 #: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
-msgstr "Meno di o uguale a"
+msgstr "По-малко или равно на"
 
 #: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
-msgstr "Contiene"
+msgstr "Съдържа"
 
 #: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
-msgstr "Non contiene"
+msgstr "Не съдържа"
 
 #: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
-msgstr "Inizia con"
+msgstr "Започва с"
 
 #: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
-msgstr "Finisce con"
+msgstr "Завършва със"
 
 #: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "Prima"
+msgstr "Преди"
 
 #: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "Dopo"
+msgstr "След"
 
 #: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
-msgstr "Dentro"
+msgstr "Вътре"
 
 #: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "Solo una tabella con le righe nella risposta, nessuna operazione aggiuntiva."
+msgstr "Само таблица с редовете в отговора, без допълнителни операции."
 
 #: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
-msgstr "Conteggio di righe"
+msgstr "Брой редове"
 
 #: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
-msgstr "Numero totale di righe nella risposta"
+msgstr "Общ брой редове в отговора."
 
 #: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
-msgstr "Somma di ..."
+msgstr "Сбор ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
-msgstr "Somma di tutti i valori di una colonna"
+msgstr "Сума от всички стойности на колона."
 
 #: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
-msgstr "Media di ..."
+msgstr "Средно от ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
-msgstr "Media di tutti i valori di una colonna"
+msgstr "Средна стойност на всички стойности на колона"
 
 #: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
-msgstr "Numeri di valori distinti di ..."
+msgstr "Брой различни стойности на ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "Numero di valori univoci di una colonna tra tutte le righe nella risposta."
+msgstr "Брой уникални стойности на колона сред всички редове в отговора."
 
 #: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
-msgstr "Somma cumulativa di ..."
+msgstr "Кумулативна сума от ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "Somma additiva di tutti i valori di una colonna. \\\\ ne.x. entrate totali nel tempo."
+msgstr "Обща сума на всички стойности на колона. \\\\ ne.x. общ приход във времето."
 
 #: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
-msgstr "Conteggio cumulativo di righe"
+msgstr "Кумулативен брой редове"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "Conteggio additivo del numero di righe. \\\\ ne.x. numero totale di vendite nel tempo."
+msgstr "Общо преброяване на броя редове. \\\\ ne.x. общ брой продажби във времето."
 
 #: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
-msgstr "Deviazione standard di ..."
+msgstr "Стандартно отклонение на ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "Numero che esprime quanto i valori di una colonna variano tra tutte le righe nella risposta."
+msgstr "Число, което изразява колко варират стойностите на колона между всички редове в отговора."
 
 #: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
-msgstr "Minimo di ..."
+msgstr "Минимум от ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
-msgstr "Minimo valore di una colonna"
+msgstr "Минимална стойност на колона"
 
 #: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
-msgstr "Massimo di ..."
+msgstr "Максимум ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
-msgstr "Massimo valore di una colonna"
+msgstr "Максимална стойност на колона"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "Scoppia per dimensione"
+msgstr "Разбийте по измерение"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "lettera minuscola"
+msgstr "малка буква"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "lettera maiuscola"
+msgstr "Главна буква"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "numero"
+msgstr "номер"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "carattere speciale"
+msgstr "специален характер"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "deve essere"
+msgstr "трябва да е"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "carattere lungo"
+msgstr "знаци дълги"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "Deve essere"
+msgstr "Трябва да е"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "e include"
+msgstr "и включват"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
-msgstr "zero"
+msgstr "нула"
 
 #: frontend/src/metabase/lib/utils.js:86
 msgid "one"
-msgstr "uno"
+msgstr "един"
 
 #: frontend/src/metabase/lib/utils.js:87
 msgid "two"
-msgstr "due"
+msgstr "две"
 
 #: frontend/src/metabase/lib/utils.js:88
 msgid "three"
-msgstr "tre"
+msgstr "три"
 
 #: frontend/src/metabase/lib/utils.js:89
 msgid "four"
-msgstr "quattro"
+msgstr "четири"
 
 #: frontend/src/metabase/lib/utils.js:90
 msgid "five"
-msgstr "cinque"
+msgstr "пет"
 
 #: frontend/src/metabase/lib/utils.js:91
 msgid "six"
-msgstr "sei"
+msgstr "шест"
 
 #: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
-msgstr "sette"
+msgstr "седем"
 
 #: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
-msgstr "otto"
+msgstr "осем"
 
 #: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
-msgstr "nove"
+msgstr "девет"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Month and Year"
-msgstr "Mese e Anno"
+msgstr "Месец и година"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like January, 2016"
-msgstr "Come Gennaio, 2016"
+msgstr "Подобно на януари 2016 г."
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Quarter and Year"
-msgstr "Trimestre e Anno"
+msgstr "Квартал и година"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like Q1, 2016"
-msgstr "Come T1, 2016"
+msgstr "Подобно на Q1, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Single Date"
-msgstr "Data Singola"
+msgstr "Единична дата"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like January 31, 2016"
-msgstr "Come Gennaio 31, 2016"
+msgstr "Подобно на 31 януари 2016 г."
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Date Range"
-msgstr "Intervallo di date"
+msgstr "Период от време"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "Come Dicembre 25, 2015 - Febbraio 14, 2016"
+msgstr "Подобно на 25 декември 2015 г. - 14 февруари 2016 г."
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Relative Date"
-msgstr "Date relative"
+msgstr "Относителна дата"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "Come \"gli ultimi 7 giorni\" o \"questo mese\""
+msgstr "Като „последните 7 дни“ или „този месец“"
 
 #: frontend/src/metabase/meta/Dashboard.js:60
 msgid "Date Filter"
-msgstr "Filtro per data"
+msgstr "Филтър за дата"
 
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "All Options"
-msgstr "Tutte le Opzioni"
+msgstr "Всички опции"
 
 #: frontend/src/metabase/meta/Dashboard.js:62
 msgid "Contains all of the above"
-msgstr "Contiene tutto quanto sopra"
+msgstr "Съдържа всичко по-горе"
 
 #: frontend/src/metabase/meta/Dashboard.js:74
 msgid "ZIP or Postal Code"
-msgstr "CAP o Codice Postale"
+msgstr "Zip или пощенски код"
 
 #: frontend/src/metabase/meta/Dashboard.js:82
 #: frontend/src/metabase/meta/Dashboard.js:112
 msgid "ID"
-msgstr "ID"
+msgstr "документ за самоличност"
 
 #: frontend/src/metabase/meta/Dashboard.js:100
 #: frontend/src/metabase/modes/components/drill/PivotByTimeDrill.jsx:9
 msgid "Time"
-msgstr "Tempo"
+msgstr "Време"
 
 #: frontend/src/metabase/meta/Dashboard.js:101
 msgid "Date range, relative date, time of day, etc."
-msgstr "Intervallo di date, data relativa, Ora del giorno, ecc,"
+msgstr "Период от време, относителна дата, час от деня и т.н."
 
 #: frontend/src/metabase/lib/core.js:56 frontend/src/metabase/lib/core.js:61
 #: frontend/src/metabase/lib/core.js:66 frontend/src/metabase/lib/core.js:71
@@ -4100,143 +4098,143 @@ msgstr "Intervallo di date, data relativa, Ora del giorno, ecc,"
 #: frontend/src/metabase/meta/Dashboard.js:106
 #: frontend/src/metabase/modes/components/drill/PivotByLocationDrill.jsx:9
 msgid "Location"
-msgstr "Posizione"
+msgstr "Местоположение"
 
 #: frontend/src/metabase/meta/Dashboard.js:107
 msgid "City, State, Country, ZIP code."
-msgstr "Citta, Stato, Paese, CAP."
+msgstr "Град, щат, държава, пощенски код."
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "User ID, product ID, event ID, etc."
-msgstr "ID utente, ID prodotto, ID evento, ecc"
+msgstr "Потребителски идентификатор, идентификатор на продукт, идентификатор на събитие и т.н."
 
 #: frontend/src/metabase/meta/Dashboard.js:118
 msgid "Other Categories"
-msgstr "Altre categorie"
+msgstr "Други категории"
 
 #: frontend/src/metabase/meta/Dashboard.js:119
 msgid "Category, Type, Model, Rating, etc."
-msgstr "Categoria, Tipo, Valutazione, ecc."
+msgstr "Категория, тип, модел, рейтинг и др."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
 #: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
-msgstr "Impostazioni di account"
+msgstr "Настройки на профила"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Exit admin"
-msgstr "Esci da amministratore"
+msgstr "Излезте от администратора"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:35
 msgid "Logs"
-msgstr "I log"
+msgstr "Дневници"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
 msgid "Help"
-msgstr "Aiuto"
+msgstr "Помогне"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:72
 msgid "About Metabase"
-msgstr "Su Metabase"
+msgstr "Относно Metabase"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:78
 msgid "Sign out"
-msgstr "Esci"
+msgstr "Отписване"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Thanks for using"
-msgstr "Grazie per l'uso"
+msgstr "Благодаря за използването"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:116
 msgid "You're on version"
-msgstr "Tu stai usando la versione"
+msgstr "Вие сте на версия"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:119
 msgid "Built on"
-msgstr "Costruita su"
+msgstr "Построен на"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:139
 msgid "is a Trademark of"
-msgstr "E un Marchio di"
+msgstr "е търговска марка на"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:141
 msgid "and is built with care in San Francisco, CA"
-msgstr "ed è costruito con cura a San Francisco, in California"
+msgstr "и е построен с внимание в Сан Франциско, Калифорния"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:224
 msgid "Metabase Admin"
-msgstr "Amministratore Metabase"
+msgstr "Администратор на метабазата"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
-msgstr "Poni una domanda"
+msgstr "Задай въпрос"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:379
 msgid "New dashboard"
-msgstr "Nuova Dashboard"
+msgstr "Ново табло за управление"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:385
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "Nuovo Pulse"
+msgstr "Нов пулс"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "Referente"
+msgstr "Справка"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "Quale metrica?"
+msgstr "Коя метрика?"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "Definire metriche comuni per il tuo team rende ancora più facile fare domande"
+msgstr "Определянето на общи показатели за вашия екип прави още по-лесно задаването на въпроси"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "Come creare metriche"
+msgstr "Как да създадете показатели"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "Visualizza i dati nel tempo, come una mappa o ruotati per aiutarti a capire tendenze o cambiamenti."
+msgstr "Вижте данните с течение на времето, като карта или пивотни, за да ви помогне да разберете тенденциите или промените."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
-msgstr "Personalizzato"
+msgstr "Персонализиран"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:157
 msgid "New question"
-msgstr "Nuove domande"
+msgstr "Нов въпрос"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "Utilizza il semplice generatore di domande per visualizzare tendenze, elenchi di cose o per creare le tue metriche."
+msgstr "Използвайте простия конструктор на въпроси, за да видите тенденции, списъци с неща или да създадете свои собствени показатели."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "Query native"
+msgstr "Родна заявка"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "Per domande più complicate, puoi scrivere la tua query SQL o nativa."
+msgstr "За по-сложни въпроси можете да напишете свой собствен SQL или собствена заявка."
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
-msgstr "Seleziona un valore predefinito ..."
+msgstr "Изберете стойност по подразбиране ..."
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "Filtro di aggiornamento"
+msgstr "Актуализиране на филтъра"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4244,22 +4242,22 @@ msgstr "Filtro di aggiornamento"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "Oggi"
+msgstr "Днес"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "Ieri"
+msgstr "Вчера"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "Ultimi 7 giorni"
+msgstr "Миналите 7 дни"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "Ultimi 30 giorni"
+msgstr "Минали 30 дни"
 
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
@@ -4267,8 +4265,8 @@ msgstr "Ultimi 30 giorni"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "Settimana"
-msgstr[1] "Settimane"
+msgstr[0] "Седмица"
+msgstr[1] "Седмици"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4276,8 +4274,8 @@ msgstr[1] "Settimane"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "Mese"
-msgstr[1] "Mesi"
+msgstr[0] "Месец"
+msgstr[1] "Месеци"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4285,812 +4283,812 @@ msgstr[1] "Mesi"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "Anno"
-msgstr[1] "Anni"
+msgstr[0] "Година"
+msgstr[1] "Години"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "Ultimi 7 Giorni"
+msgstr "Миналите 7 дни"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "Ultimi 30 Giorni"
+msgstr "Минали 30 дни"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "Ultima Settimana"
+msgstr "Миналата седмица"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "Ultimo Mese"
+msgstr "Миналия месец"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "Ultimo Anno"
+msgstr "Миналата година"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "Questa settimana"
+msgstr "Тази седмица"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "Questo mese"
+msgstr "Този месец"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
-msgstr "Quest'anno"
+msgstr "Тази година"
 
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "Inserisci un valore"
+msgstr "Въведете стойност ..."
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "Inserisci un valore predefinito..."
+msgstr "Въведете стойност по подразбиране ..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
 #: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "C'è stato un errore"
+msgstr "Възникна грешка"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "Non trovato"
+msgstr "Не е намерен"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "Hai apportato modifiche che devono essere pubblicate prima che si riflettano nell'applicazione incorporata."
+msgstr "Направихте промени, които трябва да бъдат публикувани, преди те да бъдат отразени във вашето приложение за вграждане."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "Dovrai pubblicare questo {0} prima di poterlo incorporare in un'altra applicazione."
+msgstr "Ще трябва да публикувате това {0}, преди да можете да го вградите в друго приложение."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "Scartare le modifiche"
+msgstr "Отхвърлите промените"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "Aggiornamento..."
+msgstr "Актуализира се ..."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "Aggiornato"
+msgstr "Актуализирано"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "Fallito!"
+msgstr "Се провали!"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "Pubblicato"
+msgstr "Публикувай"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 #: frontend/src/metabase/visualizations/lib/settings/column.js:345
 msgid "Code"
-msgstr "Codice"
+msgstr "Код"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:296
 msgid "Style"
-msgstr "Stile"
+msgstr "Стил"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "Quali parametri possono utilizzare gli utenti di questo embed?"
+msgstr "Кои параметри могат да използват потребителите на това вграждане?"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "Questo {0} non ha ancora parametri da configurare."
+msgstr "Този {0} все още няма параметри за конфигуриране."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "Modificabile"
+msgstr "Може да се редактира"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "Bloccato"
+msgstr "Заключен"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "Anteprima dei parametri bloccati"
+msgstr "Преглед на заключени параметри"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "Prova a passare alcuni valori ai tuoi parametri bloccati qui. Il tuo server dovrà fornire i valori reali nel token firmato quando lo utilizzi per davvero."
+msgstr "Опитайте да предадете някои стойности на вашите заключени параметри тук. Вашият сървър ще трябва да предостави действителните стойности в подписания маркер, когато използва това реално."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "Zona pericolosa"
+msgstr "Опасна зона"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "Questo disabiliterà l'incorporamento per questo {0}."
+msgstr "Това ще деактивира вграждането за този {0}."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "Spubblicato"
+msgstr "Отмяна на публикуването"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "Chiaro"
+msgstr "Светлина"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "Scuro"
+msgstr "Тъмно"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "Bordo"
+msgstr "Граница"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "per incorporare questo {0} nella tua applicazione:"
+msgstr "За да вградите това {0} във вашето приложение:"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "Inserisci questo snippet di codice nel codice del server per generare l'URL di incorporamento firmato "
+msgstr "Вмъкнете този кодов фрагмент в кода на вашия сървър, за да генерирате подписания URL за вграждане"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "Quindi inserisci questo snippet di codice nel modello HTML o nell'app singola pagina."
+msgstr "След това вмъкнете този кодов фрагмент във вашия HTML шаблон или приложение за една страница."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "Incorpora lo snippet di codice per la tua applicazione HTML o Frontend"
+msgstr "Вградете кодов фрагмент за вашето HTML или Frontend приложение"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "Più {0}"
+msgstr "Още {0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "esempi su GitHub"
+msgstr "примери за GitHub"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "Abilita condivisione"
+msgstr "Активиране на споделянето"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "Disabilitare link pubblico?"
+msgstr "Да се ​​деактивира ли тази обществена връзка?"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "Ciò causerà l'interruzione del funzionamento del collegamento esistente. Puoi riattivarlo, ma quando lo fai sarà un link diverso."
+msgstr "Това ще доведе до спиране на работата на съществуващата връзка. Можете да го активирате отново, но когато го направите, това ще бъде различна връзка."
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "Link pubblico"
+msgstr "Обществена връзка"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Condividi questo {0} con persone che non hanno un account Metabase utilizzando l'URL di seguito:"
+msgstr "Споделете това {0} с хора, които нямат акаунт в Metabase, използвайки URL адреса по-долу:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "Inserimento pubblico"
+msgstr "Публично вграждане"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "Incorpora questo {0} nei post del blog o nelle pagine Web copiando e incollando questo snippet:"
+msgstr "Вградете това {0} в публикации в блог или уеб страници, като копирате и поставите този фрагмент:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "Incorpora questo {0} in un'applicazione"
+msgstr "Вградете това {0} в приложение"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "Integrando con il codice del server delle applicazioni, è possibile fornire statistiche sicure {0} limitate a uno specifico utente, cliente, organizzazione, ecc."
+msgstr "Чрез интегриране с кода на вашия сървър за приложения можете да предоставите сигурна статистика {0}, ограничена до конкретен потребител, клиент, организация и т.н."
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "Rimuovi allegato"
+msgstr "Премахнете прикачения файл"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "Allega file con risultati"
+msgstr "Прикачете файл с резултати"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "Questa domanda verrà aggiunta come allegato al file"
+msgstr "Този въпрос ще бъде добавен като прикачен файл"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "Questa domanda non sarà inclusa nel tuo Pulse"
+msgstr "Този въпрос няма да бъде включен във вашия пулс"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Questo impulso non verrà più inviato via email a {0} {1}"
+msgstr "Този импулс вече няма да се изпраща по имейл до {0} {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0} Indirizzo"
-msgstr[1] "{0} indirizzi"
+msgstr[0] "{0} адрес"
+msgstr[1] "{0} адреси"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "Il canale Slack {0} non riceverà più questo impulso {1}"
+msgstr "Slack канал {0} повече няма да получава този импулс {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "Il canale {0} non riceverà più questo impulso {1}"
+msgstr "Канал {0} повече няма да получава този импулс {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "Modifica pulse"
+msgstr "Редактиране на пулса"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "Cosa è un Pulse?"
+msgstr "Какво е пулс?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "Fatto"
+msgstr "Схванах го"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "Dove dovrebbero andare questi dati?"
+msgstr "Къде трябва да отидат тези данни?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "Sto togliendo dall'archivio..."
+msgstr "Разархивира се ..."
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "Eliminazione dall'archivio fallita"
+msgstr "Разархивирането не бе успешно"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "Non archiviato"
+msgstr "Разархивиран"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "Cra un pulse"
+msgstr "Създайте пулс"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:91
 msgid "Attachment"
-msgstr "Allegato"
+msgstr "Прикачен файл"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "Dritta"
+msgstr "Глава нагоре"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:106
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "Mostreremo le prime 10 colonne e 20 righe di questa tabella nel tuo Pulse. Se invii un'email a questo, aggiungeremo un allegato con tutte le colonne e fino a 2.000 righe."
+msgstr "Ще покажем първите 10 колони и 20 реда от тази таблица във вашия импулс. Ако изпратите това по имейл, ще добавим прикачен файл с всички колони и до 2000 реда."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:113
 msgid "Raw data questions can only be included as email attachments"
-msgstr "Le domande relative ai dati non elaborati possono essere incluse solo come allegati di posta elettronica"
+msgstr "Въпросите за сурови данни могат да бъдат включени само като прикачени файлове към имейл"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "Looks like this pulse is getting big"
-msgstr "Sembra che questo pulse stia diventando grande"
+msgstr "Изглежда този пулс става все по-голям"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:121
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "Raccomandiamo di mantenere gli impulsi piccoli e concentrati per mantenerli digeribili e utili a tutta la squadra."
+msgstr "Препоръчваме импулсите да бъдат малки и фокусирани, за да бъдат смилаеми и полезни за целия екип."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
 #: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
-msgstr "Scegli i tuoi dati"
+msgstr "Изберете вашите данни"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:163
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "Dai un nome al tuo polso per aiutare gli altri a capire di cosa si tratta"
+msgstr "Изберете въпроси, които искате да изпратите в този импулс"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
-msgstr "Email"
+msgstr "Имейли"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
-msgstr "Messaggi Slack"
+msgstr "Слаби съобщения"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
-msgstr "Spedito"
+msgstr "Изпратено"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
-msgstr "{0} saranno spediti a"
+msgstr "{0} ще бъде изпратено в"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
-msgstr "Messaggi"
+msgstr "Съобщения"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "Spedisci email ora"
+msgstr "Изпратете имейл сега"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "Spedisci {0} ora"
+msgstr "Изпратете до {0} сега"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "Invio..."
+msgstr "Изпращане…"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "Invio fallito"
+msgstr "Изпращането не бе успешно"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "Non spedire in quanto pulse non ha risultati"
+msgstr "Не изпратих, защото пулсът няма резултати."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "Pulse ha inviato"
+msgstr "Импулсът е изпратен"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0} deve essere impostato da un amministratore."
+msgstr "{0} трябва да бъде настроен от администратор."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
-msgstr "Slack"
+msgstr "Отпуснат"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "In quale collezione dovrebbe vivere questa pulsazione?"
+msgstr "В коя колекция трябва да живее този пулс?"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "Nome del tuo Pulse"
+msgstr "Назовете пулса си"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "Dai un nome al tuo polso per aiutare gli altri a capire di cosa si tratta"
+msgstr "Дайте име на пулса си, за да помогнете на другите да разберат за какво става въпрос"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "Metriche importanti"
+msgstr "Важни показатели"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "Salta se non ci sono risultati"
+msgstr "Пропуснете, ако няма резултати"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "Salta l'invio del Pulse se nessuna question ha risultati"
+msgstr "Пропуснете насрочен импулс, ако нито един от въпросите му няма резултати"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "Inserisci l'indirizzo email a cui vuoi che vengano inviati questi dati"
+msgstr "Въведете имейл адреси, на които искате тези данни да отидат"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "Aiuta il tuo team a restare aggiornato con i vostri dati"
+msgstr "Помогнете на всички от вашия екип да останат в синхрон с вашите данни."
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:31
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "I Pulse ti fanno inviare informazioni da Metabase per email o a Slack in maniera schedulata"
+msgstr "Импулсите ви позволяват да изпращате данни от Metabase на имейл или Slack по избрания от вас график."
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
-msgstr "Dopo {0}"
+msgstr "След {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
-msgstr "Prima {0}"
+msgstr "Преди {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "è vuoto"
+msgstr "Празно е"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "Non vuoto"
+msgstr "Не е празно"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "Sempre"
+msgstr "През цялото време"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
-msgstr "Applica"
+msgstr "Приложи"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "Vedi {0}"
+msgstr "Преглед {0}"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "Confrontalo con tutte le righe nella tabella"
+msgstr "Сравнете това с всички редове в таблицата"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "Analizza i risultati di questa Query"
+msgstr "Анализирайте резултатите от тази заявка"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "Conteggio delle righe per tempo"
+msgstr "Брой редове по време"
 
 #: frontend/src/metabase/modes/components/drill/PivotByDrill.jsx:52
 msgid "Break out by {0}"
-msgstr "Spezza per {0}"
+msgstr "Разбийте до {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:36
 msgid "Summarize this segment"
-msgstr "Totalizza questo segmento"
+msgstr "Обобщете този сегмент"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "Vedi come tabella"
+msgstr "Вижте това като таблица"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "Mostra i sottostanti {0} record"
+msgstr "Прегледайте основните {0} записи"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "Applica i Raggi-X alla question"
+msgstr "Рентгенови този въпрос"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "Raggi-X {0} {1}"
+msgstr "Рентгенова снимка {0} {1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "questi"
+msgstr "тези"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "questo"
+msgstr "това"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "Confronta {0} {1} al resto"
+msgstr "Сравнете {0} {1} с останалите"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
-msgstr "Distribuzione"
+msgstr "Разпределение"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "Vedi dettagli"
+msgstr "Разгледай детайлите"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "Mostra {1} di questo {0}"
+msgstr "Преглед на тези {0} {1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "Ascendente"
+msgstr "Възходящ"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "Discendente"
+msgstr "Низходящ"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:43
 msgid "over time"
-msgstr "Fuori tempo"
+msgstr "с течение на времето"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:22
 msgid "Avg"
-msgstr "Media"
+msgstr "Ср"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:34
 msgid "Distincts"
-msgstr "Distinti"
+msgstr "Отличителни"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "Mostra questo {0}"
-msgstr[1] "Mostra questi {0}"
+msgstr[0] "Прегледай това {0}"
+msgstr[1] "Прегледай тези {0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "Avvicina"
+msgstr "Увеличавам"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
-msgstr "Espressione custom"
+msgstr "Персонализиран израз"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
-msgstr "Metriche standard"
+msgstr "Общи показатели"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
-msgstr "Metabasi"
+msgstr "Метабазики"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "Nome (opzionale)"
+msgstr "Име (по избор)"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "Scegli una aggregazione"
+msgstr "Изберете обобщение"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "Imposta il tuo alert"
+msgstr "Настройте свой собствен сигнал"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "Disiscrivendo..."
+msgstr "Отписване ..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "Errore nel cancellarsi"
+msgstr "Неуспешно отписване"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "Cancellati"
+msgstr "Отписване"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "Nessun canale"
+msgstr "Няма канал"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "Ok, sei stato cancellato"
+msgstr "Добре, отписали сте се"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "Stai ricevendo {0} alert"
+msgstr "Получавате сигналите на {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0} imposta un alert"
+msgstr "{0} настройте сигнал"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "alert"
+msgstr "сигнали"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "Impostiamo i tuoi alert"
+msgstr "Нека настроим вашия сигнал"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "Il vasto mondo degli alert"
+msgstr "Широкият свят на сигналите"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "Puoi ottenere diversi tipi di alert"
+msgstr "Има няколко различни вида сигнали, които можете да получите"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "Quando è una domanda di dati piatti {0}"
+msgstr "Когато въпрос за необработени данни {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "restituisci ogni risultato"
+msgstr "връща всички резултати"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "Quando è una linea o una barra {0}"
+msgstr "Когато линия или лента {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "supera una linea gol"
+msgstr "пресича гол линия"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "Quando è una barra di progresso {0}"
+msgstr "Когато лента за напредък {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "raggiunge il suo gol"
+msgstr "достига целта си"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "Imposta un alert"
+msgstr "Настройте сигнал"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "Modifica il tuo alert"
+msgstr "Редактирайте сигнала си"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "Modifica alert"
+msgstr "Редактиране на предупреждението"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "Questo alert non sarà più inviato a {0}."
+msgstr "Този сигнал вече няма да се изпраща по имейл до {0}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "Il canale Sllack {0} non riceverà più questo alert."
+msgstr "Slack канал {0} вече няма да получава това предупреждение."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "Il canale {0} non riceverà più questo alert."
+msgstr "Канал {0} повече няма да получава този сигнал."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "Cancella questo alert"
+msgstr "Изтрийте този сигнал"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "Ferma l'invio e cancella l'alert. Non si torna indietro, quindi sii attento."
+msgstr "Спрете доставката и изтрийте този сигнал. Няма отмяна, така че бъдете внимателни."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "Eliminare l'alert?"
+msgstr "Да се ​​изтрие ли този сигнал?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "Avvisami quando la linea..."
+msgstr "Извести ме, когато линията ..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "Avvisami quando la barra..."
+msgstr "Предупреждавайте ме, когато лентата за напредъка ..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "Supera la linea gol"
+msgstr "Отива над линията на головете"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "Raggiunge il gol"
+msgstr "Достига целта"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Va sotto la linea gol"
+msgstr "Отива под голлинията"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "Va sotto il gol"
+msgstr "Отива под целта"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "La prima volta che lo supera, oppure ogni volta?"
+msgstr "Първият път, когато се пресича, или всеки път?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "La prima volta che raggiunge l'obiettivo, oppure sempre?"
+msgstr "Първият път, когато достигне целта, или всеки път?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "La prima volta"
+msgstr "Първият път"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "Ogni volta"
+msgstr "Всеки път"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "Dove vuoi inviare questi alert?"
+msgstr "Къде искате да изпратите тези сигнали?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "Invia una email con gli alert a:"
+msgstr "Изпращайте предупреждения по имейл до:"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} Gli alert basati sugli obiettivi non sono al momento supportati per più di una linea, per cui questo alert sarà inviato ogni qualvolta il grafico abbia {1}."
+msgstr "{0} Сигналите, базирани на цели, все още не се поддържат за диаграми с повече от един ред, така че този сигнал ще бъде изпратен, когато диаграмата има {1}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 #: src/metabase/pulse.clj
 msgid "results"
-msgstr "risultati"
+msgstr "резултати"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0} Questo tipo di alert è più utile quando la tua domanda salvata "
+msgstr "{0} Този вид предупреждение е най-полезен, когато вашият запазен въпрос не {1} връща никакви резултати, но искате да знаете кога го прави."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "Consiglio"
+msgstr "Бакшиш"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
-msgstr "solitamente"
+msgstr "обикновено"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:61
 msgid "Pick a segment or table"
-msgstr "Seleziona un segmento o una tabella"
+msgstr "Изберете сегмент или таблица"
 
 #: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
-msgstr "Seleziona un database"
+msgstr "Изберете база данни"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
-msgstr "Seleziona..."
+msgstr "Изберете ..."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
-msgstr "Seleziona una tabella"
+msgstr "Изберете таблица"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
-msgstr "In questo database non è stata trovata nessuna tabella."
+msgstr "В тази база данни не са намерени таблици."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
-msgstr "Manca una domanda?"
+msgstr "Липсва въпрос?"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
-msgstr "Scopri di più sulle query annidate"
+msgstr "Научете повече за вложени заявки"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
-msgstr "Campi"
+msgstr "Полета"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:977
 msgid "No segments were found."
-msgstr "Non è stato trovato alcun segmento"
+msgstr "Не бяха намерени сегменти."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:1000
 msgid "Find a segment"
-msgstr "Trova un segmento"
+msgstr "Намерете сегмент"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "Mostra meno"
+msgstr "Вижте по-малко"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "Mostra di più"
+msgstr "Виж повече"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "Seleziona il campo in base al quale ordinare"
+msgstr "Изберете поле, по което да сортирате"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "Ordina"
+msgstr "Вид"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "Limite di righe"
+msgstr "Лимит на редовете"
 
 #: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
-msgstr "Campo sconosciuto"
+msgstr "Непознато поле"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
-msgstr "campo"
+msgstr "поле"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
-msgstr "Combinazioni"
+msgstr "Мачове"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "Aggiungi filtri per restringere la tua risposta"
+msgstr "Добавете филтри, за да стесните отговора си"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
-msgstr "Aggiungi un raggruppamento"
+msgstr "Добавете групиране"
 
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
@@ -5109,108 +5107,108 @@ msgstr "Aggiungi un raggruppamento"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
-msgstr "Dati"
+msgstr "Данни"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
-msgstr "Filtrati per"
+msgstr "Филтрирано от"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
-msgstr "Vista"
+msgstr "Изглед"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
-msgstr "Raggruppati per"
+msgstr "Групирани по"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "Nessuno"
+msgstr "Нито един"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
-msgstr "Questa domanda è scritta in {0}"
+msgstr "Този въпрос е написан на {0}."
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "Nascondi Editor"
+msgstr "Скриване на редактора"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "Nascondi Query"
+msgstr "Скриване на заявката"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
-msgstr "Apri Editor"
+msgstr "Отворете редактора"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:482
 msgid "Show Query"
-msgstr "Mostra Query"
+msgstr "Показване на заявка"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "Questa metrica è stata ritirata. Non può più essere utilizzata."
+msgstr "Този показател е оттеглен. Вече не е на разположение за употреба."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "Scarica i risultati completi"
+msgstr "Изтеглете пълните резултати"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "Scarica questi dati"
+msgstr "Изтеглете тези данни"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
-msgstr "Attenzione"
+msgstr "Внимание"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "La tua risposta ha molte righe, per cui il download potrebbe metterci un po'."
+msgstr "Отговорът ви има голям брой редове, така че изтеглянето може да отнеме известно време."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "La massima dimensione scaricabile è 1 milione di righe."
+msgstr "Максималният размер на изтеглянето е 1 милион реда."
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:11
 msgid "Edit question"
-msgstr "Modifica la domanda"
+msgstr "Редактиране на въпроса"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "SALVA LE MODIFICHE"
+msgstr "ЗАПАЗИТЕ ПРОМЕНИТЕ"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "ANNULLA"
+msgstr "ОТМЕНЯ"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "Sposta la domanda"
+msgstr "Преместване на въпроса"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:155
 msgid "Which collection should this be in?"
-msgstr "In quale collezione va inserito?"
+msgstr "В коя колекция трябва да е това?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:85
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "Variabili"
+msgstr "Променливи"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "Scopri di più sui tuoi dati"
+msgstr "Научете за вашите данни"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "Gli allarmi sono attivi"
+msgstr "Сигналите са включени"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "iniziato da"
+msgstr "започна от"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5218,169 +5216,169 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "query nativa"
+msgstr "родна заявка"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "Non supportato"
+msgstr "Не се поддържа"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "Mostra il {0}"
+msgstr "Преглед на {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "Cambia a {0}"
+msgstr "Превключване към {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "Passa al Costruttore"
+msgstr "Преминете към Builder"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "{0} per questa domanda"
+msgstr "{0} за този въпрос"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "Trasforma questa domanda in {0}"
+msgstr "Преобразувайте този въпрос в {0}"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:16
 msgid "This question will take approximately {0} to refresh"
-msgstr "Questa domanda impiegherà circa {0} per aggiornarsi"
+msgstr "Този въпрос ще отнеме приблизително {0} за опресняване"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "Aggiornato {0}"
+msgstr "Актуализирано {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
 msgid_plural "rows"
-msgstr[0] "riga"
-msgstr[1] "righe"
+msgstr[0] "ред"
+msgstr[1] "редове"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "Mostra i primi {0} {1}"
+msgstr "Показва се първата {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "Mostra {0} {1}"
+msgstr "Показва се {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "Calcolando"
+msgstr "Правейки наука"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "Se mi dai dei dati, posso mostrarti qualcosa di interessante. Lancia una Query!"
+msgstr "Ако ми дадете някои данни, мога да ви покажа нещо страхотно. Изпълнете заявка!"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "Come uso questa cosa?"
+msgstr "Как да използвам това нещо?"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Answer"
-msgstr "Ottieni la risposta"
+msgstr "Вземете отговор"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "Puoi fare delle prove con le domande salvate"
+msgstr "Добре е да си поиграете със запазени въпроси"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "Non effettuerai alcuna modifica permanente a una domanda salvata a meno che non clicchi sull'icona di modifica in alto a destra."
+msgstr "Няма да правите никакви постоянни промени в запазен въпрос, освен ако не щракнете върху иконата за редактиране горе вдясно."
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "Cerca"
+msgstr "Търся"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "Avanzate..."
+msgstr "Разширено ..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "Mi dispiace. Qualcosa è andato storto."
+msgstr "Съжалявам. Нещо се обърка."
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "Aggrega il tempo per"
+msgstr "Групово време по"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "La tua domanda ci ha messo troppo tempo"
+msgstr "Вашият въпрос отне твърде дълго"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "Non abbiamo ricevuto una risposta in tempo dal tuo database, per cui ci siamo fermati. Puoi riprovare tra un minuto e, se il problema rimane, inviare una mail a un amministratore per informarlo."
+msgstr "Не получихме отговор от вашата база данни навреме, така че трябваше да спрем. Можете да опитате отново след минута, или ако проблемът продължава, можете да изпратите имейл до администратор, за да го уведомите."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "Stiamo avendo problemi con il database"
+msgstr "Имаме проблеми със сървъра"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "Prova a rinfrescare la pagina tra un paio di minuti. Se il problema rimane, ti consigliamo di contattare un amministratore."
+msgstr "Опитайте да опресните страницата, след като изчакате минута или две. Ако проблемът продължава, препоръчваме ви да се свържете с администратор."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "C'è stato un problema con la tua domanda"
+msgstr "Имаше проблем с въпроса ви"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "La maggior parte delle volte questo è causato da una selezione invalida o dall'inserimento di un valore anomalo. Ricontrolla l'inserimento e rilancia la query."
+msgstr "По-голямата част от времето това е причинено от невалиден избор или лоша входна стойност. Проверете отново вашите данни и опитайте отново."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "Questa potrebbe essere la risposta che stai cercando. In caso contrario, prova a togliere o modificare i filtri in modo che siano meno specifici."
+msgstr "Това може да е отговорът, който търсите. Ако не, опитайте да премахнете или промените филтрите си, за да ги направите по-малко специфични."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "Puoi anche {0} quando ci sono dei risultati"
+msgstr "Можете също да {0}, когато има някои резултати."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "ricevi un alert"
+msgstr "получи сигнал"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "Torna all'ultima esecuzione"
+msgstr "Обратно към последното тичане"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:194
 msgid "Visualization"
-msgstr "Visualizzazione"
+msgstr "Визуализация"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
-msgstr "Nessuna descrizione impostata."
+msgstr "Няма зададено описание."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "Usa per la domanda corrente"
+msgstr "Използвайте за текущ въпрос"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:14
 msgid "Potentially useful questions"
-msgstr "Domande potenzialmente utili"
+msgstr "Потенциално полезни въпроси"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "Raggruppa per {0}"
+msgstr "Групиране от {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "Somma di tutti i valori di {0}"
+msgstr "Сума от всички стойности на {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "Tutti i valori che assume {0}"
+msgstr "Всички различни стойности на {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "Numero di {0} raggruppato per {1}"
+msgstr "Брой на {0}, групирани по {1}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5392,70 +5390,70 @@ msgstr "Numero di {0} raggruppato per {1}"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "Riferimento dati"
+msgstr "Справка за данни"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "Scopri di più sulla struttura dei dati per fare domande più utili"
+msgstr "Научете повече за вашата структура на данните, за да зададете още полезни въпроси"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "Non posso trovare i metadati della tabella prima di creare una nuova domanda"
+msgstr "Не можах да намеря метаданните на таблицата, преди да създам нов въпрос"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "Vedi {0}"
+msgstr "Вижте {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
-msgstr "Definizione della metrica"
+msgstr "Определение на метриката"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "Filtra per {0}"
+msgstr "Филтриране по {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:38
 msgid "Number of {0}"
-msgstr "Numero di {0}"
+msgstr "Брой на {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:48
 msgid "See all {0}"
-msgstr "Mostra tutti {0}"
+msgstr "Вижте всички {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
-msgstr "Definizione del segmento"
+msgstr "Определение на сегмента"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
-msgstr "Si è verificato un errore durante il caricamento della tabella"
+msgstr "Възникна грешка при зареждането на таблицата"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "Mostra i dati grezzi per {0}"
+msgstr "Вижте необработените данни за {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
-msgstr "Altro"
+msgstr "| Повече ▼"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
-msgstr "Espressione non valida"
+msgstr "Невалиден израз"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
-msgstr "errore sconosciuto"
+msgstr "неизвестна грешка"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
-msgstr "Campo formula"
+msgstr "Формула на полето"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "Pensa che è come scrivere una formula in un foglio di calcolo: puoi usare numeri, campi in questa tabella, simboli matematici come + e alcune funzioni. Quindi puoi digitare qualcosa come Subtotal - Cost."
+msgstr "Помислете за това като за нещо като писане на формула в програма за електронни таблици: можете да използвате числа, полета в тази таблица, математически символи като + и някои функции. Така че можете да напишете нещо като междинна сума - цена."
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
@@ -5463,267 +5461,266 @@ msgstr "Pensa che è come scrivere una formula in un foglio di calcolo: puoi usa
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
-msgstr "Scopri di più"
+msgstr "Научете повече"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
-msgstr "Assegna un nome"
+msgstr "Дайте му име"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
-msgstr "Qualcosa di chiaro e descrittivo"
+msgstr "Нещо хубаво и описателно"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "Aggiungi un campo personalizzato"
+msgstr "Добавете персонализирано поле"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "Includi {0}"
+msgstr "Включете {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "Tiene conto del maiuscolo e del minuscolo"
+msgstr "Различаващ главни от малки букви"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "oggi"
+msgstr "днес"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "settimana corrente"
+msgstr "тази седмица"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "mese corrente"
+msgstr "този месец"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
-msgstr "anno corrente"
+msgstr "тази година"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "questo minuto"
+msgstr "тази минута"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "quest'ora"
+msgstr "този час"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "non implementato {0}"
+msgstr "не е приложено {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "vero"
+msgstr "вярно"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "falso"
+msgstr "грешно"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "Aggiungi un filtro"
+msgstr "Добавяне на филтър"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
-msgstr "Elemento"
+msgstr "Вещ"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "Precedente"
+msgstr "Предишен"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "Corrente"
+msgstr "Текущ"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:257
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "On"
+msgstr "На"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "Inserisci il numero desiderato"
+msgstr "Въведете желания номер"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
-msgstr "Vuoto"
+msgstr "Празно"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
-msgstr "Trova un valore"
+msgstr "Намерете стойност"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "Nascondi il calendario"
+msgstr "Скриване на календара"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "Mostra il calendario"
+msgstr "Показване на календара"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "Puoi inserire più valori separati da virgola"
+msgstr "Можете да въведете множество стойности, разделени със запетаи"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "Inserisci il testo desiderato"
+msgstr "Въведете желания текст"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:210
 msgid "Try it"
-msgstr "Prova"
+msgstr "Опитай"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:243
 msgid "What's this for?"
-msgstr "A cosa serve?"
+msgstr "За какво е това?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:245
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "Le variabili nelle query native ti permettono di sostituire dinamicamente i valori nelle tue query utilizzando i filtri widget o attraverso l'URL."
+msgstr "Променливите в родните заявки ви позволяват да замествате динамично стойности във вашите заявки с помощта на приспособления за филтриране или чрез URL адреса."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0} crea una variabile in questo modello SQL chiamato \"nome_variabile\". Le variabili possono essere tipi dati nel pannello laterale, che cambia il loro comportamento. Tutti i tipi di variabile diversi da \"Field Filter\" causeranno automaticamente il posizionamento di un filtro su questa domanda; con i filtri di campo, questo è opzionale. Quando questo widget di filtro viene utilizzato, tale valore sostituisce la variabile nel modello SQL."
+msgstr "{0} създава променлива в този SQL шаблон, наречена „име на променлива“. Променливите могат да получат типове в страничния панел, което променя тяхното поведение. Всички типове променливи, различни от „Полеви филтър“, автоматично ще доведат до поставяне на приспособление за филтър върху този въпрос; с полеви филтри това не е задължително. Когато тази джаджа за филтър е попълнена, тази стойност замества променливата в SQL шаблона."
 
-#. Per essere più intuitivi utilizzerei il termine colonna così che gli utenti sanno che questi sono i filtri che poi si basano sui dati presenti nella colonna che andranno a scegliere
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:259
 msgid "Field Filters"
-msgstr "Filtri per colonna"
+msgstr "Полеви филтри"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Fornendo una variabile il tipo \"Campo Filtro\" consente di collegare le schede SQL ai widget filtro dashboard o utilizzare più tipi di widget filtro sulla richiesta SQL. Una variabile Field Filter inserisce SQL simile a quello generato dal generatore di query della GUI quando si aggiungono filtri su colonne esistenti."
+msgstr "Предоставянето на променлива от типа \"Field Filter\" ви позволява да свързвате SQL карти с приспособления за филтриране на таблото или да използвате повече видове приспособления за филтриране на вашия SQL въпрос. Променливата на полевия филтър вмъква SQL подобна на тази, генерирана от конструктора на GUI заявки при добавяне на филтри към съществуващи колони."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:264
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "Quando aggiungi una variabile Field Filter, dovrai mapparla a un campo specifico. Puoi quindi scegliere di visualizzare un widget filtro nella tua domanda, ma anche se non lo fai, puoi ora mappare la variabile Filtro campo a un filtro dashboard quando aggiungi questa domanda a una dashboard. I filtri di campo dovrebbero essere utilizzati all'interno di una clausola \"WHERE\"."
+msgstr "Когато добавяте променлива на филтъра на полето, ще трябва да я присвоите на конкретно поле. След това можете да изберете да покажете приспособление за филтриране на вашия въпрос, но дори и да не го направите, вече можете да присвоите променливата на вашия филтър на полето на филтър на таблото, когато добавяте този въпрос към таблото. Полевите филтри трябва да се използват в рамките на клаузата \"WHERE\"."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:271
 msgid "Optional Clauses"
-msgstr "Clausole opzionali"
+msgstr "Незадължителни клаузи"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "parentesi attorno a {0} creano una clausola facoltativa nel modello. Se è impostata \"variabile\", l'intera clausola viene inserita nel modello. In caso contrario, l'intera clausola viene ignorata."
+msgstr "скоби около {0} създават незадължителна клауза в шаблона. Ако е зададена „променлива“, тогава цялата клауза се поставя в шаблона. Ако не, тогава цялата клауза се игнорира."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:283
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "Per utilizzare più clausole facoltative, è possibile includere almeno una clausola WHERE non facoltativa seguita da clausole facoltative che iniziano con \"AND\"."
+msgstr "За да използвате множество незадължителни клаузи, можете да включите поне една незадължителна клауза WHERE, последвана от незадължителни клаузи, започващи с \"И\"."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:301
 msgid "Read the full documentation"
-msgstr "Leggi la documentazione completa"
+msgstr "Прочетете цялата документация"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:133
 msgid "Filter label"
-msgstr "Etichetta di filtro"
+msgstr "Етикет на филтъра"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
-msgstr "Tipo di variabile"
+msgstr "Променлив тип"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
-msgstr "Testo"
+msgstr "Текст"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
-msgstr "Data"
+msgstr "Дата"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
-msgstr "Filtro per colonna"
+msgstr "Полеви филтър"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
-msgstr "Campo a cui mappare"
+msgstr "Поле за картографиране"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
-msgstr "Filtro tipo di widget"
+msgstr "Филтър тип джаджа"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
-msgstr "Richiesto?"
+msgstr "Задължително?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
-msgstr "Valore di default del widget"
+msgstr "Стойност на приспособлението за филтър по подразбиране"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "Archivia questa domanda?"
+msgstr "Да се ​​архивира ли този въпрос?"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "Questa domanda sarà rimossa da ogni dashboard o pulse che la contiene"
+msgstr "Този въпрос ще бъде премахнат от всички табла или импулси, използващи го."
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
-msgstr "Domanda"
+msgstr "Въпрос"
 
 #: frontend/src/metabase/dashboard/components/AddToDashSelectQuestionModal.jsx:31
 msgid "Pick a question to add"
-msgstr "Scegli una domanda da aggiungere"
+msgstr "Изберете въпрос, който да добавите"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "Stai modificando questa pagina"
+msgstr "Вие редактирате тази страница"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:78
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:45
 msgid "See this {0}"
-msgstr "Guarda questo {0}"
+msgstr "Вижте това {0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "Un sottoinsieme di"
+msgstr "Подмножество от"
 
 #: frontend/src/metabase/reference/components/Field.jsx:48
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:31
 msgid "Select a field type"
-msgstr "Scegli un tipo di campo"
+msgstr "Изберете тип поле"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:85
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:36
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:54
 msgid "No field type"
-msgstr "Nessun tipo di campo"
+msgstr "Няма тип поле"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.jsx:26
 msgid "by"
-msgstr "per"
+msgstr "от"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:156
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:157
 msgid "Field type"
-msgstr "Tipo di campo"
+msgstr "Тип поле"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "Degli una chiave esterna"
+msgstr "Изберете външен ключ"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
-msgstr "Vedi la formula {0}"
+msgstr "Вижте формулата {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "Perché questo {0} è importante"
+msgstr "Защо това {0} е важно"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "Perché questo {0} è interessante"
+msgstr "Защо това {0} е интересно"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "Nulla di importante per ora"
+msgstr "Все още нищо важно"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:172
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:237
@@ -5732,11 +5729,11 @@ msgstr "Nulla di importante per ora"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:248
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:233
 msgid "Nothing interesting yet"
-msgstr "Nulla di interessante per ora"
+msgstr "Все още нищо интересно"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "Cose da sapere su questo {0}"
+msgstr "Неща, които трябва да знаете за това {0}"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:182
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:247
@@ -5745,77 +5742,77 @@ msgstr "Cose da sapere su questo {0}"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:258
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:243
 msgid "Nothing to be aware of yet"
-msgstr "Niente di cui essere ancora a conoscenza"
+msgstr "Все още няма какво да знам"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "Esplore questa metrica"
+msgstr "Разгледайте този показател"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "Vedi questa metrica"
+msgstr "Вижте тази метрика"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "Per {0}"
+msgstr "От {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "Rimuovi l'elemento"
+msgstr "Премахни артикул"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "Perché questa dashboard è la più importante?"
+msgstr "Защо това табло е най-важно?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "Cosa c'è di utile o interessante su questo {0}?"
+msgstr "Какво е полезно или интересно за това {0}?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "Scrivi qualcosa di utile"
+msgstr "Напишете нещо полезно тук"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "C'è qualcosa di cui gli utenti di questa dashboard debbano essere a conoscenza?"
+msgstr "Има ли нещо, което потребителите на това табло трябва да знаят?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "Qualcosa di cui gli utenti debbano essere a conoscenza di questo {0}?"
+msgstr "Нещо, което потребителите трябва да знаят за това {0}?"
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "Secondo quali 2 o 3 campi raggruppi solitamente questa metrica?"
+msgstr "Кои 2-3 полета обикновено групирате този показател?"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:25
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "Questo è il punto di partenza perfetto se sei nuovo ai dati della tua azienda o se vuoi semplicemente controllare cosa sta succedendo."
+msgstr "Това е идеалното място да започнете, ако сте нови в данните на вашата компания или просто искате да проверите какво се случва."
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:52
 msgid "Most useful fields to group this metric by"
-msgstr "Campi più utili secondo cui raggruppare questa metrica"
+msgstr "Най-полезни полета за групиране на този показател по"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "Motivo delle modifiche"
+msgstr "Причина за промени"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "Lascia una nota per spiegare quali modifiche hai effettuato e perché erano necessarie"
+msgstr "Оставете бележка, за да обясните какви промени сте направили и защо са необходими"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:170
 msgid "Why this database is interesting"
-msgstr "Perchè questo database è interessante"
+msgstr "Защо тази база данни е интересна"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:180
 msgid "Things to be aware of about this database"
-msgstr "Punti di attenzione su questo database"
+msgstr "Неща, които трябва да знаете за тази база данни"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "Database e tabelle"
+msgstr "Бази данни и таблици"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:28
@@ -5829,374 +5826,373 @@ msgstr "Database e tabelle"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:31
 msgid "Details"
-msgstr "Dettagli"
+msgstr "Подробности"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
 #: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
-msgstr "Tabelle in {0}"
+msgstr "Маси в {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:226
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:204
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:222
 msgid "Actual name in database"
-msgstr "Nome reale nel database"
+msgstr "Действително име в базата данни"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:235
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:231
 msgid "Why this field is interesting"
-msgstr "Perché questo campo è interessante"
+msgstr "Защо това поле е интересно"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:245
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:241
 msgid "Things to be aware of about this field"
-msgstr "Punti di attenzione su questo campo"
+msgstr "Неща, които трябва да знаете в тази област"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:257
 #: frontend/src/metabase/reference/databases/FieldList.jsx:159
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:253
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:160
 msgid "Data type"
-msgstr "Tipo dati"
+msgstr "Тип данни"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "I campi in questa tabella appariranno qui man mano verranno aggiunti"
+msgstr "Полетата в тази таблица ще се появят тук, когато бъдат добавени"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "Campi in {0}"
+msgstr "Полета в {0}"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:153
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:154
 msgid "Field name"
-msgstr "Nome del campo"
+msgstr "Име на полето"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:46
 msgid "X-ray this field"
-msgstr "Fai un x-ray al campo"
+msgstr "Рентгеново това поле"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabase non è divertente senza dati"
+msgstr "Metabase не е забавно без данни"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "I tuoi database appariranno qui quando li collegherai"
+msgstr "Вашите бази данни ще се появят тук, след като ги свържете"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "I database appariranno qui quando i tuoi amministratori li avranno aggiunti"
+msgstr "Базите данни ще се появят тук, след като вашите администратори добавят някои"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "Connetti un database"
+msgstr "Свържете база данни"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "Conteggio di {0}"
+msgstr "Брой на {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "Visualizza i dati piatti di {0}"
+msgstr "Вижте необработени данни за {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:213
 msgid "Why this table is interesting"
-msgstr "Perchè questa tabella è interessante"
+msgstr "Защо тази таблица е интересна"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:223
 msgid "Things to be aware of about this table"
-msgstr "Cose di cui essere a conoscenza riguardanti questa tabella"
+msgstr "Неща, които трябва да знаете за тази таблица"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
-msgstr "Le tabelle in questo database appariranno qui man mano verranno aggiunte"
+msgstr "Таблиците в тази база данни ще се показват тук при добавянето им"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
-msgstr "Le domande su questa tabella appariranno qui man mano verranno aggiunte"
+msgstr "Въпросите за тази таблица ще се показват тук при добавянето им"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
-msgstr "Domande riguardanti {0}"
+msgstr "Въпроси за {0}"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
-msgstr "Creato {0} per {1}"
+msgstr "Създадено {0} от {1}"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "Campi in questa tabella"
+msgstr "Полета в тази таблица"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:46
 msgid "Questions about this table"
-msgstr "Domande relative a questa tabella"
+msgstr "Въпроси относно тази таблица"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "Aiuta il tuo team ad iniziare a lavorare con i vostri dati."
+msgstr "Помогнете на вашия екип да започне с вашите данни."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "Mostra al tuo team la cosa più importante scegliendo la dashboard, le metriche e i segmenti più importanti."
+msgstr "Покажете на екипа си кое е най-важното, като изберете най-горното табло за управление, показатели и сегменти."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "Inizia"
+msgstr "Първи стъпки"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "La nostra dashboard più importante"
+msgstr "Най-важното ни табло за управление"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "Numeri importanti per noi"
+msgstr "Числа, на които обръщаме внимание"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "Le metriche sono numeri importanti che la tua azienda ritiene essenziali. Rappresentano spesso un indicatore chiave di come si sta svolgendo l'attività."
+msgstr "Показателите са важни числа, за които вашата компания се грижи. Те често представляват основен индикатор за това как бизнесът се представя."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "Mostra tutte le metriche"
+msgstr "Вижте всички показатели"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "Segmenti e tabelle"
+msgstr "Сегменти и таблици"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:82
 msgid "Tables"
-msgstr "Tabelle"
+msgstr "Маси"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "Segmenti e tabelle sono gli elementi costitutivi dei dati della tua azienda. Le tabelle sono raccolte delle informazioni non elaborate mentre i segmenti sono sezioni specifiche con significati specifici, come {0}"
+msgstr "Сегментите и таблиците са градивните елементи на данните на вашата компания. Таблиците са колекции от сурова информация, докато сегментите са конкретни срезове с конкретни значения, като {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "Le tabelle sono i mattoncini che compongono l'insieme dei dati della vostra azienda."
+msgstr "Таблиците са градивните елементи на данните на вашата компания."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "Mostra tutti i segmenti"
+msgstr "Вижте всички сегменти"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "Mostra tutte le tabelle"
+msgstr "Вижте всички таблици"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "Altre cose da sapere sui nostri dati"
+msgstr "Други неща, които трябва да знаете за нашите данни"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "Scopri di più"
+msgstr "Открийте повече"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "Un buon modo per conoscere i tuoi dati è trascorrere un po 'di tempo esplorando le diverse tabelle e altre informazioni disponibili. Potrebbe volerci un po ', ma inizierai a riconoscere nomi e significati nel tempo."
+msgstr "Един добър начин да опознаете данните си, като отделите малко време за проучване на различните таблици и друга налична информация. Може да отнеме известно време, но с времето ще започнете да разпознавате имена и значения."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "Esplora i nostri dati"
+msgstr "Разгледайте нашите данни"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "Ci sono domande?"
+msgstr "Имате въпроси?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "Contatta {0}"
+msgstr "Свържете се с {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "Aiuta i nuovi utenti di Metabase a sentirsi a casa."
+msgstr "Помогнете на новите потребители на Metabase да се ориентират."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "La Guida introduttiva evidenzia la dashboard, le metriche, i segmenti e le tabelle che contano di più e informa gli utenti delle cose importanti che dovrebbero sapere prima di scavare nei dati."
+msgstr "Ръководството „Първи стъпки“ подчертава най-важното табло, показатели, сегменти и таблици и информира потребителите ви за важни неща, които трябва да знаят, преди да се впуснат в данните."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "C'è una dashboard importante per il tuo team?"
+msgstr "Има ли важно табло за управление на вашия екип?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "Crea ora una dashboard"
+msgstr "Създайте табло за управление сега"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "Qual è la tua dashboard più importante?"
+msgstr "Кое е най-важното ви табло за управление?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "Hai delle metriche a cui fai riferimento di frequente?"
+msgstr "Имате ли често използвани показатели?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "Impara come definire una metrica"
+msgstr "Научете как да дефинирате показател"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "Quali solo le 3-5 metriche più richiamate?"
+msgstr "Кои са вашите 3-5 най-често използвани показатели?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "Aggiungi un'altra metrica"
+msgstr "Добавете друг показател"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "Hai dei segmenti o delle tabelle che sono richiamati frequentemente?"
+msgstr "Имате ли някакви често цитирани сегменти или таблици?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "Impara come creare un segmento"
+msgstr "Научете как да създадете сегмент"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "Quali sono 3-5 segmenti o tabelle comunemente citati che sarebbero utili per questo pubblico?"
+msgstr "Кои са 3-5 често посочени сегмента или таблици, които биха били полезни за тази аудитория?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "Aggiungi un'altro segmento o tabella"
+msgstr "Добавете друг сегмент или таблица"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "C'è qualcosa che i tuoi utenti dovrebbero capire o sapere prima di iniziare ad accedere ai dati?"
+msgstr "Има ли нещо, което потребителите ви трябва да разберат или знаят, преди да започнат достъп до данните?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "Cosa deve sapere un utente di questi dati prima di iniziare ad accedervi?"
+msgstr "Какво трябва да знае потребителят на тези данни, преди да започне достъп до тях?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "p.e., aspettative sulla privacy e sull'uso dei dati, insidie o incomprensioni comuni, informazioni sulle prestazioni del data warehouse, note legali, ecc."
+msgstr "Например, очаквания относно поверителността на данните и използването им, често срещани клопки или недоразумения, информация за работата на хранилището на данни, правни съобщения и др"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "C'è qualcuno che i tuoi utenti potrebbero contattare per chiedere aiuto se sono confusi su questa guida?"
+msgstr "Има ли някой, на когото потребителите ви да се обърнат за помощ, ако са объркани относно това ръководство?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "Chi dovrebbe contattare gli utenti per chiedere assistenza se sono confusi su questi dati?"
+msgstr "Към кого трябва да се свържат потребителите за помощ, ако са объркани относно тези данни?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:76
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:97
 msgid "Please enter a revision message"
-msgstr "Per favore scrivi un messaggio per la revisione"
+msgstr "Моля, въведете съобщение за ревизия"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "Perché questa metrica è interessante"
+msgstr "Защо този показател е интересен"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "Cose di che dovresti sapere riguardo questa metrica"
+msgstr "Неща, които трябва да знаете за тази метрика"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "Come viene calcolata questa metrica"
+msgstr "Как се изчислява този показател"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:240
 msgid "Nothing on how it's calculated yet"
-msgstr "Per ora nulla rispetto a come è calcolato"
+msgstr "Все още нищо за това как се изчислява"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:297
 msgid "Other fields you can group this metric by"
-msgstr "Altri campi puoi raggruppare questa metrica per"
+msgstr "Други полета, по които можете да групирате този показател"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:298
 msgid "Fields you can group this metric by"
-msgstr "Campi con cui puoi raggruppare questa metrica"
+msgstr "Полета, по които можете да групирате този показател"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "Le metriche sono i numeri ufficiali di cui il tuo team si prende cura"
+msgstr "Метриките са официалните цифри, от които се грижи вашият екип"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
-msgstr "Le metriche appariranno qui una volta che i tuoi amministratori ne avranno creati alcuni"
+msgstr "Показатели ще се появят тук, след като вашите администратори са създали някои"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
-msgstr "Scopri come si creano metriche"
+msgstr "Научете как да създавате показатели"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
-msgstr "Le 'question' su questa metrica verranno visualizzate qui man mano che vengono aggiunte"
+msgstr "Въпросите за този показател ще се показват тук, когато бъдат добавени"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "Non ci sono revisioni per questa metrica"
+msgstr "Няма ревизии за тази метрика"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:90
 msgid "Revision history for {0}"
-msgstr "Storia delle revisioni per {0}"
+msgstr "История на редакциите за {0}"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:44
 msgid "X-ray this metric"
-msgstr "Esegui raggi-X su questa metrica"
+msgstr "Рентгеново тази метрика"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:246
 msgid "Why this Segment is interesting"
-msgstr "Perché questo segmento è interessante"
+msgstr "Защо този сегмент е интересен"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:256
 msgid "Things to be aware of about this Segment"
-msgstr "Cose da sapere su questo segmento"
+msgstr "Неща, които трябва да знаете за този сегмент"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
-msgstr "I segmenti sono sottoinsiemi interessanti di tabelle"
+msgstr "Сегментите са интересни подмножества на таблици"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "Definire segmenti comuni per il tuo team rende ancora più facile fare domande"
+msgstr "Определянето на общи сегменти за вашия екип прави още по-лесно задаването на въпроси"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
-msgstr "I segmenti appariranno qui non appena i tuoi admin ne avranno creati"
+msgstr "Сегментите ще се появят тук, след като вашите администратори са създали някои"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
-msgstr "Impara come creare dei segmenti"
+msgstr "Научете как да създавате сегменти"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
-msgstr "Le domande su questo segmento appariranno qui non appena saranno aggiunte"
+msgstr "Въпросите за този сегмент ще се показват тук при добавянето им"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:28
 msgid "There are no revisions for this segment"
-msgstr "Non ci sono revisioni per questo segmento"
+msgstr "Няма ревизии за този сегмент"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:37
 msgid "Fields in this segment"
-msgstr "Campi in questo segmento"
+msgstr "Полета в този сегмент"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:43
 msgid "Questions about this segment"
-msgstr "Domande su questo segmento"
+msgstr "Въпроси за този сегмент"
 
-#. Purtroppo in italiano non possiamo essere così snelli come in inglese...
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:50
 msgid "X-ray this segment"
-msgstr "Analizza il segmento ai Raggi-X"
+msgstr "Рентгеново този сегмент"
 
 #: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
-msgstr "Accedi"
+msgstr "Влизам"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:390
@@ -6204,595 +6200,595 @@ msgstr "Accedi"
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
 #: frontend/src/metabase/routes.jsx:197
 msgid "Search"
-msgstr "Cerca"
+msgstr "Търсене"
 
-#. Usare cruscotto lo trovo agghiacciante
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
 #: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
-msgstr "Dashboard"
+msgstr "Табло"
 
 #: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
-msgstr "Nuova domanda"
+msgstr "Нов въпрос"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:127
 msgid "Select the type of Database you use"
-msgstr "Seleziona il tipo di Database che utilizzi"
+msgstr "Изберете типа база данни, която използвате"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:103
 msgid "Add your data"
-msgstr "Aggiungi i tuoi dati"
+msgstr "Добавете вашите данни"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:107
 msgid "I'll add my own data later"
-msgstr "Aggiungerò i miei dati più tardi"
+msgstr "Ще добавя собствените си данни по-късно"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:108
 msgid "Connecting to {0}"
-msgstr "Mi sto connettendo a {0}"
+msgstr "Свързване с {0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:130
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "Avrai bisogno di alcune informazioni sul tuo database, come il nome utente e la password. Se non lo hai in questo momento, Metabase viene fornito con un set di dati di esempio con cui puoi iniziare."
+msgstr "Ще ви трябва информация за вашата база данни, като потребителско име и парола. Ако нямате това в момента, Metabase се предлага и с примерен набор от данни, с който можете да започнете."
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my data later"
-msgstr "Aggiungerò i miei dati più tardi"
+msgstr "Ще добавя данните си по-късно"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:42
 msgid "Control automatic scans"
-msgstr "Controlla le scansioni automatiche"
+msgstr "Контролирайте автоматичното сканиране"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:59
 msgid "Usage data preferences"
-msgstr "Preferenze di utilizzo dei dati "
+msgstr "Предпочитания за данни за използване"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:62
 msgid "Thanks for helping us improve"
-msgstr "Grazie per averci aiutato a migliorare"
+msgstr "Благодаря, че ни помогнахте да се подобрим"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:63
 msgid "We won't collect any usage events"
-msgstr "Non raccoglieremo eventi di utilizzo"
+msgstr "Няма да събираме никакви събития за използване"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Per aiutarci a migliorare Metabase, desideriamo raccogliere determinati dati sull'utilizzo tramite Google Analytics."
+msgstr "За да ни помогнем да подобрим Metabase, бихме искали да събираме определени данни за използването чрез Google Analytics."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
-msgstr "Qui trovi la lista completa di cosa tracciamo e perché"
+msgstr "Ето пълен списък на всичко, което проследяваме и защо."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Consenti a Metabase di raccogliere dati anonimi sugli eventi"
+msgstr "Позволете на Metabase да събира анонимно събития за използване"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0} reccoglie nulla riguardo i tuoi dati e risultati."
+msgstr "Metabase {0} събира всичко относно вашите данни или резултати от въпроси."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
-msgstr "mai"
+msgstr "никога"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
-msgstr "Tutte le raccolte dati sono completamente anonime."
+msgstr "Цялата колекция е напълно анонимна."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "La raccolta dati può essere disabilitata in qualsiasi momento dalle impostazioni di amministrazione."
+msgstr "Събирането може да бъде изключено по всяко време в настройките на вашия администратор."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
-msgstr "Se ti senti bloccato"
+msgstr "Ако се чувствате заседнали"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
-msgstr "la nostra guida rapida"
+msgstr "нашето начално ръководство"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
-msgstr "ti manca solo un click."
+msgstr "е само на един клик разстояние."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
-msgstr "Benvenuto in Metabase"
+msgstr "Добре дошли в Metabase"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "Sembra che tutto funzioni. Ora ti conosciamo, ti colleghiamo ai tuoi dati e inizi a trovarti delle risposte!"
+msgstr "Изглежда всичко работи. Сега нека да ви опознаем, да се свържем с вашите данни и да започнем да ви намираме някои отговори!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
-msgstr "Iniziamo"
+msgstr "Да започваме"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
-msgstr "Abbiamo impostato tutto!"
+msgstr "Готови сте!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
-msgstr "Portami su Metabase"
+msgstr "Заведете ме в Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:49
 msgid "What should we call you?"
-msgstr "Come dovremmo chiamarti?"
+msgstr "Как да ви наречем?"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "Ciao {0}. Piacere di conoscerti!"
+msgstr "Здравей, {0}. приятно ми е да се запознаем!"
 
 #: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
-msgstr "Crea una password"
+msgstr "Създай парола"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
 #: frontend/src/metabase/entities/users/forms.js:50
 #: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
-msgstr "Shhh..."
+msgstr "Шшш ..."
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:265
 msgid "Confirm password"
-msgstr "Conferma la password"
+msgstr "Потвърди парола"
 
 #: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
-msgstr "Shhh... un'ultima volta così non sbagliamo"
+msgstr "Шшш ... но още веднъж, за да се оправим"
 
 #: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
-msgstr "Il nome della tua Società o del tuo team"
+msgstr "Име на вашата компания или екип"
 
-#. Propongo lieve cambio
 #: frontend/src/metabase/setup/components/UserStep.jsx:291
 msgid "Department of awesome"
-msgstr "Team che spacca"
+msgstr "Отдел за страхотни"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "Metabot sta ammirando i tuoi interi..."
+msgstr "Metabot се любува на вашите цели числа ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "Metabot sta effettuando miliardi di equazioni differenziali..."
+msgstr "Metabot изпълнява милиарди диференциални уравнения ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "Metabot sta facendo scienza..."
+msgstr "Metabot се занимава с наука ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "Metabot sta ammirando le tue metriche..."
+msgstr "Metabot проверява вашите показатели ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "Metabot sta cercando tendenze e anomalie..."
+msgstr "Metabot търси тенденции и извънредни стойности ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "Metabot sta consultando l'abaco quantistico..."
+msgstr "Metabot консултира квантовото сметало ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "Metabot ha un ottimo presentimento riguardo tutto ciò..."
+msgstr "Metabot се чувства доста добре за всичко това ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr "Tra pochi minuti ti mostreremo alcune indagini molto interessanti sui tuoi dati."
+msgstr "Ще ви покажем няколко интересни проучвания на вашите данни\n"
+"само след няколко минути."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "Sembra che ci voglia un po'. Nel frattempo, puoi dare un'occhiata a una di queste esplorazioni di esempio per vedere cosa Metabase può fare per te."
+msgstr "Изглежда, че това отнема известно време. Междувременно можете да проверите едно от тези примерни проучвания, за да видите какво може да направи Metabase за вас."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "Ho dato un'occhiata ai dati che hai appena collegato, e ho alcune esplorazioni di cose interessanti che ho trovato. Spero che ti piacciano!"
+msgstr "Разгледах данните, които току-що свързахте, и имам някои проучвания на интересни неща, които открих. Надявам се да ви харесат!"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "Per ora ho finito di esplorare"
+msgstr "Засега приключих с проучванията"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "Benvenuto nel costruttore di query!"
+msgstr "Добре дошли в Query Builder!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "Query Builder ti consente di riunire domande (o \"query\") per chiedere informazioni sui tuoi dati."
+msgstr "Query Builder ви позволява да събирате въпроси (или „заявки“), които да задавате относно вашите данни."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "Dimmi di più"
+msgstr "Кажи ми повече"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "Inizia scegliendo la tabella con i dati di cui hai una domanda."
+msgstr "Започнете, като изберете таблицата с данните, за които имате въпрос."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "Vai avanti e seleziona la tabella \"Ordini\" dal menu a discesa."
+msgstr "Продължете и изберете таблицата „Поръчки“ от падащото меню."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "Filtra i dati per vedere ciò che vuoi."
+msgstr "Филтрирайте данните си, за да получите точно това, което искате."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "Clicca il pulsante più  e seleziona il campo \"Creato alle\""
+msgstr "Щракнете върху бутона плюс и изберете полето „Създадено в“."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "Qui possiamo selezionare per quanti giorni vogliamo vedere i dati, prova 10"
+msgstr "Тук можем да изберем за колко дни искаме да видим данни, опитайте 10"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "Qui puoi scegliere di aggiungere o calcolare i tuoi dati, contare il numero di righe nella tabella o semplicemente visualizzare i dati non elaborati."
+msgstr "Тук можете да изберете да добавите или усредните данните си, да преброите броя на редовете в таблицата или просто да видите необработените данни."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "Provalo: fai clic su <strong> Dati grezzi (Raw data) </ strong> per cambiarlo in <strong> Numero di righe </ strong> in modo che possiamo contare quanti ordini ci sono in questa tabella."
+msgstr "Опитайте: кликнете върху <strong> Необработени данни </strong>, за да го промените на <strong> Брой редове </strong>, за да можем да преброим колко поръчки има в тази таблица."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "Aggiungi un raggruppamento per suddividere i risultati per categoria, giorno, mese e altro."
+msgstr "Добавете групиране, за да разпределите резултатите си по категории, ден, месец и други."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "Facciamolo: fai clic su <strong> Aggiungi un gruppo </ strong> e scegli <strong> Creato a: per settimana </ strong>."
+msgstr "Нека го направим: кликнете върху <strong> Добавяне на групиране </strong> и изберете <strong> Създадено при: по седмица </strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "Clicca su \"per giorno\" per cambiarlo in \"Settimana\"."
+msgstr "Кликнете върху „по ден“, за да го промените на „Седмица“."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "Esegui la tua query."
+msgstr "Изпълнете вашата заявка."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "Stai andando così bene! Fai clic su <strong> Esegui query </ strong> per ottenere i risultati!"
+msgstr "Справяте се толкова добре! Щракнете върху <strong> Изпълни заявка </strong>, за да получите резултатите си!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "Puoi visualizzare i risultati come grafico invece di un a tabella."
+msgstr "Можете да видите резултатите си като диаграма вместо таблица."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "A tutti piacciono i grafici! Clicca <strong>Visualizzazione</strong> e seleziona <strong>Linea</strong>."
+msgstr "Всеки харесва класации! Кликнете върху падащото меню <strong> Визуализация </strong> и изберете <strong> Линия </strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "Ben fatto!"
+msgstr "Много добре!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "E' tutto! Se hai altre domande, chiedi pure"
+msgstr "Това е всичко! Ако все още имате въпроси, разгледайте нашите"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "Manuale Utente"
+msgstr "Ръководство на потребителя"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "Divertiti ad esplorare i tuoi dati"
+msgstr "Забавлявайте се, изследвайки вашите данни!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "Grazie"
+msgstr "Благодаря"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "Salva le tue domande"
+msgstr "Запазете вашите въпроси"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "In ogni caso, puoi salvare le tue domande (question) così puoi recuperarle dopo. Le Domande (question) salvate possono anche essere messe all'interno di Dashboard o Pulse"
+msgstr "Между другото, можете да запазите въпросите си, за да можете да се обърнете към тях по-късно. Запазените въпроси също могат да бъдат поставени в таблата или импулсите."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "Suona bene"
+msgstr "Звучи добре"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "Ooops!"
+msgstr "Ами сега!"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "Ci spiace, sembra qualcosa sia andato storto. Prova a ricominciare il tutorial tra un minuto."
+msgstr "Извинете, изглежда нещо се обърка. Моля, опитайте да рестартирате урока след минута."
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "Password aggiornata correttamente!"
+msgstr "Паролата е актуализирана успешно!"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "Account aggiornato correttamente!"
+msgstr "Акаунтът е актуализиран успешно!"
 
 #: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
-msgstr "Password attuale"
+msgstr "Настояща парола"
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Accedi con Google"
+msgstr "Влезте с имейл адрес на Google"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "Dettagli utente"
+msgstr "Потребителски данни"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
-msgstr "Ripristina i valori di default"
+msgstr "Нулирайте по подразбиране"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:167
 msgid "unknown map"
-msgstr "mappa sconosciuta"
+msgstr "неизвестна карта"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "La mappa a griglia richiede longitudine / latitudine separate."
+msgstr "Картата на мрежата изисква binned дължина / ширина."
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:117
 msgid "more"
-msgstr "di più"
+msgstr "Повече ▼"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "Quali campi vuoi usare per le coordinate X e Y?"
+msgstr "Кои полета искате да използвате за осите X и Y?"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "Scegli i campi"
+msgstr "Изберете полета"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
-msgstr "Salva come vista di default"
+msgstr "Запазване като изглед по подразбиране"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
-msgstr "Disegna un box per filtrare"
+msgstr "Начертайте полето за филтриране"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
-msgstr "Annulla filtro"
+msgstr "Филтър за отмяна"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "Mappa a punti"
+msgstr "Пин карта"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
-msgstr "Non impostato"
+msgstr "Деактивирано"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
-msgstr "Righe {0}-{1} di {2}"
+msgstr "Редове {0} - {1} от {2}"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
-msgstr "Dati troncati a {0} righe"
+msgstr "Данните са съкратени до {0} реда."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
-msgstr "Impossibile trovare visualizzazione"
+msgstr "Не можах да намеря визуализация"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
-msgstr "Impossibile visualizzare questo grafico con questi dati"
+msgstr "Тази диаграма не можа да се покаже с тези данни."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
-msgstr "Nessun risultato!"
+msgstr "Няма резултати!"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
-msgstr "Sto ancora aspettando..."
+msgstr "Още чакам..."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
-msgstr "Solitamente impiega una media di {0}"
+msgstr "Това обикновено отнема средно {0}."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
-msgstr "(Questo è un po' lungo per una dashboard)"
+msgstr "(Това е малко дълго за табло)"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "Di solito è abbastanza veloce, ma sembra che ci stia prendendo un po' troppo"
+msgstr "Това обикновено е доста бързо, но изглежда, че отнема известно време в момента."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "Select a field"
-msgstr "Seleziona un campo"
+msgstr "Изберете поле"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "errore"
+msgstr "грешка"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:117
 msgid "Click and drag to change their order"
-msgstr "Clicca e trascina per cambiarne l'ordine"
+msgstr "Щракнете и плъзнете, за да промените реда им"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:130
 msgid "Add fields from the list below"
-msgstr "Aggiungi i campi dalla lista sotto"
+msgstr "Добавете полета от списъка по-долу"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "minore di"
+msgstr "по-малко от"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "maggiore di"
+msgstr "по-голям от"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "minore o uguale a"
+msgstr "по-малко или равно на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "maggiore o uguale a"
+msgstr "по-голямо или равно на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "uguale a"
+msgstr "равна на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "diverso da"
+msgstr "не е равно на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "Formattazione condizionale"
+msgstr "Условно форматиране"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "Puoi aggiungere regole per fare in modo che le celle di questa tabella cambino colore se soddisfano determinate condizioni."
+msgstr "Можете да добавите правила, за да накарате клетките в тази таблица да променят цвета си, ако\n"
+"отговарят на определени условия."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "Aggiungi un regola"
+msgstr "Добавете правило"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "Le regole saranno applicate in quest'ordine"
+msgstr "Правилата ще се прилагат в този ред"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "Clicca e trascina per riordinare"
+msgstr "Щракнете и плъзнете, за да пренаредите."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "Nessuna colonna selezionata"
+msgstr "Няма избрани колони"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "Le celle in questa colonna saranno colorate in base ai loro valori."
+msgstr "Клетките в тази колона ще бъдат оцветени въз основа на техните стойности."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "Quando una cella in queste colonne è {0}, verrà colorato di questo colore."
+msgstr "Когато клетка в тези колони е {0}, тя ще бъде оцветена в този цвят."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "Quali colonne dovrebbero essere influenzate?"
+msgstr "Кои колони трябва да бъдат засегнати?"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "Stile di formattazione"
+msgstr "Стил на форматиране"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "Singolo colore"
+msgstr "Едноцветен"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "Intervallo di colori"
+msgstr "Цветова гама"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "Quando una cella in questa colonna è..."
+msgstr "Когато клетка в тази колона е ..."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "...cambia il suo sfondo con questo colore:"
+msgstr "... превърнете фона му в този цвят:"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "Evidenzia l'intera riga"
+msgstr "Маркирайте целия ред"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
-msgstr "Colori"
+msgstr "Цветове"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "Inizia la serie a"
+msgstr "Започнете диапазона от"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "Il più piccolo valore in questa colonna"
+msgstr "Най-малката стойност в тази колона"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "Il più piccolo valore in ogni colonna"
+msgstr "Най-малката стойност във всяка колона"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "Il più piccolo valore in tutte queste colonne"
+msgstr "Най-малката стойност във всички тези колони"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "Valore personalizzato"
+msgstr "Персонализирана стойност"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "Fine della serie a"
+msgstr "Завършете диапазона на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "Il più grande valore in questa colonna"
+msgstr "Най-голяма стойност в тази колона"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "Il più grande valore in ogni colonna"
+msgstr "Най-голяма стойност във всяка колона"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "Il valore maggiore di tutte queste colonne"
+msgstr "Най-голяма стойност във всички тези колони"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "Aggiungi regola"
+msgstr "Добавяне на правило"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "Aggiorna regola"
+msgstr "Актуализиране на правилото"
 
 #: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
-msgstr "La visualizzazione è nulla"
+msgstr "Визуализацията е нула"
 
 #: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "La visualizzazione deve definire una variabile statica 'identificatore':"
+msgstr "Визуализацията трябва да дефинира статична променлива „идентификатор“:"
 
 #: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
-msgstr "La visualizzazione con quell'identificatore è già registrata"
+msgstr "Визуализацията с този идентификатор вече е регистрирана:"
 
 #: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
-msgstr "Nessuna visualizzazione per {0}"
+msgstr "Няма визуализация за {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "\"{0}\" è un campo non aggregato: se ha più di un valore nello stesso punto dell'asse X, i valori saranno sommati"
+msgstr "„{0}“ е неагрегирано поле: ако има повече от една стойност в точка по оста x, стойностите ще бъдат сумирани."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:93
 msgid "This chart type requires at least 2 columns."
-msgstr "Questo tipo di grafico richiede almeno 2 colonne"
+msgstr "Този тип диаграма изисква поне 2 колони."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:98
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "Questo tipo di grafico non supporta più di {0} serie di dati"
+msgstr "Този тип диаграма не поддържа повече от {0} поредица от данни."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "Obbiettivo"
+msgstr "Цел"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "Mannaggia! I dati della tua query non ci stanno nella modalità di visualizzazione scelta. La visualizzazione richiede almeno {0} {1} di dati,"
+msgstr "Да! Данните от вашата заявка не отговарят на избрания избор за показване. Тази визуализация изисква поне {0} {1} данни."
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
@@ -6840,715 +6836,715 @@ msgstr "Mannaggia! I dati della tua query non ci stanno nella modalità di visua
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
-msgstr "colonna"
+msgstr "колона"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "Niente da fare. Abbiamo {0} dati {1} da mostrare e non è abbastanza per questa visualizzazione."
+msgstr "Без зарове. Имаме {0} данни {1} за показване и това не е достатъчно за тази визуализация."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
 msgid_plural "points"
-msgstr[0] "punto"
-msgstr[1] "punti"
+msgstr[0] "точка"
+msgstr[1] "точки"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "Non possiamo fare una mappa a punti con questi dati perchè servono le colonne con latitudine e longitudine"
+msgstr "Ужасно. Всъщност не можем да направим пин карта за тези данни, защото се нуждаем както от колона за географска ширина, така и за дължина."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "Per favore configura questo grafico nelle impostazioni"
+msgstr "Моля, конфигурирайте тази диаграма в настройките на диаграмата"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "Modifica Impostazioni"
+msgstr "Редактиране на настройките"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:39
 msgid "xValues missing!"
-msgstr "Manca il valore X!"
+msgstr "xValues ​​липсва!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
-msgstr "Asse-X"
+msgstr "Оста X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Aggiungi una serie di interruzioni..."
+msgstr "Добавяне на пробив от серия ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
-msgstr "Asse-Y"
+msgstr "Ос Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "Aggiungi un'altra serie..."
+msgstr "Добавяне на друга серия ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "Dimensione del fumetto"
+msgstr "Размер на мехурчетата"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
-msgstr "Linea"
+msgstr "Линия"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "Curva"
+msgstr "Крива"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "Passaggio"
+msgstr "Стъпка"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "Mostra marcatori di punti sulle linee"
+msgstr "Показване на маркери на точки върху линии"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "impilabile"
+msgstr "Подреждане"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "Non impilare"
+msgstr "Не подреждайте"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "Pila"
+msgstr "Стек"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "Pila - 100%"
+msgstr "Стек - 100%"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "Mostra obiettivo"
+msgstr "Показване на целта"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "Valore da raggiungere"
+msgstr "Целева стойност"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "Sostituisci i valori mancanti con"
+msgstr "Заменете липсващите стойности с"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
-msgstr "Zero"
+msgstr "Нула"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "Niente"
+msgstr "Нищо"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "Interpolato lineare"
+msgstr "Линеен интерполиран"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
-msgstr "Scala dell'asse-X"
+msgstr "X-ос скала"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
-msgstr "Serie temporali"
+msgstr "Часовници"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:425
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
-msgstr "Lineare"
+msgstr "Линейна"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
-msgstr "Esponente"
+msgstr "Мощност"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:428
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
-msgstr "Log"
+msgstr "Влезте"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
-msgstr "Istogramma"
+msgstr "Хистограма"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
-msgstr "Ordinale"
+msgstr "Пореден"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
-msgstr "scala asse Y"
+msgstr "Скала на оста Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
-msgstr "Mostra linea e punti sull'asse X"
+msgstr "Показване на линията и знаците по оста x"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:349
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
-msgstr "Compatta"
+msgstr "Компактен"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
-msgstr "Ruota di 45°"
+msgstr "Завъртете на 45 °"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
-msgstr "Ruota di 90°"
+msgstr "Завъртете на 90 °"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
-msgstr "Mostra linea e punti sull'asse X"
+msgstr "Показване на линията и маркировката на оста y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
-msgstr "Auto range l'asse Y"
+msgstr "Автоматичен обхват на оста y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
-msgstr "Dividi l'asse Y quando necessario"
+msgstr "Използвайте разделена ос y, когато е необходимо"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
-msgstr "Mostra etichetta sul asse X"
+msgstr "Показване на етикета по оста x"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
-msgstr "Etichetta asse X"
+msgstr "Етикет на оста X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
-msgstr "Mostra etichetta sul asse Y"
+msgstr "Показване на етикета по оста y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
-msgstr "Etichetta asse Y"
+msgstr "Етикет на оста Y"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Standard Deviation"
-msgstr "Deviazione Standard"
+msgstr "Стандартно отклонение"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
-msgstr "Area"
+msgstr "■ площ"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
-msgstr "grafico ad area"
+msgstr "диаграма на площта"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
-msgstr "barre"
+msgstr "Бар"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
-msgstr "grafico a barre"
+msgstr "стълбовидна диаграма"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "Quali campi vuoi usare?"
+msgstr "Кои полета искате да използвате?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "Imbuto"
+msgstr "Фуния"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
-msgstr "Misura"
+msgstr "Измерете"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "Tipo di imbuto"
+msgstr "Тип фуния"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "grafico a barre"
+msgstr "Стълбовидна диаграма"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
-msgstr "grafico lineare"
+msgstr "линейна диаграма"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "Si prega di selezionare le colonne di longitudine e latitudine nelle impostazioni del grafico."
+msgstr "Моля, изберете колони за дължина и ширина в настройките на диаграмата."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
-msgstr "Si prega di selezionare una mappa della regione."
+msgstr "Моля, изберете карта на региона."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
-msgstr "Seleziona le colonne della regione e delle metriche nelle impostazioni del grafico."
+msgstr "Моля, изберете регион и метрични колони в настройките на диаграмата."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
-msgstr "Mappa"
+msgstr "Карта"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
-msgstr "Tipo di mappa"
+msgstr "Тип карта"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
-msgstr "Mappa della regione"
+msgstr "Карта на региона"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
-msgstr "Mappa puntine"
+msgstr "Прикачване на карта"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
-msgstr "Tipo di puntine"
+msgstr "Тип щифт"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
-msgstr "Riquadri"
+msgstr "Плочки"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
-msgstr "Marcatori"
+msgstr "Маркери"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
-msgstr "Campo latitudine"
+msgstr "Latitude поле"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
-msgstr "Campo longitudine"
+msgstr "Географска дължина"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
-msgstr "Campo per Metrica"
+msgstr "Метрично поле"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
-msgstr "Campo Regione"
+msgstr "Регионално поле"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
-msgstr "Raggio"
+msgstr "Радиус"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
-msgstr "Offusca"
+msgstr "Размазване"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
-msgstr "Opacità minima"
+msgstr "Минимална непрозрачност"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
-msgstr "Max Zoom"
+msgstr "Максимално увеличение"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
-msgstr "Nessuna relazione trovata"
+msgstr "Няма намерени връзки."
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
-msgstr "via {0}"
+msgstr "чрез {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
-msgstr "Questo {0} è connesso a:"
+msgstr "Това {0} е свързано със:"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
-msgstr "Dettagli oggetto"
+msgstr "Подробности за обекта"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
-msgstr "oggetto"
+msgstr "обект"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
-msgstr "Totale"
+msgstr "Обща сума"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
-msgstr "Quali colonne vuoi usare?"
+msgstr "Кои колони искате да използвате?"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
-msgstr "Torta"
+msgstr "Пай"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
-msgstr "Dimensione"
+msgstr "Измерение"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
-msgstr "Mostra legenda"
+msgstr "Покажи легенда"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
-msgstr "Mostra percentuali nella legenda"
+msgstr "Показвайте процентите в легендата"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
-msgstr "Percentuale della fetta minore"
+msgstr "Минимален процент на филийки"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "Obiettivo raggiunto"
+msgstr "Постигната цел"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "Obiettivo superato"
+msgstr "Целта е надвишена"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "Obiettivo {0}"
+msgstr "Цел {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "La visualizzazione del progresso richiede un numero."
+msgstr "Визуализацията на напредъка изисква номер."
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "Avanzamento"
+msgstr "Напредък"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/entities/snippet-collections.js:87
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "Colore"
+msgstr "Цвят"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "Grafico a righe"
+msgstr "Диаграма на редовете"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
-msgstr "grafico a righe"
+msgstr "редова диаграма"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:381
 msgid "Separator style"
-msgstr "stile del separatore"
+msgstr "Стил на разделител"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "Numero di posizioni decimali"
+msgstr "Брой десетични знаци"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:405
 msgid "Add a prefix"
-msgstr "Aggiungi un prefisso"
+msgstr "Добавете префикс"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:409
 msgid "Add a suffix"
-msgstr "Aggiungi un suffisso"
+msgstr "Добавете суфикс"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:398
 msgid "Multiply by a number"
-msgstr "Moltiplica per un numero"
+msgstr "Умножете по число"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
-msgstr "Dispersione"
+msgstr "Скатер"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
-msgstr "Trama sparsa"
+msgstr "разпръснат парцел"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
-msgstr "Tabella Pivot"
+msgstr "Завъртете масата"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "Campi visibili"
+msgstr "Видими полета"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Scrivi qui, e usa `Markdown` se vuoi"
+msgstr "Пишете тук и използвайте Markdown, ако искате"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "Allineamento verticale"
+msgstr "Вертикално подравняване"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "Alto"
+msgstr "Горна част"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "Medio"
+msgstr "Средна"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "Basso"
+msgstr "Отдолу"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "Allineamento Orizzontale"
+msgstr "Хоризонтално подравняване"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "Sinistra"
+msgstr "Наляво"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "Centro"
+msgstr "Център"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "Destra"
+msgstr "Нали"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "Mostra sfondo"
+msgstr "Показване на фона"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0} bidone"
-msgstr[1] "{0} bidoni"
+msgstr[0] "{0} кошче"
+msgstr[1] "{0} кошчета"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
-msgstr "intervallo automatico"
+msgstr "Автоматично binned"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "DELETE /api/alert/:id è deprecato. Modifica il valore `archiviato` tramite PUT /api/alert/:id."
+msgstr "ИЗТРИВАНЕ / api / alert /: идентификаторът е остарял. Вместо това променете стойността на „архивирана“ чрез PUT / api / alert /: id."
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "Mostra valore non valido"
+msgstr "невалидна шоу стойност"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "valore invalido per il prefisso"
+msgstr "невалидна стойност за префикс"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "valore invalido per il nome della regola"
+msgstr "невалидна стойност за име на правило"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "Il valore non può essere convertito in un JSON a codifica base64"
+msgstr "Стойността не може да бъде анализирана като JSON, кодиран в base64"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "tipo di entità invalido"
+msgstr "Невалиден тип обект"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "Comparazione non valida tra tipi di entità. Può essere solo uno di \"tabella\", \"segmento\" or \"adhoc\""
+msgstr "Невалиден тип обект за сравнение. Може да бъде само един от „таблица“, „сегмент“ или „adhoc“"
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "Errore durante lo svolgimento della query atto a determinare la Carta metadato risultato:"
+msgstr "Грешка при изпълнение на заявка за определяне на метаданните за резултата от картата:"
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/alert/:id è deprecato. Modifica il valore `archiviato` tramite PUT /api/alert/:id."
+msgstr "DELETE / api / card /: идентификаторът е оттеглен. Вместо това променете стойността на „архивирана“ чрез PUT / api / card /: id."
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "Campo non valido: {0}"
+msgstr "Невалидно поле: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "Valore non valido \"{0}\" per \"{1}\": {2}"
+msgstr "Невалидна стойност '' {0} '' за '' {1} '': {2}"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "dev'essere uno di: {0}"
+msgstr "трябва да е едно от: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid Request."
-msgstr "Richiesta invalida"
+msgstr "Невалидна заявка."
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "Non trovato."
+msgstr "Не е намерен."
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "Non hai i permessi per farlo."
+msgstr "Нямате разрешения за това."
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "Errore interno del server."
+msgstr "Вътрешна сървърна грешка."
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "Avviso: l'endpoint {0}/{1} non ha una docstring."
+msgstr "Предупреждение: крайната точка {0} / {1} няма документ."
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "avviare la richiesta di streaming"
+msgstr "стартиране на заявка за стрийминг"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "connessione chiusa, richiesta di cancellazione"
+msgstr "връзката затворена, заявка за анулиране"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "Risposta non pronta, scrittura di un byte e sospensione ..."
+msgstr "Отговорът не е готов, запис на един байт и сън ..."
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "La condivisione pubblica non è abilitata."
+msgstr "Публичното споделяне не е активирано."
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "L'incorporamento non è abilitato."
+msgstr "Вграждането не е активирано."
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "L'oggetto è stato archiviato."
+msgstr "Обектът е архивиран."
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "Tentato di tornare un boolean come una risposta API. Non è permesso."
+msgstr "Опит да се върне булев като API отговор. Това не е позволено!"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "La query sorgente per questa query è Carta {0}"
+msgstr "Заявка за източник за тази заявка е Карта {0}"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "Formato di esportazione non valido: {0}"
+msgstr "Невалиден формат за експортиране: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "JSON URL o risorsa non valida: {0}"
+msgstr "Невалиден JSON URL или ресурс: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "JSON contenente le informazioni riguardo i file GeoJSON da usare nelle visualizzazioni su mappa al posto di quelli US o mondiali presenti di default"
+msgstr "JSON, съдържащ информация за персонализирани GeoJSON файлове за използване при визуализации на карти, вместо по подразбиране за щатския щат или World GeoJSON."
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "Chiave GeoJSON personalizzata non valida: {0}"
+msgstr "Невалиден персонализиран ключ на GeoJSON: {0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "Parametro invalido: {0} "
+msgstr "Невалиден параметър: {0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
-msgstr " DELETE /api/pulse/:id è deprecato. Cambia il suo valore `archiviato` tramite PUT /api/pulse/:id."
+msgstr "ИЗТРИВАНЕ / api / pulse /: id е остарял. Вместо това променете стойността на „архивирана“ чрез PUT / api / pulse /: id."
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "Endpoint della API non esiste"
+msgstr "Крайната точка на API не съществува."
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "La password non corrisponde a quella salvata"
+msgstr "Паролата не съответства на съхранената парола."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "non corrisponde alla password salvata"
+msgstr "не съответства на съхранената парола"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "Problemi di connessione a un server LDAP, ricadrà su autenticazione locale"
+msgstr "Проблем при свързване с LDAP сървър, ще се върне към локално удостоверяване {0}"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "Token di reset invalido"
+msgstr "Невалиден маркер за нулиране"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "Client ID per Google Auth SSO. Se impostato, Google Auth è considerato abilitato"
+msgstr "Клиентски идентификатор за Google Auth SSO. Ако това е зададено, Google Auth се счита за активиран."
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "Quando è impostato, consente agli utenti di registrarsi autonomamente se l'indirizzo email riferito al proprio Google account appartiene a questo dominio."
+msgstr "Когато е зададено, позволете на потребителите да се регистрират сами, ако имейл адресът на акаунта им в Google е от този домейн."
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr " Google Auth token invalido."
+msgstr "Невалиден маркер на Google Auth."
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "Email non verificata"
+msgstr "Имейлът не е проверен."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Avrai bisogno di un amministratore per creare un account su Metabase prima che tu possa usare Google per accedere."
+msgstr "Ще ви е необходим администратор, за да създадете акаунт в Metabase, преди да можете да използвате Google за влизане."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "Autenticato con successo Google Auth token per: {0} {1}"
+msgstr "Успешно удостоверен токен на Google Auth за: {0} {1}"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "Aggiungi database"
+msgstr "Добавете база данни"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "Resta connesso"
+msgstr "Свържи се"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "Connetti i tuoi dati così tutto il tuo team puoi iniziare ad esplorare."
+msgstr "Свържете се с вашите данни, за да може целият ви екип да започне да изследва."
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "Imposta una email"
+msgstr "Настройте имейл"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "Aggiungi le credenziali email così puoi invitare i membri del team e avere aggiornamenti tramite Pulse."
+msgstr "Добавете идентификационни данни за имейл, за да можете по-лесно да каните членове на екипа и да получавате актуализации чрез импулси."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Imposta credenziali slack"
+msgstr "Задайте идентификационни данни на Slack"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "Il tuo team usa Slack? Se cos', puoi inviare aggiornamenti automatici tramite pulse e chiedere domande con MetaBot"
+msgstr "Използва ли вашият екип Slack? Ако е така, можете да изпращате автоматични актуализации чрез импулси и да задавате въпроси с MetaBot."
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "Invita i membri del tuo team"
+msgstr "Поканете членове на екипа"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "Condividi risposte e dati con il resto del tuo team."
+msgstr "Споделете отговори и данни с останалата част от екипа си."
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "Nascondi tabelle non rilevanti"
+msgstr "Скриване на неподходящи таблици"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "Cura i tuoi dati"
+msgstr "Подгответе вашите данни"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "Se i tuoi dati contengono informazioni tecniche o irrilevanti puoi nasconderle."
+msgstr "Ако вашите данни съдържат техническа или неподходяща информация, можете да ги скриете."
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "Organizza le Question"
+msgstr "Организирайте въпроси"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "Hai molte Question salvate in {0}? Crea collezioni per aiutare a gestirle e aggiungi il contesto."
+msgstr "Имате ли много запазени въпроси в {0}? Създавайте колекции, за да помогнете за управлението им и да добавите контекст."
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7561,1694 +7557,1694 @@ msgstr "Hai molte Question salvate in {0}? Crea collezioni per aiutare a gestirl
 #: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
 #: src/metabase/email/messages.clj
 msgid "Metabase"
-msgstr "Metabase"
+msgstr "Метабаза"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "Crea metriche"
+msgstr "Създайте показатели"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "Stabilisce metriche canoniche per rendere più facile ottenere le giuste risposte agli altri membri del tuo gruppo"
+msgstr "Дефинирайте канонични показатели, за да улесните останалите от вашия екип да получат правилните отговори."
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "Crea segmenti"
+msgstr "Създайте сегменти"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "Mantieni ognuno sulla stessa pagina creando insiemi canonici di filtri che ognuno può utilizzare quando interroga"
+msgstr "Дръжте всички на една и съща страница, като създавате канонични набори от филтри, които всеки може да използва, докато задава въпроси."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "La tabella \"{0}\" è ora visibile. Risincronizza."
+msgstr "Таблица „{0}“ вече е видима. Пресинхронизиране."
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "intervallo automatico"
+msgstr "Автоматично кошче"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "nessun intervallo"
+msgstr "Не бин"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "Giorno"
-msgstr[1] "Giorni"
+msgstr[0] "Ден"
+msgstr[1] "Дни"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "Minuto"
-msgstr[1] "Minuti"
+msgstr[0] "Минута"
+msgstr[1] "Минути"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "Ora"
-msgstr[1] "Ore"
+msgstr[0] "Час"
+msgstr[1] "Часове"
 
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "Trimestre"
-msgstr[1] "Trimestri"
+msgstr[0] "Тримесечие"
+msgstr[1] "Тримесечия"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "Minute dell'ora"
+msgstr "Минута час"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "Ore del giorno"
+msgstr "Час на деня"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "Giorno della settimana"
+msgstr "Ден на седмицата"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "Giorno del mese"
+msgstr "Ден на месеца"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "Giorno dell'anno"
+msgstr "Ден на годината"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "Settimana dell'anno"
+msgstr "Седмица от годината"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "Mese dell'anno"
+msgstr "Месец на годината"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "Trimestre dell'anno"
+msgstr "Квартал на годината"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10 bidoni"
+msgstr "10 кошчета"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50 bidoni"
+msgstr "50 кошчета"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100 bidoni"
+msgstr "100 кошчета"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "intervalla ogni 0.1 gradi"
+msgstr "Кошче на всеки 0,1 градуса"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "intervalla ogni 1 grado"
+msgstr "Кошче на всеки 1 градус"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "intervalla ogni 10 gradi"
+msgstr "Кошче на всеки 10 градуса"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "intervalla ogni 20 gradi"
+msgstr "Кошче на всеки 20 градуса"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "Nessun Image Writer appropriato trovato!"
+msgstr "Не е намерен подходящ писател на изображения!"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "Indirizzo email già utilizzato"
+msgstr "Имейл адресът вече се използва."
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "Indirizzo email già associato ad un altro utente."
+msgstr "Имейл адрес, вече свързан с друг потребител."
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "Non è possibile riattivare un utente attivo"
+msgstr "Не е в състояние да активира отново активен потребител"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "Password non valida"
+msgstr "Невалидна парола"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "Tutto {0}"
+msgstr "Всички {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}, tutto {1}"
+msgstr "{0}, всички {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "Confronto di {0} e {1}"
+msgstr "Сравнение на {0} и {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "Dashboard di confronto generato automaticamente che confronta {0} e {1}"
+msgstr "Автоматично генерирано табло за сравнение, сравняващо {0} и {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "somma"
+msgstr "сума"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "media"
+msgstr "средно аритметично"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "minimo"
+msgstr "минимум"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "massimo"
+msgstr "максимум"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "distinct count"
-msgstr "conta distinti"
+msgstr "отчетлив брой"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "deviazione standard"
+msgstr "стандартно отклонение"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "conta comulato"
+msgstr "кумулативен брой"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "somma cumulata"
+msgstr "кумулативна сума"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0} e {1}"
+msgstr "{0} и {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{0} di {1}"
+msgstr "{0} от {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{0} per {1}"
+msgstr "{0} от {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{0} nel segmento di {1}"
+msgstr "{0} в сегмента {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "{0} segmento"
+msgstr "{0} сегмент"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "{0} metrica"
-msgstr[1] "{0} metriche"
+msgstr[0] "{0} метричен показател"
+msgstr[1] "{0} метрични показатели"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "{0} campo"
+msgstr "Поле {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "\"{0}\" question"
+msgstr "Въпрос „{0}“"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "Confronta con {0}"
+msgstr "Сравнете с {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "Confronta con l'intero dataset"
+msgstr "Сравнете с целия набор от данни"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "Applicando l'euristico %s a %s."
+msgstr "Прилагане на евристична% s към% s."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "Dimensioni delle associazioni: n%s"
+msgstr "Размери обвързвания: n% s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "Utilizzando le definizioni::nMetrics:n%snFilters:n%s"
+msgstr "Използване на дефиниции: nMetrics: n% sn Филтри: n% s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "Non posso creare la dashboard per {0}"
+msgstr "Не мога да създам табло за управление за {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "{0}primo"
+msgstr "{0} ул"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "{0}secondo"
+msgstr "{0} и"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "{0}terzo"
+msgstr "{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0}mo"
+msgstr "{0} th"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "a {0}"
+msgstr "в {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "su {0}"
+msgstr "на {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "in {0} settimane - {1}"
+msgstr "след {0} седмица - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "in {0}"
+msgstr "в {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "in Q{0} - {1}"
+msgstr "в Q {0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "Q{0}"
+msgstr "В {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0} è {1}"
+msgstr "{0} е {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "0} è tra {1} e {2}"
+msgstr "{0} е между {1} ​​и {2}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "0} è tra {1} e {2}; e {3} è tra {4} e {5}"
+msgstr "{0} е между {1} ​​и {2}; и {3} е между {4} и {5}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "dove {0}"
+msgstr "където {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "Uno sguardo più da vicino a {0}"
+msgstr "По-подробен поглед към {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "Uno sguardo più da vicino al {0}"
+msgstr "По-подробен поглед към {0}"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "Aggiungendo %s cards alla dashboard %s:n%s"
+msgstr "Добавяне на% s карти към таблото за управление% s: n% s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
-msgstr "0 <= punteggio <= {0}"
+msgstr "0 <= резултат <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= larghezza <= {0}"
+msgstr "1 <= ширина <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "Riferimenti di metrica validi"
+msgstr "Валидни референции за показатели"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "Riferimenti validi per i filtri"
+msgstr "Валидни препратки към филтри"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "Riferimenti validi per il raggruppamento"
+msgstr "Валидни препратки към групата"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "Riferimenti validi per order_by"
+msgstr "Валиден ред_ по препратки"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "Riferimenti validi per i filtri della dashboard"
+msgstr "Валидни справки за филтри на таблото за управление"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "Riferimenti validi per la dimensione"
+msgstr "Валидни препратки към измерения"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "Riferimenti validi per la dimensione "
+msgstr "Валидни референтни размери на картата"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "Errore nel parsing %s:n%s"
+msgstr "Грешка при синтактичния анализ на% s: n% s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "Nessun utente trovato con l'indirizzo email \"{0}\""
+msgstr "Не е намерен потребител с имейл адрес „„ {0} “."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "Per favore verifica lo spelling e prova ancora."
+msgstr "Моля, проверете правописа и опитайте отново."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "Sto resettando la password per {0}"
+msgstr "Нулиране на парола за {0} ..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
-msgstr "OK [[[{0}]]]"
+msgstr "ОК [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "FALLITO [[[{0}]]]"
+msgstr "FAIL [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Per favore usare il seguente URL per settare l'installazione di Metabase:"
+msgstr "Моля, използвайте следния URL, за да настроите вашата инсталация на Metabase:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Metabase si sta spegnendo"
+msgstr "Изключване на метабазата ..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabase si è spento completamente"
+msgstr "Изключване на метабазата ПЪЛНО"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Metabase versione {0} in avvio ..."
+msgstr "Стартира се версия на Metabase {0} ..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "La timezone di sistema è \"{0}\" ..."
+msgstr "Системната часова зона е „{0}“ ..."
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Prepariamo e migriamo il database di Metabase"
+msgstr "Настройка и мигриране на Metabase DB. Моля, седнете здраво, това може да отнеме минута ..."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "Sembra che questa sia una nuova installazione... prepariamo il wizard di setup"
+msgstr "Изглежда, че това е нова инсталация ... подготвяне на съветника за настройка"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Inizializzazione Metabase COMPLETA"
+msgstr "Инициализация на метабаза ИЗПЪЛНЕНА"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "Lanciando il Webserver Jetty Embedded"
+msgstr "Стартиране на Embedded Jetty Webserver с config:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "Shutting down il Webserver Jetty Embedded"
+msgstr "Изключване на вградения уеб сървър на Jetty"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "Start di Metabase in STANDALONE mode"
+msgstr "Стартиране на Metabase в режим STANDALONE"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "Inizializzazione di Metabase FALLITA"
+msgstr "Инициализирането на метабаза НЕ Е УСПЕШНО"
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "Il database ha un lock di migrazione; non è possibile lanciare migrazioni"
+msgstr "Базата данни има заключване за миграция; не може да изпълнява миграции."
 
 #: src/metabase/db/liquibase.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "Puoi forzare il rilascio di questi vincoli tramite `java -jar metabase.jar migrate release-locks`."
+msgstr "Можете да освободите тези ключалки принудително, като стартирате `java -jar metabase.jar migrate release-locks`."
 
 #: src/metabase/db/liquibase.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "Verifica se il Database ha migrazioni non eseguite"
+msgstr "Проверка дали базата данни има неизпълнени миграции ..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "Il Database ha migrazioni non eseguite. Attendere che il blocco migrazione sia cancellato..."
+msgstr "Базата данни има неизпълнени миграции. Изчаква се заключването на миграцията да бъде изчистено ..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "Il blocco della migrazione è cancellato. Esecuzione migrazioni ..."
+msgstr "Заключването на миграцията е изчистено. Изпълняват миграции ..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "vincoli di migrazione ripuliti, ma non c'è nulla da fare qui! Le migrazioni sono state terminate da un'altra istanza."
+msgstr "Заключването на миграцията е изчистено, но тук няма какво да се прави! Миграциите бяха завършени от друга инстанция."
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Settando Liquibase"
+msgstr "Настройване на Liquibase ..."
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibase è pronto"
+msgstr "Liquibase е готов."
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "Verifica {0} Database Connection ..."
+msgstr "Проверка на {0} връзка с база данни ..."
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "Verifica delle Connessioni al database..."
+msgstr "Проверка на връзката с база данни ..."
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Migrazione Database in corso"
+msgstr "Изпълняват се миграции на база данни ..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "Migrazione Database corrente ..."
+msgstr "Текущи миграции на база данни ..."
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "Mmm, non abbiamo potuto connetterci al database"
+msgstr "Хм, не успяхме да се свържем с базата данни."
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "Verifica che host e porte siano settate correttamente"
+msgstr "Уверете се, че настройките на вашия хост и порт са правилни"
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "Non abbiamo potuto connetterci al host del tunnel ssh"
+msgstr "Не успяхме да се свържем с ssh тунелния хост."
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "Verifica username e password."
+msgstr "Проверете потребителското име, паролата."
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "Controlla l'hostname e la porta"
+msgstr "Проверете името на хоста и порта."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "Sembra che il nome del database non sia corretto"
+msgstr "Изглежда името на базата данни е неправилно."
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "Sembra che il tuo host non sia valido."
+msgstr "Изглежда вашият хост е невалиден."
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "Per favore fare una doppia verifica e provare ancora"
+msgstr "Моля, проверете го отново и опитайте отново."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "Sembra che la tua password sia errata."
+msgstr "Изглежда паролата ви е неправилна."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "Sembra che hai dimenticato di inserire la tua password"
+msgstr "Изглежда сте забравили да въведете паролата си."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "Sembra che il tuo username non sia corretto"
+msgstr "Изглежда потребителското ви име е неправилно."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "Sembra che username e password siano incorretti"
+msgstr "Изглежда потребителското име или паролата са неправилни."
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "Timezone da usare quando si eseguino le query. Il default è la timezone di sistema"
+msgstr "Часова зона на връзката, която да се използва при изпълнение на заявки. По подразбиране системната часова зона."
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "Driver registrati {0} {1}"
+msgstr "Регистриран драйвер {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "Nessuna funzione -init-driver trovata per \"{0}\""
+msgstr "Не е намерена функция -init-driver за „{0}“"
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "Impossibile adattare la stringa data \"{0}\" per il sistema base di dati \"{1}\""
+msgstr "Не може да се анализира низа на дата '' {0} '' за механизма на базата данни '' {1} ''"
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "Non si riesce a mappare la classe \"{0}\" ad un Campo base_type, ritorno a :type/*."
+msgstr "Не знам как да свържа клас '' {0} '' с поле base_type, връщайки се към: type / *."
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "Connessione fallita al database {0}"
+msgstr "Неуспешно свързване с база данни: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "Idendificatore BigQuery non valido: \"{0}\""
+msgstr "Невалиден идентификатор на BigQuery: „„ {0} “"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "L'istruzione BigQuery non può essere parametrizzata!"
+msgstr "Операторите на BigQuery не могат да бъдат параметризирани!"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "Impostazione timezone fallita:"
+msgstr "Неуспешно задаване на часовата зона:"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Devi abilitare le Google Analytics API. Usa questo link per accedere alla Google Developers Console: {0}"
+msgstr "Трябва да активирате API на Google Analytics. Използвайте тази връзка, за да отворите конзолата на Google Developers: {0}"
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "è vietato utilizzare query SQL per database H2 mediante l'utente database di default (admin)"
+msgstr "Изпълнението на SQL заявки срещу H2 бази данни с използване на потребител на база данни (администратор) по подразбиране е забранено."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "Errore: metabase.driver.FixedHiveDriver è registrato, ma sembra che JDBC non lo stia usando."
+msgstr "Грешка: metabase.driver.FixedHiveDriver е регистриран, но JDBC изглежда не го използва."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "Trovato metabase.driver.FixedHiveDriver."
+msgstr "Намерен metabase.driver.FixedHiveDriver."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "Registrato con successo il metabase.driver.FixedHiveDriver con JDBC."
+msgstr "Успешно регистриран metabase.driver.FixedHiveDriver с JDBC."
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "L'indirizzo email che vuoi usare come mittente di Metabase"
+msgstr "Имейл адрес, който искате да използвате като подател на Metabase."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "L'indirizzo del server SMTP che invia le tue email."
+msgstr "Адресът на SMTP сървъра, който обработва имейлите ви."
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "Username SMTP"
+msgstr "SMTP потребителско име."
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "Password SMTP"
+msgstr "SMTP парола."
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "La porta che il server SMTP usa per le email outgoing"
+msgstr "Портът, който вашият SMTP сървър използва за изходящи имейли."
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "Protocollo SMTP sicuro (tls, ssl, starttls, o nessuno)"
+msgstr "SMTP протокол за защитена връзка. (tls, ssl, starttls или няма)"
 
 #: src/metabase/email.clj
 msgid "none"
-msgstr "nessuno"
+msgstr "нито един"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "L'host SMTP non è settato"
+msgstr "SMTP хост не е зададен."
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "L'invio email è fallito"
+msgstr "Изпращането на имейл не бе успешно"
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "Errore nel test della connessione SMTP"
+msgstr "Грешка при тестване на SMTP връзка"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "Abilitare autenticazione LDAP"
+msgstr "Активирайте LDAP удостоверяване."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "Hostname server"
+msgstr "Име на хост на сървъра."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "Porta server, normalmente 389 o 636, se si usa SSL"
+msgstr "Порт на сървъра, обикновено 389 или 636, ако се използва SSL."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "Usa SSL, TLS o testo in chiaro"
+msgstr "Използвайте SSL, TLS или обикновен текст."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "Il Nome Unificativo da associare (se presente), questo utente verrà utilizzato per gestire le informazioni sugli altri utenti."
+msgstr "Отличителното име, което да се обвърже като (ако има такова), този потребител ще се използва за търсене на информация за други потребители."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "La password da associare per il gestore."
+msgstr "Паролата, с която да се свържете за потребителя за търсене."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "Ricerca base per utenti (verrà fatta ricorsivamente)"
+msgstr "База за търсене на потребители. (Ще бъде търсено рекурсивно)"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "filtri di ricerca utente, il segnaposto '{login}' verrà rimpiazzato dall'utente autenticato"
+msgstr "Потребителски филтър за търсене, заместителят „{login}“ ще бъде заменен от предоставения от потребителя вход."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "Attributo per usare l'email dell'utente. (solitamente \"mail\", \"email\" o \"userPrincipalName\")"
+msgstr "Атрибут, който да се използва за имейла на потребителя. (обикновено '' mail '', '' email '' или '' userPrincipalName '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "Attributo da utilizzare per il nome dell'utente (generalmente \"givenName\")"
+msgstr "Атрибут, който да се използва за собственото име на потребителя. (обикновено '' givenName '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "Attributo da utilizzare per il cognome dell'utente (generalmente \"sn\")"
+msgstr "Атрибут, който да се използва за фамилното име на потребителя. (обикновено '' sn '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "Abilita la sincronizzazione dei gruppi di utenze con LDAP"
+msgstr "Активирайте синхронизирането на членството в група с LDAP."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "Ricerca base per gruppi, non è richiesta se la tua cartella LDAP fornisce uno strato \"memberOf\". (ricercherà ricorsivamente)"
+msgstr "База за търсене на групи, не се изисква, ако вашата LDAP директория предоставя наслагване '' memberOf ''. (Ще бъде търсено рекурсивно)"
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "JSON contiene le mappature di LDAP ai gruppi Metabase."
+msgstr "JSON, съдържащ съпоставяния на LDAP към Metabase група."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "token di trasporto delle API Slack ottenuto da https://api.slack.com/web#authentication"
+msgstr "Slack API носител токен, получен от https://api.slack.com/web#authentication"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "Abilita MetaBot, per effettuare le tue ricerche e vedere le domande salvate direttamente tramite Slack"
+msgstr "Активирайте MetaBot, който ви позволява да търсите и преглеждате запазените си въпроси директно чрез Slack."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "L'ultima controllo MetaBot è stato {0} fa."
+msgstr "Последното означаване на MetaBot беше преди {0}."
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "Questa istanza ora gestirà i compiti di MetaBot."
+msgstr "Този екземпляр вече ще обработва задълженията на MetaBot."
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "Ecco cosa posso {0}:"
+msgstr "Ето какво мога {0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "Non so come {0} `{1}` .n{2}"
+msgstr "Не знам как да {0} „{1}` .n {2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr "Uh oh! :piangi:n> {0}"
+msgstr "Ъъъ! : cry: n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "Ecco le tua {0} più recenti cards:n{1}"
+msgstr "Ето вашите {0} най-скорошни карти: n {1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "Potresti essere un po' più preciso? Ho trovato queste cards con nomi corrispondenti:n{0}"
+msgstr "Бихте ли могли да бъдете малко по-конкретни? Намерих тези карти с имена, които съвпадат: n {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "Non so cos'è la Card `{0}`. Dammi un Card ID o il nome"
+msgstr "Не знам какво е Карта „{0}“. Дайте ми ИД на карта или име."
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "Quale carta visualizzare? Dammi una parte di nome o ID e te la mostro. Se non sai quale carta vuoi visualizzare prova la `lista di metabot`"
+msgstr "Покажете коя карта? Дайте ми част от името на картата или нейния идентификационен номер и мога да ви го покажа. Ако не знаете коя карта искате, опитайте `metabot list`."
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "Ok, solo un secondo ..."
+msgstr "Добре, само секунда ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "Non trovato"
+msgstr "Не е намерен"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "Carica le citazioni di Kanye"
+msgstr "Зареждането на цитати на Kanye ..."
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "Valutazione comando Metabot:"
+msgstr "Оценяване на командата Metabot:"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "Vai a casa websocket, sei ubriaco."
+msgstr "Върнете се вкъщи, вие сте пиян."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "Errore lanciando il metabot:"
+msgstr "Грешка при стартиране на метабот:"
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "Il MetaBot WebSocket è chiuso. Riconnessione ora."
+msgstr "MetaBot WebSocket е затворен. Повторно свързване сега."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "Errore connettendo il websocket:"
+msgstr "Грешка при свързването на websocket:"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "Questa istanza sta eseguendo i compiti di MetaBot."
+msgstr "Този екземпляр изпълнява задълженията на MetaBot."
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "Un'altra istanza stra gestendo i compiti di MetaBot."
+msgstr "Друг екземпляр вече се справя със задълженията на MetaBot."
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "Avvio dei thread di MetaBot..."
+msgstr "Стартиране на нишки на MetaBot ..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "Arresto di MetaBot..."
+msgstr "Спиране на MetaBot ... 🤖"
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBot è già avviato. Ferma prima il precedente WebSocket listener."
+msgstr "MetaBot вече работи. Първо убиване на предишния слушател на WebSocket."
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "Chiave pubblica a codifica Base-64 per il certificato SSL di questo sito"
+msgstr "Публичен ключ, кодиран в Base-64 за SSL сертификата на този сайт."
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "Specificalo per abilitare il Pinning della chiave pubblica HTTP"
+msgstr "Посочете това, за да активирате закрепването на HTTP публичен ключ."
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "Vedi {0} per ulteriori informazioni."
+msgstr "Вижте {0} за повече информация."
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "Non puoi salvare la Domanda: la query ha riferimenti circolari"
+msgstr "Въпросът не може да бъде запазен: заявката за източник има циркулярни препратки."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "La Carta {0} non esiste."
+msgstr "Карта {0} не съществува."
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "Non possiedi i permessi per eseguire query native sul database {0}."
+msgstr "Нямате разрешения за изпълнение на ad-hoc естествени заявки срещу база данни {0}."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "Colore non valido"
+msgstr "Невалиден цвят"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "deve essere un colore con codice hex di 6 caratteri"
+msgstr "трябва да е валиден 6-знаков шестнадесетичен цветен код"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "Il nome della collezione non può essere vuoto!"
+msgstr "Името на колекцията не може да бъде празно!"
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "non può essere vuoto"
+msgstr "не може да остане празно"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "locazione della Collezione non valida: percorso non valido"
+msgstr "Невалидно местоположение на колекцията: пътят е невалиден."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "Non puoi muovere una Collezione Personale"
+msgstr "Не можете да преместите Лична колекция."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "locazione della Collezione non valida: alcuni degli ancestori non esistono"
+msgstr "Невалидно местоположение на колекцията: някои или всички предци не съществуват."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "Non puoi archiviare la Collezione Root"
+msgstr "Не можете да архивирате Root Collection."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "Non puoi archiviare la Collezione Personale"
+msgstr "Не можете да архивирате Лична колекция."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "Non puoi spostare la Collezione Root"
+msgstr "Не можете да преместите Root Collection."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "Non puoi spostare una Collezione dentro se stessa o in una discendente da se stessa."
+msgstr "Не можете да преместите колекция в себе си или в един от нейните потомци."
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "Sto spostando la Collezione {0} e le proprie discendenti da {1} a {2}"
+msgstr "Преместване на колекция {0} и нейните потомци от {1} в {2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "Non sei autorizzato a cambiare il proprietario di una Collezione Personale."
+msgstr "Нямате право да променяте собственика на лична колекция."
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "Non sei autorizzatio a spostare una Collezione Personale."
+msgstr "Нямате право да премествате лична колекция."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "Non puoi spostare una collezione e archiviarla allo stesso tempo."
+msgstr "Не можете да премествате колекция и да я архивирате едновременно."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "Non puoi cancellare una Collezione Personale!"
+msgstr "Не можете да изтриете Лична колекция!"
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "{0} {1} è una Collezione Personale"
+msgstr "Лична колекция на {0} {1}"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "Non puoi aggiornare una Revisione di una Collezione!"
+msgstr "Не можете да актуализирате CollectionRevision!"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "Il campo {0} è stato impostato prima automaticamente per visualizzare una lista di widget ma adesso ha {1} valori."
+msgstr "Полето {0} по-рано беше автоматично зададено да показва приспособление за списък, но сега има стойности {1}."
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "Cambia il campo per usare lo strumento di ricerca"
+msgstr "Превключване на полето, за да се използва вместо това джаджа за търсене."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "Memorizzo i valori aggornati per il Campo {0}..."
+msgstr "Съхраняване на актуализирани FieldValues ​​за поле {0} ..."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "In registrazione il valore per il campo {0}..."
+msgstr "Съхраняване на FieldValues ​​за поле {0} ..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabase può tentare di trasformare i nomi della tua tabella e dei campi in una versione più umana, esempio \"somehorriblename\" diventa \"Some Horrible Name\""
+msgstr "Metabase може да се опита да трансформира имената на вашите таблици и полета в по-разумни, разбираеми за човека версии, напр. „Somehorriblename“ става „Some Horrible Name“."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "In ogni caso, non è garantito che funzioni bene se i nomi non sono in inglese."
+msgstr "Това обаче не работи толкова добре, ако имената са на език, различен от английския, обаче."
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "Vuoi che indoviniamo?"
+msgstr "Искате ли да предположим?"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "Non puoi creare o revocare permessi per il gruppo `Admin`"
+msgstr "Не можете да създавате или отменяте разрешения за групата „Администратор“."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "permessi non validi per il percorso: \"{0}\""
+msgstr "Невалиден път на обекта за разрешения: „„ {0} “."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "Non puoi modificare un campo di permessi!"
+msgstr "Не можете да актуализирате запис за разрешения!"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "Cancellalo e creane uno nuovo."
+msgstr "Изтрийте го и създайте нов."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "Non puoi modificare i permessi per una Collezione Personale o sue discendenti."
+msgstr "Не можете да редактирате разрешения за Лична колекция или нейните потомци."
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "Sembra che qualcun altro abbia modificato i permessi ed i tuoi dati siano scaduti."
+msgstr "Изглежда някой друг е редактирал разрешенията и данните ви са остарели."
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "Per favore controlla i nuovi dati e riprova."
+msgstr "Моля, извлечете нови данни и опитайте отново."
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "Creato il magico gruppo di permessi \"{0}\" (ID = {1})"
+msgstr "Създадена магическа група разрешения „{0}“ (ID = {1})"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "Un gruppo con questo nome è già presente."
+msgstr "Група с това име вече съществува."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "Non puoi modificare o eliminare i permessi del gruppo \"{0}\" "
+msgstr "Не можете да редактирате или изтривате групата с разрешения '' {0} ''!"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "Non puoi aggiungere né rimuovere utenti dal gruppo `MetaBot`."
+msgstr "Не можете да добавяте или премахвате потребители към / от групата „MetaBot“."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "Non puoi aggiungere né rimuovere utenti dal gruppo `Tutti gli Utenti`."
+msgstr "Не можете да добавяте или премахвате потребители към / от групата „Всички потребители“."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "Non puoi rimuovere l'ultimo utente del gruppo `Amministratori`."
+msgstr "Не можете да премахнете последния член на групата \"Администратор\"!"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "Non puoi aggiornare una Revisione di Permessi."
+msgstr "Не можете да актуализирате PermissionsRevision!"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "Allarme non valido: non ha una Carta associata."
+msgstr "Невалидно предупреждение: Alert няма карта, свързана с него"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "Il valore deve essere una mappa con le chiavi  `{0}`, `{1}` e `{2}`."
+msgstr "стойността трябва да е карта с ключовете \"{0}\", \"{1}\" и \"{2}\"."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "Il valore deve essere una mappa con le seguenti chiavi  `{0}`"
+msgstr "стойност трябва да е карта със следните ключове `({0})`"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "Errore nell'elaborazione dei permessi per la query: {0}"
+msgstr "Грешка при изчисляването на разрешенията за заявка: {0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "Tipo di query non valido: {0}"
+msgstr "Невалиден тип заявка: {0}"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "Non puoi aggiornare una Esecuzione di Query!"
+msgstr "Не можете да актуализирате QueryExecution!"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "Non puoi aggiornare una Revisione!"
+msgstr "Не можете да актуализирате Ревизия!"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "Impostazione {0} non esiste. nTrovato: {1}"
+msgstr "Настройката {0} не съществува. NFound: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "Aggiornamento del valore dei settings-last-updated nel DB..."
+msgstr "Актуализиране на стойността на настройките, последно актуализирани в DB ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "Controlla se le impostazioni in cache sono scadute (con chiamata al DB)"
+msgstr "Проверка дали кешът за настройки е остарял (изисква обаждане в DB) ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "Le impostazioni sono stata modificate su un'altra istanza, e saranno ricaricate qui."
+msgstr "Настройките са променени в друг екземпляр и ще бъдат презаредени тук."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "Ricaricamento delle impostazioni di cache..."
+msgstr "Опресняване на кеша за настройки ..."
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "Stringa non valida: deve essere o \"true\" o \"false\" (case-insensitive)."
+msgstr "Невалидна стойност за низ: трябва да бъде или „true“, или „false“ (без регистрация)."
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "Non puoi aggiornare  `settings-last-updated` direttamente! Verrà fatto automaticamente."
+msgstr "Не можете сами да актуализирате `settings-last-updated`! Това се прави автоматично."
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "Errore nell'inserire una nuova Impostazione:"
+msgstr "Грешка при вмъкването на нова настройка:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "Presupposto che Setting esiste già nel DB e aggiornando il valore esistente."
+msgstr "Ако приемем, че вече съществува настройка в DB и актуализиране на съществуваща стойност."
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "il valore deve essere una mappa per ogni valore che sia una stringa che un numero."
+msgstr "стойност трябва да бъде карта с всяка стойност или низ или число."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "Caricamento dei plugins nella cartella {0}..."
+msgstr "Зареждат се приставки в директория {0} ..."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "Caricamento plugin {0}..."
+msgstr "Приставката за зареждане {0} ..."
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Sembra che non hai alcune dipendenze esterne nella cartella di plugin di Metabase."
+msgstr "Изглежда, че имате някои външни зависимости в директорията на вашите приставки Metabase."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Con Java 9 o superiore, Metabase non può aggiungerli automaticamente nel tuo classpath."
+msgstr "С Java 9 или по-нова версия, Metabase не може автоматично да ги добавя към вашия път на класа."
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "Invece, dovresti includerli all'avvio con l'opzione -op. Per esempio:"
+msgstr "Вместо това трябва да ги включите при стартиране с опцията -cp. Например:"
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "Per maggiori dettagli, visita https://metabase.com/docs/latest/operations-guide/start.html#java-versions."
+msgstr "Вижте https://metabase.com/docs/latest/operations-guide/start.html#java-versions за повече подробности."
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "(Se stai già eseguendo Metabase in questa maniera, puoi ignorare questo messaggio.)"
+msgstr "(Ако вече използвате Metabase по този начин, можете да игнорирате това съобщение.)"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Identifica quando le nuove versioni di Metabase sono disponibili."
+msgstr "Определете кога са налични нови версии на Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Informazioni sulle versioni disponibili di Metabase."
+msgstr "Информация за наличните версии на Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "Nome utilizzato per questa istanza di Metabase"
+msgstr "Името, използвано за този екземпляр на Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "URL base di questa istanza di Metabase. es.  \"http://metabase.my-company.com\"."
+msgstr "Основният URL адрес на този екземпляр на Metabase, например \"http://metabase.my-company.com\"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "La lingua principale per questa istanza di Metabase."
+msgstr "Езикът по подразбиране за този екземпляр на Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "Questo sarà applicato solo alle email, Picchi, etc. Il browser specificherà la lingua utilizzata nell'interfaccia utente."
+msgstr "Това се отнася само за имейли, импулси и др. Потребителските браузъри ще посочат езика, използван в потребителския интерфейс."
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "L'indirizzo email di riferimento in caso di incontro di un problema."
+msgstr "Потребителите на имейл адреси трябва да бъдат насочени, ако срещнат проблем."
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Consenti di raccogliere anonimamente l'utilizzo dei dati per aiutarci a migliorare Metabase."
+msgstr "Активирайте събирането на анонимни данни за използване, за да помогнете на Metabase да се подобри."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "Il template URL del map tile server usato nelle visualizzazioni della mappa, per esempio da OpenStreetMaps o MapBox."
+msgstr "Шаблонът за URL адрес на сървъра за плочки на карта, използван при визуализации на карти, например от OpenStreetMaps или MapBox."
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "Abilita gli amministratori per creare link di visualizzazione pubblica (ed iframes integrabili) per Domande e Dashboard?"
+msgstr "Да се ​​разреши ли на администраторите да създават обществено видими връзки (и вграждащи се рамки) за Въпроси и табла за управление?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "Consentire agli amministratori di integrare in sicurezza domande e dashboard all'interno di altre applicazioni?"
+msgstr "Да се ​​разреши ли на администраторите да вграждат сигурно въпроси и табла за управление в други приложения?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "Consentire di utilizzare le domande salvate come sorgente per altre query?"
+msgstr "Да се ​​разреши ли използването на запазен въпрос като източник за други заявки?"
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "Abilitare la cache consentirà di salvare i risultati delle query che richiedono un lungo tempo di esecuzione"
+msgstr "Активирането на кеширането ще запази резултатите от заявките, които се изпълняват дълго време."
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "La dimensione massima della cache, per domanda salvata, in kilobytes:"
+msgstr "Максималният размер на кеша за всеки запазен въпрос в килобайта:"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "Il tempo massimo assoluto (secondi) per gestire i risultati delle query in cache"
+msgstr "Абсолютното максимално време за запазване на всички кеширани резултати от заявка, в секунди."
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabase registrerà tutte le domande salvate con un tempo medio di esecuzione delle query superiore in secondi di:"
+msgstr "Metabase ще кешира всички запазени въпроси със средно време за изпълнение на заявката, по-дълго от толкова много секунди:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "Per determinare quanto tempo i risultati delle query devono restare in cache, prendiamo il tempo di esecuzione medio e lo moltiplichiamo per questo valore."
+msgstr "За да определим колко дълго трябва да остане кешираният резултат на всеки запазен въпрос, вземаме средното време за изпълнение на заявката и умножаваме по това, което въведете тук."
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "Così se una query impiega mediamente 2 minuti, impostando un moltiplicatore di 10, il suo risultato rimarrà in cache per 20 minuti."
+msgstr "Така че, ако заявката отнеме средно 2 минути, за да се изпълни и въведете 10 за вашия множител, въвеждането в кеша ще продължи 20 минути."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "Quando si utilizza la strategia degli intervalli predefinita e non viene fornito un numero di intervalli, questo numero verrà utilizzato come predefinito."
+msgstr "Когато се използва стратегията за разделяне по подразбиране и не се предоставят определен брой кошчета, този номер ще се използва като подразбиране."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "Quando si utilizza la strategia degli intervalli predefinita per un campo di tipo Coordinate (come Latitudine e Longitudine), questo numero verrà utilizzato come larghezza predefinita dell'intervallo (in gradi)."
+msgstr "Когато използвате стратегията за подреждане по подразбиране за поле от тип Coordinate (като Latitude и Longitude), този номер ще се използва като ширина на кошчето по подразбиране (в градуси)."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "Impossibile validare il token."
+msgstr "Не може да се провери маркера."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Errore nel recuperare lo stato del token:"
+msgstr "Грешка при извличане на състоянието на маркера:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "Si è verificato un errore durante il controllo della validità di questo token."
+msgstr "При проверката дали този маркер е валиден възникна грешка."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "Convalida del token scaduta."
+msgstr "Времето за валидиране на токена изтече."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "Token non valido: il token non è nel formato giusto."
+msgstr "Невалиден маркер: маркерът не е в правилния формат."
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "Controllo con il MetaStore per vedere se {0} è valido..."
+msgstr "Проверка с MetaStore дали {0} е валидна ..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "Token per l'incorporamento premium. Vai al MetaStore per ottenere il tuo!"
+msgstr "Токен за първокласно вграждане. Отидете в MetaStore, за да вземете своя!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "Il token è valido."
+msgstr "Токенът е валиден."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "Errore nell'installazione dell'incorporamento premium"
+msgstr "Грешка при задаване на премиум маркер за вграждане"
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "Impossibile confrontare il risultato con l'obiettivo per l'avviso."
+msgstr "Не може да се сравнят резултатите с целта за предупреждение."
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "L'ID della domanda è ''{0}'' con le impostazioni di visualizzazione ''{1}''"
+msgstr "Идентификаторът на въпроса е „{0}“ „с настройки за визуализация“ „{1}“"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "Avviso non riconosciuto con condizione \"{0}\""
+msgstr "Неразпознат сигнал с условие „{0}“"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "Tipo di canale {0} non riconosciuto"
+msgstr "Неразпознат тип канал {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "Errore nell'inviare la notifica!"
+msgstr "Грешка при изпращане на известие!"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "Impossibile trovare il selettore di colori JS a ''{0}''"
+msgstr "Не мога да намеря селектора за цвят на JS в „„ {0} “"
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "La carta ha errori: {0}"
+msgstr "Картата има грешки: {0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "Errore di rendering della carta a impulsi"
+msgstr "Грешка при изобразяване на импулсна карта"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "Ritaglio del commento finale dalla carta con ID {0}"
+msgstr "Изрязване на последващ коментар от карта с идентификатор {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "Non si trova il campo con ID: {0}"
+msgstr "Не може да се намери поле с идентификатор: {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "\"{0}\" è un campo richiesto."
+msgstr "„{0}“ е задължителен параметър."
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "Trovato \"{0}\" senza terminazione \"{1}\" nella query \"{2}\""
+msgstr "Намерен „„ {0} “„ без край на „„ {1} “„ в заявката „„ {2} “"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "Impossibile di sostituire \"{0}\": parametro non specificato.nTrovato: {1}"
+msgstr "Не може да се замени '' {0} '': параметърът не е посочен.nFound: {1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "Non possiedi i permessi per visualizzare Card {0}."
+msgstr "Нямате разрешения за преглед на карта {0}."
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "Non hai i permessi per eseguire questa query."
+msgstr "Нямате разрешения за изпълнение на тази заявка."
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "Aggiornamento Impronta eseguita {0}, aggiornata {1}, nessun dato trovato {2}, fallito {3}."
+msgstr "Опит за актуализации на пръстови отпечатъци {0}, актуализиран {1}, няма намерени данни {2}, неуспешен {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "Numero totale di campi classificati {0}, {1} falliti"
+msgstr "Общият брой на класифицираните полета {0}, {1} е неуспешен"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "Numero totale di tabelle classificate {0}, modificate {1}"
+msgstr "Общ брой класифицирани таблици {0}, {1} актуализирани"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "Errore nel generare l'impronta per {0}"
+msgstr "Грешка при генерирането на пръстов отпечатък за {0}"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "Aggiornati {0} campi set di valore, creati {1}, rimossi {2} con {3} errori."
+msgstr "Актуализирани {0} набори от стойности на полета, създадени {1}, изтрити {2} с {3} грешки"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "Numero totale di campi: sincronizzati {0}, aggiornati {1}"
+msgstr "Общ брой полета, синхронизирани {0}, брой полета актуализирани {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "Numero totale di tabelle: sincronizzate {0}, aggiornate {1}"
+msgstr "Общ брой таблици, синхронизирани {0}, брой таблици актуализирани {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "Trovato timezone id {0}"
+msgstr "Намерен идент. № на часовата зона {0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "Numero totale di chiavi esterne sincronizzate {0}, aggiornate {1}, {2} tabelle fallite durante l'aggiornamento."
+msgstr "Общият брой синхронизирани външни ключове {0}, {1} актуализирани и {2} таблици не успяха да се актуализират"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
-msgstr "{0} Database {1} \"{2}\""
+msgstr "{0} База данни {1} „„ {2} “"
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "Tabella {0} \"{1}\""
+msgstr "Таблица {0} „{1}“"
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "Campo {0} \"{1}\""
+msgstr "Поле {0} „{1}“"
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "Campo {0}"
+msgstr "Поле „{0}“"
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "passo \"{0}\" per {1}"
+msgstr "стъпка „{0}“ за {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "Completati {0} su {1}"
+msgstr "Завършен {0} на {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "Inizio: {0}"
+msgstr "Начало: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "Fine: {0}"
+msgstr "Край: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "Durata: {0}"
+msgstr "Продължителност: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "Step completato \"{0}\""
+msgstr "Изпълнена стъпка „{0}“"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "Caricando lo spazio dei nomi delle attività:"
+msgstr "Зареждане на пространство от имена на задачи:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Schedulatore Quartz in avvio"
+msgstr "Стартиране на Quartz Scheduler"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Schedulatore Quartz in fase di arresto"
+msgstr "Спиране на кварцов планировчик"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "Il lavoro esiste già:"
+msgstr "Работата вече съществува:"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Caricamento in corso di Metabase..."
+msgstr "Зарежда се метабазата ..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "Possibile conflitto di fuso orario trovato nel database {0}."
+msgstr "Намерен е възможен конфликт на часовата зона в базата данни {0}."
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "Il fuso orario della JVM è {0} e il fuso orario rilevato del database è {1}."
+msgstr "Часовата зона на JVM е {0}, а установената часова зона на базата данни е {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configura un rapporto del fuso orario per garantire conversioni corrette di data e ora."
+msgstr "Конфигурирайте часовата зона на отчета, за да осигурите правилно преобразуване на дата и час."
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "Chiave segreta utilizzata per firmare Token Web JSON per le richieste agli endpoint `/ api / embed`."
+msgstr "Секретен ключ, използван за подписване на JSON Web Tokens за заявки за крайни точки `/ api / embed`."
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEY deve essere di almeno 16 caratteri."
+msgstr "MB_ENCRYPTION_SECRET_KEY трябва да съдържа поне 16 знака."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "La crittografia delle credenziali salvate è ABILITATA per questa istanza di Metabase."
+msgstr "Шифроването на запазените идентификационни данни е АКТИВИРАНО за този екземпляр на Metabase."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "La crittografia delle credenziali salvate è DISABILITATA per questa istanza di Metabase."
+msgstr "Шифроването на запазените идентификационни данни е ЗАБРАНЕНО за този екземпляр на Metabase."
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "nPer ulteriori informazioni, vedere"
+msgstr "nЗа повече информация вижте"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "il valore deve essere un numero intero."
+msgstr "стойност трябва да е цяло число."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "il valore deve essere una stringa."
+msgstr "стойност трябва да е низ."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a boolean."
-msgstr "il valore deve essere un booleano."
+msgstr "стойност трябва да е булева стойност."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "il valore deve essere una stringa che corrisponde all'espressione regolare '{0}'."
+msgstr "стойност трябва да е низ, който съответства на регулярния израз \"{0}\"."
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "il valore deve soddisfare uno dei seguenti requisiti: "
+msgstr "стойност трябва да отговаря на едно от следните изисквания:"
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "il valore potrebbe essere 0, o se non 0, {0}"
+msgstr "стойността може да е нула или ако не е нула, {0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "il valore deve essere uno di: {0}."
+msgstr "стойност трябва да е една от: {0}."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "il valore deve essere un array."
+msgstr "стойност трябва да е масив."
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "Ogni {0}"
+msgstr "Всеки {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "L'array non può essere vuoto"
+msgstr "Масивът не може да бъде празен."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "il valore non deve essere una stringa vuota."
+msgstr "стойност трябва да е непразен низ."
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "Numero intero maggiore di zero"
+msgstr "Цяло число по-голямо от нула"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "Il valore deve essere un numero intero maggiore di zero."
+msgstr "стойност трябва да е цяло число, по-голямо от нула."
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "Numero maggiore di zero"
+msgstr "Число по-голямо от нула"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "il valore deve essere un numero maggiore di zero."
+msgstr "стойност трябва да бъде число, по-голямо от нула."
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "Parola chiave o stringa"
+msgstr "Ключова дума или низ"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "Tipo di campo valido"
+msgstr "Валиден тип поле"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "il valore deve essere un tipo di campo valido"
+msgstr "стойност трябва да е валиден тип поле."
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "Tipo di campo valido (parola chiave o stringa)"
+msgstr "Валиден тип поле (ключова дума или низ)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "il valore deve essere un tipo di campo valido (parola chiave o stringa)"
+msgstr "стойност трябва да е валиден тип поле (ключова дума или низ)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "Tipo di entità valido (parola chiave o stringa)"
+msgstr "Валиден тип обект (ключова дума или низ)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "il valore deve essere un tipo di entità valido (parola chiave o stringa)."
+msgstr "стойност трябва да е валиден тип обект (ключова дума или низ)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "Mappa valida"
+msgstr "Валидна карта"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "il valore deve essere una mappa."
+msgstr "стойност трябва да е карта."
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "Indirizzo email valido"
+msgstr "Валиден имейл адрес"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "il valore deve essere un indirizzo email valido."
+msgstr "стойност трябва да е валиден имейл адрес."
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "Password non abbastanza robusta"
+msgstr "Недостатъчна сила на паролата"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "il valore deve essere un numero intero valido."
+msgstr "стойност трябва да е валидно цяло число."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "il valore deve essere un numero intero valido maggiore di zero."
+msgstr "стойност трябва да е валидно цяло число, по-голямо от нула."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "il valore deve essere una stringa booleana valida (\"true\" or \"false\")"
+msgstr "Стойността трябва да е валиден булев низ ('' true '' или '' false '')."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "il valore deve essere una stringa JSON valida."
+msgstr "стойността трябва да е валиден JSON низ."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid embedding params map."
-msgstr "Il valore deve essere presente nei parametri della mappa"
+msgstr "стойност трябва да е валидна карта за параметри за вграждане."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "Permesso dati"
+msgstr "Разрешения за данни"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "Permessi della raccolta"
+msgstr "Разрешения за събиране"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
-msgstr "Vedi tutti i permessi della raccolta"
+msgstr "Вижте всички разрешения за събиране"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
-msgstr "Cambia anche sotto-raccolte"
+msgstr "Променете и подколекциите"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "Puoi modificare questa raccolta e i suoi contenuti"
+msgstr "Може да редактира тази колекция и нейното съдържание"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "Può visualizzare gli elementi in questa raccolta"
+msgstr "Може да преглежда елементи в тази колекция"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
-msgstr "Accesso alla raccolta"
+msgstr "Достъп до колекция"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "Questo gruppo ha il permesso di vedere almeno una sottoraccolta di questa raccolta."
+msgstr "Тази група има разрешение да преглежда поне една подколекция от тази колекция."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "Questo gruppo ha il permesso di modificare almeno una sottoraccolta di questa raccolta."
+msgstr "Тази група има разрешение да редактира поне една подколекция от тази колекция."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
-msgstr "Visualizza sotto-raccolte"
+msgstr "Преглед на подколекциите"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:245
 msgid "Remember Me"
-msgstr "Ricordami"
+msgstr "Помни ме"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
-msgstr "Raggi X di questo schema"
+msgstr "Рентгеново тази схема"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "Modifica i permessi per questa raccolta"
+msgstr "Редактирайте разрешенията за тази колекция"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "Aggiungi questa domanda alla dashboard"
+msgstr "Добавете този въпрос към таблото за управление"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "Creare una nuova dashboard"
+msgstr "Създайте ново табло за управление"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:47
 msgid "The page you asked for couldn't be found."
-msgstr "La pagina che hai rihiesto non può essere trovata."
+msgstr "Страницата, която поискахте, не можа да бъде намерена."
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "Seleziona un {0}"
+msgstr "Изберете {0}"
 
 #: frontend/src/metabase/containers/Overworld.jsx:234
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "Salva dashboard, domande e collezioni in \"{0}\""
+msgstr "Запазване на табла за управление, въпроси и колекции в „{0}“"
 
 #: frontend/src/metabase/containers/Overworld.jsx:235
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "Accedi a dashboard, domande e collezioni in \"{0}\" "
+msgstr "Достъп до табла за управление, въпроси и колекции в „{0}“"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "Confronto"
+msgstr "Сравнете"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "Rimpicciolire"
+msgstr "Отдалечавам"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "Relazionato"
+msgstr "Свързани"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "Altri raggi X"
+msgstr "Още рентгенови лъчи"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "Nessun risultato"
+msgstr "Няма резултати"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:42
 msgid "Metabase couldn't find any results for your search."
-msgstr "Metabase non può trovare nessun risultato per la tua ricerca."
+msgstr "Metabase не можа да намери резултати за вашето търсене."
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "Nessuna metrica presente"
+msgstr "Няма показатели"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
 msgid "Aggregations"
-msgstr "aggregazioni"
+msgstr "Агрегации"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
-msgstr "operatori"
+msgstr "Оператори"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
-msgstr "campi personalizzati"
+msgstr "Персонализирани полета"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "Dashboard migrati"
+msgstr "Мигрирани табла за управление"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "Pulse migrati"
+msgstr "Мигрирани импулси"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "Domande migrate"
+msgstr "Мигрирани въпроси"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "Spostamento di istanze di {0} che non sono in una collezione nella collezione {1} {2}"
+msgstr "Преместване на екземпляри на {0}, които не са в колекция, в {1} колекция {2}"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "Impossibile concedere le autorizzazioni: {0}"
+msgstr "Неуспешно предоставяне на разрешения: {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "Impossibile decodificare la stringa crittografata. Hai cambiato o ti sei dimenticato di impostare MB_ENCRYPTION_SECRET_KEY?"
+msgstr "Не може да се дешифрира криптиран низ. Променили ли сте или сте забравили да зададете MB_ENCRYPTION_SECRET_KEY?"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "tutte le collezioni personali"
+msgstr "Всички лични колекции"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "Host"
+msgstr "Водещ"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "Porta"
+msgstr "Порт"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "Username del database"
+msgstr "Потребителско име за база данни"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "Quale username usi per accedere al database?"
+msgstr "Какво потребителско име използвате за влизане в базата данни?"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "Password del database"
+msgstr "Парола за база данни"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "Nome del database"
+msgstr "Име на базата данни"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
-msgstr "birds_of_the_world"
+msgstr "птици_на_света"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "Usi una connesione sicura (SSL)?"
+msgstr "Да се ​​използва сигурна връзка (SSL)?"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "Opzioni stringhe di connessione JDBC aggiuntive"
+msgstr "Допълнителни опции за низ на JDBC връзка"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
-msgstr "ID del progetto"
+msgstr "Идент. № на проекта"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
-msgstr "praxis-beacon-120871"
+msgstr "praxis-маяк-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
-msgstr "ID del Dataset"
+msgstr "Идент. № на набора от данни"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
@@ -9256,35 +9252,35 @@ msgstr "toucanSightings"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "ID client"
+msgstr "Идентификатор на клиента"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "Client segreto"
+msgstr "Клиентска тайна"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "codice di autorizzazione"
+msgstr "Код за авторизация"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "Hosts"
+msgstr "Домакини"
 
 #: src/metabase/driver/druid.clj
 msgid "Broker node port"
-msgstr "Porta del nodo intermediario"
+msgstr "Порт за възел на посредник"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "Id dell'account di Google Analytics"
+msgstr "Идент. № на акаунт в Google Analytics"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "stringa di connessione"
+msgstr "Свързващ низ"
 
 #: src/metabase/driver/h2.clj
 msgid "Users/camsaul/bird_sightings/toucans"
-msgstr "Utenti/camsaul/bird_sightings/toucans"
+msgstr "Потребители / camsaul / bird_sightings / toucans"
 
 #: src/metabase/driver/mongo.clj
 msgid "carrierPigeonDeliveries"
@@ -9292,60 +9288,59 @@ msgstr "carrierPigeonDeliveries"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "Database di autenticazione"
+msgstr "База данни за удостоверяване"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "database optionale da usare in autenticazione"
+msgstr "Незадължителна база данни, която да се използва при удостоверяване"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "opzioni aggiuntive di stringa di connessione Mongo"
+msgstr "Допълнителни опции за низ за връзка на Mongo"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "ID di Sistema di Oracle (SID)"
+msgstr "Идентификатор на системата на Oracle (SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "Normalmente qualcosa come ORCL o XE"
+msgstr "Обикновено нещо като ORCL или XE."
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "opzionale se usi il nome del servizio"
+msgstr "По избор, ако използвате име на услуга"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Nome del servizio Oracle"
+msgstr "Име на услугата Oracle"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "alias opzionale TNS"
+msgstr "Незадължителен TNS псевдоним"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
-msgstr "alveare"
+msgstr "кошер"
 
 #: src/metabase/driver/redshift.clj
 msgid "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
 
-#. not sure for the context
 #: src/metabase/driver/redshift.clj
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
 #: src/metabase/models/collection.clj
 msgid "default"
-msgstr "predefinito"
+msgstr "по подразбиране"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "Nomefile"
+msgstr "Име на файл"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr "/home/camsaul/toucan_sightings.sqlite"
+msgstr "/home/camsaul/toucan_sightings.sqlite 😋"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
@@ -9353,46 +9348,46 @@ msgstr "BirdsOfTheWorld"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "Nome dell'istanza del Database"
+msgstr "Име на екземпляр на база данни"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "N/A"
+msgstr "Неприложимо"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "dominio Windows"
+msgstr "Windows домейн"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:528
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:534
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:543
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
-msgstr "Etichette"
+msgstr "Етикети"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
-msgstr "Aggiungi membri"
+msgstr "Добавете членове"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "Collezione in cui è salvato"
+msgstr "Колекция, в която е запазена"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "Tutti gli utenti"
+msgstr "Всички потребители"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Amministratori"
+msgstr "Администратори"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
-msgstr "Metabot"
+msgstr "MetaBot"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "Condividi"
+msgstr "Споделяне"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
@@ -9416,7 +9411,7 @@ msgstr "Condividi"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "Display"
+msgstr "Дисплей"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:402
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:437
@@ -9427,111 +9422,112 @@ msgstr "Display"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
-msgstr "Assi"
+msgstr "Брадви"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
-msgstr "Formattazione"
+msgstr "Форматиране"
 
 #: frontend/src/metabase/containers/Overworld.jsx:121
 msgid "Try these x-rays based on your data."
-msgstr "Prova questi raggi-x basati sui tuoi dati"
+msgstr "Опитайте тези рентгенови лъчи въз основа на вашите данни."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:38
 msgid "There was a problem displaying this chart."
-msgstr "Si é verificato un errore nel visualizzare questo grafico."
+msgstr "При показването на тази диаграма възникна проблем."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:39
 msgid "Sorry, you don't have permission to see this card."
-msgstr "Spiacenti, non hai i permessi per vedere questa card."
+msgstr "За съжаление нямате разрешение да видите тази карта."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "Solo un avviso:"
+msgstr "Само по-горе:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "{0} senza il 'Sample Dataset', il tutorial del 'Query Builder' non funzionerà. Puoi sempre ripristinare il set di dati campione, ma tutte le domande che hai salvato utilizzando questi dati andranno perse."
+msgstr "{0} без пробния набор от данни урокът на Query Builder няма да работи. Винаги можете да възстановите примерния набор от данни, но всички въпроси, които сте запазили с помощта на тези данни, ще бъдат загубени."
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "Raggi-X"
+msgstr "Рентгенов"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "Confronta con il resto"
+msgstr "Сравнете с останалите"
 
 #: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "Usa la timezone di Java Virtual Machine (JVM)"
+msgstr "Използвайте часовата зона на Java Virtual Machine (JVM)"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "Ti suggeriamo di lasciar perdere, a meno che tu non stia eseguendo manualmente il fuso orario in molte o la maggior parte delle tue query con questi dati."
+msgstr "Предлагаме ви да оставите това, освен ако не правите ръчно леене на часови зони в\n"
+"много или повечето от вашите заявки с тези данни."
 
 #: frontend/src/metabase/containers/Overworld.jsx:395
 msgid "Your team's most important dashboards go here"
-msgstr "le dashboard più importanti del tuo team vanno qui"
+msgstr "Най-важните табла за управление на вашия екип отиват тук"
 
 #: frontend/src/metabase/containers/Overworld.jsx:396
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "Inserisci le dashboard in {0} per visualizzarli in questo spazio per tutti"
+msgstr "Фиксирайте таблата за управление в {0}, за да се показват в това пространство за всички"
 
 #: src/metabase/db/liquibase.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "Impossibile rilasciare il blocco Liquibase dopo una migrazione fallita"
+msgstr "Не може да освободи заключването на Liquibase след неуспешна миграция"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "Usa Il Time Zone di JVM"
+msgstr "Използвайте часовата зона на JVM"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "Stiamo analizzando le tabelle e i campi per aiutarti a esplorare i tuoi dati."
+msgstr "В момента анализираме таблиците и полетата, за да ви помогнем да изследвате данните си."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
-msgstr "Suggerimento: "
+msgstr "Бакшиш:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
-msgstr "Seleziona un tipo di valuta"
+msgstr "Изберете тип валута"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
-msgstr "Tipo Campo"
+msgstr "Тип поле"
 
 #: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
-msgstr "Risoluzione Problemi"
+msgstr "Отстраняване на неизправности"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
-msgstr "Abilita funzioni raggi X"
+msgstr "Активирайте рентгеновите функции"
 
 #: frontend/src/metabase/admin/settings/selectors.js:220
 msgid "Formatting Options"
-msgstr "Opzioni formattazione"
+msgstr "Опции за форматиране"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "Dettagli processo"
+msgstr "Подробности за задачата"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "Log di Troubleshooting"
+msgstr "Отстраняване на проблеми в дневниците"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "Stai cercando di arrivare al fondo di qualcosa? Questa sezione mostra i log delle attività in background di Metabase, che possono aiutare a far luce su cosa sta succedendo."
+msgstr "Опитвате се да стигнете до дъното на нещо? Този раздел показва журнали на фоновите задачи на Metabase, които могат да помогнат да се хвърли светлина върху случващото се."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "Attività"
+msgstr "Задача"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
@@ -9539,499 +9535,499 @@ msgstr "DB ID"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "Iniziato alle"
+msgstr "Започна в"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "Finito alle"
+msgstr "Завършен в"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "Durata (ms)"
+msgstr "Продължителност (ms)"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:34
 #: frontend/src/metabase/lib/core.js:92
 msgid "Currency"
-msgstr "Valuta"
+msgstr "Валута"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
-msgstr "Scegli un utente o un canale..."
+msgstr "Изберете потребител или канал ..."
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
 msgid "No formatting settings"
-msgstr "Nessuna impostazione di formattazione"
+msgstr "Няма настройки за форматиране"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "Etichetta per questo intervallo (facoltativo)"
+msgstr "Етикет за този диапазон (по избор)"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "Aggiungi un intervallo"
+msgstr "Добавете диапазон"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "è minore di"
+msgstr "е по-малко от"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "è maggiore di"
+msgstr "е по-голямо от"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "è uguale o minore di"
+msgstr "е по-малко или равно на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "è uguale o maggiore di"
+msgstr "е по-голямо или равно на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "è uguale a"
+msgstr "е равно на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "è diverso da"
+msgstr "не е равно на"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "è nullo"
+msgstr "е нула"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "non è nullo"
+msgstr "не е нула"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "contiene"
+msgstr "съдържа"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "non contiene"
+msgstr "не съдържа"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "inizia con"
+msgstr "започва с"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "finisce con"
+msgstr "завършва със"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "Quando una cella in queste colonne {0} sarà colorata in questo colore."
+msgstr "Когато клетка в тези колони {0} ще бъде оцветена в този цвят."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "Quando una cella in questa colonna..."
+msgstr "Когато клетка в тази колона ..."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "La visualizzazione richiede che raggruppi per un campo."
+msgstr "Тази визуализация изисква да се групирате по поле."
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:184
 msgid "Date style"
-msgstr "Stile Data"
+msgstr "Стил на датата"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:207
 msgid "Date separators"
-msgstr "Separatori della data"
+msgstr "Разделители на дати"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:226
 msgid "Abbreviate names of days and months"
-msgstr "Abbrevia i nomi dei giorni e dei mesi"
+msgstr "Съкратете имена на дни и месеци"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:236
 msgid "Show the time"
-msgstr "Mostra l'ora"
+msgstr "Покажете часа"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM"
-msgstr "HH:MM"
+msgstr "НЧ: ММ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:251
 msgid "HH:MM:SS"
-msgstr "HH:MM:SS"
+msgstr "HH: MM: SS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:254
 msgid "HH:MM:SS.MS"
-msgstr "HH:MM:SS.MS"
+msgstr "HH: MM: SS.MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:265
 msgid "Time style"
-msgstr "Stile ora"
+msgstr "Стил на времето"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:314
 msgid "Unit of currency"
-msgstr "Unità per valuta"
+msgstr "Валутна единица"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:334
 msgid "Currency label style"
-msgstr "Stile etichetta valuta"
+msgstr "Стил на валутния етикет"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:361
 msgid "Where to display the unit of currency"
-msgstr "Dove mostrare l'unità della valuta"
+msgstr "Къде да се показва валутната единица"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:394
 msgid "Minimum number of decimal places"
-msgstr "Numero minimo di posizioni decimali"
+msgstr "Минимален брой десетични знаци"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "Tipo di grafico in pila"
+msgstr "Подредени тип диаграма"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "etichetta obbiettivo"
+msgstr "Етикет на целта"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "Mostra la linea del trend"
+msgstr "Показване на линия на тенденция"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "Stile della linea"
+msgstr "Линия стил"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "Mostra i punti sulla linea"
+msgstr "Показване на точки на линии"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
-msgstr "Auto"
+msgstr "Автоматичен"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "Quale asse?"
+msgstr "Коя ос?"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "Linea + Barra"
+msgstr "Линия + лента"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
-msgstr "Grafico a barre e linea"
+msgstr "линейна и стълбовидна диаграма"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "La visualizzazione Gauge richiede un numero."
+msgstr "Визуализацията на датчика изисква номер."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
 msgid "Gauge"
-msgstr "Gauge"
+msgstr "Габарит"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
-msgstr "Intervallo Gauge"
+msgstr "Габаритни диапазони"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:107
 msgid "Field to show"
-msgstr "Campo da mostrare"
+msgstr "Поле за показване"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
-msgstr "l'ultimo {0}"
+msgstr "последно {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
-msgstr "{0} era {1} {2}"
+msgstr "{0} беше {1} {2}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
-msgstr "Raggruppa per un campo \"time\" per vedere come è cambiato nel tempo"
+msgstr "Групирайте по поле за време, за да видите как това се е променило с времето"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:51
 msgid "Switch positive / negative colors?"
-msgstr "Cambia colori positivi / negativi"
+msgstr "Превключване на положителни / отрицателни цветове?"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
-msgstr "Colonna Pivot"
+msgstr "Осева колона"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
-msgstr "Colonna della cella"
+msgstr "Клетка на клетка"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
-msgstr "Colonne visibili"
+msgstr "Видими колони"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
-msgstr "Formattazione condizionale"
+msgstr "Условно форматиране"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
-msgstr "Titolo della colonna"
+msgstr "Заглавие на колона"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:243
 msgid "Show a mini bar chart"
-msgstr "Mostra un grafico a barre mini"
+msgstr "Показване на мини бар диаграма"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:254
 msgid "Link"
-msgstr "Link"
+msgstr "Връзка"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:258
 msgid "Email link"
-msgstr "Link dell'email"
+msgstr "Имейл връзка"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:262
 msgid "Image"
-msgstr "Immagine"
+msgstr "Изображение"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:266
 msgid "Automatic"
-msgstr "Automatico"
+msgstr "Автоматично"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:271
 msgid "View as link or image"
-msgstr "Visualizza come link o immagine"
+msgstr "Преглед като връзка или изображение"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:281
 msgid "Link text"
-msgstr "Testo del link"
+msgstr "Текст на връзката"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "Non è un intero valido: \"{0}\""
+msgstr "Не е валидно цяло число: „„ {0} “"
 
 #: src/metabase/api/embed.clj
 msgid "Embedding is not enabled for this object."
-msgstr "L'incorporamento non è abilitato per questo oggetto."
+msgstr "Вграждането не е активирано за този обект."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "Il problema di connessione al server LDAP fallirà con l'autenticazione locale: {0}"
+msgstr "Проблем при свързване с LDAP сървър, ще се върне към локално удостоверяване: {0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "Quando si include un offset, deve essere incluso anche un limite."
+msgstr "Когато се включва отместване, трябва да се включи и лимит."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "Quando si include un limite, deve essere incluso anche un offset."
+msgstr "Когато се включва лимит, трябва да се включи и отместване."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr "Applicando l'euristico {0} a {1}."
+msgstr "Прилагане на евристична {0} към {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr "Vincoli di dimensione:n{0}"
+msgstr "Обвързвания с размери: n {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr "Utilizzo delle definizioni:nMetrica:n{0}Filtri:n{1}"
+msgstr "Използване на дефиниции: nMetrics: n {0} nFilters: n {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
-msgstr "minuto"
+msgstr "минута"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "ora"
+msgstr "час"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "giorno della settimana"
+msgstr "ден на седмицата"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "giorno del mese"
+msgstr "ден от месеца"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "giorno dell'anno"
+msgstr "ден от годината"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "settimana"
+msgstr "седмица"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
-msgstr "mese"
+msgstr "месец"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "trimestre"
+msgstr "тримесечие"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "Aggiunta di {0} carte alla dashboard {1}: n {2}"
+msgstr "Добавяне на {0} карти към таблото за управление {1}: n {2}"
 
 #: src/metabase/util/yaml.clj
 msgid "Error parsing {0}:n{1}"
-msgstr "Analisi degli errori {0}:n{1}"
+msgstr "Грешка при синтактичния анализ на {0}: n {1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "ATTENZIONE: il filtraggio funziona solo sulle dimensioni! '' {0} '' è una metrica. Filtro ignorato."
+msgstr "ВНИМАНИЕ: Филтрирането работи само върху размери! „{0}“ е показател. Пренебрегване на филтъра."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "ATTENZIONE: una data non può appartenere a più intervalli discreti, quindi usarli insieme con AND non ha senso."
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Датата не може да принадлежи на множество дискретни интервали, така че АНТИРАНЕТО им заедно няма смисъл."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "Questi intervalli sono ignorati: {0}"
+msgstr "Пренебрегване на тези интервали: {0}"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "ATTENZIONE: non so come negare: {0}"
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Не знам как да отричам: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "L'ordinamento con Druid è consentito solo nelle query che hanno una o più colonne di breakout. Ignorando: clausola order-by."
+msgstr "Сортирането с друид е разрешено само в заявки, които имат една или повече колони за разбиване. Игнориране: клауза за подреждане."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "ATTENZIONE: ha senso solo specificare: campi per una query senza aggregazione. Ignorando la clausola."
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Има смисъл само да се посочат: полета за заявка без агрегиране. Пренебрегване на клаузата."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "AVVISO: Druid non permette limitSpec nelle query timeseries. La clausola LIMIT verrà ignorata."
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Друидът не позволява limitSpec в запитванията за времеви серии. Пренебрегване на клаузата LIMIT."
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "Form per HoneySQL:"
+msgstr "HoneySQL форма:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "Impossibile analizzare la data \"{0}\""
+msgstr "Не може да се анализира датата „„ {0} “"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "Connessione del client chiusa, annullamento della query"
+msgstr "Затворена връзка на клиента, анулиране на заявка"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "Impostazione del fusorario con istruzione: {0}"
+msgstr "Задаване на часова зона с изявление: {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "Non sono supportati più filtri di data"
+msgstr "Не се поддържат множество филтри за дата"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":not non è ancora stato implementato"
+msgstr ": not все още не е изпълнено"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "È consentito un solo segmento di Google Analytics alla volta."
+msgstr "В даден момент е разрешен само един сегмент на Google Analytics."
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "MONGO AGGREGATION PIPELINE:"
+msgstr "MONGO АГРЕГАЦИОНЕН ТРУБОПРОВОД:"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "Errore: colonne non corrispondenti nei risultati! Previsto: {0} Got: {1}"
+msgstr "Грешка: несъответстващи колони в резултатите! Очаквано: {0} Получено: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "Impossibile creare il file temp in `{0}` per gli allegati di posta elettronica"
+msgstr "Не може да се създаде временен файл в „{0}“ за прикачени файлове към имейл"
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "Errore nella richiesta di pre-elaborazione:"
+msgstr "Грешка при предварителната обработка на заявката:"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "Clausola del filtro non valida: {0}"
+msgstr "Недопустима клауза за филтриране: {0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "Clausola non valida:"
+msgstr "Невалидна клауза:"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Errore: la query di origine della query non è stata risolta. Probabilmente hai prima bisogno di 'pre-elaborare' la query."
+msgstr "Грешка: Изходната заявка на заявката не е разрешена. Вероятно първо трябва да `предварително обработите 'заявката."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "Nessuna espressione chiamata \"{0}\""
+msgstr "Няма израз с име „„ {0} “"
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "Nessuna aggregazione all'indice: {0}"
+msgstr "Няма агрегиране по индекс: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "La lunghezza totale dei valori del campo è {0} (max {1})."
+msgstr "Общата дължина на стойностите на полето е {0} (макс. {1})."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "Valori ammessi per questo Campo."
+msgstr "FieldValues ​​са разрешени за това поле."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "Valori non ammessi per questo Campo."
+msgstr "FieldValues ​​НЕ са разрешени за това поле."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr "Il campo {0} ''{1}'' dovrebbe avere FieldValues ​​e appartiene a un database con l'aggiornamento FieldValues ​​On-Demand."
+msgstr "Полето {0} '' {1} '' трябва да има FieldValues ​​и принадлежи към база данни с актуализиране на FieldValues ​​при поискване."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "Non puoi creare o revocare i permessi per il gruppo \"Admin\"."
+msgstr "Не можете да създавате или отменяте разрешения за групата „„ Администратор “."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "Non puoi aggiungere o rimuovere utenti al/dal gruppo \"MetaBot\"."
+msgstr "Не можете да добавяте или премахвате потребители към / от групата '' MetaBot ''."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "Non puoi aggiungere o rimuovere utenti al/dal gruppo \"All Users\"."
+msgstr "Не можете да добавяте или премахвате потребители към / от групата „Всички потребители“."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "Non puoi rimuovere l'ultimo membro del gruppo \"Admin\"!"
+msgstr "Не можете да премахнете последния член на групата '' Администратор ''!"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "Errore nell'inserimento di una nuova Impostazione: {0}"
+msgstr "Грешка при вмъкването на нова настройка: {0}"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr "le descrizioni defsetting devono essere ':internal?' o internazionalizzate, trovate: '{0}'"
+msgstr "десетирането на описателни низове трябва да бъде „: вътрешно?“ или интернационализирано, намерено: „{0}“"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "Caricamento plugin {0}...{1}"
+msgstr "Приставката се зарежда {0} ... {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr "Oggetto digitato per tipo, contenente le impostazioni di formattazione"
+msgstr "Обект, въведен по тип, съдържащ настройки за форматиране"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "Permettere agli utenti di esplorare i dati usando i raggi X"
+msgstr "Позволете на потребителите да изследват данни с помощта на рентгенови лъчи"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "Usando questo URL per controllare il token: {0}"
+msgstr "Използване на този URL адрес за проверка на маркера: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "Impossibile validare il token: 404 non trovato."
+msgstr "Не може да се провери маркера: 404 не е намерен."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "Si è verificato un errore durante il controllo della validità di questo token:"
+msgstr "При проверката дали този маркер е валиден възникна грешка:"
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -10039,292 +10035,292 @@ msgstr "Si è verificato un errore durante il controllo della validità di quest
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "Token per funzionalità premium. Vai al MetaStore per ottenere il tuo!"
+msgstr "Токен за премиум функции. Отидете в MetaStore, за да вземете своя!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "Il formato del token non è valido. Il token dovrebbe essere 64 caratteri esadecimali."
+msgstr "Форматът на маркера е невалиден. Токенът трябва да съдържа 64 шестнадесетични знака."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium features token"
-msgstr "Errore durante l'impostazione delle funzioni premium del token"
+msgstr "Грешка при задаване на токен на премиум функции"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "Errore durante la convalida del token:"
+msgstr "Грешка при проверка на маркера:"
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "Errore durante la pre-elaborazione della query"
+msgstr "Грешка при предварителната обработка на заявката"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "Nessun form nativo è stato restituito"
+msgstr "Не е върната родна форма."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "Risposta non valida dal driver del database. Nessuno stato fornito."
+msgstr "Невалиден отговор от драйвера на базата данни. №: предоставен статус."
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "Errore generale"
+msgstr "Обща грешка"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "Hash della query mancante!"
+msgstr "Липсващ хеш на заявката!"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "La tabella ''{0}'' non ha campi associati."
+msgstr "Таблица „{0}“ няма свързани полета."
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "È stato raggiunto il limite massimo di query simultanee"
+msgstr "Достигнат е максималният лимит на едновременните заявки"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "Non so come ottenere informazioni sul Campo:"
+msgstr "Не знам как да получа информация за Field:"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr "metabase.query-processor.interface/*driver* non associato."
+msgstr "metabase.query-processor.interface / * драйвер * е несвързан."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "Errore nel processo di query: numero non corrispondente di colonne nella query e nei risultati."
+msgstr "Грешка в процесора за заявки: несъответстващ брой колони в заявката и резултатите."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "{0} campi previsti, {1} ottenuti"
+msgstr "Очаквани {0} полета, получихте {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "Previsti: {0}"
+msgstr "Очаквано: {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "Effettivo: {0}"
+msgstr "Действително: {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "Impossbile binnare il Campo senza un valore min/max"
+msgstr "Не може да се смени полето без минимална / максимална стойност"
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "{0} non supportato da questo driver."
+msgstr "{0} не се поддържа от този драйвер."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "Segmento {0} non esistente o non valido."
+msgstr "Сегмент {0} не съществува или е невалиден."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "Metrica {0} non esistente o non valido."
+msgstr "Показател {0} не съществува или е невалиден."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "Query sorgente mancante nella Scheda {0}"
+msgstr "Липсваща заявка за източник в карта {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "Query sorgente recuperata dalla Scheda {0}:"
+msgstr "Извлечена заявка за източник от карта {0}:"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "Errore durante la conversione della query MBQL in nativa:"
+msgstr "Грешка при трансформиране на MBQL заявка в родна:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "Non riesco a eseguire la query: non posso trovare la tabella sorgente {0}."
+msgstr "Не може да се изпълни заявка: не можа да се намери изходната таблица {0}."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr "Errore durante la registrazione dei metadati dei risultati della query:"
+msgstr "Грешка при запис на метаданни за резултатите за заявка:"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr "Errore: Query Processor Store non inizializzato."
+msgstr "Грешка: Съхранението на процесора на заявки не е инициализирано."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "Errore: la tabella {0} non è presente nel Query Processor Store."
+msgstr "Грешка: Таблица {0} не присъства в хранилището на процесора на заявки."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "Errore: il Campo {0} non è presente nel Query Processor Store."
+msgstr "Грешка: Полето {0} не присъства в хранилището на процесора за заявки."
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "Elenco attività pulito con successo, eliminate {0} righe."
+msgstr "Почистването на историята на задачите е успешно, редовете са {0} изтрити"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "no"
+msgstr "не"
 
 #: src/metabase/db.clj src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "Per maggiori informazioni, guardare"
+msgstr "За повече информация вижте"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "Numero intero maggiore o uguale a zero"
+msgstr "Цяло число, по-голямо или равно на нула"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "il valore deve essere un numero intero maggiore o uguale a zero."
+msgstr "стойност трябва да бъде цяло число, по-голямо или равно на нула."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "il valore deve essere 0 o un numero intero maggiore."
+msgstr "стойност трябва да бъде цяло число нула или по-голяма."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "il valore deve essere un numero intero valido, maggiore o uguale a zero."
+msgstr "стойност трябва да бъде валидно цяло число, по-голямо или равно на нула."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "Nuovi utenti per stato negli ultimi 30 giorni"
+msgstr "Нови потребители по държави през последните 30 дни"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "Creato il, per giorno della settimana"
+msgstr "Създадено в по ден от седмицата"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "Creato il, per trimestre di anno"
+msgstr "Създадено на до тримесечие на годината"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "[[this.short-name]] per paese"
+msgstr "[[this.short-name]] за държава"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "Utenti per sorgente"
+msgstr "Потребители на източник"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "Le principali pagine esterne che hanno portato gli utenti al tuo sito"
+msgstr "Най-добрите външни страници, които доведоха потребителите до вашия сайт"
 
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 msgid "How [[this]] is distributed and more."
-msgstr "Come [[this]] è distribuito e altro."
+msgstr "Как се разпространява [[това]] и др."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "Il [[this]] nel tempo"
+msgstr "[[Това]] с течение на времето"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "Crescita dell'utente"
+msgstr "Ръст на потребителите"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "Indipendentemente dal fatto che ci siano o no dei modelli in cui accadono."
+msgstr "Независимо дали има някакви модели, когато те се случват."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "Utenti per stato"
+msgstr "Потребители в държава"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "Sessioni"
+msgstr "Сесии"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr "Come alcuni dei numeri in [[this]] si mettono in relazione l'uno con l'altro"
+msgstr "Как някои числа в [[това]] са свързани помежду си"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "Vendite per paese"
+msgstr "Продажби за държава"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "Unire la data per mese dell'anno"
+msgstr "Дата на присъединяване по месец от годината"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "[[Timestamp]] per ora del giorno"
+msgstr "[[Timestamp]] по час от деня"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "Uno sguardo a [[this]]"
+msgstr "Поглед към [[това]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "Le ultime 5 per catogoria"
+msgstr "Отдолу 5 за категория"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "Numero di ordini"
+msgstr "Брой поръчки"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "Crescita degli eventi"
+msgstr "Ръст на събитията"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
-msgstr "Totale [[GenericTable]]"
+msgstr "Общо [[GenericTable]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "Crescita degli incassi"
+msgstr "Ръст на доходите"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "10 migliori paesi per vendite negli ultimi 30 giorni"
+msgstr "Топ 10 държави по продажби през последните 30 дни"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "[[this]] per mese dell'anno"
+msgstr "[[това]] по месец от годината"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "Transazioni per giorno della settimana"
+msgstr "Транзакции на ден от седмицата"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "Sessioni per tipo di dispositivo"
+msgstr "Сесии по тип устройство"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "Transazioni per paese"
+msgstr "Транзакции за държава"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "Unisci la data per trimestre"
+msgstr "Дата на присъединяване по тримесечие на годината"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "Eventi per ora del giorno"
+msgstr "Събития на час от деня"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
-msgstr "[[Singleton]]"
+msgstr "[[Сингълтън]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
-msgstr "Top 5 [[this]]"
+msgstr "Топ 5 [[това]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "Ultimi 5 [[this]]"
+msgstr "Дъно 5 [[това]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "[[Timestamp]] per giorno del mese"
+msgstr "[[Timestamp]] по ден от месеца"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
-msgstr "Per [[GenericCategoryLarge]]"
+msgstr "На [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10332,335 +10328,335 @@ msgstr "Per [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
-msgstr "Valori nulli"
+msgstr "Нулеви стойности"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "Eventi totali"
+msgstr "Общо събития"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr "Uno sguardo a [[GenericTable]] attraverso il tuo [[this]], e come cambia nel tempo."
+msgstr "Поглед върху [[GenericTable]] във вашия [[this]] и как се променя с времето."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
-msgstr "[[this]] per [[GenericCategoryMedium]]"
+msgstr "[[това]] на [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "Come [[this]] cambia nel tempo"
+msgstr "Как [[това]] се променя с времето"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "Come si confrontano per stagionalità"
+msgstr "Как се сравняват по сезонност"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "Reddito medio per transazione"
+msgstr "Среден доход на транзакция"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
-msgstr "[[this]] per paese"
+msgstr "[[това]] за държава"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "Reddito per stato"
+msgstr "Доход на държава"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
-msgstr "Per [[GenericCategoryMedium]]"
+msgstr "На [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "Un'occhiata da vicino al tuo [[this]]"
+msgstr "По-подробен поглед към вашия [[този]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How [[GenericNumber]] is distributed"
-msgstr "Come è distribuito [[GenericNumber]]"
+msgstr "Как се разпределя [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "[[Timestamp]] per trimestre"
+msgstr "[[Timestamp]] по тримесечие на годината"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "Eventi per paese"
+msgstr "Събития по държави"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "Giorni della settimana in cui [[this.short-name]] sono stati aggiunti"
+msgstr "Делнични дни, когато [[this.short-name]] бяха добавени"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] were added"
-msgstr "Mesi in cui [[this.short-name]] sono stati aggiunti"
+msgstr "Месеци, когато [[this.short-name]] бяха добавени"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "Come si confrontano tra categorie diverse"
+msgstr "Как се сравняват в различните категории"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "Nuovi utenti per sorgente negli ultimi 30"
+msgstr "Нови потребители на източник през последните 30"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "Eventi per trimestre"
+msgstr "Събития за тримесечие на годината"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "Ecco una rapida occhiata al tuo [[this]]"
+msgstr "Ето бърз поглед на вашия [[този]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[this]] per [[GenericCategoryLarge]], primi 5"
+msgstr "[[това]] на [[GenericCategoryLarge]], топ 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days when [[this.short-name]] were added"
-msgstr "Giorni in cui [[this.short-name]] sono stati aggiunti"
+msgstr "Дни, когато е добавено [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "Totale ordini per sorgente"
+msgstr "Общ брой поръчки на източник"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "[[this]] per trimestre"
+msgstr "[[това]] по тримесечие на годината"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "Eventi per [[GenericCategoryMedium]]"
+msgstr "Събития на [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per state"
-msgstr "Eventi per stato"
+msgstr "Събития по държави"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top landing pages"
-msgstr "Top landing pages"
+msgstr "Топ целеви страници"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "Ecco uno sguardo più vicino al tuo [[this]] nel tempo"
+msgstr "Ето по-отблизо вашето [[това]] с течение на времето"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "Somma di [[this]] per [[Country]]"
+msgstr "Сума от [[това]] от [[Държава]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "Stati che stanno ottenendo i migliori risultati"
+msgstr "Държави, които се представят най-добре"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "Creato per mese dell'anno"
+msgstr "Създадено от по месец на годината"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "Somma di [[this]] per [[State]]"
+msgstr "Сума от [[това]] от [[щат]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "Somma di [[GenericNumber]] per [[this]]"
+msgstr "Сума от [[GenericNumber]] на [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "Eventi per coordinate"
+msgstr "Събития по координати"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "Migliori pagine di riferimento"
+msgstr "Топ страници с препоръки"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr "Un'esplorazione ai tuoi utenti per cominciare."
+msgstr "Проучване на вашите потребители, за да започнете."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr "Una panoramica del tuo [[this]] e di come è distribuito nel tempo, luogo e categorie."
+msgstr "Преглед на вашия [[този]] и как той се разпределя във времето, мястото и категориите."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "Entrate medie per stato"
+msgstr "Среден доход за държава"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[this]] per [[GenericCategoryMedium]]"
+msgstr "[[това]] от [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "Transazioni totali"
+msgstr "Общо транзакции"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] che si sono uniti nel tempo"
+msgstr "[[this.short-name]], които са се присъединили с течение на времето"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "Il [[this]] per luogo"
+msgstr "[[Това]] по местоположение"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "Eventi per mese dell'anno"
+msgstr "Събития за месец от годината"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[this]] per [[GenericNumber]]"
+msgstr "[[това]] от [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "Trimestri quando [[this.short-name]] sono stati aggiunti"
+msgstr "Четвърти, когато [[this.short-name]] бяха добавени"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "Come questi [[this.short-name]] sono distribuiti"
+msgstr "Как се разпределят тези [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[this.short-name]] per [[GenericNumber]]"
+msgstr "[[this.short-name]] от [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "Da dove stanno arrivando gli utenti"
+msgstr "Откъде идват потребителите"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "[[this]] confronti e correlazioni"
+msgstr "[[това]] сравнения и корелации"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "Entrate totali"
+msgstr "Общ доход"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "Entrate totali per mese"
+msgstr "Общ доход на месец"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "Numero di utenti per sorgente"
+msgstr "Брой потребители на източник"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "Transazioni per stato"
+msgstr "Транзакции за държава"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[this]] per [[Timestamp]]"
+msgstr "[[това]] от [[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "Nuovi utenti per sorgente negli ultimi 30 giorni"
+msgstr "Нови потребители на източник през последните 30 дни"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "Unisci la data per giorno del mese"
+msgstr "Дата на присъединяване по ден на месеца"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "Sconto medio %"
+msgstr "Среден% отстъпка"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "Metrica generata automaticamente su [[GenericTable]]"
+msgstr "Автоматично генерирани показатели за [[GenericTable]]."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "[[this]] per giorno del mese"
+msgstr "[[това]] на ден от месеца"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "Sessioni totali in ogni paese"
+msgstr "Общ брой сесии във всяка държава"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "Transazioni per mese dell'anno"
+msgstr "Транзакции за месец от годината"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "Vendite per prodotto"
+msgstr "Продажби на продукт"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "Utenti in ogni paese"
+msgstr "Потребители във всяка държава"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "[[this]] per ora del giorno"
+msgstr "[[това]] по час от деня"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "Eventi negli ultimi 30 giorni"
+msgstr "Събития през последните 30 дни"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "Transazioni per sorgente"
+msgstr "Транзакции на източник"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "Dove hai acquisito i tuoi utenti"
+msgstr "Къде сте придобили вашите потребители"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "Come si confrontano attraverso la posizione"
+msgstr "Как те сравняват местоположението"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "[[this]] per prodotto"
+msgstr "[[това]] на продукт"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr "[[this]] per mese dell'anno"
+msgstr "[[това]] на месец от годината"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "Per paese"
+msgstr "За държава"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr "Uno sguardo profondo a come i paesi operino in modo differente per te."
+msgstr "По-задълбочен поглед върху това как различните държави се представят за вас."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "Vendite per stato"
+msgstr "Продажби по щат"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
-msgstr "Eventi per [[GenericNumber]]"
+msgstr "Събития от [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "Vendite per prodotto [[ProductCategoryMedium]]"
+msgstr "Продажби на продукт [[ProductCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "Acquisizione degli utenti per paesi"
+msgstr "Придобиване на потребител по държава"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "[[this]] per source"
-msgstr "[[this]] per sorgente"
+msgstr "[[това]] на източник"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by day of the week"
-msgstr "[[this]] per giorno della settimana"
+msgstr "[[това]] по ден от седмицата"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "Giorni del mese in cui [[this.short-name]] si sono uniti"
+msgstr "Дни от месеца, когато [[this.short-name]] се присъедини"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "Ecco una panoramica delle persone nel tuo [[this]]"
+msgstr "Ето общ преглед на хората във вашия [[този]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr "Come [[GenericTable]] sono distribuiti in questo campo temporale e se ha schemi stagionali."
+msgstr "Как [[GenericTable]] се разпределя в това времево поле и дали има някакви сезонни модели."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10671,200 +10667,200 @@ msgstr "Come [[GenericTable]] sono distribuiti in questo campo temporale e se ha
 #: resources/automagic_dashboards/table/UserTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
-msgstr "Panoramica"
+msgstr "Общ преглед"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "In che modo questa metrica è distribuita tra diverse categorie"
+msgstr "Как този показател се разпределя в различни категории"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr "[[this.short-name]] per stato"
+msgstr "[[this.short-name]] за държава"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "Giorni ferial quando [[this.short-name]] si è unito."
+msgstr "Делнични дни, когато [[this.short-name]] се присъедини"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] joined"
-msgstr "Ore quando [[this.short-name]] si è unito"
+msgstr "Часове, когато [[this.short-name]] се присъедини"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "Entrate totali per mese"
+msgstr "Общ доход по месеци"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "Una ripartizione del tuo [[this]] nel tempo, il suo minimo, massimo, medio e altro."
+msgstr "Разбивка на вашето [[това]] с течение на времето, както и неговата мин., Макс., Средна стойност и други."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "Quantità media per stato"
+msgstr "Средно количество за държава"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr "Come confrontare attraverso numeri diversi"
+msgstr "Как се сравняват по различни числа"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "Nuovi utenti per paese negli ultimi 30 giorni"
+msgstr "Нови потребители за държава през последните 30 дни"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr "Transazioni nel tempo"
+msgstr "Транзакции във времето"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "[[this]] per [[GenericCategorySmall]]"
+msgstr "[[това]] на [[GenericCategorySmall]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "Qualche ripartizione"
+msgstr "Някаква разбивка"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[State]]"
-msgstr "Media di [[this]] per [[State]]"
+msgstr "Средно от [[това]] от [[щат]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "Transazioni per trimestre"
+msgstr "Транзакции на тримесечие на годината"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "Per coordinate"
+msgstr "По координати"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "Un'occhiata da vicino al tuo [[this]] per prodotti"
+msgstr "Ето по-отблизо вашия [[този]] продукт"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per quarter of the year"
-msgstr "[[this]] per trimestre"
+msgstr "[[това]] на тримесечие на годината"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Una panoramica del tuo dato [[this]] da Google Analytics"
+msgstr "Ето преглед на вашите [[тези]] данни от Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "Trimestri quando [[this.short-name]] si è unito"
+msgstr "Четвърти, когато [[this.short-name]] се присъедини"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "Nuovo [[this.short-name]] negli ultimi 30 giorni"
+msgstr "Ново [[this.short-name]] през последните 30 дни"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "Sessioni totali per desktop, mobile o tablet"
+msgstr "Общ брой сесии на настолни компютри, мобилни устройства или таблети"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "Esempio approfondito"
+msgstr "Пример за дълбочина"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "Entrata media per sorgente"
+msgstr "Среден доход на източник"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "[[Timestamp]] per giorno della settimana"
+msgstr "[[Timestamp]] по ден от седмицата"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "Un'occhiata da vicino al tuo [[this]]"
+msgstr "Ето по-отблизо вашия [[този]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "Ecco uno sguardo più vicino al tuo [[this]] campo"
+msgstr "Ето по-отблизо вашето [[това]] поле"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
-msgstr "Riepilogo"
+msgstr "Обобщение"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "Come [[this]] è distribuito geograficamente"
+msgstr "Как [[това]] се разпределя географски"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "Le pagine con le visite maggiori"
+msgstr "Страниците с най-много показвания"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "Come [[Number1]] è correlato con [[Number2]]"
+msgstr "Как [[Number1]] е свързано с [[Number2]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "Migliori 10 stati per vendite negli ultimi 30 giorni"
+msgstr "Топ 10 състояния по продажби през последните 30 дни"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "Top 10 stati per vendite"
+msgstr "Топ 10 състояния по продажби"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
-msgstr "[[Timestamp]]"
+msgstr "[[Отпечатък]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "Dove queste transazioni sono avvenute"
+msgstr "Където се случиха тези транзакции"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "Migliori 10 paesi per vendite"
+msgstr "Топ 10 държави по продажби"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "Vendite per stato"
+msgstr "Продажби по държави"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "Da dove proviene la maggior parte delle sessioni"
+msgstr "Откъде произхождат повечето ви сесии"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "Migliori canali di acquisizione"
+msgstr "Топ канали за придобиване"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These [[this.short-name]] across time"
-msgstr "Questi [[this.short-name]] nel tempo"
+msgstr "Те [[this.short-name]] във времето"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "Quantità media"
+msgstr "Средно количество"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "Vendite per sorgente"
+msgstr "Продажби на източник"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "Reddito medio per paese"
+msgstr "Среден доход за държава"
 
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 msgid "How [[this]] is distributed"
-msgstr "Come [[this]] è distribuito"
+msgstr "Как се разпределя [[това]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr "Distinti [[FK]]"
+msgstr "Различен [[FK]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "Come sono distribuite queste transazioni"
+msgstr "Как се разпределят тези транзакции"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "Per stato"
+msgstr "За държава"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr "Conteggio di [[GenericCategoryMedium]] per [[this]]"
+msgstr "Брой на [[GenericCategoryMedium]] от [[този]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10879,68 +10875,68 @@ msgstr "Conteggio di [[GenericCategoryMedium]] per [[this]]"
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
-msgstr "Uno sguardo al tuo [[this]]"
+msgstr "Поглед към вашия [[този]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[GenericNumber]] by [[this]]"
-msgstr "[[GenericNumber]] per [[this]]"
+msgstr "[[GenericNumber]] от [[този]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "Somma di [[GenericNumber]] per [[this]]"
+msgstr "Сума от [[GenericNumber]] от [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your [[this]] table"
-msgstr "Uno sguardo alla tua tabella [[this]]"
+msgstr "Поглед към вашата [[тази]] таблица"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr "Quante [[GenericTable]] ci sono per stato, e quanto è rappresentato ogni stato per altre categorie"
+msgstr "Колко [[GenericTable]] има за държава и как всяко състояние е представено в други категории."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "Pagine più visitate"
+msgstr "Най-гледани страници"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "Esplorazione di esempio"
+msgstr "Примерно проучване"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales vs. rating"
-msgstr "Vendite vs Rating"
+msgstr "Продажби спрямо рейтинг"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per hour of the day"
-msgstr "[[this]] per ora del giorno"
+msgstr "[[това]] на час от деня"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Where your [[this.short-name]] are"
-msgstr "Dove sono i tuoi [[this.short-name]]"
+msgstr "Къде е вашето [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These are the same for all your [[this.short-name]]"
-msgstr "Queste sono le stesse per tutti i tuoi [[this.short-name]]"
+msgstr "Те са еднакви за всичките ви [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "Eventi per categorie diverse"
+msgstr "Събития от различни категории"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Where these [[this.short-name]] are"
-msgstr "Dove sono questi [[this.short-name]]"
+msgstr "Където са тези [[this.short-name]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr "Fuori tempo"
+msgstr "С течение на времето"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr "Un riepilogo degli eventi nella tua tabella [[this]]"
+msgstr "Обобщение на събитията във вашата [[тази]] таблица"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "Transazioni per sorgente nel tempo"
+msgstr "Транзакции на източник във времето"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10948,221 +10944,221 @@ msgstr "Transazioni per sorgente nel tempo"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
-msgstr "Come è stato distribuito il [[this]]"
+msgstr "Как се разпределя [[това]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "Reddito totale per sorgente"
+msgstr "Общ доход на източник"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "Totale [[this.short-time]]"
+msgstr "Общо [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Some metrics we found about your transactions."
-msgstr "Alcune metriche che abbiamo trovato sulle tue transazioni."
+msgstr "Някои показатели, които открихме за вашите транзакции."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr "Come stanno andando i tuoi diversi prodotti."
+msgstr "Как се представят различните ви продукти."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "Dove questi eventi stanno accadendo"
+msgstr "Където се случват тези събития"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "Quali stati USA ti stanno portando più affari."
+msgstr "Кои щати на САЩ ви носят най-много бизнес."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare across time"
-msgstr "Come si paragonano nel tempo"
+msgstr "Как се сравняват във времето"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average transaction income per month"
-msgstr "Entrate medie delle transazioni al mese"
+msgstr "Среден доход от транзакции на месец"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "Quantità media al mese"
+msgstr "Средно количество на месец"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "Modelli stagionali in [[this]]"
+msgstr "Сезонни модели в [[това]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr "Eventi nel tempo"
+msgstr "Събития във времето"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "Ordini e reddito per sorgente"
+msgstr "Поръчки и доход на източник"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "Transazioni per ora del giorno"
+msgstr "Транзакции на час от деня"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "Da dove proviene la maggior parte del tuo traffico."
+msgstr "Откъде идва по-голямата част от трафика ви."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr "Ecco uno sguardo veloce a [[this]]"
+msgstr "Ето бърз поглед към [[това]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr "Sembra che il tuo [[this]] abbia transazioni, quindi ecco uno sguardo ad esse"
+msgstr "Изглежда, че вашият [[този]] има транзакции, така че ето поглед към тях"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "Sconto medio al mese"
+msgstr "Средна отстъпка на месец"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "[[Timestamp]] per mese dell'anno"
+msgstr "[[Timestamp]] по месец от годината"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr "[[this]] per [[GenericCategorySmall]] nel tempo"
+msgstr "[[това]] на [[GenericCategorySmall]] с течение на времето"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "Distribuzione per coordinate"
+msgstr "Разпределение по координати"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "Vendite per sorgente"
+msgstr "Продажби по източник"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "Vendite per ogni categoria di prodotto"
+msgstr "Продажби за всяка продуктова категория"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "Un'occhiata da vicino alle metriche ed alle dimensioni utilizzate nella question salvata."
+msgstr "По-подробен поглед върху показателите и измеренията, използвани в този запазен въпрос."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr "[[this.short-name]] per [[GenericCategoryMedium]]"
+msgstr "[[this.short-name]] на [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "Vendite per prodotto [[ProductCategoryLarge]]"
+msgstr "Продажби на продукт [[ProductCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "Quantità media per paese"
+msgstr "Средно количество за държава"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr "[[this.short-name]] per [[GenericCategoryLarge]]"
+msgstr "[[this.short-name]] на [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "Ecco uno sguardo al tuo [[this]] per sorgente"
+msgstr "Ето по-отблизо вашия [[този]] за всеки източник"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "Eventi per giorno del mese"
+msgstr "Събития на ден от месеца"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "Se sei in correlazioni, questi sono i raggi-X per te."
+msgstr "Ако искате корелации, това е рентгеновият лъч за вас."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
-msgstr "Sessioni per paese"
+msgstr "Сесии по държави"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr "Qualche metrica interessante sulle tue statistiche GA per iniziare."
+msgstr "Някои интересни показатели за вашите статистически данни за GA, за да започнете."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
-msgstr "[[this]] per stato"
+msgstr "[[това]] за държава"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "[[Timestamp]] per trimestre"
+msgstr "[[Timestamp]] по тримесечие на годината"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "Com'è distribuito attraverso il tempo e altre categorie."
+msgstr "Как се разпределя във времето и други категории."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr "Uno sguardo ai tuoi eventi nel tempo e per varie categorie."
+msgstr "Поглед върху вашите събития с течение на времето и по няколко категории."
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[GenericTable]] per [[this]]"
-msgstr "[[GenericTable]] per [[this]]"
+msgstr "[[GenericTable]] на [[това]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "Quantità media per sorgente"
+msgstr "Средно количество на източник"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "Top 5 per categoria"
+msgstr "Топ 5 на категория"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "Eventi per giorno della settimana"
+msgstr "Събития за ден от седмицата"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] per month"
-msgstr "Nuovo [[this.short-name]] per mese"
+msgstr "Ново [[this.short-name]] на месец"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "I migliori esecutori"
+msgstr "Топ изпълнители"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "Transazioni negli ultimi 30 giorni"
+msgstr "Транзакции през последните 30 дни"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr "[[GenericTable]] per [[this]]"
+msgstr "[[GenericTable]] от [[този]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Panoramica dei tuoi [[this]] dati da Google Analytics"
+msgstr "Преглед на вашите [[този]] данни от Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "Creato Il per ora del giorno"
+msgstr "Създадено в по час на деня"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "Vendite mensili"
+msgstr "Продажби по месеци"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
-msgstr "Come il [[this]] è distribuito per categorie"
+msgstr "Как [[това]] се разпределя между категориите"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "[[Timestamp]] per mese dell'anno"
+msgstr "[[Timestamp]] по месец от годината"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "Quante sessioni totali rispetto a quanti singoli utenti hai avuto ogni giorno."
+msgstr "Колко общо сесии спрямо колко отделни потребители сте имали всеки ден."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "Come questa metrica è distribuira attraverso numeri differenti"
+msgstr "Как този показател се разпределя между различни числа"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "Sessioni per pagina in cui è iniziata la sessione"
+msgstr "Сесии по страница, където сесията е започнала"
 
 #: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -11171,20 +11167,20 @@ msgstr "Sessioni per pagina in cui è iniziata la sessione"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
-msgstr "Valori distinti"
+msgstr "Различни стойности"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] were added"
-msgstr "Ore quando [[this.short-name]] è stato aggiunto"
+msgstr "Часове, когато беше добавено [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "[[Timestamp]] per giorno della settimana"
+msgstr "[[Timestamp]] по ден от седмицата"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] attraverso il tempo"
+msgstr "[[GenericNumber]] с течение на времето"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11193,43 +11189,43 @@ msgstr "[[GenericNumber]] attraverso il tempo"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Heres an overview of your [[this]]"
-msgstr "Ecco una panoramica del tuo [[this]]"
+msgstr "Ето преглед на вашия [[този]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by coordinates"
-msgstr "[[this.short-name]] per coordinate"
+msgstr "[[this.short-name]] по координати"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "Ecco uno sguardo più vicino al tuo [[this]] per stato"
+msgstr "Ето по-отблизо вашия [[този]] за държава"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "\"Creato il\" per giorno del mese"
+msgstr "Създадено в по ден на месеца"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "Vendite per coordinate"
+msgstr "Продажби по координати"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "Nuovo [[this.short-name]] nel tempo"
+msgstr "Ново [[this.short-name]] с течение на времето"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
-msgstr "Unire la data per ora del giorno"
+msgstr "Дата на присъединяване по час от деня"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by hour of day"
-msgstr "[[Timestamp]] per ora del giorno"
+msgstr "[[Timestamp]] по час от деня"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "Sessioni e utenti unici per giorno"
+msgstr "Сесии и уникални потребители на ден"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr "Eventi per [[GenericCategoryLarge]]"
+msgstr "Събития на [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11238,636 +11234,635 @@ msgstr "Eventi per [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr "Come confrontano per distribuzione"
+msgstr "Как се сравняват по разпределение"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "Entrata per paese"
+msgstr "Доход за държава"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "Eccoti alcuni dettagli in merito al tuo [[this]] per regione"
+msgstr "Ето по-отблизо вашия [[този]] за всяка държава"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by product [[ProductCategory]]"
-msgstr "Vendite per prodotto [[ProductCategory]]"
+msgstr "Продажби по продукти [[ProductCategory]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr "[[this]] per [[GenericCategoryLarge]], ultimi 5"
+msgstr "[[това]] на [[GenericCategoryLarge]], отдолу 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "[[this.short-name]] aggiunti negli ultimi 30 giorni"
+msgstr "[[this.short-name]] добавено през последните 30 дни"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
-msgstr "Per [[Source]]"
+msgstr "На [[Източник]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "Quantità media articolo per mese"
+msgstr "Средно количество артикул на месец"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr "Il numero di [[GenericTable]] per paese, e come ogni paese è rappresentato in categorie diverse."
+msgstr "Броят на [[GenericTable]] за държава и как всяка държава е представена в различни категории."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the week"
-msgstr "[[this]] per giorno della settimana"
+msgstr "[[това]] на ден от седмицата"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "Quantità media per sorgente"
+msgstr "Средно количество на източник"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr "[[this.short-name]] by [[Timestamp]]"
+msgstr "[[this.short-name]] от [[Timestamp]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "Riepilogo statistiche"
+msgstr "Обобщена статистика"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "Vendite per mese"
+msgstr "Продажби на месец"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
-msgstr "[[GenericNumber]] per data di unione"
+msgstr "[[GenericNumber]] по дата на присъединяване"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[Country]]"
-msgstr "Media di [[this]] per [[Country]]"
+msgstr "Средно от [[това]] от [[Държава]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] attraverso il tempo"
+msgstr "[[това]] с течение на времето"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "Unire la data per giorno della settimana"
+msgstr "Дата на присъединяване по ден от седмицата"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "We crunched the numbers for your [[this]]"
-msgstr "Abbiamo ridotto i numeri per il tuo [[this]]"
+msgstr "Преценихме номерата за вашия [[този]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] joined"
-msgstr "Mesi quando [[this.short-name]] si è unito"
+msgstr "Месеци, когато [[this.short-name]] се присъедини"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "Impossibile analizzare la risorsa `{0}` come JSON"
+msgstr "Не може да се анализира ресурс „{0}“ като JSON"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "Impossibile trovare JSON tramite il percorso relativo `{0}`"
+msgstr "Не може да се намери JSON чрез относителна пътека „{0}“"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "Connessione all'host scaduta per URL `{0}`"
+msgstr "Времето за свързване с хоста изтече за URL адрес „{0}“"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "Impossibile collegare URL `{0}` ad un host sconosciuto "
+msgstr "Не може да се свърже с неизвестен хост на URL адрес „{0}“"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "Impossibile collegare URL `{0}` ad un host"
+msgstr "Не може да се свърже с хост на URL адрес „{0}“"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "Connessione a URL `{0}` rifiutata dall'host"
+msgstr "Връзката е отказана от хоста при за URL адрес „{0}“"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "Impossibile trovare la risorsa su URL `{0}`"
+msgstr "Не може да се извлече ресурс на URL адрес „{0}“"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "Impossibile formattare la risorsa su URL `{0}` come JSON"
+msgstr "Не може да се анализира ресурс на URL „{0}“ като JSON"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "Problemi durante la connessione al server LDAP, procedere con l'autenticazione in locale: {0}"
+msgstr "Проблем с свързването към LDAP сървър, ще се върне към локалното удостоверяване: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "Gli stati delle BigQuery non possono essere parametrizzate."
+msgstr "Операторите на BigQuery не могат да бъдат параметризирани!"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "ATTENZIONE: Druid non consente limitSpec nelle query di serie temporali. Ignorare la condizione LIMIT"
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Друидът не позволява limitSpec в запитвания от времеви редове. Пренебрегване на клаузата LIMIT."
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "Dettagli di connessione Snowflake non validi: Manca il nome del DB"
+msgstr "Невалидни данни за връзката на Снежинка: липсва име на DB."
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "Apprezzeremo il tuo feedback"
+msgstr "Ще се радваме на вашите отзиви."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Sembra che Metabase non sia rientrato nelle tue aspettative"
+msgstr "Изглежда, че Metabase не е съвсем подходящ за вас."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "Ti andrebbe di rispondere a 5 domandine veloci per aiutare il nostro team a comprendere perchè e migliorare le cose in futuro?"
+msgstr "Бихте ли се възползвали от бързо проучване с 5 въпроса, за да помогнете на екипа на Metabase да разбере защо и да направи нещата по-добри в бъдеще?"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Ci auguriamo che ti sia trovato bene con Metabase."
+msgstr "Надяваме се, че сте се наслаждавали на Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "Ti andrebbe di dirci come sta andando, rispondendo a 6 domandine veloci?"
+msgstr "Бихте ли имали нещо против да вземете бързо проучване с 6 въпроса, за да ни кажете как върви?"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} ha creato un account Metabase."
+msgstr "{0} създаде акаунт в Metabase"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} ha accettato l'invito a Metabase."
+msgstr "{0} прие поканата си за Metabase"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "[Metabase] Richiesta di recupero Password"
+msgstr "[Метабаза] Заявка за нулиране на парола"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metabase] Notifica"
+msgstr "[Метабаза] Известие"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metabase] Aiuta a migiorare Metabase"
+msgstr "[Metabase] Помогнете да подобрите Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Metabase] Raccontaci come vanno le cose."
+msgstr "[Metabase] Кажете ни как вървят нещата."
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Errore: la query di origine della query non è stata risolta. Probabilmente hai prima bisogno di 'pre-elaborare' la query."
+msgstr "Грешка: заявката за източник на query не е разрешена. Вероятно първо трябва да `предварително обработите 'заявката."
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "Non so che farci"
+msgstr "Не знам какво да правя с:"
 
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "Non so come impacchettare:"
+msgstr "Не знам как да опаковам:"
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "Impostazione di `query-caching-max-kb` a {0} fallita."
+msgstr "Неуспешна настройка на „query-caching-max-kb“ на {0}."
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "Valori maggiori a {1} non sono consentiti."
+msgstr "Стойности, по-големи от {1}, не са разрешени."
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "Il database {0} non esiste"
+msgstr "База данни {0} не съществува."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "Errore: Il database non risulta presente nel Query Processor Store"
+msgstr "Грешка: Базата данни не присъства в хранилището на процесора на заявки."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr "Chiave segreta per l'inclusione non valida! Deve essere una chiave esadecimale a codifica 256-bit (ad esempio una stringa di 64 caratteri)."
+msgstr "Невалиден секретен ключ за вграждане! Тайният ключ трябва да бъде шестнадесетичен кодиран 256-битов ключ (т.е. 64-символен низ)."
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "JWT manca `alg`."
+msgstr "JWT липсва `alg`."
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "JWT `alg` non può essere `none`"
+msgstr "JWT `alg` не може да бъде` none`."
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "La chiave segreta per l'inclusione non è stata configurata"
+msgstr "Тайният ключ за вграждане не е зададен."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "Token mancante nel keypath"
+msgstr "За маркера липсва стойност за път на ключ"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr "esempio in profondità"
+msgstr "Задълбочен пример"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "Chiave"
+msgstr "Ключ"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "Classe"
+msgstr "Клас"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "Trigger"
+msgstr "Задействания"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr "Vedi trigger"
+msgstr "Преглед на задействания"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "Informazioni sullo scheduler"
+msgstr "Информация за планировчика"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "Priorità"
+msgstr "Приоритет"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr "Ultima Esecuzione"
+msgstr "Последно уволнен"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "Prossima Esecuzione"
+msgstr "Следващо време за пожар"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "Data inizio"
+msgstr "Начален час"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "Data fine"
+msgstr "Крайно време"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "Tempo di innesco finale"
+msgstr "Крайно време за пожар"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr "Può Lanciare ancora?"
+msgstr "Може ли отново да стреля?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "Innesco per {0}"
+msgstr "Задействания за {0}"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:26
 msgid "Tasks"
-msgstr "Tasks"
+msgstr "Задачи"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:31
 msgid "Jobs"
-msgstr "Jobs"
+msgstr "Работни места"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:735
 msgid "Duplicated {0}"
-msgstr "Duplicato {0}"
+msgstr "Дублиран {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "Duplica questo elemento"
+msgstr "Дублирайте този елемент"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "Archivia questo elemento"
+msgstr "Архивирайте този елемент"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
-msgstr "Duplica dashboard"
+msgstr "Дублирано табло за управление"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "Duplica \"{0}\""
+msgstr "Дубликат на „{0}“"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "Duplica"
+msgstr "Дубликат"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "Domani"
+msgstr "Утре"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "Questo {0}"
+msgstr "Това {0}"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "Prossimo {0}"
+msgstr "Следващ {0}"
 
 #: frontend/src/metabase/lib/query_time.js:135
 #: src/metabase/pulse/render/datetime.clj
 msgid "Previous {0}"
-msgstr "Precedente {0}"
+msgstr "Предишен {0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "Precedente {0} {1}"
+msgstr "Предишен {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "Prossimo {0} {1}"
+msgstr "Следваща {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "Ora"
+msgstr "Сега"
 
 #: frontend/src/metabase/lib/query_time.js:174
 msgid "{0} {1} ago"
-msgstr "{0} {1} fa"
+msgstr "Преди {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:175
 msgid "{0} {1} from now"
-msgstr "{0} {1} da ora"
+msgstr "{0} {1} от сега"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] "Intervallo di default"
-msgstr[1] "Intervalli di default"
+msgstr[0] "Период по подразбиране"
+msgstr[1] "Периоди по подразбиране"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] "Minuto dell'ora"
-msgstr[1] "Minuti dell'ora"
+msgstr[0] "Минута от часа"
+msgstr[1] "Минути от часа"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] "Ora del giorno"
-msgstr[1] "Ore del giorno"
+msgstr[0] "Час от деня"
+msgstr[1] "Часа от деня"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] "Giorno della settimana"
-msgstr[1] "Giorni della settimana"
+msgstr[0] "Ден на седмицата"
+msgstr[1] "Дни на седмицата"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] "Giorno del mese"
-msgstr[1] "Giorni del mese"
+msgstr[0] "Ден от месеца"
+msgstr[1] "Дни от месеца"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] "Giorno dell'anno"
-msgstr[1] "Giorni dell'anno"
+msgstr[0] "Ден от годината"
+msgstr[1] "Дни от годината"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] "Settimana dell'anno"
-msgstr[1] "Settimane dell'anno"
+msgstr[0] "Седмица в годината"
+msgstr[1] "Седмици в годината"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] "Mese dell'anno"
-msgstr[1] "Mesi dell'anno"
+msgstr[0] "Месец в годината"
+msgstr[1] "Месеци в годината"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] "Trimestre dell'anno"
-msgstr[1] "Trimestri dell'anno"
+msgstr[0] "Тримесечие на годината"
+msgstr[1] "Тримесечия на годината"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
 #: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] "{0} selezione"
-msgstr[1] "{0} selezioni"
+msgstr[0] "{0} избор"
+msgstr[1] "{0} избора"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
 msgid "[Q]Q"
-msgstr "[Q]Q"
+msgstr "[Q] Q"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr "Questo"
+msgstr "Това"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
-msgstr "Invalido"
+msgstr "Невалидно"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "Aggiungi tempo"
+msgstr "Добавете време"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
-msgstr "Niente da confrontare con il precedente {0}"
+msgstr "Няма нищо за сравнение за предишния {0}."
 
 #: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
-msgstr "di {0}"
+msgstr "от {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "il valore deve essere un tipo di database valido"
+msgstr "стойност трябва да е валиден механизъм на базата данни."
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "Connessione rifiutata dall'host per URL `{0}`"
+msgstr "Връзката е отказана от хоста за URL адрес „{0}“"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "Attenzione: rilevata stringa di connessione Postgres con `ssl=true`"
+msgstr "Внимание: Открит е низ за връзка на Postgres с `ssl = true`."
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "Potresti aver bisogno di aggiungere `?sslmode=require` alla stringa di connessione al tuo DB."
+msgstr "Може да се наложи да добавите `? Sslmode = require` към низа на свързване с DB на вашето приложение."
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Se Metabase fallisce l'avvio, per favore aggiungilo e riprova."
+msgstr "Ако Metabase не успее да се стартира, моля, добавете го и опитайте отново."
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "Vedi https://github.com/metabase/metabase/issues/8908 per ulteriori dettagli."
+msgstr "Вижте https://github.com/metabase/metabase/issues/8908 за повече подробности."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "ATTENZIONE: Utilizzare Metabase con H2 come database interno non è raccomandato per ambienti di produzione."
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Използването на Metabase с база данни на приложения H2 не се препоръчва за производствени внедрения."
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "Per installazioni di produzione si raccomanda caldamente di usare invece Postgres, MySQL o MariaDB."
+msgstr "За производствени разгръщания горещо препоръчваме вместо това да използвате Postgres, MySQL или MariaDB."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "Se decidi di utilizzare ancora H2, si prega di eseguire regolarmente il backup del file di database."
+msgstr "Ако решите да продължите да използвате H2, моля, не забравяйте да архивирате редовно файла на базата данни."
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "Vedi https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres per ulteriori informazioni"
+msgstr "Вижте https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres за повече информация."
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "Impossibile collegarsi al DB Metabase {0}"
+msgstr "Не може да се свърже с DB на Metabase {0}."
 
-#. I have more than one doubt about this. How can we translate Question in general in this software?
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr "Errore nell'aggiunta della direttiva SQL sulla Domanda (`Question`) salvata di BigQuery"
+msgstr "Грешка при добавяне на наследена SQL директива към BigQuery запазен въпрос"
 
 #: src/metabase/driver.clj
 msgid "Failed to notify {0} Database {1} updated"
-msgstr "Fallimento della notifica {0} Database {1} aggiornato"
+msgstr "Уведомяването за {0} база данни {1} не бе актуализирано"
 
 #: src/metabase/driver/impl.clj
 msgid "Loading driver {0} {1}"
-msgstr "Caricamento driver {0} {1}"
+msgstr "Зарежда се драйвер {0} {1}"
 
 #: src/metabase/driver/impl.clj
 msgid "Load driver {0}"
-msgstr "Carica driver {0}"
+msgstr "Заредете драйвер {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Driver non registrato dopo il caricamento: {0}"
+msgstr "Шофьор не е регистриран след зареждане: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr "Errore: tentativo di modificare {0} proprietà `:abstract?` da {1} a {2}."
+msgstr "Грешка: опит за промяна на {0} свойство `: abstract?` От {1} на {2}."
 
 #: src/metabase/driver/impl.clj
 msgid "Registered abstract driver {0}"
-msgstr "Registrato driver astratto {0}"
+msgstr "Регистриран абстрактен драйвер {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered driver {0}"
-msgstr "Driver registrato {0}"
+msgstr "Регистриран водач {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "(parents: {0})"
-msgstr "(genitori: {0})"
+msgstr "(родители: {0})"
 
 #: src/metabase/driver/impl.clj
 msgid "Initializing driver {0}..."
-msgstr "Inizializzazione del driver {0}..."
+msgstr "Инициализиране на драйвера {0} ..."
 
 #: src/metabase/driver/impl.clj
 msgid "Reason:"
-msgstr "Ragione:"
+msgstr "Причина:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
-msgstr "Caratteristiche del driver non valido: {0}"
+msgstr "Невалидна функция на драйвера: {0}"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "Modulo HoneySQL non valido:"
+msgstr "Невалиден HoneySQL формуляр:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr "Chiusura del pool di connessioni per il database {0} ..."
+msgstr "Затваряне на пула от връзки за база данни {0} ..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "Errore di caricamento del namespace"
+msgstr "Грешка при зареждането на пространството от имена"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "Avvio listener di eventi:"
+msgstr "Слушател на стартови събития:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "Errore inaspettato ascoltando eventi"
+msgstr "Неочаквана грешка при прослушването на събития"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "Errore di sincronizzazione Database {0}"
+msgstr "Грешка при синхронизирането на базата данни {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr "Impossibile eseguire la sincronizzazione del database."
+msgstr "Неуспешно обработване на събитие за синхронизиране на база данни."
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr "Livello della query nidificata errato: la query non ha una query sorgente"
+msgstr "Лошо ниво на вложена заявка: заявката няма заявка за източник"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
-msgstr "Non so come fare {0}"
+msgstr "Не знам как да „{0}“."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr "Qui c'è cosa posso fare: "
+msgstr "Ето какво мога да направя:"
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "Errore nel comando Metabot"
+msgstr "Грешка в командата на Metabot"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "Websocket associato a questo evento Slack è diverso dal websocket che si sta attualmente utilizzando."
+msgstr "Websocket, свързан с това събитие Slack, се различава от websocket, който използваме в момента."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr "Il ValoreDelCampo per il Campo {0} rimane invariato. Saltando..."
+msgstr "FieldValues ​​за поле {0} остават непроменени. Пропуска се ..."
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "Impossibile normalizzare: "
+msgstr "Не може да се нормализира:"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
-msgstr "Impossibile trovare l'ID campo corrispondente per la destinazione:"
+msgstr "Не можах да намеря съвпадащ идентификатор на поле за цел:"
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabase non ha le autorizzazioni per scrivere nella directory dei plugin {0}"
+msgstr "Metabase няма разрешения за запис в директорията на приставки {0}"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabase non può utilizzare la directory dei plugin {0}"
+msgstr "Metabase не може да използва директорията с приставки {0}"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "Controlla che la directory esista e che Metabase abbia i permessi per scriverci."
+msgstr "Моля, уверете се, че директорията съществува и че Metabase има разрешение да пише в нея."
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "Puoi cambiare la directory che Metabase utilizza per i moduli impostando la variabile d'ambiente MB_PLUGINS_DIR."
+msgstr "Можете да промените директорията, която Metabase използва за модули, като зададете променливата на околната среда MB_PLUGINS_DIR."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "Tornando a una directory temporanea per ora."
+msgstr "Засега се връщам към временна директория."
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabase non può scrivere sulla cartella temporanea. Imposta MB_PLUGINS_DIR su una directory scrivibile e riavvia Metabase."
+msgstr "Metabase не може да пише във временна директория. Моля, задайте MB_PLUGINS_DIR на записваема директория и рестартирайте Metabase."
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar non è più richiesto da Metabase 1.0+. Puoi cancellarlo dalla directory dei plugin."
+msgstr "spark-deps.jar вече не е необходим на Metabase 1.0+. Можете да го изтриете от директорията с приставки."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "Inizializzazione plugin fallita {0}"
+msgstr "Неуспешно инициализиране на приставка {0}"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "Caricamento plugin in {0}..."
+msgstr "Зареждане на приставки в {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Utilizzo del caricatore di base Clojure come classloader di contesto condiviso: {0}"
+msgstr "Използване на Clojure базово зареждане като споделен контекстен loadloader: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr "Impostando il classloader del contesto thread corrente a classloader condiviso {0} ..."
+msgstr "Задаване на текущ контекстен клас за изтегляне на нишка към споделен клас за зареждане {0} ..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11875,318 +11870,318 @@ msgstr "Impostando il classloader del contesto thread corrente a classloader con
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr "Impostando il classloader del contesto thread a classloader APPENA CREATO {0} ..."
+msgstr "Задаване на текущ клас за зареждане на контекст на нишка на НОВО СЪЗДАДЕН classloader {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "Aggiunto l'URL {0} al classpath"
+msgstr "Добавен URL адрес {0} към пътя на класа"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "Il plugin {0} dichiara una dipendenza che Metabase non comprende: {1}"
+msgstr "Приставката {0} декларира зависимост, която Metabase не разбира: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "Fare riferimento al riferimento manifest del plugin per un elenco completo delle dipendenze del plugin valide:"
+msgstr "Вижте препратката към манифеста на приставката за пълен списък на валидни зависимости на приставките:"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "Metabase non può inizializzare il plugin {0} per via di dipendenze richieste."
+msgstr "Metabase не може да инициализира приставката {0} поради необходими зависимости."
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr "Classe non trovata: {0}"
+msgstr "Класът не е намерен: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "Il plugin ''{0}'' dipende dal plugin ''{1}''"
+msgstr "Приставка „{0}“ зависи от приставка „„ {1} “"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} dipendenza {1} soddisfatta? {2}"
+msgstr "{0} зависимост {1} удовлетворена? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "Plugins con dipendenze insoddisfatte: {0}"
+msgstr "Приставки с незадоволени депа: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr "Estrai file {0} -> {1}"
+msgstr "Извличане на файл {0} -> {1}"
 
 #: src/metabase/util/files.clj
 msgid "Resource does not exist."
-msgstr "La risorsa è inesistente"
+msgstr "Ресурсът не съществува."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "Caricamento plugin namespace {0} ..."
+msgstr "Зарежда се пространство от имена на приставки {0} ..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "Dipendenze soddisfatte; questi plugin verranno caricati adesso: {0}"
+msgstr "Удовлетворени зависимости; тези приставки вече ще бъдат заредени: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "Registrazione del driver proxy JDBC per {0} ..."
+msgstr "Регистрира се JDBC прокси драйвер за {0} ..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "Annullamento della registrazione del driver JDBC originale {0} ..."
+msgstr "Отмяна на регистрацията на оригиналния драйвер на JDBC {0} ..."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
-msgstr "Proprietà di connessione predefinita {0} non esiste."
+msgstr "Свойството по подразбиране за връзка {0} не съществува."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "proprietà di connessione non valida {0}: non una stringa o una mappa."
+msgstr "Невалидно свойство на връзката {0}: не е низ или карта."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr "Carica driver di caricamento in modo `lazy` {0}"
+msgstr "Заредете драйвер за мързеливо зареждане {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "Impossibile inizializzare il plugin: manca la proprieta' richiesta 'nome-driver'"
+msgstr "Не може да се инициализира приставката: липсва необходимото свойство „име на драйвер“"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "Attenzione: Il plugin manifest per {0} non contiene proprieta' di connessione"
+msgstr "Предупреждение: Манифестът на приставката за {0} не включва свойства на връзката"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr "Registrazione del driver di caricamento in modo `lazy` {0}..."
+msgstr "Регистриране на драйвер за мързеливо зареждане {0} ..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "Errore nell'esecuzione della query per la Scheda {0}"
+msgstr "Грешка при изпълнение на заявката за карта {0}"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "Ultima settimana"
+msgstr "Миналата седмица"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "Questa settimana"
+msgstr "Тази седмица"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "Ultimo mese"
+msgstr "Миналия месец"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "Questo mese"
+msgstr "Този месец"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr "Ultimo trimestre"
+msgstr "Последно тримесечие"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "Questo trimestre"
+msgstr "Това тримесечие"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "Ultimo anno"
+msgstr "Миналата година"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr "Quest'anno"
+msgstr "Тази година"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr "*driver* senza restrizioni."
+msgstr "* драйвер * е необвързан."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr "Errore di sincronizzazione dei campi per Tabella \"{0}\""
+msgstr "Грешка при синхронизирането на полета за таблица „{0}“"
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr "L'hash di {0} corrispende all'hash registrato, salto la sincronizzazione dei campi"
+msgstr "Хеш от {0} съвпадащи съхранени хешове, като се пропуска синхронизирането на полета"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "Campo"
+msgstr "Поле"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr "Si è verificato un errore verificando se il camp {0} ha bisogno di essere creato o riattivato"
+msgstr "Грешка при проверката дали полетата {0} трябва да бъдат създадени или активирани отново"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "Sto marcando il campo \"{0}\" come inattivo."
+msgstr "Полето „{0}“ се маркира като неактивно."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr "Errore di ritiro {0}"
+msgstr "Грешка при оттеглянето на {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Il tipo Database di {0} è stato modificato da \"{1}\" a \"{2}\"."
+msgstr "Типът база данни на {0} се е променил от '' {1} '' на '' {2} ''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Il tipo base di {0} è stato modificato da \"{1}\" a \"{2}\"."
+msgstr "Основният тип на {0} е променен от '' {1} '' на '' {2} ''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Il tipo Speciale di {0} è stato modificato da \"{1}\" a \"{2}\"."
+msgstr "Специалният тип на {0} е променен от „„ {1} “на„ „{2}“."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "Il commento è stato aggiunto per {0}."
+msgstr "Добавен е коментар за {0}."
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Schedulatore Quartz in fase di arresto {0}"
+msgstr "Спиране на кварцов планировщик {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Schedulatore Quartz in fase di avvio {0}"
+msgstr "Стартиране на кварцов планировщик {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
-msgstr "Errore nel caricamento dello spazio dei nomi delle attività {0}"
+msgstr "Грешка при зареждането на пространството от имена на задачите {0}"
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "Inizializzazione task {0}"
+msgstr "Инициализиране на задача {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "Errore nell'inizializzazione task {0}"
+msgstr "Грешка при инициализиране на задача {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "Problema nell'invio dell'email di abbandono"
+msgstr "Проблем при изпращане на имейл за изоставяне"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "Invio statistiche anonime in corso"
+msgstr "Изпращане на анонимни статистически данни за употребата."
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "Errore di invio statistiche d'uso anonime"
+msgstr "Грешка при изпращане на анонимни статистически данни за употребата"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "Errore nell'invio di Pulse {0}"
+msgstr "Грешка при изпращане на импулс {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "Invio pulse pianificati..."
+msgstr "Изпращане на планирани импулси ..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "Task SendPulses fallito"
+msgstr "Задачата SendPulses не бе успешна"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "Impossibile eseguire le attività di pianificazione per il database {0}"
+msgstr "Неуспешно изпълнение на задачи по планиране за база данни {0}"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "Cancella l'history dei task"
+msgstr "Почистване на историята на задачите"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "Task history eliminata correttamente, le righe sono state cancellate"
+msgstr "Почистването на историята на задачите е успешно, редовете са изтрити"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "Task history eliminata correttamente, nessuna riga è stata cancellata"
+msgstr "Почистването на историята на задачите е успешно, не са изтрити редове"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "Controllo le informazioni della nuova versione di Metabase"
+msgstr "Проверка за нова информация за версията на Metabase."
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "Errore nel recupero delle informazioni di versione"
+msgstr "Грешка при извличането на информацията за версията"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "Massima memoria disponibile per la JVM: {0}"
+msgstr "Максимална памет, достъпна за JVM: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr "Non qualcosa con un ID: {0}"
+msgstr "Не е нещо с идентификатор: {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
-msgstr "[[CreateDate]] per mese dell'anno"
+msgstr "[[CreateDate]] по месец от годината"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr "Ecco un rapido sguardo al tuo [[this]]"
+msgstr "Ето бърз преглед на вашия [[този]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "[[CreateTimestamp]] con l'ora del giorno"
+msgstr "[[CreateTimestamp]] по час от деня"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "Dove hai acquisito i tuoi utenti"
+msgstr "Къде сте придобили потребителите си"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr "Com'è distribuito attraverso il tempo e altre categorie"
+msgstr "Как се разпределя във времето и други категории."
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per sorgente"
+msgstr "Ето по-подробен поглед върху [[това]] за всеки източник"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr "Ecco un rapido sguardo al [[this]] "
+msgstr "Ето кратък преглед на [[това]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "[[CreateTimestamp]] con il giorno del mese"
+msgstr "[[CreateTimestamp]] по ден от месеца"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Here's an overview of the people in your [[this]]"
-msgstr "Ecco una panoramica delle persone nel tuo [[this]]"
+msgstr "Ето преглед на хората във вашия [[този]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "[[CreateTimestamp]] con il trimestre dell'anno"
+msgstr "[[CreateTimestamp]] по тримесечие на годината"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare across location"
-msgstr "Come confrontano tramite il luogo"
+msgstr "Как се сравняват по местоположение"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per prodotto"
+msgstr "Ето по-подробно разглеждане на вашите [[това]] по продукти"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "[[CreateTimestamp]] con il mese dell'anno"
+msgstr "[[CreateTimestamp]] по месец от годината"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "Una panoramica del tuo [[this]] e com'è distribuito attraverso il tempo, il luogo e le categorie"
+msgstr "Преглед на вашето [[това]] и как се разпределя във времето, мястото и категориите."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]]"
+msgstr "Ето по-отблизо вашия [[този]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "[[CreateTimestamp]] con il giorno della settimana"
+msgstr "[[CreateTimestamp]] по ден от седмицата"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Ecco una panoramica dei dati del tuo [[this]] da Google Analytics"
+msgstr "Ето преглед на вашите [[тези]] данни от Google Analytics"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -12195,1645 +12190,1647 @@ msgstr "Ecco una panoramica dei dati del tuo [[this]] da Google Analytics"
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 msgid "Here's an overview of your [[this]]"
-msgstr "Ecco una panoramica del tuo [[this]]"
+msgstr "Ето преглед на вашия [[този]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Here's a closer look at your [[this]] field"
-msgstr "Ecco uno sguardo più da vicino al campo del tuo [[this]]"
+msgstr "Ето по-отблизо вашето [[това]] поле"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per nazione"
+msgstr "Ето по-подробен поглед върху вашата [[тази]] за държава"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "Se ti interessano le correlazioni, questa è la `x-ray` per te."
+msgstr "Ако се интересувате от корелации, това е рентгеновият лъч за вас."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
-msgstr "[[CreateDate]] con il giorno della settimana"
+msgstr "[[CreateDate]] по ден от седмицата"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr "Sembra che il tuo [[this]] abbia delle transazioni, quindi eccone uno sguardo"
+msgstr "Изглежда, че вашият [[this]] има транзакции, така че ето ги погледнете"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per stato"
+msgstr "Ето по-подробен поглед върху [[това]] за всеки щат"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the month"
-msgstr "[[CreateTime]] per giorno del mese"
+msgstr "[[CreateDate]] по ден от месеца"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTime]] by hour of the day"
-msgstr "[[CreateTime]] per ora del giorno"
+msgstr "[[CreateTime]] по час от деня"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] nel tempo"
+msgstr "Ето по-подробен поглед върху вашето [[това]] с течение на времето"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "[[CreateDate]] per trimestre dell'anno"
+msgstr "[[CreateDate]] по тримесечие на годината"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:202
 msgid "Edit user"
-msgstr "Modifica utente"
+msgstr "Редактиране на потребител"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "Nuovo utente"
+msgstr "Нов потребител"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:206
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "Reset password"
+msgstr "Нулирайте паролата"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:210
 msgid "Deactivate user"
-msgstr "Disattiva utente"
+msgstr "Деактивиране на потребителя"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "Riattivare {0}?"
+msgstr "Да активирате отново {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "Non è stato possibile inviare loro un invito via email, quindi assicurati di dire loro di accedere al log utilizzando {0} e questa password che abbiamo generato per loro:"
+msgstr "Не можахме да им изпратим покана по имейл, затова не забравяйте да им кажете да влязат с помощта на {0} и тази парола, която сме генерирали за тях:"
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "collezione"
+msgstr "колекция"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "collezioni"
+msgstr "колекции"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
-msgstr "dashboard"
+msgstr "табло"
 
 #: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
-msgstr "dashboards"
+msgstr "табла"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "Il nome è richiesto"
+msgstr "Името е задължително"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "Deve essere 100 caratteri o meno"
+msgstr "Трябва да съдържа 100 знака или по-малко"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "Il cognome è richiesto"
+msgstr "Изисква се фамилно име"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "L'email è obbligatoria"
+msgstr "Имейлът е задължителен"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "Gli oggetti che archivierai appariranno qui."
+msgstr "Елементите, които архивирате, ще се появят тук."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "Nessuna descrizione"
+msgstr "няма описание"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "Somma di tutti i valori"
+msgstr "Сума от всички стойности"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "Vedi tutti i valori DISTINCT"
+msgstr "Вижте всички различни стойности"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "Sfoglia i contenuti dei tuoi database, tabelle e colonne. Scegli un database per iniziare"
+msgstr "Прегледайте съдържанието на вашите бази данни, таблици и колони. Изберете база данни, за да започнете"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr "I metadati dei risultati delle carte passati alle API sono VALIDI. Grazie!"
+msgstr "Метаданните за резултатите от картите, предадени в API, са ВАЛИДНИ. Благодаря!"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr "i metadati dei risultati delle card passati alle API sono NON VALIDI. Esecuzione della query per recuperare i metadati corretti."
+msgstr "Метаданните за резултатите от картите, предадени на API, са НЕВАЛИДНИ. Изпълнява се заявка за извличане на правилни метаданни."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr "I metadati dei risultati delle carte trasmessi all'API sono MANCANTI. Esecuzione della query per recuperare i metadati corretti."
+msgstr "Метаданните за резултатите от картите, предадени на API, са ISSING. Изпълнява се заявка за извличане на правилни метаданни."
 
 #: src/metabase/api/email.clj
 msgid "{0} was autocorrected to {1}"
-msgstr "{0} è stato corretto automaticamente in {1}"
+msgstr "{0} бе автоматично коригирано на {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id è deprecato. Invece, modifica il valore `archiviato` tramite PUT /api/metric/:id."
+msgstr "ИЗТРИВАНЕ / api / metric /: id е остарял. Вместо това променете стойността на „архивирана“ чрез PUT / api / metric /: id."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:id è deprecato. Invece, modifica il valore `archiviato` tramite PUT /api/segment/:id."
+msgstr "ИЗТРИВАНЕ / api / segment /: id е остарял. Вместо това променете стойността на „архивирана“ чрез PUT / api / segment /: id."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "Il valore di is_superuser deve corrispondere alla presenza dell'ID del gruppo di amministratori in group_ids."
+msgstr "Стойността на is_superuser трябва да съответства на присъствието на идентификатор на администраторска група в group_ids."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "Errore imprevisto durante la scrittura di caratteri `keepalive`"
+msgstr "Неочаквана грешка при писане на поддържащи символи"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "Output imprevisto nella risposta asincrona delle API"
+msgstr "Неочакван изход в асинхронния API отговор"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
-msgstr "avvio della risposta in streaming"
+msgstr "стартиране на стрийминг отговор"
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "Uscita chiusa, annullamento della richiesta keepalive."
+msgstr "Изходният канал е затворен, анулиране на заявка за поддържане."
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "Finita la risposta asincrona, chiusura dei canali."
+msgstr "Асинхронният отговор приключи, затваряне на канали."
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr "Nessuna risposta dopo aver atteso {0}. Annullamento della richiesta."
+msgstr "Няма отговор след изчакване {0}. Отмяна на заявка."
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "Canale di input chiuso inaspettatamente."
+msgstr "Входният канал неочаквано се затвори."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr "f finito, il permesso verrà restituito"
+msgstr "f завършено, разрешението ще бъде върнато"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr "richiesta annullata, il permesso verrà restituito"
+msgstr "заявката е отменена, разрешението ще бъде върнато"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr "Errore imprevisto che tenta di eseguire la funzione dopo aver ottenuto il permesso"
+msgstr "Неочаквана грешка при опит за стартиране на функция след получаване на разрешение"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr "Non è in esecuzione la chiamata di funzione in attesa: canale di output già chiuso."
+msgstr "Не се изпълнява изчакващо извикване на функция: изходният канал вече е затворен."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr "Il thread corrente ha già un permesso per {0}, non aspetterà di acquisirne un altro"
+msgstr "Текущата нишка вече има разрешение за {0}, няма да чака да придобие друга"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr "Canale di output chiuso, salterà l'esecuzione di {0}."
+msgstr "Изходният канал е затворен, пропускането на {0} ще бъде пропуснато."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "Eseguendo {0} su thread separati..."
+msgstr "Изпълнява се {0} в отделна нишка ..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr "Errore in esecuzione {0}"
+msgstr "Уловена грешка при стартиране на {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr "Richiesta annullata, annullamento futuro"
+msgstr "Заявката е анулирана, анулирана в бъдеще"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
-msgstr "Chiusura del vecchio pool di connessioni per il database {0} ..."
+msgstr "Затваря се стар пул от връзки за база данни {0} ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:"
-msgstr "Ecco le tue {0} carte più recenti:"
+msgstr "Ето вашите {0} най-скорошни карти:"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr "Potresti essere un po' più specifico o usare l'ID? Ho trovato queste carte con nomi corrispondenti:"
+msgstr "Бихте ли могли да бъдете малко по-конкретни или да използвате идентификационния номер? Намерих тези карти с имена, които съвпадат:"
 
 #: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "Scheda {0} non trovata."
+msgstr "Карта {0} не е намерена."
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "Eccezione nella chiamata API"
+msgstr "Изключение в API извикване"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "Richiesta annullata prima della fine."
+msgstr "Заявката е анулирана преди завършване."
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "Metabase supporta solo richieste di tipo JSON."
+msgstr "Metabase поддържа само JSON заявки."
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Assicurati di aver impostato l'header 'Content-Type: application/json'"
+msgstr "Уверете се, че сте задали заглавката „Content-Type: application / json“."
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "Impostazione dell'URL del sito di Metabase su {0}"
+msgstr "Задаване на URL адрес на сайта на Metabase на {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "Errore schedulando l'attività per il DB"
+msgstr "Грешка при планиране на задачи за DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "Errore eliminando la schedulazione dell'attività per il DB"
+msgstr "Грешка при разсрочване на задачи за DB."
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr "{0} Database \"{1}\" la schedulazione della sincronizzazione/analisi è stata modificata!"
+msgstr "{0} Графиците за синхронизиране / анализ на базата данни „{1}“ са променени!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr "La sincronizzazione dei metadati era: \"{0}\" - ora è: \"{1}\""
+msgstr "Синхронизираните метаданни бяха: „„ {0} “„ сега е: „„ {1} “"
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr "La cache dei `FieldValues` era: ''{0}'', ora è: ''{1}''"
+msgstr "Кеш FieldValues ​​беше: '' {0} '', сега е: '' {1} ''"
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "Non puoi aggiornare il \"creator_id\" della Metrica"
+msgstr "Не можете да актуализирате creator_id на метрика."
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBot può avere soltanto i permessi della Collezione"
+msgstr "MetaBot може да има само разрешения за събиране."
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "Impossibile concedere i permessi"
+msgstr "Неуспешно предоставяне на разрешения"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "Modifica permessi"
+msgstr "Промяна на разрешенията"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr "DA:"
+msgstr "ОТ:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr "A:"
+msgstr "ДА СЕ:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "Non puoi aggiornare il \"creator_id\" di un Segmento"
+msgstr "Не можете да актуализирате Creator_id на сегмент."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr "Tentativo di impostare l'impostazione {0} su valore offuscato. Cambiamento ignorato."
+msgstr "Опит за задаване на настройка {0} на неясна стойност. Пренебрегване на промяната."
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
-msgstr "Usando il valore della variabile ambiente {0}"
+msgstr "Използване на стойност на env var {0}"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "Sto aggiungendo l'utente {0} al gruppo di Tutti gli Utenti"
+msgstr "Добавяне на потребител {0} към групата с разрешения за всички потребители ..."
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "Sto aggiungendo l'utente {0} al gruppo dell'Amministratore"
+msgstr "Добавяне на потребител {0} към групата с разрешения за администратор ..."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "Fallimento query"
+msgstr "Неуспешна заявка"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "Numero massimo di query contemporanee per il Database a cui si è connessi"
+msgstr "Максимален брой едновременни заявки, които да се разрешат за свързана база данни."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "Si è verificato un Time out dopo {0} millisecondi."
+msgstr "Времето за изчакване е след {0} милисекунди."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr "Istruzione per mancata accensione"
+msgstr "Инструкция за прекъсване на запалването"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
-msgstr "Archiviare?"
+msgstr "Да се ​​архивира ли това?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
-msgstr "Impara dai nostri dati"
+msgstr "Научете за нашите данни"
 
 #: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
-msgstr "usa DNS SRV quando ti connetti"
+msgstr "Използвайте DNS SRV при свързване"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "L'utilizzo di questa opzione richiede che l'host fornito sia un nome di dominio completo. Se ci si connette a un cluster Atlas, potrebbe essere necessario abilitare questa opzione. Se non sai cosa significa, lascialo disabilitato."
+msgstr "Използването на тази опция изисква предоставеният хост да е FQDN. Ако се свързвате\n"
+"с клъстер Atlas, може да се наложи да активирате тази опция. Ако не знаете какво означава това,\n"
+"оставете това деактивирано."
 
 #: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "Esegui automaticamente query quando esegui semplici filtri e riepiloghi"
+msgstr "Автоматично изпълнявайте заявки, когато правите просто филтриране и обобщаване"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Quando è attivo, Metabase eseguirà automaticamente le query quando gli utenti eseguono semplici esplorazioni con i pulsanti Riassumi e Filtro durante la visualizzazione di una tabella o di un grafico. È possibile disattivarlo se l'interrogazione di questo database è lenta. Questa impostazione non influisce sui drill-through o sulle query SQL."
+msgstr "Когато това е в Metabase, автоматично ще се изпълняват заявки, когато потребителите правят прости проучвания с бутоните Summarize и Filter, когато преглеждат таблица или диаграма. Можете да изключите това, ако заявката за тази база данни е бавна. Тази настройка не се отразява на подробности или SQL заявки."
 
 #: frontend/src/metabase/containers/Overworld.jsx:329
 msgid "Learn about this database"
-msgstr "Impara da questo database"
+msgstr "Научете за тази база данни"
 
 #: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
-msgstr "Archiviare questa dashboard?"
+msgstr "Да се ​​архивира ли таблото за управление?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:112
 msgid "All results"
-msgstr "Tutti i risultati"
+msgstr "Всички резултати"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:175
 msgid "Our Analytics"
-msgstr "La nostra analisi"
+msgstr "Нашият анализ"
 
 #: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr "Somma additiva di tutti i valori di una colonna. \\ne.x. entrate totali nel tempo."
+msgstr "Адитивна сума на всички стойности на колона. \\ ne.x. общ приход във времето."
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr "Conteggio additivo di tutti i valori di una riga. \\ne.x. numero totale di vendite nel tempo."
+msgstr "Брой адитиви на броя редове. \\ ne.x. общ брой продажби във времето."
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:98
 msgid "Filter"
-msgstr "Filtro"
+msgstr "Филтър"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
-msgstr[0] "record"
-msgstr[1] "record"
+msgstr[0] "запис"
+msgstr[1] "записа"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:369
 msgid "Browse Data"
-msgstr "Sfoglia i dati"
+msgstr "Преглед на данни"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:402
 msgid "Write SQL"
-msgstr "Scrivi SQL"
+msgstr "Напишете SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
-msgstr "Domanda semplice"
+msgstr "Прост въпрос"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "Raccogli qualche dato, guardalo, e filtra, riepilogalo e visualizzalo facilemnte"
+msgstr "Изберете някои данни, прегледайте ги и лесно ги филтрирайте, обобщавайте и визуализирайте."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
-msgstr "Domanda personalizzata"
+msgstr "Въпрос по поръчка"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "Usa l'editor avanzato per notebook per unire i dati, creare colonne personalizzate, fare matematica e altro."
+msgstr "Използвайте разширения редактор на бележници, за да обединявате данни, да създавате персонализирани колони, да правите математика и др."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
-msgstr "Metriche di base"
+msgstr "Основни показатели"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
-msgstr "Personalizzato... "
+msgstr "Персонализиран…"
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "Aggiungi raggruppamento"
+msgstr "Добавяне на групиране"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr "Scegli un limite"
+msgstr "Изберете лимит"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "Mostra massimo"
+msgstr "Покажи максимум"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Preview"
-msgstr "Anteprima"
+msgstr "Вземете визуализация"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "Torna ai risultati precedenti"
+msgstr "Назад към предишните резултати"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "Valori di esempio"
+msgstr "Примерни стойности"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "Naviga il contenuto dei tuoi database, tabelle e colonna. Scegli un database per iniziare. "
+msgstr "Прегледайте съдържанието на вашите бази данни, таблици и колони. Изберете база данни, за да започнете."
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "Visualizza"
+msgstr "Визуализирайте"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "Dati in join"
+msgstr "Данни за присъединяване"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "Colonna personalizzata"
+msgstr "Персонализирана колона"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:60
 msgid "Summarize"
-msgstr "Riassume"
+msgstr "Обобщете"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr "Aggregazione"
+msgstr "Агрегат"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Punto di rottura"
+msgstr "Пробив"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "Scegli la metrica che vuoi vedere"
+msgstr "Изберете показателя, който искате да видите"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 msgid "Pick a column to group by"
-msgstr "Scegli la colonna da raggruppare "
+msgstr "Изберете колона, по която да групирате"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:28
 msgid "Pick your starting data"
-msgstr "Scegli una data d'inizio"
+msgstr "Изберете началните си данни"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
-msgstr "Seleziona nula"
+msgstr "Изберете Няма"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
-msgstr "Seleziona tutto"
+msgstr "Избери всичко"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
-msgstr "Scegli una tabela"
+msgstr "Изберете маса ..."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "Inserisci un limite"
+msgstr "Въведете лимит"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:273
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "Le parentesi attorno a {0} creano una clausola facoltativa nel modello.  Se è impostata \"variabile\", l'intera clausola viene inserita nel modello.  In caso contrario, l'intera clausola viene ignorata."
+msgstr "Скоби около {0} създават незадължителна клауза в шаблона. Ако е зададена „променлива“, тогава цялата клауза се поставя в шаблона. Ако не, тогава цялата клауза се игнорира."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:290
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "Quando si utilizza un Field Filter, il nome della colonna non deve essere incluso in SQL.  Invece, la variabile dovrebbe essere mappata su un campo nel pannello laterale."
+msgstr "Когато използвате полеви филтър, името на колоната не трябва да се включва в SQL. Вместо това променливата трябва да бъде картографирана в поле в страничния панел."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "Vedi la query originale"
+msgstr "Вижте родната заявка"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "Query nativa per questa domanda"
+msgstr "Вътрешна заявка за този въпрос"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "Converti questa domanda a una query nativa"
+msgstr "Преобразувайте този въпрос в собствена заявка"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "SQL per questa domanda"
+msgstr "SQL за този въпрос"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "Converti questi domande a SQL"
+msgstr "Преобразувайте този въпрос в SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "Ricevi avvisi"
+msgstr "Получавайте сигнали"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "{0} punto di rottura"
-msgstr[1] "{0} punti di rottura"
+msgstr[0] "{0} пробив"
+msgstr[1] "{0} пробива"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Hide filters"
-msgstr "Nascondi i filtri"
+msgstr "Скриване на филтри"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Show filters"
-msgstr "Mostra i filtri"
+msgstr "Показване на филтри"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:18
 msgid "Started from"
-msgstr "Iniziato da"
+msgstr "Започна от"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0} riga"
-msgstr[1] "{0} righe"
+msgstr[0] "{0} ред"
+msgstr[1] "{0} реда"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "Mostra tutte le righe"
+msgstr "Показване на всички редове"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "Mostra {0}"
+msgstr "Показване на {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "Mostra prima {0}"
+msgstr "Показва се първата {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "Mostra {0}"
+msgstr "Показва се {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "Riassunto"
+msgstr "Обобщено"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Hide editor"
-msgstr "Nascondi l'editor"
+msgstr "Скриване на редактора"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Show editor"
-msgstr "Mostra l'editor"
+msgstr "Шоу редактор"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "Seleziona la metrica che vorresti vedere"
+msgstr "Изберете показателя, който искате да видите"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:29
 msgid "{0} options"
-msgstr "{0} opzioni"
+msgstr "{0} опции"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "Selezione una visualizzazione"
+msgstr "Изберете визуализация"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "Filtrato da"
+msgstr "Филтрирайте по"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
-msgstr "Somma per"
+msgstr "Обобщете по"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
-msgstr "Raggruppato da"
+msgstr "Групирай по"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
-msgstr "Aggiungi una metrica"
+msgstr "Добавете показател"
 
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
 #: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
-msgstr "Profilo"
+msgstr "Профил"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "Questo di solito è piuttosto veloce ma sembra richiedere del tempo proprio ora."
+msgstr "Това обикновено е доста бързо, но изглежда, че отнема известно време точно сега."
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
-msgstr "Combo"
+msgstr "Комбо"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
-msgstr "Riga"
+msgstr "Ред"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "Tendenza "
+msgstr "Тенденция"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "Booleano"
+msgstr "Булево"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
-msgstr "Segmento sconosciuto"
+msgstr "Неизвестен сегмент"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
-msgstr "Filtro sconosciuto "
+msgstr "Неизвестен филтър"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Left outer join"
-msgstr "Left outer join"
+msgstr "Ляво външно съединение"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:26
 msgid "Right outer join"
-msgstr "Right outer join"
+msgstr "Дясно външно съединение"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:27
 msgid "Inner join"
-msgstr "Inner join"
+msgstr "Вътрешно присъединяване"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:28
 msgid "Full outer join"
-msgstr "Full outer join"
+msgstr "Пълно външно съединение"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr "I metadati dei risultati delle carte trasmessi all'API sono MANCANTI.  Esecuzione della query per recuperare i metadati corretti."
+msgstr "Метаданните за резултатите от картите, предадени на API, липсват. Изпълнява се заявка за извличане на правилни метаданни."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "Problema di connessione al server LDAP, si ritorna all'autenticazione locale"
+msgstr "Проблемът с свързването към LDAP сървъра ще се върне към локалното удостоверяване"
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "Impossibile creare il Database: impossibile trovare il driver {0}."
+msgstr "Не може да се създаде база данни: не може да се намери драйвер {0}."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "Query fallita"
+msgstr "Заявката не бе успешна"
 
 #: src/metabase/async/util.clj
 msgid "Warning: {0} returned `nil`"
-msgstr "Attenzione: {0} ha restituito `nil`"
+msgstr "Предупреждение: {0} върна `нула`"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "Errore imprevisto durante la scrittura del risultato sul canale di output: già chiuso"
+msgstr "Неочаквана грешка при запис на резултата в изходния канал: вече затворен"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "Errore imprevisto durante la scrittura dell' eccezione sull' output: già chiuso"
+msgstr "Неочаквана грешка при записване на изключение в изходния канал: вече е затворено"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future."
-msgstr "Richiesta annullata, annullamento futuro."
+msgstr "Заявката е анулирана, анулирана в бъдеще."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "Metabase può trasferire dati solo da database H2 a database Postgres o MySQL/MariaDB."
+msgstr "Metabase може да прехвърля данни само от H2 към Postgres или MySQL / MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "ATTENZIONE: L'uso di Metabase con un database di applicazioni H2 non è raccomandato per gli ambienti di produzione."
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Използването на Metabase с база данни на приложения H2 не се препоръчва за производствени инсталации."
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "Impostazione database dell'applicazione"
+msgstr "Настройка на базата данни на приложението"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "Impossibile trovare il driver {0}."
+msgstr "Не можах да намеря драйвер за {0}."
 
 #: src/metabase/driver/impl.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "I driver astratti non possono derivare da driver genitori concreti"
+msgstr "Абстрактните драйвери не могат да произлизат от конкретни родителски драйвери."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "Potrebbe essere necessario aggiungere \"trustServerCertificate = true\" alle opzioni di connessione aggiuntive per connettersi con SSL."
+msgstr "Може да се наложи да добавите 'trustServerCertificate = true' към допълнителните опции за свързване, за да се свържете с SSL."
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr "Non conosco come alias {0}, previsto un identificatore"
+msgstr "Не знам как да псевдоним {0}, очаква се идентификатор."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "Il client ha chiuso la connesione. Annullamento query"
+msgstr "Затворена връзка на клиента, анулиране на заявка"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0} non è un valido DN."
+msgstr "{0} не е валиден DN."
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "Errore durante la registrazione della richiesta API"
+msgstr "Грешка при регистриране на заявката за API"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "Impostazione del site-url fallita"
+msgstr "Неуспешно задаване на URL адрес на сайта"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "Errore nel terminare il thread pool per il DB"
+msgstr "Грешка при унищожаването на пула от нишки за DB."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Aggiornato il nome mostrato per {0} \"{1}\"_ \"{2}\" -> \"{3}\""
+msgstr "Актуализиране на показваното име за {0} '' {1} '': '' {2} '' -> '' {3} ''"
 
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr "Strategia di umanizzazione \"{0}\" invalida. Strategie valide: {1}"
+msgstr "Невалидна стратегия за хуманизация „„ {0} “. Валидни стратегии са: {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Strategia di umanizzazione {0} invalida. Strategie valide: {1}"
+msgstr "Стратегия за хуманизиране на имената на таблици и полета от „„ {0} “на„ „{1}“"
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr "Errore durante il salvataggio della cronologia delle attività"
+msgstr "Грешка при запазване на историята на задачите"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar non è più necessario da Metabase 0.32.0+. Puoi cancellarlo dalla cartella dei plugins."
+msgstr "spark-deps.jar вече не е необходим на Metabase 0.32.0+. Можете да го изтриете от директорията с приставки."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "Usare il classloader APPENA CREATO per contesto condiviso: {0} "
+msgstr "Използване на НОВО СЪЗДАДЕН classloader като споделен контекстен classloader: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Failed to copy file"
-msgstr "Impossibile copiare il file"
+msgstr "Копирането на файла не бе успешно"
 
 #. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "Url non valido: {0}"
+msgstr "Невалиден URL адрес на сайта: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "site-url non è valido;  restituendo zero per ora.  Sarà ripristinato alla prossima richiesta."
+msgstr "URL адресът на сайта е невалиден; връщайки нула засега. Ще бъде нулиран при следваща заявка."
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "Altri risultati sono stati inclusi come file allegati"
+msgstr "Още резултати са включени като прикачен файл"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "Questa domanda è stata inclusa come allegato"
+msgstr "Този въпрос е включен като прикачен файл"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "Non è stato possibile visualizzare questo Pulse. "
+msgstr "Не успяхме да покажем този импулс."
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "Si prega di visualizzare questa scheda in Metabase."
+msgstr "Моля, прегледайте тази карта в Metabase."
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "Si è verificato un errore durante la visualizzazione di questa scheda."
+msgstr "Възникна грешка при показване на тази карта."
 
 #: src/metabase/query_processor.clj
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "Si possono solo determinare le colonne richieste per le interrogazioni MBQL"
+msgstr "Може да определя само очаквани колони за MBQL заявки."
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "Non ci sono colonne disponibili"
+msgstr "Няма върнати колони."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Attenzione: non è possibile determinare i campi per una \"query-source\" esplicita a meno che non si includano anche \"metadati\" di origine."
+msgstr "Предупреждение: не може да определи полета за изрична „заявка за източник“, освен ако не включите и „метаданни за източника“."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "Impossibile risolvere {0}: il campo non esiste o la sua tabella appartiene a un database diverso."
+msgstr "Не може да се реши {0}: Полето не съществува или неговата таблица принадлежи на друга база данни."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr "Impossibile risolvere :field-literal dentro :fk-> senza un join interno con esplicito :alias."
+msgstr "Не може да се реши: field-literal inside: fk-> освен ако вътре не се присъедини с изрично: псевдоним"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "Non trovata Tabella ID per {0}"
+msgstr "Не мога да намеря идентификатор на таблица за {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "Nessuna informazione di corrispondenza trovata"
+msgstr "Не е намерена съответстваща информация."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "Non è stato possibile risolvere {0}"
+msgstr "{0} не можа да бъде разрешен"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr "Clausola chiave esterna non valida: impossibile aggiungere join corrispondente."
+msgstr "Невалидна клауза fk->: няма къде да се добави съответно присъединяване."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "Il driver {0} non supporta le chiavi esterne."
+msgstr "{0} драйверът не поддържа външни ключове."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr "Impossibile dedurre ':source-metadata' per la query con query nativa senza metadati di origine."
+msgstr "Не може да се заключи `: source-metadata` за заявка за източник с входна заявка за източник без метаданни на източника."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "Errore del processore di query: il numero di colonne ritornate dal driver non corrisponde ai risultati."
+msgstr "Грешка в процесора на заявките: броят на колоните, върнати от драйвера, не съответства на резултатите."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "Previste {0} colonne, ma la prima riga dei risultati ha {1} colonne."
+msgstr "Очаквани {0} колони, но първият ред с резултати има {1} колони."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "Nessuna espressione denominata {0} trovata. Trovata {1}"
+msgstr "Не е намерен израз с име {0}. Намерено: {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "Valori distinti di {0}"
+msgstr "Различни стойности на {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "Media di {0}"
+msgstr "Средно от {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "Somma di {0}"
+msgstr "Сума от {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "Devizione standard di {0}"
+msgstr "SD от {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "Minimo di {0}"
+msgstr "Минимално от {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "Massimo di {0}"
+msgstr "Макс. От {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "Somma di {0} che soddisfano la condizione"
+msgstr "Сума от {0} съвпадащо условие"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
-msgstr "Percentuali di righe che soddisfano la condizione"
+msgstr "Дял на редовете, отговарящи на условието"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "Numero di righe che soddisfano la condizione"
+msgstr "Брой редове, отговарящи на условието"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "Richiesta già cancellata, non verrà eseguito il codice QP sincrono."
+msgstr "Заявката вече е анулирана, няма да изпълнява синхронен QP код."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "Inaspettata risposta 'nil' dal Processore di Query."
+msgstr "Неочаквано получи \"нулев\" отговор на процесора за заявки."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "Ottenuta una InterruptedException. Query in cancellazione"
+msgstr "Получих InterruptException. Отмяна на заявката."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr "Eccezione non gestita, aspettata 'catch-exceptions' middleware per gestirla."
+msgstr "Необработено изключение, очаква се междинния софтуер на „catch-exceptions“, за да се справи с него."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after %s"
-msgstr "Time out query dopo %s"
+msgstr "Заявката изтече след% s"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "Creazione di un nuovo pool di thread di query per Database {0}"
+msgstr "Създаване на нов пул от нишки за заявки за база данни {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "Distruzione del pool di thread per il Database {0}"
+msgstr "Унищожаване на пула от нишки на заявки за база данни {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "RIchiesta annullata, annullamento della query in sospeso"
+msgstr "Заявката е анулирана, анулиращата изчакваща заявка"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "Impossibile aggiornare il campo cestinato: mancano i metadati sorgente alla query"
+msgstr "Не може да се актуализира свързаното поле: в заявката липсват метаданни източник"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "Impossibile aggiornare il campo cestinato: impossibile trovare i metadati sorgente corrispondenti per il Campo \"{0}\""
+msgstr "Не може да се актуализира свързаното поле: не можа да се намерят съответстващи метаданни на източника за поле „{0}“"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "Usare il backend cache del processore query: {0}"
+msgstr "Използване на бекенда на кеша на процесора на заявки: {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "Metrica invalida: {0} motivo {1}"
+msgstr "Невалиден показател: {0} причина: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "Errore sconosciuto"
+msgstr "Неизвестна грешка"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "Risposta nil inaspettata dal query processor"
+msgstr "Неочакван нулев отговор от процесора за заявки."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "Query annullata"
+msgstr "Заявката е анулирана"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "Impossibile risolvere i driver per la query: ':database' ID non valido o mancante."
+msgstr "Не може да се разреши драйвер за заявка: липсващ или невалиден идентификатор `: база данни`."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "Impossibile risolvere il driver per la query:  Database {0} non esiste "
+msgstr "Не може да се разреши драйвер за заявка: База данни {0} не съществува."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "Impossibile usare :fields :all in join contro la query sorgente a meno che non abbia :source-metadata"
+msgstr "Не може да се използват: полета: всички в присъединяване срещу заявка за източник, освен ако няма: източник-метаданни."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "Clausola :joined-field sbagliata: join con alias \"{0}\" non esiste. Trovato: {1}"
+msgstr "Лошо: клауза за присъединено поле: присъединяването с псевдоним '' {0} '' не съществува. Намерено: {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr ":source-table \"{0}\" invalida: deve essere risolta a un ID di una tabella ora."
+msgstr "Невалидно: таблица на източника „„ {0} “„: досега трябва да бъде преобразувана в идентификатор на таблица."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "Impossibile memorizzare Tabelle o Campi prima che il Database sia memorizzato"
+msgstr "Не могат да се съхраняват таблици или полета, преди базата данни да се съхранява."
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "Tentativo di recuperare il secondo database. Le query possono referenziare solo un database."
+msgstr "Опит за извличане на втора база данни. Заявките могат да се позовават само на една база данни."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "Recupero tabella {0} fallito: la tabella non esiste o appartiene a un database differente."
+msgstr "Извличането на таблица не бе успешно {0}: Таблицата не съществува или принадлежи към друга база данни."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "Recupero campo {0} fallito: il campo non esiste o appartiene a un database differente."
+msgstr "Неуспешно извличане на поле {0}: Полето не съществува или принадлежи на друга база данни."
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "Recupero template \"{0}\" fallito. Ti sei ricordato di costruire il frontend di metabase?"
+msgstr "Зареждането на шаблон „„ {0} “не бе успешно. Сетихте ли се да изградите интерфейса на Metabase?"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "Impossibile trovare il file DB \"{0}\"."
+msgstr "Не може да бъде намерен примерен DB файл на набора от данни „„ {0} “."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "Caricamento database di esempio..."
+msgstr "Зарежда се примерен набор от данни ..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "Caricamento del database di esempio fallito"
+msgstr "Зареждането на примерния набор от данни не бе успешно"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "Trovate nuove tabelle:"
+msgstr "Намерени нови таблици:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "Spunta tabelle come inattive:"
+msgstr "Означаване на таблици като неактивни:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "Aggiornamento descrizioni tabelle:"
+msgstr "Актуализиране на описание за таблици:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "Riprogrammando lavoro {0}"
+msgstr "Промяна на заданието {0}"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "Errore riprogrammazione lavoro"
+msgstr "Грешка при пренасрочване на заданието"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "Avvio Esecuzione Pulse: {0}"
+msgstr "Стартиране на импулсното изпълнение: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "Esecuzione Pulse Terminata: {0}"
+msgstr "Завършено импулсно изпълнение: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "Scheduling dei task per il Database {0} non riuscita"
+msgstr "Неуспешно планиране на задачи за база данни {0}"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "All elements must be distinct."
+msgstr "Всички елементи трябва да са различни."
 
-#:
+#: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "Scegli le colonne che desideri includere"
+msgstr "Изберете колоните, които искате да включите"
 
 #: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Quando questa opzione è attiva, Metabase eseguirà automaticamente query quando l'utente fa semplici esplorazioni con il bottone Riassunto e Filtri mentre osserva una tabella o un grafico. Puoi disattivarla se interrogare il database è lento. Questa impostazione non influisce sui drill-throughs o sulle query SQL."
+msgstr "Когато това е включено, Metabase автоматично ще изпълнява заявки, когато потребителите правят прости проучвания с бутоните Summarize и Filter, когато преглеждат таблица или диаграма. Можете да изключите това, ако заявката за тази база данни е бавна. Тази настройка не се отразява на подробности или SQL заявки."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "Cambia tipo di join"
+msgstr "Променете типа на присъединяване"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr "Non so come alias {0}, atteso un identificatore."
+msgstr "Не знам как да псевдоним {0}, очаква се идентификатор."
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "Errore nell' aggiungere l' Utente {0} al Gruppo {1}"
+msgstr "Грешка при добавяне на потребител {0} към група {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la strategia di umanizzazione dei nomi tabella e campo da ''{0}'' a ''{1}''"
+msgstr "Промяна на стратегията за хуманизация на имената на таблици и полета от „„ {0} “на„ „{1}“"
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "Loop infinito rilevato: query pre-processata ricorsivamente {0} volte "
+msgstr "Открит е безкраен цикъл: рекурсивно предварително обработена заявка {0} пъти."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Attenzione: impossibile determinare i campi per una 'source-query' esplicita a meno che non si includano 'source-metadata'."
+msgstr "Внимание: не може да се определят полета за изрична „заявка за източник“, освен ако не включите и „метаданни за източника“."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Error determining expected columns for query"
-msgstr "Errore nel determinare le colonne previste per la query"
+msgstr "Грешка при определяне на очакваните колони за заявка"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr "Eccezione non gestita, previsto `catch-exception`middleware per gestirla."
+msgstr "Необработено изключение, очаква се междинният софтуер за „catch-exceptions“, който да се справи с него."
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
-msgstr "Informazioni Diagnostiche"
+msgstr "Диагностична информация"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:123
 msgid "Select Metabase process:"
-msgstr "Seleziona i processi di Metabase:"
+msgstr "Изберете процес на метабаза:"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:133
 msgid "All Metabase processes"
-msgstr "Tutti i processi di Metabase:"
+msgstr "Всички процеси на Metabase"
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:13
 msgid "The window was closed before completing Google Authentication."
-msgstr "La finestra è stata chiusa prima di aver completato l'Autenticazione Google."
+msgstr "Прозорецът беше затворен, преди да завърши удостоверяването с Google."
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:51
 msgid "There was an issue signing in with Google. Pleast contact an administrator."
-msgstr "Si è verificato un errore loggandosi tramite Google. Si prega di contattare un amministratore."
+msgstr "Възникна проблем при влизането с Google. Моля, свържете се с администратор."
 
 #: frontend/src/metabase/plugins/builtin/auth/password.js:9
 msgid "Sign in with email"
-msgstr "Loggati con email"
+msgstr "Влезте с имейл"
 
 #: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
-msgstr "Usare questa opzione richiede che l'host fornito sia un FQDN. Se ti connetti ad un cluster Atlas, potresti aver bisogno di abilitare questa opzione. Se non sai cosa significa, lasciala disattivata."
+msgstr "Използването на тази опция изисква предоставеният хост да е FQDN. Ако се свързвате с клъстер Atlas, може да се наложи да активирате тази опция. Ако не знаете какво означава това, оставете това деактивирано."
 
 #: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "Di default, Metabase esegue una sincronizzazione oraria leggera e un'intensa scansione giornaliera dei valori dei campi. Se si dispone di un grande database, si consiglia di attivare questa opzione e rivedere quando e quanto spesso accadono le scansioni del valore del campo."
+msgstr "По подразбиране Metabase извършва лека почасова синхронизация и интензивно ежедневно сканиране на стойностите на полетата. Ако имате голяма база данни, препоръчваме да я включите и да прегледате кога и колко често се случват сканиранията на стойността на полето."
 
 #: frontend/src/metabase/containers/Overworld.jsx:126
 msgid "Remove these suggestions"
-msgstr "Rimuovi questi suggerimenti"
+msgstr "Премахнете тези предложения"
 
 #: frontend/src/metabase/containers/Overworld.jsx:135
 msgid "Remove these suggestions?"
-msgstr "Rimuovere questi suggerimenti?"
+msgstr "Да се ​​премахнат ли тези предложения?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:151
 msgid "These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt icon on one of your tables."
-msgstr "Questi non si presenterà più sulla homepage di ognuno dei vostri utenti, ma si può sempre ottenere i raggi-x facendo clic su Naviga Dati nella navigazione principale, quindi facendo clic sull'icona fulmine su una delle tue tabelle."
+msgstr "Те вече няма да се показват на началната страница за никой от вашите потребители, но винаги можете да стигнете до рентгенови лъчи, като щракнете върху Преглед на данни в основната навигация, след което щракнете върху иконата на мълния на една от вашите таблици."
 
 #: frontend/src/metabase/containers/Overworld.jsx:274
 msgid "Hide this section"
-msgstr "Nascondi questa sezione"
+msgstr "Скрийте този раздел"
 
 #: frontend/src/metabase/containers/Overworld.jsx:282
 msgid "Remove this section?"
-msgstr "Rimuovi questa sezione?"
+msgstr "Да се ​​премахне ли този раздел?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:298
 msgid "\"Our Data\" won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation."
-msgstr "\"I nostri dati\" non apparirà più sulla homepage di nessuno dei tuoi utenti, ma puoi sempre navigare attraverso i tuoi database e tabelle facendo clic su Naviga Dati nella navigazione principale."
+msgstr "„Нашите данни“ вече няма да се показват на началната страница за никой от вашите потребители, но винаги можете да разглеждате вашите бази данни и таблици, като щракнете върху Преглед на данни в основната навигация."
 
 #: frontend/src/metabase/entities/collections.js:95
 msgid "My new fantastic collection"
-msgstr "La mia nuova fantastica collezione"
+msgstr "Моята нова фантастична колекция"
 
 #: frontend/src/metabase/lib/core.js:178
 msgid "Cancelation timestamp"
-msgstr "Timestamp annullamento"
+msgstr "Отметка за време за анулиране"
 
 #: frontend/src/metabase/lib/core.js:173
 msgid "Cancelation time"
-msgstr "Orario di annullamento"
+msgstr "Време за анулиране"
 
 #: frontend/src/metabase/lib/core.js:168
 msgid "Cancelation date"
-msgstr "Data di annullamento"
+msgstr "Дата на отмяна"
 
 #: frontend/src/metabase/lib/core.js:208
 msgid "Deletion timestamp"
-msgstr "Timestamp cancellazione"
+msgstr "Клеймо за изтриване"
 
 #: frontend/src/metabase/lib/core.js:203
 msgid "Deletion time"
-msgstr "Orario cancellazione"
+msgstr "Време за изтриване"
 
 #: frontend/src/metabase/lib/core.js:198
 msgid "Deletion date"
-msgstr "Data cancellazione"
+msgstr "Дата на изтриване"
 
 #: frontend/src/metabase/lib/core.js:298
 msgid "Only in detail views"
-msgstr "Solo nelle visualizzazioni dettagliate"
+msgstr "Само в подробности изгледи"
 
 #: frontend/src/metabase/lib/core.js:303
 msgid "Do not include"
-msgstr "Non includere"
+msgstr "Не включвайте"
 
 #: frontend/src/metabase/lib/core.js:304
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
-msgstr "Questo campo non sarà visibile o selezionabile nelle domande create con le interfacce GUI. Sarà comunque accessibile nelle query SQL/native."
+msgstr "Това поле няма да бъде видимо или избираемо при въпроси, създадени с GUI интерфейси. Той все още ще бъде достъпен в SQL / собствени заявки."
 
 #: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
-msgstr "Somma cumulativa"
+msgstr "Кумулативна сума"
 
 #: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
-msgstr "Deviazione standard"
+msgstr "Стандартно отклонение"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be at least {0} characters long"
-msgstr "deve essere almeno lunga {0} caratteri"
+msgstr "трябва да е с дължина поне {0} знака"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be at least {0} characters long"
-msgstr "Deve essere almeno lunga {0} caratteri"
+msgstr "Трябва да е с дължина поне {0} знака"
 
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
-msgstr "Nome (obbligatorio)"
+msgstr "Име (задължително)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
-msgstr "Esegui testo selezionato"
+msgstr "Изпълнете избрания текст"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
-msgstr "Esegui query"
+msgstr "Изпълнете заявка"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
-msgstr "(⌘ + invio)"
+msgstr "(⌘ + въведете)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
-msgstr "(Ctrl + invio)"
+msgstr "(Ctrl + enter)"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "Here's where your results will appear"
-msgstr "Qui è dove appariranno i tuoi risultati"
+msgstr "Ето къде ще се покажат вашите резултати"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:16
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
-msgstr "Non farai alcuna modifica permanente ad una domanda salvata a meno che non fai clic su Salva e scegli di sostituire la domanda originale."
+msgstr "Няма да правите никакви постоянни промени в запазен въпрос, освен ако не щракнете върху Запазване и изберете да замените оригиналния въпрос."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
-msgstr "Non esiste ancora alcun widget filtro per questo tipo di campo."
+msgstr "Все още няма приспособления за филтриране за този тип поле."
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:27
 msgid "Look up this field"
-msgstr "Cerca questo campo"
+msgstr "Потърсете това поле"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
 msgid "Why this metric is interesting"
-msgstr "Perché questa metrica è interessante"
+msgstr "Защо този показател е интересен"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
 msgid "Things to be aware of about this metric"
-msgstr "Cose da sapere su questa metrica"
+msgstr "Неща, които трябва да знаете за тази метрика"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "How this metric is calculated"
-msgstr "Come è calcolata questa metrica"
+msgstr "Как се изчислява тази метрика"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:215
 msgid "Table this is based on"
-msgstr "Questa tabella è basata su"
+msgstr "Таблица, на която се базира"
 
 #: frontend/src/metabase/visualizations/lib/renderer_utils.js:276
 msgid "(empty)"
-msgstr "(vuoto)"
+msgstr "(празно)"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Goal line"
-msgstr "Linea obbiettivo"
+msgstr "Голова линия"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Trend line"
-msgstr "Linea tendenza"
+msgstr "Тенденционна линия"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
-msgstr "Mostra i valori sui data points"
+msgstr "Показване на стойности в точките с данни"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
-msgstr "Valori da mostrare"
+msgstr "Стойности за показване"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
-msgstr "Quanti più si adattano bene"
+msgstr "Колкото могат да се поберат добре"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
-msgstr "Tutti"
+msgstr "всичко"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:9
 msgid "Data includes missing dimension values."
-msgstr "I dati includono dei valori dimensionali mancanti."
+msgstr "Данните включват липсващи стойности на измерения."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:17
 msgid "We encountered an invalid date: \"{0}\""
-msgstr "Abbiamo riscontrato una data invalida: \"{0}\""
+msgstr "Срещнахме невалидна дата: „{0}“"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:38
 msgid "The query for this chart was run in {0} rather than {1} due to database or driver constraints."
-msgstr "La query per questo grafico è stata eseguita in {0} invece di {1} a causa del database o dei vincoli del driver."
+msgstr "Заявката за тази диаграма се изпълнява в {0}, а не {1} поради ограничения на базата данни или драйвери."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:47
 msgid "This chart contains queries run in multiple timezones: {0}"
-msgstr "Questo grafico contiene query eseguite in fusi orari multipli: {0}"
+msgstr "Тази диаграма съдържа заявки, изпълнявани в множество часови зони: {0}"
 
 #: src/metabase/api/public.clj
 msgid "An error occurred while running the query."
-msgstr "Si è verificato un errore durante l'esecuzione della query."
+msgstr "При изпълнението на заявката възникна грешка."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Output H2 database already exists: %s, removing."
-msgstr "Il database di output H2 esiste già: %s, rimozione."
+msgstr "Изходна база данни H2 вече съществува:% s, премахване."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Don't need to migrate, just use the existing H2 file"
-msgstr "Non c'è bisogno di migrare, basta usare il file H2 esistente"
+msgstr "Не е необходимо да мигрирате, просто използвайте съществуващия H2 файл"
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Target DB is already populated!"
-msgstr "Target DB è già popolato!"
+msgstr "Целевата DB вече е попълнена!"
 
 #: src/metabase/core.clj
 msgid "System info:n {0}"
-msgstr "Info di sistema:n {0}"
+msgstr "Информация за системата: n {0}"
 
 #: src/metabase/db.clj
 msgid "Database setup"
-msgstr "Setup database"
+msgstr "Настройка на база данни"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren''t in a Collection to {1} Collection {2}"
-msgstr "Muovendo istanze di {0} che non sono in una Collezione a {1} Collezione {2}"
+msgstr "Преместване на екземпляри на {0}, които не са в колекция, в {1} колекция {2}"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid '{{...}}' clause: expected a param name"
-msgstr "Clausola '{{..}}' invalida: atteso il nome di un parametro"
+msgstr "Невалидна клауза „{{...}}“: очаквано име на параметър"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'{{...}}' clauses cannot be empty."
-msgstr "'{{...}}' clausole non possono essere vuote."
+msgstr "„{{...}}“ не могат да бъдат празни."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'[[...]]' clauses must contain at least one '{{...}}' clause."
-msgstr "'[[...]]' clausole devono contenere almeno una '{{...}}' clausola."
+msgstr "„[[...]]“ трябва да съдържат поне едin пaраметър от  „{{...}}“."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'"
-msgstr "Query invalida: trovati '[[' o '{{' senza corrispondenza ']]' or '}}'"
+msgstr "Невалидна заявка: намерено '[[' или '{{' без съвпадение ']]' или '}}'"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "You''ll need to pick a value for ''{0}'' before this query can run."
-msgstr "Dovrai prendere un valore per \"{0}\" prima che questa query possa essere eseguita."
+msgstr "Ще трябва да изберете стойност за „{0}“, преди тази заявка да може да се изпълни."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Can''t find field with ID: {0}"
-msgstr "Impossibile trovare campo con ID: {0}"
+msgstr "Не мога да намеря поле с идентификатор: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error loading driver namespace"
-msgstr "Errore durante il caricamento del driver namespace"
+msgstr "Грешка при зареждането на пространството от имена на драйвера"
 
 #: src/metabase/driver/impl.clj
 msgid "Could not load {0} driver."
-msgstr "Non è possibile caricare il driver {0}."
+msgstr "Драйверът на {0} не можа да се зареди."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run query: missing required parameters: {0}"
-msgstr "Impossibile eseguire la query: mancano dei parametri richiesti: {0}"
+msgstr "Не може да се изпълни заявка: липсват задължителни параметри: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1}"
-msgstr "Non so come analizzare {0} {1}"
+msgstr "Не знам как да анализирам {0} {1}"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don''t know how to alias {0}, expected an Identifier."
-msgstr "Non so come fare l'alias {0}, aspettato un Identificativo."
+msgstr "Не знам как да псевдоним {0}, очаква се идентификатор."
 
 #. it's better return a slightly broken SQL query with a probably incorrect string representation of the value than
 #. to have the entire QP run fail because of an unknown type.
 #: src/metabase/driver/sql/util/unprepare.clj
 msgid "Don''t know how to unprepare values of class {0}"
-msgstr "Non so come disfare i valori della classe {0}"
+msgstr "Не знам как да подготвям стойности на клас {0}"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Creating new connection pool for {0} database {1} ..."
-msgstr "Creando un nuovo pool di connessione per {0} database {1} ..."
+msgstr "Създава се нов пул за връзка за {0} база данни {1} ..."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Invalid timezone ''{0}''"
-msgstr "Fuso orario non valido ''{0}''"
+msgstr "Невалидна часова зона „{0}“"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Cannot set timezone: invalid or missing SQL format string for driver {0}."
-msgstr "Impossibile settare fuso orario: formato SQL per driver {0} mancante o non valida."
+msgstr "Не може да се зададе часова зона: невалиден или липсващ низ на SQL формат за драйвер {0}."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Did you implement set-timezone-sql?"
-msgstr "Hai implementato set-timezone-sql?"
+msgstr "Приложихте ли set-timezone-sql?"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}''"
-msgstr "Settaggio fuso orario ''{0}'' fallito"
+msgstr "Задаването на часовата зона „{0}“ не бе успешно"
 
 #: src/metabase/driver/util.clj
 msgid "Database connection error"
-msgstr "Errore nella connessione al database"
+msgstr "Грешка при свързване на база данни"
 
 #: src/metabase/models/interface.clj
 msgid "Error parsing JSON"
-msgstr "Errore nel parsing JSON"
+msgstr "Грешка при синтактичния анализ на JSON"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data"
-msgstr "Indica se visualizzare o meno i dati sulla homepage. Gli amministratori potrebbero disattivare questo al fine di indirizzare gli utenti a contenuti migliori di dati grezzi"
+msgstr "Дали да се показват данни на началната страница. Администраторите могат да изключат това, за да насочат потребителите към по-добро съдържание от суровите данни"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data"
-msgstr "Indica se visualizzare o meno i suggerimenti a raggi x sulla homepage. Essi saranno anche nascosti se eventuali dashboard sono bloccate. Gli amministratori potrebbero nascondere questo per indirizzare gli utenti a contenuti migliori di dati grezzi"
+msgstr "Дали да се показват рентгенови предложения на началната страница. Те също ще бъдат скрити, ако са закрепени някакви табла за управление. Администраторите могат да скрият това, за да насочат потребителите към по-добро съдържание от суровите данни"
 
 #: src/metabase/public_settings.clj
 msgid "Identify the source of HTTP requests by this header's value, instead of its remote address."
-msgstr "Identificare la fonte delle richieste HTTP dal valore di questa intestazione, invece del suo indirizzo remoto."
+msgstr "Идентифицирайте източника на HTTP заявки по стойността на тази заглавка, вместо по отдалечения адрес."
 
 #: src/metabase/public_settings.clj
 msgid "Could not resolve Setting {0}/{1}"
-msgstr "Impossibile risolvere Impostazioni {0}/{1}"
+msgstr "Настройката {0} / {1} не можа да бъде разрешена"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid Setting: {0}/{1}"
-msgstr "Impostazione invalida: {0}/{1}"
+msgstr "Невалидна настройка: {0} / {1}"
 
 #: src/metabase/pulse.clj
 msgid "reached its goal"
-msgstr "ha raggiunto l'obiettivo"
+msgstr "достигна целта си"
 
 #: src/metabase/pulse.clj
 msgid "gone below its goal"
-msgstr "non ha raggiunto l'obiettivo"
+msgstr "отиде под целта си"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via email"
-msgstr "Inviando Pulse ({0}: {1}) via email"
+msgstr "Изпращане на импулс ({0}: {1}) по имейл"
 
 #: src/metabase/pulse.clj
 msgid "Pulse: {0}"
-msgstr "Pulse: {0}"
+msgstr "Пулс: {0}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via Slack"
-msgstr "Inviando Pulse ({0}: {1}) via Slack"
+msgstr "Изпращане на импулс ({0}: {1}) чрез Slack"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via email"
-msgstr "Inviando avviso ({0}: {1}) via email"
+msgstr "Изпращане на предупреждение ({0}: {1}) по имейл"
 
 #: src/metabase/pulse.clj
 msgid "Metabase alert: {0} has {1}"
-msgstr "L'avviso Metabase {0} ha {1}"
+msgstr "Сигнал за метабаза: {0} има {1}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via Slack"
-msgstr "Inviando avviso ({0}: {1}) via Slack"
+msgstr "Изпращане на предупреждение ({0}: {1}) чрез Slack"
 
 #: src/metabase/pulse.clj
 msgid "Alert: {0}"
-msgstr "Avviso: {0}"
+msgstr "Сигнал: {0}"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can''t find JS color selector at ''{0}''"
-msgstr "Impossibile trovare selettore colore JS in \"{0}\""
+msgstr "Не мога да намеря JS селектор за цвят в „{0}“"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attemping to format them as such?"
-msgstr "SISTEMAMI: Questi non sono letterali temporali validi: {0} {1}. Per quale motivo si sta tentando di utilizzare tale formato?"
+msgstr "FIXME: Това не са валидни временни литерали: {0} {1}. Защо се опитваме да ги форматираме като такива?"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found for join against Table {0} ''{1}'' on Field {2} ''{3}'' via FK {4} ''{5}''"
-msgstr "Nessuna informazione corrispondente trovata per join con tabella {0} ''{1}'' nei campi {2} ''{3}'' via FK {4} ''{5}''"
+msgstr "Не е намерена съвпадаща информация за присъединяване срещу таблица {0} '' {1} '' в поле {2} '' {3} '' чрез FK {4} '' {5} ''"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don''t know how to get information about Field: {0}"
-msgstr "Non so come ottenere informazioni riguardo il campo: {0}"
+msgstr "Не знам как да получа информация за Field: {0}"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after {0}"
-msgstr "Time out query dopo {0}"
+msgstr "Времето за изчакване на заявката изтече след {0}"
 
 #: src/metabase/query_processor/middleware/format_rows.clj
 msgid "Formatting rows with results timezone ID {0}"
-msgstr "La formattazione delle righe con i risultati timezone ID {0}"
+msgstr "Форматиране на редове с идентификатор на часовата зона на резултатите {0}"
 
 #: src/metabase/query_processor/timezone.clj
 msgid "Invalid timezone ID ''{0}''"
-msgstr "ID fuso orario ''{0}'' non valido"
+msgstr "Невалиден идентификатор на часовата зона „„ {0} “"
 
 #: src/metabase/sync/analyze/fingerprint.clj
 msgid "Saving fingerprint for {0}"
-msgstr "Salvataggio impronte digitali per {0}"
+msgstr "Запазване на пръстов отпечатък за {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandoment email!"
-msgstr "Invio email di abbandono!"
+msgstr "Изпращане на имейл по поръчка!"
 
 #: src/metabase/transforms/core.clj
 msgid "Resulting transforms do not conform to expectations.nExpected: {0}"
-msgstr "Le trasformazioni risultanti non sono conformi a expectations.nExpected: {0}"
+msgstr "Резултатните трансформации не отговарят на очакванията. N Очаквано: {0}"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0}"
-msgstr "Time out dopo {0}"
+msgstr "Времето за изчакване е след {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "No temporal adjuster named {0}"
-msgstr "Nessun regolatore temporale denominato {0}"
+msgstr "Няма временен регулатор на име {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "Invalid unit: {0}"
-msgstr "Unità non valida: {0}"
+msgstr "Невалидна единица: {0}"
 
 #: src/metabase/util/date_2/parse.clj
 msgid "Don''t know how to parse {0} using format {1}"
-msgstr "Non so come analizzare {0} usando il formato {1}"
+msgstr "Не знам как да анализирам {0} с помощта на формат {1}"
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath {0}"
-msgstr "Il token non ha valore per il keypath {0}"
+msgstr "За маркера липсва стойност за път на ключ {0}"
 
 #: src/metabase/util/stats.clj
 msgid "Sending usage stats FAILED"
-msgstr "Invio statistiche di utilizzo FALLITO"
+msgstr "Изпращането на статистически данни за употребата не бе успешно"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:69
 msgid "There was an error saving"
-msgstr "Si è verificato un errore durante il salvataggio"
+msgstr "При запазването възникна грешка"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:75
 msgid "OK"
-msgstr "OK"
+msgstr "Добре"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}."
-msgstr "Per autorizzare gli utenti a registrarsi con Google hai bisogno di dare a Metabase una Google Developers console di applicazione client ID. Questo prevede pochi passi, e le istruzioni su come creare una chiave possono essere trovate qua {0}."
+msgstr "За да позволите на потребителите да влизат с Google, ще трябва да дадете на Metabase клиентски идентификационен номер на приложение за конзола на Google Developers. Необходими са само няколко стъпки и инструкции как да създадете ключ можете да намерите {0}."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:134
 msgid "Be sure to include the full client ID, including the apps.googleusercontent.com suffix."
-msgstr "Assicurati di includere tutto il client ID, includendo il suffisso apps.googleusercontent.com"
+msgstr "Не забравяйте да включите пълния идентификатор на клиента, включително суфикса apps.googleusercontent.com."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:30
 msgid "Metabase {0} is available."
-msgstr "Metabase {0} è disponibile."
+msgstr "Налична е метабаза {0}."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:31
 msgid "You're running {0}"
-msgstr "Stai eseguendo {0}"
+msgstr "Изпълнявате {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:57
 msgid "Sorry, we were unable to check for updates at this time."
-msgstr "Siamo spiacenti, non siamo stati in grado di controllare gli aggiornamenti in questo momento."
+msgstr "За съжаление в момента не успяхме да проверим за актуализации."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:96
 msgid "patch release"
-msgstr "rilascio patch"
+msgstr "освобождаване на кръпка"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:10
 msgid "Dates and Times"
-msgstr "Date e Orari"
+msgstr "Дати и времена"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:25
 msgid "Numbers"
-msgstr "Numeri"
+msgstr "Числа"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
-msgstr "Nessun gruppo mappabile"
+msgstr "Няма картиращи се групи"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
-msgstr "Documentazione Metabase"
+msgstr "Документация на метабазата"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
-msgstr "Contiene una guida di risoluzione dei problemi"
+msgstr "Включва ръководство за отстраняване на неизправности"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
-msgstr "Posta sul forum di supporto di Metabase"
+msgstr "Публикувайте във форума за поддръжка на Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
-msgstr "Un forum comunitario per tutte le cose di Metabase"
+msgstr "Форум на общността за всички неща Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
-msgstr "Invia un file di bug report"
+msgstr "Подайте доклад за грешка"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
-msgstr "Crea una issue su GitHub (includendo le informazioni di diagnostica riportate sotto)"
+msgstr "Създайте проблем с GitHub (включва диагностичната информация по-долу)"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
-msgstr "Si prega di includere questi dettagli nelle richieste di supporto. Grazie!"
+msgstr "Моля, включете тези подробности в исканията за поддръжка. Благодаря ти!"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:37
 msgid "youlooknicetoday@email.com"
-msgstr "staibenissimooggi@email.it"
+msgstr "youlooknicetoday@email.com"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:50
 msgid "Remember me"
-msgstr "Ricordami"
+msgstr "Помни ме"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
-msgstr "Per ragioni di sicurezza, i link per il reset della password scadono dopo poco. Se hai ancora bisogno di resettare la password puoi {0}."
+msgstr "От съображения за сигурност връзките за нулиране на паролата изтичат след малко. Ако все пак трябва да зададете нова парола, можете да {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
-msgstr "Salva la nuova password"
+msgstr "Запазете нова парола"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
-msgstr "Nessuna corrispondenza"
+msgstr "Няма съвпадащ резултат"
 
 #: frontend/src/metabase/components/form/CustomForm.jsx:178
 msgid "Submit"
-msgstr "Invia"
+msgstr "Изпращане"
 
 #: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
-msgstr "Alcune installazioni di database sono accessibili solo collegandosi tramite un host SSH bastion. Questa opzione fornisce anche un ulteriore livello di sicurezza quando una VPN non è disponibile. Abilitarla è di solito più lenta di una connessione diretta."
+msgstr "До някои инсталации на база данни може да се осъществи достъп само чрез свързване чрез SSH бастион хост. Тази опция също така осигурява допълнителен слой сигурност, когато VPN не е налице. Активирането на това обикновено е по-бавно от директната връзка."
 
 #: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
-msgstr "Vi suggeriamo di lasciare disattivata questa opzione a meno che non si sta facendo il fuso orario manuale in molti o nella maggior parte delle vostre domande con questi dati."
+msgstr "Предлагаме ви да оставите това, освен ако не правите ръчно леене на часови зони в много или повечето от вашите заявки с тези данни."
 
 #: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
-msgstr "{0} per ottenere un auth code"
+msgstr "{0}, за да получите код за удостоверяване."
 
 #: frontend/src/metabase/entities/databases/forms.js:136
 #: src/metabase/models/collection.clj
 msgid "or"
-msgstr "o"
+msgstr "или"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
 #: frontend/src/metabase/entities/databases/forms.js:227
@@ -13841,46 +13838,46 @@ msgstr "o"
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
-msgstr "richiesto"
+msgstr "задължително"
 
 #: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
-msgstr "Tipo database"
+msgstr "Тип база данни"
 
 #: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
-msgstr "Questo è un processo leggero che controlla la presenza di aggiornamenti dello schema di questo database. Nella maggior parte dei casi, sarebbe bene lasciare questo settaggio per sincronizzare ogni ora."
+msgstr "Това е лек процес, който проверява за актуализации на схемата на тази база данни. В повечето случаи трябва да сте добре, като оставите този комплект да се синхронизира ежечасно."
 
 #: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
-msgstr "Metabase può scansire i valori presenti in questo campo di questo database per abilitare i filtri checkbox nelle dashboard e nelle query. Questo può essere un processo ad alta intensità di risorse, in particolare se si dispone di un database molto ampio."
+msgstr "Metabase може да сканира стойностите, налични във всяко поле в тази база данни, за да активира филтрите за отметки в таблата и въпроси. Това може да бъде донякъде интензивен процес, особено ако имате много голяма база данни."
 
 #: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
-msgstr "Collezione"
+msgstr "колекция"
 
 #: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
-msgstr "Conferma la tua password"
+msgstr "Потвърдите паролата"
 
 #: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
-msgstr "le password non corrispondono"
+msgstr "Паролите не съвпадат"
 
 #: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
-msgstr "Dipartimento del Fantastico"
+msgstr "Отдел за страхотни"
 
 #: frontend/src/metabase/lib/core.js:88 frontend/src/metabase/lib/core.js:93
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "Finanziario"
+msgstr "Финансов"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
 msgid "Numeric"
-msgstr "Numerico"
+msgstr "Числови"
 
 #: frontend/src/metabase/lib/core.js:169 frontend/src/metabase/lib/core.js:174
 #: frontend/src/metabase/lib/core.js:179 frontend/src/metabase/lib/core.js:184
@@ -13890,44 +13887,44 @@ msgstr "Numerico"
 #: frontend/src/metabase/lib/core.js:219 frontend/src/metabase/lib/core.js:224
 #: frontend/src/metabase/lib/core.js:229 frontend/src/metabase/lib/core.js:234
 msgid "Date and Time"
-msgstr "Data e Ora"
+msgstr "Дата и час"
 
 #: frontend/src/metabase/lib/core.js:241 frontend/src/metabase/lib/core.js:246
 #: frontend/src/metabase/lib/core.js:251
 msgid "Categorical"
-msgstr "Categorico"
+msgstr "Категорично"
 
 #: frontend/src/metabase/lib/core.js:258 frontend/src/metabase/lib/core.js:263
 #: frontend/src/metabase/lib/core.js:268
 msgid "URLs"
-msgstr "URL"
+msgstr "URL адреси"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
-msgstr "Ritorna la media dei valori nella colonna."
+msgstr "Връща средната стойност на стойностите в колоната."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
-msgstr "La colonna i cui valori medi."
+msgstr "Колоната, чиито стойности да се осредняват."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
-msgstr "inizio"
+msgstr "старт"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
-msgstr "fine"
+msgstr "край"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
-msgstr "Controlla il valore di una colonna con date o numeri per controllare se i valori sono dentro un range specifico."
+msgstr "Проверява стойностите на датата или числовата колона, за да види дали са в посочения диапазон."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
-msgstr "Rating"
+msgstr "Рейтинг"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
@@ -13938,171 +13935,171 @@ msgstr "Rating"
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
-msgstr "condizione"
+msgstr "състояние"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
-msgstr "output"
+msgstr "изход"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "Testa una lista di casi e ritorna il valore della prima corrispondenza, con un valore di default opzionale nel caso non si trovino corrispondenze."
+msgstr "Тества списък със случаи и връща съответната стойност на първия истински случай, с незадължителна стойност по подразбиране, ако не е изпълнено нищо друго."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
-msgstr "Peso"
+msgstr "Тегло"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
-msgstr "Grande"
+msgstr "Голям"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
-msgstr "Medio"
+msgstr "Среден"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
-msgstr "Piccolo"
+msgstr "Малък"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
-msgstr "Qualcosa che possa essere espressa come vera o falsa."
+msgstr "Нещо, което трябва да се оцени като вярно или невярно."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
-msgstr "Il valore che verrà restituito se la condizione precedente è vera."
+msgstr "Стойността, която ще бъде върната, ако предходното условие е вярно."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
-msgstr "valore1"
+msgstr "стойност1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
-msgstr "valore2"
+msgstr "стойност2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
-msgstr "Esamina i valori di ogni argomento in ordine e restituisce il primo valore non nullo per ogni riga."
+msgstr "Разглежда стойностите във всеки аргумент по ред и връща първата ненулева стойност за всеки ред."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
-msgstr "Commenti"
+msgstr "Коментари"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
-msgstr "Note"
+msgstr "Бележки"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
-msgstr "Nessun commento"
+msgstr "Без коментари"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
-msgstr "Una colonna o un valore."
+msgstr "Колона или стойност."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
-msgstr "Se valore1 è vuoto, valore2 viene restituito e così via."
+msgstr "Ако value1 е празно, value2 се връща, ако не е празно и т.н."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
-msgstr "Combina due o più stringhe di testo assieme."
+msgstr "Комбинира два или повече низа от текст заедно."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
-msgstr "Cognome"
+msgstr "Фамилия"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
-msgstr "Nome"
+msgstr "Първо име"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
-msgstr "valore2 verrà aggiunto alla fine di questo."
+msgstr "value2 ще бъде добавен към края на това."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
-msgstr "Questo verrà aggiunto alla fine del valore1"
+msgstr "Това ще бъде добавено към края на value1."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
-msgstr "stringa1"
+msgstr "низ1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
-msgstr "stringa2"
+msgstr "низ2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
-msgstr "Verifica se stringa1 contiene al suo interno stringa2."
+msgstr "Проверява дали string1 съдържа string2 в себе си."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
-msgstr "Stato"
+msgstr "Състояние"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
-msgstr "Approvare"
+msgstr "Подайте"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
-msgstr "Il contenuto di questa stringa sarà oggetto di verifica."
+msgstr "Съдържанието на този низ ще бъде проверено."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
-msgstr "La stringa del testo da cercare."
+msgstr "Низът от текст, който да търсите."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
-msgstr "Ritorna il numero di righe nei dati sorgente."
+msgstr "Връща броя на редовете в изходните данни."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
-msgstr "Conta solo le righe dove la condizione è vera."
+msgstr "Брои само редове, когато условието е вярно."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
-msgstr "Subtotale"
+msgstr "Междинна сума"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
-msgstr "L'additivo totale di righe attraverso un breakout."
+msgstr "Сумата на добавките на редове през пробив."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
-msgstr "La somma progressiva di una colonna attraverso un breakout."
+msgstr "Подвижната сума на колона през пробив."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
-msgstr "La colonna da sommare."
+msgstr "Колоната за сумиране."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
-msgstr "Il numero di valori distinti in questa colonna."
+msgstr "Броят на различните стойности в тази колона."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
-msgstr "La colonna di cui contare i valori distinti."
+msgstr "Колоната, чиито отделни стойности да се броят."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
@@ -14129,1190 +14126,1188 @@ msgstr "La colonna di cui contare i valori distinti."
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
-msgstr "testo"
+msgstr "текст"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
-msgstr "comparazione"
+msgstr "сравнение"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
-msgstr "Ritorna vero se la fine del testo corrisponde al testo di comparazione."
+msgstr "Връща true, ако краят на текста съвпада с текста за сравнение."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
-msgstr "Appetito"
+msgstr "Апетит"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
-msgstr "affamato"
+msgstr "гладен"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
-msgstr "Una colonna o stringa di testo da verificare."
+msgstr "Колона или низ от текст за проверка."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
-msgstr "La stringa di testo con cui dovrebbe terminare il testo originale."
+msgstr "Низът текст, с който трябва да завършва оригиналният текст."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
-msgstr "regular_expression"
+msgstr "редовен_израз"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
-msgstr "Estrae le sottostringhe corrispondenti secondo un'espressione regolare."
+msgstr "Извлича съвпадащи поднизове според регулярния израз."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
-msgstr "Indirizzo"
+msgstr "Адрес"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
-msgstr "La colonna o la stringa di testo da cercare."
+msgstr "Колоната или низът от текст за търсене обаче."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
-msgstr "L'espressione regolare da corrispondere."
+msgstr "Регулярният израз, който да съвпада."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
-msgstr "Ritorna la stringa di testa in minuscolo."
+msgstr "Връща низа от текст с малки букви."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
-msgstr "La colonna con i valori da convertire in minuscolo."
+msgstr "Колоната със стойности за преобразуване в малки букви."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
-msgstr "Rimuove lo spazio bianco iniziale da una stringa di testo."
+msgstr "Премахва водещото празно пространство от низ от текст."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
-msgstr "La colonna con i valori su cui vuoi effettuare il trim."
+msgstr "Колоната със стойности, които искате да отрежете."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
-msgstr "Ritorna il valore maggiore trovato nella colonna."
+msgstr "Връща най-голямата стойност, намерена в колоната."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
-msgstr "Età"
+msgstr "Възраст"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
-msgstr "La colonna numerica di cui vuoi trovare il massimo."
+msgstr "Числовата колона, чийто максимум искате да намерите."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
-msgstr "Ritorna il valore minore trovato nella colonna."
+msgstr "Връща най-малката стойност, намерена в колоната."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
-msgstr "Salario"
+msgstr "Заплата"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
-msgstr "La colonna numerica di cui vuoi trovare il minimo."
+msgstr "Числовата колона, чийто минимум искате да намерите."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
-msgstr "posizione"
+msgstr "позиция"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
-msgstr "lunghezza"
+msgstr "дължина"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:185
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "new_text"
-msgstr "nuovo_testo"
+msgstr "нов_текст"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
-msgstr "Sostituisce una parte del testo in input con il nuovo testo."
+msgstr "Заменя част от въведения текст с нов текст."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "ID Ordine"
+msgstr "Идентификационен номер на поръчката"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
-msgstr "Parte dell'ID aggiornata"
+msgstr "Актуализирана част от ID"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
-msgstr "Il testo che verrà modificato."
+msgstr "Текстът, който ще бъде модифициран."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:193
 msgid "The position where the replacing will start."
-msgstr "La posizione in cui inizia la sostituzione"
+msgstr "Позицията, където ще започне подмяната."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
 msgid "The number of characters to replace."
-msgstr "Il numero di caratteri da sostituire."
+msgstr "Броят на знаците за замяна."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:197
 msgid "The text to use in the replacement."
-msgstr "Il testo da usare in sostituzione"
+msgstr "Текстът, който да се използва при замяната."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
-msgstr "Rimuove lo spazio bianco da una stringa di testo."
+msgstr "Премахва последващото празно пространство от низ от текст."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
-msgstr "Restituisce la percentuale di righe nei dati che corrispondono alla condizione, sottoforma di decimale."
+msgstr "Връща процента на редовете в данните, които съответстват на условието, като десетичен знак."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
-msgstr "Restituisce vero se l'inizio del testo corrisponde al testo di confronto."
+msgstr "Връща true, ако началото на текста съвпада с текста за сравнение."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
-msgstr "Nome Corso"
+msgstr "Име на курса"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
-msgstr "Scienze Informatiche"
+msgstr "Информатика"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
-msgstr "La stringa di testo con cui dovrebbe cominciare il testo originale."
+msgstr "Низът текст, с който трябва да започва оригиналният текст."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
-msgstr "Calcola la deviazione standard della colonna."
+msgstr "Изчислява стандартното отклонение на колоната."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
-msgstr "Popolazione"
+msgstr "Население"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
-msgstr "Una colona numerica."
+msgstr "Числова колона."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
-msgstr "Ritorna una porzione del testo sottoposto."
+msgstr "Връща част от предоставения текст."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
-msgstr "Il testo di cui ritornare una porzione."
+msgstr "Текстът за връщане на част от."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
-msgstr "La posizione da cui iniziare a copiare i caratteri."
+msgstr "Позицията за започване на копиране на знаци."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
-msgstr "Il numero di caratteri da ritornare."
+msgstr "Броят на символите, които трябва да се върнат."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
-msgstr "Aggiunge tutti i valori della colonna."
+msgstr "Събира всички стойности на колоната."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
-msgstr "La colonna numerica da sommare"
+msgstr "Числовата колона за сумиране."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
-msgstr "Somma i valori in una colonna dove le righe corrispondono alla condizione."
+msgstr "Сумира стойности в колона, където редовете съответстват на условието."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
-msgstr "Stato Ordine"
+msgstr "Състояние на поръчката"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
-msgstr "Valido"
+msgstr "Валидно"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
-msgstr "Rimuove spazi bianchi iniziali e finali da una stringa di testo."
+msgstr "Премахва водещото и последващото празно пространство от низ от текст."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
-msgstr "Ritorna la stringa di testo con tutte lettere maiuscole."
+msgstr "Връща низа от текст във всички главни букви."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
-msgstr "La colonna i cui valori sono da convertire in maiuscoli."
+msgstr "Колоната със стойности за преобразуване в главни букви."
 
 #: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
-msgstr "deve essere {0} ed includere {1}."
+msgstr "трябва да е {0} и да включва {1}."
 
 #: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
-msgstr "deve essere {0}."
+msgstr "трябва да е {0}."
 
 #: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
-msgstr "deve includere {0}."
+msgstr "трябва да включва {0}."
 
 #: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
-msgstr[0] "lunghezza minima {0} carattere"
-msgstr[1] "lunghezza minima {0} caratteri"
+msgstr[0] "дължина поне {0} знак"
+msgstr[1] "дължина поне {0} знака"
 
 #: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
-msgstr[0] "{0} lettera minuscola"
-msgstr[1] "{0} lettere minuscole"
+msgstr[0] "{0} малка буква"
+msgstr[1] "{0} малки букви"
 
 #: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
-msgstr[0] "{0} lettera maiuscola"
-msgstr[1] "{0} lettere maiuscole"
+msgstr[0] "{0} главна буква"
+msgstr[1] "{0} главни букви"
 
 #: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
-msgstr[0] "{0} numero"
-msgstr[1] "{0} numeri"
+msgstr[0] "{0} число"
+msgstr[1] "{0} числа"
 
 #: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
-msgstr[0] "{0} carattere speciale "
-msgstr[1] "{0} caratteri speciali "
+msgstr[0] "{0} специален знак"
+msgstr[1] "{0} специални знаци"
 
 #: frontend/src/metabase/lib/validate.js:8
 msgid "must be a valid email address"
-msgstr "deve essere un indirizzo di posta valido"
+msgstr "Трябва да е валиден имейл адрес"
 
 #: frontend/src/metabase/lib/validate.js:10
 msgid "must be {0} characters or less"
-msgstr "deve essere {0} caratteri o meno"
+msgstr "трябва да съдържа {0} знака или по-малко"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:113
 msgid "Thanks for using Metabase!"
-msgstr "Grazie per utilizzare Metabase!"
+msgstr "Благодаря, че използвате Metabase!"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "Powered by {0}"
+msgstr "Осъществено от {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
-msgstr "A:"
+msgstr "Да се:"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
-msgstr "Questa domanda non può essere utilizzata perché si basa su di un database differente."
+msgstr "Този въпрос не може да се използва, защото се основава на различна база данни."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
-msgstr "Non è stato possibile trovare una domanda salvata con questo numero ID."
+msgstr "Не можах да намеря запазен въпрос с този идентификационен номер."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
-msgstr "Scegli una domanda salvata"
+msgstr "Изберете запазен въпрос"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
-msgstr "Scegli una domanda differente"
+msgstr "Изберете различен въпрос"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
-msgstr "Caricamento..."
+msgstr "Зареждане…"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
-msgstr "Domanda #..."
+msgstr "Въпрос # ..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "Domanda #{0}"
+msgstr "Въпрос № {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
-msgstr "Ultima modifica {0}"
+msgstr "Последна редакция {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:250
 msgid "{0} creates a variable in this query template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the query template."
-msgstr "{0} crea una variabile in questo modello di query chiamata \"variable_name\". Alle variabili possono essere date tipi dal pannello laterale, che cambia il loro comportamento. Tutti i tipi di variabile diversi da \"Filtro di campo\" causeranno automaticamente un widget di filtro da posizionare su questa domanda; con i Filtri di Campo è opzionale. Quando questo widget di filtro è compilato, questo valore sostituisce la variabile nel template della query."
+msgstr "{0} създава променлива в този шаблон за заявка, наречена „име на променлива“. Променливите могат да получат типове в страничния панел, което променя тяхното поведение. Всички типове променливи, различни от „Полеви филтър“, автоматично ще доведат до поставяне на приспособление за филтър върху този въпрос; с полеви филтри това не е задължително. Когато тази джаджа за филтър е попълнена, тази стойност замества променливата в шаблона за заявка."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:261
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Dare a una variabile del tipo \"Filtro Campo\" consente di collegare le domande a widget filtro dashboard o utilizzare più tipi di widget filtro sulla vostra domanda SQL. Una variabile Filtro Campo inserisce SQL simile a quella generata dal costruttore di query GUI quando si aggiungono filtri su colonne esistenti."
+msgstr "Предоставянето на променлива от типа \"Field Filter\" ви позволява да свързвате въпроси към приспособленията за филтриране на таблото или да използвате повече видове приспособления за филтриране на вашия SQL въпрос. Променливата на полевия филтър вмъква SQL подобна на тази, генерирана от конструктора на GUI заявки при добавяне на филтри към съществуващи колони."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
-msgstr "Nome variabile"
+msgstr "Име на променлива"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
-msgstr "Etichetta widget filtro"
+msgstr "Етикет на джаджа за филтриране"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:64
 msgid "Select a foreign key"
-msgstr "Seleziona una chiave esterna"
+msgstr "Изберете външен ключ"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:50
 msgid "Hi, {0}. Nice to meet you!"
-msgstr "Ciao, {0}. Piacere di fare la tua conoscenza!"
+msgstr "Здравей, {0}. Приятно ми е да се запознаем!"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:270
 msgid "12-hour clock"
-msgstr "12 ore"
+msgstr "12-часов часовник"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:274
 msgid "24-hour clock"
-msgstr "24 ore"
+msgstr "24-часов часовник"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:341
 msgid "Symbol"
-msgstr "Simbolo"
+msgstr "Символ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:365
 msgid "In the column heading"
-msgstr "Nell'intestazione colonna"
+msgstr "В заглавието на колоната"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:366
 msgid "In every table cell"
-msgstr "In ogni cella della tabella"
+msgstr "Във всяка клетка на таблица"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
-msgstr "Formattazione del valore"
+msgstr "Форматиране на стойност"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
-msgstr "Pieno"
+msgstr "Пълна"
 
-#. nella versione v.0.35 questa traduzione non funziona
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
-msgstr "Non variato rispetto al {0} precedente."
+msgstr "Без промяна от последния {0}"
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
-msgstr "Connessione a ''{0}:{1}'' avvenuta, ma non posso connettermi al database."
+msgstr "Връзката с „{0}: {1}“ е успешна, но не може да се свърже с DB."
 
 #: src/metabase/api/database.clj
 msgid "Connection to host ''{0}'' successful, but port {1} is invalid."
-msgstr "Connessione all'host ''{0}'' avvenuta, ma la porta {1} è invalida."
+msgstr "Връзката с хоста „{0}“ е успешна, но портът {1} е невалиден."
 
 #: src/metabase/api/database.clj
 msgid "Host ''{0}'' is not reachable"
-msgstr "L'host ''{0}'' non è raggiungibile"
+msgstr "Хостът „{0}“ не е достъпен"
 
 #: src/metabase/api/database.clj
 msgid "Unable to connect to database."
-msgstr "Impossibile collegarsi al database."
+msgstr "Не може да се свърже с база данни."
 
 #: src/metabase/api/database.clj
 msgid "Cannot connect to Database"
-msgstr "Non è possibile collegarsi al Database"
+msgstr "Не може да се свърже с база данни"
 
 #: src/metabase/api/embed.clj
 msgid "You''re not allowed to specify a value for {0}."
-msgstr "Non è possibile specificare un valore per {0}."
+msgstr "Нямате право да посочвате стойност за {0}."
 
 #: src/metabase/api/embed.clj
 msgid "You can''t specify a value for {0} if it''s already set in the JWT."
-msgstr "Non puoi specificare un valore per {0} se è già settato in JWT."
+msgstr "Не можете да посочите стойност за {0}, ако тя вече е зададена в JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You must specify a value for {0} in the JWT."
-msgstr "Devi specificare un valore per {0} nel token JWT"
+msgstr "Трябва да посочите стойност за {0} в JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You can only specify a value for {0} in the JWT."
-msgstr "Puoi specificare un solo valore per {0} nel token JWT"
+msgstr "Можете да посочите стойност само за {0} в JWT."
 
 #: src/metabase/api/field.clj
 msgid "Error searching field values"
-msgstr "Errore durante la ricerca dei valori del campo"
+msgstr "Грешка при търсене на стойности на полета"
 
 #: src/metabase/api/field.clj
 msgid "Error searching for remapping"
-msgstr "Errore durante la ricerca per la rimappatura"
+msgstr "Грешка при търсене на повторно картографиране"
 
 #: src/metabase/api/session.clj
 msgid "Google Auth token appears to be incorrect. "
-msgstr "Il token Google Auth sembra non corretto"
+msgstr "Токенът на Google Auth изглежда неправилен."
 
 #: src/metabase/api/session.clj
 msgid "Double check that it matches in Google and Metabase."
-msgstr "Doppio controllo che corrisponda in Google e metabase."
+msgstr "Проверете отново дали той съвпада в Google и Metabase."
 
 #: src/metabase/api/table.clj
 msgid "Everything else"
-msgstr "Tutto il resto"
+msgstr "Всичко друго"
 
 #: src/metabase/core.clj
 msgid "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."
-msgstr "ATTENZIONE: Hai abilitato la tracciatura dei namespace, attività che può loggare informazioni sensibili come le password dei database."
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Активирали сте проследяване на пространство от имена, което може да регистрира чувствителна информация като db пароли."
 
 #: src/metabase/db.clj
 msgid "Database Upgrade Required"
-msgstr "Aggiornamento del database necessario"
+msgstr "Необходимо е надстройване на базата данни"
 
 #: src/metabase/db.clj
 msgid "NOTICE: Your database requires updates to work with this version of Metabase."
-msgstr "AVVISO: Il tuo database richiede aggiornamenti per poter funzionare con questa versione di Metabase."
+msgstr "ЗАБЕЛЕЖКА: Вашата база данни изисква актуализации, за да работи с тази версия на Metabase."
 
 #: src/metabase/db.clj
 msgid "Please execute the following sql commands on your database before proceeding."
-msgstr "Si prega di eseguire i seguenti comandi sql nel proprio database prima di procedere."
+msgstr "Моля, изпълнете следните SQL команди във вашата база данни, преди да продължите."
 
 #: src/metabase/db.clj
 msgid "Once your database is updated try running the application again."
-msgstr "Una volta che il tuo database è aggiornato, prova a lanciare nuovamente l'applicazione."
+msgstr "След като вашата база данни се актуализира, опитайте да стартирате приложението отново."
 
 #: src/metabase/db.clj
 msgid "Database requires manual upgrade."
-msgstr "Il database necessita di un aggiornamento manuale."
+msgstr "Базата данни изисква ръчно надстройване."
 
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "Imposta la transaction per il rollback automatico..."
+msgstr "Задайте транзакцията да се връща автоматично ..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
 msgid "Disable auto-commit..."
-msgstr "Disabilita l'auto-commit..."
+msgstr "Деактивиране на автоматичното фиксиране ..."
 
 #: src/metabase/db.clj
 msgid "Set default db connection with connection pool..."
-msgstr "Imposta la connessione db predefinita con il pool di connessioni..."
+msgstr "Задайте db връзка по подразбиране с пул от връзки ..."
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
-msgstr "Verificata con successo {0} {1} la connessione al database."
+msgstr "Успешно потвърдена връзка с база данни на приложението {0} {1}."
 
 #. if both of the decoders above fail, then the date string is invalid
 #: src/metabase/driver/common/parameters/dates.clj
 msgid "Don''t know how to parse date param ''{0}'' — invalid format"
-msgstr "Non so come analizzare il parametro data ''{0}'' - formato non valido"
+msgstr "Не знам как да анализирам параметъра на датата „{0}“ - невалиден формат"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "The sub-query from referenced question #{0} failed with the following error: {1}"
-msgstr "La sub-query da domanda referenziata #{0} è fallita con il seguente errore: {1}"
+msgstr "Подзаявката от препратен въпрос № {0} не успя със следната грешка: {1}"
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
-msgstr "ATTENZIONE: Metabase supporta ufficialmente solo MySQL {0}/MariaDB {1} e superiore."
+msgstr "ПРЕДУПРЕЖДЕНИЕ: Metabase поддържа официално само MySQL {0} / MariaDB {1} и по-нови версии."
 
 #: src/metabase/driver/mysql.clj
 msgid "All Metabase features may not work properly when using an unsupported version."
-msgstr "Tutti i componenti di Metabase potrebbero non funzionare correttamente usando una versione non supportata."
+msgstr "Всички функции на Metabase може да не работят правилно, когато използвате неподдържана версия."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Unable to substitute parameters"
-msgstr "Impossibile sostituire i parametri"
+msgstr "Параметрите не могат да бъдат заменени"
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run the query: missing required parameters: {0}"
-msgstr "Impossibile lanciare la query: parametri mancanti: {0}"
+msgstr "Заявката не може да се изпълни: липсват необходимите параметри: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1} as a temporal literal"
-msgstr "Non so come analizzare {0} {1} come letterale temporale"
+msgstr "Не знам как да анализирам {0} {1} като временен литерал"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting {0} database timezone with statement: {1}"
-msgstr "Settando {0} al database fusorario con statement: {1}"
+msgstr "Задаване на {0} часова зона на базата данни с изявление: {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to readwrite"
-msgstr "Errore durante l'impostazione della connessione per la lettura/scrittura"
+msgstr "Грешка при настройването на връзката за четене"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}'' for {1} database"
-msgstr "Settaggio fuso orario ''{0}'' per {1} database fallito"
+msgstr "Неуспешно задаване на часовата зона '' {0} '' за базата данни {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting transaction isolation level for {0} database to {1}"
-msgstr "Errore nell'impostare il livello di isolamento delle transazioni per il database {0} in {1}"
+msgstr "Грешка при задаване на ниво на изолиране на транзакциите за {0} база данни на {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to read-only"
-msgstr "Errore durante l'impostazione della connessione solo lettura"
+msgstr "Грешка при настройването на връзката само за четене"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting default holdability for connection"
-msgstr "Errore impostando di default il \"set hold\" per la connessione"
+msgstr "Грешка при задаване на задържане по подразбиране за връзка"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting result set fetch direction to FETCH_FORWARD"
-msgstr "Errore impostando la direzione di recupero del risultato a FETCH_FORWARD"
+msgstr "Грешка при настройката на резултата зададе посоката на извличане на FETCH_FORWARD"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Query canceled, calling PreparedStatement.cancel()"
-msgstr "Query cancellata, calling PreparedStatement.cancel()"
+msgstr "Заявката е анулирана, извиква се PreparedStatement.cancel ()"
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database"
-msgstr "Fallita connessione al database"
+msgstr "Неуспешно свързване с база данни"
 
 #: src/metabase/driver/util.clj
 msgid "Unable to determine connection properties for driver {0}"
-msgstr "Impossibile determinare le proprietà di connessione per il driver {0}"
+msgstr "Не може да се определят свойствата на връзката за драйвер {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Error fetching field values"
-msgstr "Errore nel caricamento dei valori dei campi"
+msgstr "Грешка при извличането на стойностите на полетата"
 
 #: src/metabase/models/setting.clj
 msgid "You cannot set {0}; it is a read-only setting."
-msgstr "Non puoi settare {0}; è un opzione readonly."
+msgstr "Не можете да зададете {0}; това е настройка само за четене."
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must have `:visibilty` `:internal`, `:setter` `:none`, or internationalized, found: `{0}`"
-msgstr "la stringa di descrizione defsettind deve avere ':visibility' ':internal', ':setter' ':none', o internazionalizzato, trovato: '{0}'"
+msgstr "десетиращите описания низове трябва да имат \": visibilty\" \": internal\", \": setter\" \": none\" или интернационализирани, намерено: \"{0}\""
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} is internal"
-msgstr "L'impostazione {0} è interna"
+msgstr "Настройката {0} е вътрешна"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "Caricando i plugin locali del manifest a {0}"
+msgstr "Зарежда се локален манифест на приставката на {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Codice tracciatura Google Analytics."
+msgstr "Проследяващ код на Google Analytics."
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
-msgstr "Inviando Pulse ({0}: {1}) con {2} Card via email"
+msgstr "Изпращане на импулс ({0}: {1}) с {2} карти по имейл"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
-msgstr "Inviando Pulse ({0}: {1}) con {2} Card via Slack"
+msgstr "Изпращане на импулс ({0}: {1}) с {2} карти чрез Slack"
 
 #: src/metabase/pulse/render.clj
 msgid "Rendering pulse card with chart-type {0} and render-type {1}"
-msgstr "Renderizzando pulse card con grafico di tipo {0} e render di tipo {1}"
+msgstr "Рендериране на импулсна карта с тип диаграма {0} и тип рендериране {1}"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "SISTEMAMI: Questi non sono letterali temporali validi: {0} {1}. Per quale motivo si sta tentando di utilizzare tale formato?"
+msgstr "FIXME: Това не са валидни временни литерали: {0} {1}. Защо се опитваме да ги форматираме като такива?"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
-msgstr "Errore durante la riduzione dei risultati"
+msgstr "Грешка при намаляване на редовете с резултати"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Unexpected nil result"
-msgstr "Risultato vuoto inaspettato"
+msgstr "Неочакван нулев резултат"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0} ms, raising timeout exception."
-msgstr "Query timeout dopo {0} ms, sollevando timeout exception."
+msgstr "Времето за изчакване на заявката изтече след {0} мс, повишавайки изключение за изчакване."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Timed out after {0}."
-msgstr "Time out dopo {0}."
+msgstr "Времето за изчакване е след {0}."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query canceled before finishing."
-msgstr "Query cancellata prima del termine."
+msgstr "Заявката е анулирана преди завършване."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Unknown query type {0}"
-msgstr "Tipo query {0} non riconosciuto"
+msgstr "Неизвестен тип заявка {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error purging old cache entires"
-msgstr "Errore durante l'eliminazione della cache precedente"
+msgstr "Грешка при изчистването на стария кеш се включва"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Caching results for next time for query with hash {0}."
-msgstr "Risulatati nella cache per la prossima volta per query con hash {0}"
+msgstr "Кеширане на резултатите за следващ път за заявка с хеш {0}."
 
 #: src/metabase/query_processor/middleware/cache.clj
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error saving query results to cache."
-msgstr "Errore durante il salvataggio dei risultati della query nella cache."
+msgstr "Грешка при запазване на резултатите от заявката в кеш."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Successfully cached results for query."
-msgstr "Risultati memorizzati nella cache per la query."
+msgstr "Успешно кеширани резултати за заявка."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Query took {0} to run; miminum for cache eligibility is {1}"
-msgstr "La query ci ha messo {0} per essere eseguita; il minimo idoneo per la cache è {1}"
+msgstr "Заявката отне {0} за изпълнение; miminum за допустимост за кеш е {1}"
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Results are too large to cache."
-msgstr "I risultati sono troppi per entrare in cache"
+msgstr "Резултатите са твърде големи за кеширане."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Serialization timed out after {0}."
-msgstr "Serializzazione timeout dopo {0}."
+msgstr "Времето за сериализация изтече след {0}."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Error parsing serialized results"
-msgstr "Errore durante l'analisi dei risultati serializzati"
+msgstr "Грешка при синтактичния анализ на сериализираните резултати"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error purging old cache entries"
-msgstr "Errore durante la pulizia della cache."
+msgstr "Грешка при изчистването на старите записи в кеша"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Caching results for query with hash {0}."
-msgstr "Risultati nella cache per query con hash {0}."
+msgstr "Кеширане на резултати за заявка с хеш {0}."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Cannot save QueryExecution, missing :context"
-msgstr "Impossibile salvare QueryExecution, :context mancante"
+msgstr "Не може да се запази QueryExecution, липсва: контекст"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Error saving query execution info"
-msgstr "Errore nel salvare le informazioni di esecuzione della query"
+msgstr "Грешка при запазване на информация за изпълнение на заявката"
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve database for query: missing or invalid `:database` ID."
-msgstr "Impossibile risolvere il database per la query: ID ':database' mancante o non valido."
+msgstr "Не може да се разреши база данни за заявка: липсващ или невалиден идентификатор на „: база данни“."
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve driver for query"
-msgstr "Impossibile risolvere i driver per la query"
+msgstr "Не може да се разреши драйвер за заявка"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced question #{0} could not be found"
-msgstr "La domanda di riferimento #{0} non può essere trovata"
+msgstr "Препратен въпрос № {0} не можа да бъде намерен"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced query is from a different database"
-msgstr "La query referenziata è di un altro database"
+msgstr "Запитването, на което се прави препратка, е от друга база данни"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "This query has circular referencing sub-queries. "
-msgstr "La query ha un riferimento circolare alla sotto-query"
+msgstr "Тази заявка има циркулярни препратки към подзаявки."
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "These questions seem to be part of the problem: \"{0}\" and \"{1}\"."
-msgstr "Queste domande sembrano essere parte del problema: \"{0}\" e \"{1}\"."
+msgstr "Тези въпроси изглежда са част от проблема: „{0}“ и „{1}“."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query"
-msgstr "Errore durante la registrazione dei metadata della query"
+msgstr "Грешка при запис на метаданни за резултатите за заявка"
 
 #: src/metabase/query_processor/streaming/xlsx.clj
 msgid "Query result"
-msgstr "Risultato della query"
+msgstr "Резултат от заявката"
 
 #: src/metabase/sync/analyze/query_results.clj
 msgid "Error generating insights for column:"
-msgstr "Errore durante la generazione dell'approfondimento della colonnna:"
+msgstr "Грешка при генериране на статистика за колона:"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
-msgstr "Sto inviando l'email di abbandono!"
+msgstr "Изпращане на имейл за изоставяне!"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "È possibile creare metriche salvate per aggiungere un'opzione metrica denominata. Le metriche salvate includono il tipo di aggregazione, il campo aggregato e, opzionalmente, qualsiasi filtro aggiunto. Come esempio, si potrebbe usare questo per creare qualcosa di simile ad un modo ufficiale di calcolare il \"Prezzo medio\" per una tabella degli ordini."
+msgstr "Можете да създадете запазени метрики, за да добавите опция с име метрика. Запазените показатели включват типа на агрегиране, агрегираното поле и по избор всеки филтър, който добавяте. Като пример можете да използвате това, за да създадете нещо като официалния начин за изчисляване на \"Средна цена\" за таблица за поръчки."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
 msgid "Select and add filters to create your new segment."
-msgstr "Selezione e aggiungi i filtri per creare il tuo nuovo segmento."
+msgstr "Изберете и добавете филтри, за да създадете своя нов сегмент."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
-msgstr "Alfabetico"
+msgstr "Азбучно"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
-msgstr "Smart"
+msgstr "Умен"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
-msgstr "Ordine colonna: {0}"
+msgstr "Поръчка на колона: {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
 msgid "Unhide all"
-msgstr "Mostra tutto"
+msgstr "Разкрийте всички"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
 msgid "Hide all"
-msgstr "Nascondi tutto"
+msgstr "Скрий всичко"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
 msgid "Unhide"
-msgstr "Mostra"
+msgstr "Разкрийте"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
 msgid "New metric"
-msgstr "Nuova metrica"
+msgstr "Нова метрика"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
 msgid "Create metrics to add them to the Summarize dropdown in the query builder"
-msgstr "Crea metriche per aggiungerle al menu a tendina Riassumere del costruttore delle query"
+msgstr "Създайте показатели, за да ги добавите към падащото меню Summarize в конструктора на заявки"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
 msgid "New segment"
-msgstr "Nuovo segmento"
+msgstr "Нов сегмент"
 
 #: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
 msgid "Filter by table"
-msgstr "Filtra per tabella"
+msgstr "Филтрирайте по таблица"
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
 msgid "Checking HTTPS..."
-msgstr "Controllo HTTPS..."
+msgstr "Проверява се HTTPS ..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
 msgid "It looks like HTTPS is not properly configured"
-msgstr "Sembra che l'HTTPS non sia configurato correttamente"
+msgstr "Изглежда, че HTTPS не е конфигуриран правилно"
 
 #: frontend/src/metabase/admin/settings/selectors.js:57
 msgid "Redirect to HTTPS"
-msgstr "Redirect verso HTTPS"
+msgstr "Пренасочване към HTTPS"
 
 #: frontend/src/metabase/admin/settings/selectors.js:219
 msgid "Localization"
-msgstr "Localizzazione"
+msgstr "Локализация"
 
 #: frontend/src/metabase/admin/settings/selectors.js:222
 msgid "Instance language"
-msgstr "Lingua d'istanza"
+msgstr "Инстанционен език"
 
 #: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
-msgstr "Opzioni di Localizzazione"
+msgstr "Опции за локализация"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:51
 msgid "This database doesn't have any tables."
-msgstr "Questo database non ha tabelle."
+msgstr "Тази база данни няма таблици."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
 msgid "This field only accepts a single value because it's used in a SQL query."
-msgstr "Questo campo accetta un valor singolo in quanto è utilizzato in una query SQL."
+msgstr "Това поле приема само една стойност, защото се използва в SQL заявка."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:17
 msgid "Service Accounts"
-msgstr "Account di servizio"
+msgstr "Сметки за услуги"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:26
 msgid "Metabase connects to Big Query via {0}."
-msgstr "Metabase si collega a Big Query con {0}."
+msgstr "Metabase се свързва с Big Query чрез {0}."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:29
 msgid "Continue using an OAuth application to connect"
-msgstr "Prosegui con un'applicazione OAuth per connetterti"
+msgstr "Продължете да използвате приложение OAuth за свързване"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:43
 msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
-msgstr "Raccomandiamo di usare {0} invece di un' applicazione OAuth per collegarsi a BigQuery"
+msgstr "Препоръчваме да превключите към използване на {0} вместо приложение OAuth за свързване с BigQuery"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:48
 msgid "Connect to a Service Account instead"
-msgstr "Collegati invece a un Account di Servizio"
+msgstr "Вместо това се свържете със акаунт за услуга"
 
 #: frontend/src/metabase/entities/databases/forms.js:44
 msgid "invalid JSON"
-msgstr "JSON invalido"
+msgstr "невалиден JSON"
 
 #: frontend/src/metabase/entities/databases/forms.js:50
 msgid "SSH private key"
-msgstr "Chiave privata SSH"
+msgstr "SSH частен ключ"
 
 #: frontend/src/metabase/entities/databases/forms.js:51
 msgid "Paste the contents of your ssh private key here"
-msgstr "Incolla qui il contenuto della tua chiave privata SSH"
+msgstr "Поставете тук съдържанието на вашия ssh частен ключ"
 
 #: frontend/src/metabase/entities/databases/forms.js:55
 msgid "Passphrase for the SSH private key"
-msgstr "Passphrase per la chiave privata SSH"
+msgstr "Пропуск за частния ключ на SSH"
 
 #: frontend/src/metabase/entities/databases/forms.js:58
 msgid "SSH Authentication"
-msgstr "autenticazione SSH"
+msgstr "SSH удостоверяване"
 
 #: frontend/src/metabase/entities/databases/forms.js:60
 msgid "SSH Key"
-msgstr "chiave SSH"
+msgstr "SSH ключ"
 
 #: frontend/src/metabase/entities/databases/forms.js:65
 msgid "Server SSL certificate chain"
-msgstr "Certificate chain per il server SSL"
+msgstr "Сървърна верига за SSL сертификати"
 
 #: frontend/src/metabase/entities/databases/forms.js:66
 msgid "Paste the contents of the server's SSL certificate chain here"
-msgstr "Incolla qui il contenuto del certificate chain del server SSL"
+msgstr "Поставете тук съдържанието на веригата от SSL сертификати на сървъра"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:11
 msgid "Paste a connection string"
-msgstr "Incolla la stringa di connessione"
+msgstr "Поставете низ за връзка"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:12
 msgid "Fill out individual fields"
-msgstr "Compilare i singoli campi"
+msgstr "Попълнете отделни полета"
 
 #: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
-msgstr "Inserisci qui del codice SQL che puoi riutilizzare in seguito"
+msgstr "Въведете малко SQL тук, за да можете да го използвате повторно по-късно"
 
 #: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
-msgstr "Dai un nome al tuo snippet"
+msgstr "Дайте име на вашия фрагмент"
 
 #: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
-msgstr "Clienti Attuali"
+msgstr "Настоящи клиенти"
 
 #: frontend/src/metabase/entities/snippet-collections.js:80
 #: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
-msgstr "Aggiungi una descrizione"
+msgstr "Добави описание"
 
 #: frontend/src/metabase/entities/users/forms.js:37
 msgid "Use site default"
-msgstr "Usa i default del sito"
+msgstr "Използвайте сайта по подразбиране"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
-msgstr "trova"
+msgstr "намирам"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
-msgstr "sostituisci"
+msgstr "замени"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
-msgstr "Il testo da cercare."
+msgstr "Текстът за намиране."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
-msgstr "Il testo con cui sostituire."
+msgstr "Текстът, който да се използва като заместител."
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
-msgstr "Modificando {0}"
+msgstr "Редактиране на {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
-msgstr "Crea il tuo nuovo snippet"
+msgstr "Създайте новия си фрагмент"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
-msgstr "Snippet Archiaviati"
+msgstr "Архивирани фрагменти"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
-msgstr "Gli snippet sono pezzi di SQL riutilizzabili"
+msgstr "Фрагментите са битове за SQL за многократна употреба"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
-msgstr "Crea uno snippet"
+msgstr "Създайте фрагмент"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
-msgstr "Snippet"
+msgstr "Фрагменти"
 
 #: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
 msgid "SQL Snippets"
-msgstr "Snippet SQL"
+msgstr "SQL фрагменти"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:38
 msgid "Your language is set to {0}"
-msgstr "La tua lingua è impostata su {0}"
+msgstr "Езикът ви е зададен на {0}"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:50
 msgid "What's your preferred language?"
-msgstr "Qual è la tua lingua preferita?"
+msgstr "Кой е предпочитаният от вас език?"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:54
 msgid "This language will be used throughout Metabase and will be the default for new users."
-msgstr "Questa lingua verrà utilizzata in Metabase è sarà il default per i nuovi utenti."
+msgstr "Този език ще се използва в Metabase и ще бъде по подразбиране за нови потребители."
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:159
 msgid "We filtered out {0} row(s) containing null values."
-msgstr "Abbiamo filtrato {0} riga/righe contenenti valori null."
+msgstr "Филтрирахме {0} ред / и, съдържащи нулеви стойности."
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:133
 msgid "Show values for this series"
-msgstr "Mostra i valori per queste serie"
+msgstr "Показване на стойности за тази поредица"
 
 #: src/metabase/api/card.clj
 msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
-msgstr "Il tempo medio di esecuzione della query è {0}; usando \"magic\" TTL di {1}"
+msgstr "Средната продължителност на изпълнение на въпроса е {0}; използвайки „магически“ TTL от {1}"
 
 #: src/metabase/api/native_query_snippet.clj
 msgid "A snippet with that name already exists. Please pick a different name."
-msgstr "Esiste già uno snippet con questo nome. Scegli un nome diverso per piacere."
+msgstr "Фрагмент с това име вече съществува. Моля, изберете друго име."
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Metric]"
-msgstr "[Metrica Sconosciuta]"
+msgstr "[Неизвестна метрика]"
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Segment]"
-msgstr "[Segmento Sconosciuto]"
+msgstr "[Неизвестен сегмент]"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error writing error to output stream"
-msgstr "Errore di scrittura nel flusso di uscita"
+msgstr "Грешка при записване на грешка в изходния поток"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Caught unexpected Exception in streaming response body"
-msgstr "Errore inaspettato nel corpo della risposta"
+msgstr "Хвана неочаквано изключение в тялото на отговора за стрийминг"
 
 #: src/metabase/async/streaming_response.clj
 msgid "bound-fn caught unexpected Exception"
-msgstr "Eccezione inaspettata della funzione bound"
+msgstr "bound-fn улови неочаквано изключение"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error determining whether HTTP request was canceled"
-msgstr "Errore nel determinare se la richiesta HTTP è stata annullata"
+msgstr "Грешка при определяне дали HTTP заявката е била отменена"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Check cancelation status timed out after {0}"
-msgstr "time out del controllo annullamento dopo {0}"
+msgstr "Проверете времето за анулиране на времето за изчакване след {0}"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Unexpected exception in do-f-async"
-msgstr "Eccezione non gestita in do-f-async"
+msgstr "Неочаквано изключение в do-f-async"
 
 #: src/metabase/async/streaming_response.clj src/metabase/server.clj
 msgid "Unexpected exception writing error response"
-msgstr "Eccezione non gestita nella scrittura della risposta d'errore"
+msgstr "Неочакван отговор на грешка при писане на изключение"
 
 #: src/metabase/driver/common.clj
 msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
-msgstr "Certificato Server non affidabile - hai utilizzato la certificate chain SSL corretta?"
+msgstr "Сертификатът на сървъра не е надежден - посочихте ли правилната верига на SSL сертификати?"
 
 #: src/metabase/driver/common.clj
 msgid "Server appears to require SSL - please enable SSL above"
-msgstr "Sembra che il server richieda SSL - per favore abilita SSL sopra"
+msgstr "Изглежда, че сървърът изисква SSL - моля, активирайте SSL по-горе"
 
 #: src/metabase/driver/common.clj
 msgid "Username"
-msgstr "Nome utente"
+msgstr "Потребителско име"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Don''t know how to parse parameter of type {0}"
-msgstr "Impossibile fare il parse del parametro di tipo {0}"
+msgstr "Не знам как да анализирам параметър от тип {0}"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Invalid :card parameter: missing `:card-id`"
-msgstr ":card parameter: invalido. ':card-id' mancante"
+msgstr "Невалиден: параметър на картата: липсва `: card-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Unable to resolve Snippet: missing `:snippet-id`"
-msgstr "Impossibile risolvere lo Snippet: ':snippet-id' mancante"
+msgstr "Не може да се разреши Snippet: липсва `: snippet-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Snippet {0} {1} not found."
-msgstr "Snippet {0} {1} non trovato."
+msgstr "Фрагментът {0} {1} не е намерен."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error determining value for parameter"
-msgstr "Errore nel determinare il valore del parametro"
+msgstr "Грешка при определяне на стойността на параметъра"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error building query parameter map"
-msgstr "Errore nella costruzione della mappa dei parametri query"
+msgstr "Грешка при изграждането на карта с параметри на заявката"
 
 #: src/metabase/middleware/log.clj
 msgid "ASYNC"
-msgstr "Asincrono"
+msgstr "ASYNC"
 
 #: src/metabase/middleware/log.clj
 msgid "{0} ({1} DB calls)"
-msgstr "{0} ({1} Chiamate DB)"
+msgstr "{0} ({1} DB обаждания)"
 
 #: src/metabase/middleware/log.clj
 msgid "App DB connections: {0}/{1}"
-msgstr "Connessioni DB App: {0}/{1}"
+msgstr "Връзки с DB за приложения: {0} / {1}"
 
 #: src/metabase/middleware/log.clj
 msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
-msgstr "Threads Jetty: {0}/{1} ({2} inattivo/i, {3} accodato/i)"
+msgstr "Конци на джета: {0} / {1} ({2} в неактивност, {3} на опашка)"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} total active threads)"
-msgstr "({0} thread attivi totale/i)"
+msgstr "(Общо {0} активни нишки)"
 
 #: src/metabase/middleware/log.clj
 msgid "Queries in flight: {0}"
-msgstr "Query in partenza: {0}"
+msgstr "Запитвания в полет: {0}"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} queued)"
-msgstr "({0} accodato/i)"
+msgstr "({0} на опашка)"
 
 #: src/metabase/models/collection.clj
 msgid "Collection must be in the same namespace as its parent"
-msgstr "La Collection deve stare assieme alle altre Collection parenti"
+msgstr "Колекцията трябва да бъде в същото пространство на имена като нейния родител"
 
 #: src/metabase/models/collection.clj
 msgid "Personal Collections must be in the default namespace"
-msgstr "Le Collection personali devono essere nello spazio di default"
+msgstr "Личните колекции трябва да са в пространството на имената по подразбиране"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection to a different namespace once it has been created."
-msgstr "Non puoi spostare una Collection in uno spazio differente una volta che è stata creata."
+msgstr "Не можете да премествате колекция в друго пространство от имена, след като е създадена."
 
 #: src/metabase/models/collection.clj src/metabase/models/permissions.clj
 msgid "Collection does not exist."
-msgstr "La collezione non esiste."
+msgstr "Колекцията не съществува."
 
 #: src/metabase/models/collection.clj
 msgid "A {0} can only go in Collections in the {1} namespace."
-msgstr "Un {0} può andare solo in Collezioni {1}"
+msgstr "А {0} може да отиде само в Колекции в пространството от имена {1}."
 
 #: src/metabase/models/database.clj
 msgid "Error sending database deletion notification"
-msgstr "Errore invio notifica cancellazione database"
+msgstr "Грешка при изпращане на известие за изтриване на база данни"
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "You cannot update the creator_id of a NativeQuerySnippet."
-msgstr "Non puoi aggiornare il creator_id di una NativeQuerySnippet"
+msgstr "Не можете да актуализирате Creator_id на NativeQuerySnippet."
 
 #: src/metabase/models/setting.clj
 msgid "Error fetching value of Setting"
-msgstr "Errore recupero Impostazione"
+msgstr "Грешка при извличането на стойността на настройката"
 
 #: src/metabase/public_settings.clj
 msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
-msgstr "Il linguaggio che verrà usato per l'interfaccia utente di Metabase, le e-mail di sistema, i pulses e gli alert."
+msgstr "Езикът, който трябва да се използва за потребителския интерфейс на Metabase, системните имейли, импулси и сигнали."
 
 #: src/metabase/public_settings.clj
 msgid "This is also the default language for all users, which they can change from their own account settings."
-msgstr "Questa è anche la lingua di default per tutti gli utenti, la quale può essere cambiata dagli utenti nelle loro impostazioni account."
+msgstr "Това е и езикът по подразбиране за всички потребители, който те могат да променят от собствените си настройки на акаунта."
 
 #: src/metabase/public_settings.clj
 msgid "Invalid locale {0}"
-msgstr "Località non trovata {0}"
+msgstr "Невалиден локал {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
-msgstr "Forza tutto il traffico a usare HTTPS con un redirect se il sito utilizza HTTPS"
+msgstr "Принудете целия трафик да използва HTTPS чрез пренасочване, ако URL адресът на сайта е HTTPS"
 
 #: src/metabase/public_settings.clj
 msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
-msgstr "Impossibile reindirizzare le richieste ad HTTPS finchè 'site-url' non è HTTPS"
+msgstr "Не може да пренасочва заявки към HTTPS, освен ако адресът на сайта (site-url) не е HTTPS."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error registering fonts: Metabase will not be able to send Pulses."
-msgstr "Errore registrazione fonts: Metabase non potrà inviare i Pulse"
+msgstr "Грешка при регистрацията на шрифтове: Metabase няма да може да изпраща импулси."
 
 #: src/metabase/pulse/render/png.clj
 msgid "This is a known issue with certain JVMs. See {0} and for more details."
-msgstr "Questo è un problema noto con alcune Macchine Virtuali Java (JVM). Vedi {0} per maggiori informazioni."
+msgstr "Това е известен проблем с някои JVM. Вижте {0} и за повече подробности."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error rendering Pulse"
-msgstr "Errore nel rendering del Pulse"
+msgstr "Грешка при изобразяването на Pulse"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0}, raising timeout exception."
-msgstr "Timeout query dopo {0}, eccezione timeout inviata"
+msgstr "Времето за изчакване на заявката изтече след {0}, повишавайки изключение за изчакване"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "No fields found for table {0}."
-msgstr "Non ci sono campi trovati per la tabella {0}."
+msgstr "Не са намерени полета за таблица {0}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Case"
-msgstr "Casistica"
+msgstr "Дело"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Variance of {0}"
-msgstr "Variazione di {0}"
+msgstr "Дисперсия на {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Median of {0}"
-msgstr "Media di {0}"
+msgstr "Медиана на {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "{0}th percentile of {1}"
-msgstr "{0} percentile di {1}"
+msgstr "{0}-ти процентил от {1}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Not caching results: results are larger than {0} KB"
-msgstr "I risultati non saranno messi in cache: la dimensione dei risultati supera {0} KB"
+msgstr "Резултатите не се кешират: резултатите са по-големи от {0} KB"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Cannot cache results: expected byte array, got {0}"
-msgstr "Impossibile mettere in cache i risultati: atteso un array di bi byte, ottenuto {0}"
+msgstr "Резултатите не могат да се кешират: очакван байтов масив, има {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Request is closed; no one to return cached results to"
-msgstr "La richiesta è chiusa; Impossibile restituire la richiesta cache a qualcuno"
+msgstr "Заявката е затворена; няма кой да върне кеширани резултати"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error attempting to fetch cached results for query with hash {0}"
-msgstr "Errore nel tentativo di recupero dei dati cache per la query con hash {0}"
+msgstr "Грешка при опит за извличане на кеширани резултати за заявка с хеш {0}"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error preparing statement to fetch cached query results"
-msgstr "Errore creazione dichiarazione per il recupero dei dati cache della query"
+msgstr "Грешка при подготовката на изявление за извличане на кеширани резултати от заявка"
 
 #: src/metabase/query_processor/middleware/catch_exceptions.clj
 msgid "Error processing query: {0}"
-msgstr "Errore elaborazione query: {0}"
+msgstr "Грешка при обработката на заявката: {0}"
 
 #: src/metabase/server.clj
 msgid "Unexpected exception in endpoint"
-msgstr "Eccezione non gestita nella destinazione"
+msgstr "Неочаквано изключение в крайна точка"
 
 #: src/metabase/server.clj
 msgid "Unexpected Exception in API request handler"
-msgstr "Eccezione non gestita nel gestore delle chiamate API"
+msgstr "Неочаквано изключение в обработчика на заявки за API"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error reducing {0}"
-msgstr "Errore nel ridurre {0}"
+msgstr "Грешка при намаляване на {0}"
 
 #: src/metabase/sync/analyze/fingerprint/insights.clj
 msgid "Error generating timeseries insight keyed by: {0}"
-msgstr "Errore nella generazione delle serie temporali con chiave: {0}"
+msgstr "Грешка при генерирането на статистика за времевите серии, въведена от: {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "La posizione {0} del database è cambiata da \"{1}\" a \"{2}\"."
+msgstr "Позицията на базата данни на {0} е променена от '' {1} '' на '' {2} ''."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Unscheduling task for Database {0}: trigger: {1}"
-msgstr "Rimuovere programmazione per Database {0}: evento: {1}"
+msgstr "Задача за непланиране за база данни {0}: спусък: {1}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a keyword or string."
-msgstr "il valore deve essere una keyword o una stringa."
+msgstr "стойност трябва да е ключова дума или низ."
 
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
-msgstr "La stringa deve avere un valore valido \"two-letter ISO\" o \"language-country\".\n"
-"Esempio 'it' o 'it_IT'"
+msgstr "Низът трябва да е валиден двубуквен ISO език или код на държава-език, например „en“ или „en_US“."
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
 msgid "Rows {0}-{1}"
-msgstr "Righe {0}-{1}"
+msgstr "Редове {0}-{1}"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
 #: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
 msgid "Audit"
-msgstr "Revisione"
+msgstr "Одит"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
@@ -15321,11 +15316,11 @@ msgstr "JWT"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
 msgid "User attribute configuration (optional)"
-msgstr "Configurazione degli attributi utente (opzionale)"
+msgstr "Конфигурация атрибути на потребител (по избор)"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
 msgid "Using {0}"
-msgstr "In uso {0}"
+msgstr "Използва {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
@@ -15334,450 +15329,450 @@ msgstr "SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
 msgid "Set up SAML-based SSO"
-msgstr "Configura SSO basato su SAML"
+msgstr "Настройте SAML-базирано SSO"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
 msgid "SAML Authentication"
-msgstr "Autenticazione SAML"
+msgstr "SAML удостоверяване"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
 msgid "Configure your identity provider (IdP)"
-msgstr "Configura il tuo identity provider (IdP)"
+msgstr "Конфигурирайте вашия доставчик на услуги за удостоверяване на самоличност (IdP)"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
 msgid "Your identity provider will need the following info about Metabase."
-msgstr "Al tuo identity provider serviranno le seguenti informazioni da Metabase"
+msgstr "Вашият доставчик на доставчик на услуги за удостоверяване на самоличност ще се нуждае от следната информация за Metabase."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
 msgid "URL the IdP should redirect back to"
-msgstr "URL a cui l'IdP deve reindirizzare l'IdP"
+msgstr "URL адрес, към който IdP трябва да пренасочи обратно"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
 msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
 "and the ACS (Consumer) URL in OneLogin."
-msgstr "Questo si chiama Single Sign On URL in Okta, l'Application Callback URL in Auth0,\n"
-"e l'URL ACS (Consumer) in OneLogin."
+msgstr "Това се нарича URL за единичен вход в Okta, URL адрес за обратно извикване на приложението в Auth0,\n"
+"и ACS (потребителския) URL в OneLogin."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
 msgid "SAML attributes"
-msgstr "attributi SAML"
+msgstr "SAML атрибути"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
 msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
 "\"Name\" in the attribute statements section."
-msgstr "Nella maggior parte degli IdP, è necessario inserire ciascuno di questi in una casella di input etichettata\n"
-"\"Nome\" nella sezione delle dichiarazioni degli attributi."
+msgstr "В повечето IdP ще трябва да поставите всеки от тях в поле за въвеждане, обозначено\n"
+"„Име“ в раздела с изявления за атрибути."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
 msgid "User's email attribute"
-msgstr "Attributo e-mail dell'utente"
+msgstr "Атрибут на имейл на потребителя"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
 msgid "User's first name attribute"
-msgstr "Attributo del nome dell'utente"
+msgstr "Атрибут на собственото име на потребителя"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
 msgid "User's last name attribute"
-msgstr "Attributo del cognome dell'utente"
+msgstr "Атрибут на фамилното име на потребителя"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
 msgid "Tell Metabase about your identity provider"
-msgstr "Comunicate a Metabase il vostro fornitore di identità"
+msgstr "Кажете на Metabase за вашия доставчик на самоличност"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
 msgid "Metabase will need the following info about your provider."
-msgstr "A Metabase servono le seguenti informazioni del tuo provider"
+msgstr "Metabase ще се нуждае от следната информация за вашия доставчик."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
 msgid "SAML Identity Provider URL"
-msgstr "URL del fornitore di identità SAML"
+msgstr "URL адрес на доставчика на самоличност на SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
 msgid "SAML Identity Provider Certificate"
-msgstr "Certificato di identità SAML"
+msgstr "Сертификат за доставчик на самоличност SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
 msgid "SAML Application Name"
-msgstr "Nome dell'applicazione SAML"
+msgstr "Име на приложението SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
 msgid "Sign SSO requests (optional)"
-msgstr "Firmare le richieste di SSO (opzionale)"
+msgstr "Подписване на заявки за SSO (по избор)"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
 msgid "SAML Keystore Path"
-msgstr "Percorso SAML Keystore"
+msgstr "Път на хранилището на SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
 msgid "SAML Keystore Password"
-msgstr "Password SAML Keystore"
+msgstr "Парола за хранилище на ключове SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
 msgid "Shh..."
-msgstr "Shh..."
+msgstr "Шшш ..."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
 msgid "SAML Keystore Alias"
-msgstr "SAML Keystore Alias"
+msgstr "Псевдоним на SAML Keystore"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
 msgid "Synchronize group membership with your SSO"
-msgstr "Sincronizzare l'appartenenza al gruppo con la vostra SSO"
+msgstr "Синхронизирайте членството в група с вашия SSO"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
 msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
 "be added to based on the SSO group they're in."
-msgstr "Per abilitare questo, è necessario creare delle mappature per dire a Metabase quale gruppo (o gruppi) i vostri utenti devono\n"
-"essere aggiunti in base al gruppo SSO in cui si trovano."
+msgstr "За да активирате това, ще трябва да създадете съпоставяния, за да кажете на Metabase кои групи да използват вашите потребители\n"
+"да бъдат добавени към групата SSO, в която се намират."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
 msgid "Group Name"
-msgstr "Nome del gruppo"
+msgstr "Име на групата"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
 msgid "Group attribute name"
-msgstr "Nome dell'attributo del gruppo"
+msgstr "Име на атрибута на групата"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
 msgid "Note:"
-msgstr "Nota:"
+msgstr "Забележка:"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
 msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
-msgstr "Se si modifica una qualsiasi delle impostazioni di un'impostazione attiva SAML esistente, allora sarà necessario riavviare Metabase per renderla effettiva."
+msgstr "Ако промените някоя от настройките на съществуваща активна настройка на SAML, ще трябва да рестартирате Metabase, за да влязат в сила."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
 msgid "Allows users to login via a SAML Identity Provider."
-msgstr "Consente agli utenti di effettuare il login tramite un fornitore di identità SAML."
+msgstr "Позволява на потребителите да влизат чрез доставчик на самоличност SAML."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
 msgid "Allows users to login via a JWT Identity Provider."
-msgstr "Consente agli utenti di effettuare il login tramite un fornitore di identità JWT."
+msgstr "Позволява на потребителите да влизат чрез доставчик на самоличност JWT."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
 msgid "Enable Password Authentication"
-msgstr "Attivare l'autenticazione con password"
+msgstr "Активирайте удостоверяване с парола"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
 msgid "When enabled, users can additionally log in with email and password."
-msgstr "Se abilitato, gli utenti possono inoltre effettuare il login con e-mail e password."
+msgstr "Когато е активирано, потребителите могат допълнително да влизат с имейл и парола."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
 msgid "Notify admins of new SSO users"
-msgstr "Informare gli amministratori dei nuovi utenti SSO"
+msgstr "Уведомете администраторите на новите потребители на SSO"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
 msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
-msgstr "Quando è abilitato, gli amministratori riceveranno un'e-mail la prima volta che un utente utilizza il Single Sign-On."
+msgstr "Когато са активирани, администраторите ще получат имейл при първия път, когато потребителят използва Единен вход."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
 msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
-msgstr "Utilizzare le seguenti impostazioni per configurare l'SSO tramite SAML. Se avete domande, consultate il nostro {0}."
+msgstr "Използвайте настройките по-долу, за да конфигурирате вашия SSO чрез SAML. Ако имате някакви въпроси, разгледайте нашата {0}."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
 msgid "documentation"
-msgstr "documentazione"
+msgstr "документация"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
 msgid "SAML Identity Provider URI"
-msgstr "SAML Identity Provider URI"
+msgstr "URI на доставчика на самоличност на SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
 msgid "JWT Authentication"
-msgstr "Autenticazione JWT"
+msgstr "JWT удостоверяване"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
 msgid "JWT Identity Provider URI"
-msgstr "JWT Identity Provider URI"
+msgstr "URI на доставчика на самоличност на JWT"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
 msgid "String used by the JWT signing key"
-msgstr "Stringa utilizzata dalla chiave di firma JWT"
+msgstr "Низ, използван от ключа за подписване на JWT"
 
 #: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
 msgid "Embedding the entire Metabase app"
-msgstr "Incorporare l'intera app Metabase"
+msgstr "Вграждане на цялото приложение Metabase"
 
 #: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
 msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
-msgstr "Se vuoi incorporare tutto Metabase, inserisci le origini dei siti web o delle web app dove vuoi permettere l'incorporazione in un iframe, separati da uno spazio. Ecco i {0} per ciò che può essere inserito."
+msgstr "Ако искате да вградите цялата Metabase, въведете произхода на уебсайтовете или уеб приложенията, където искате да разрешите вграждането в рамка, разделена с интервал. Ето {0} какво може да се въведе."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
 msgid "Grant sandboxed access to this table"
-msgstr "Concedere l'accesso a questa tabella in sandbox"
+msgstr "Осигурете достъп до тази таблица в пясъчна среда"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
 msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
-msgstr "Quando gli utenti di questo gruppo visualizzano questa tabella, ne vedranno una versione filtrata dai loro attributi utente, o una vista personalizzata basata su una domanda salvata."
+msgstr "Когато потребителите в тази група преглеждат тази таблица, ще видят нейната версия, която е филтрирана по техните потребителски атрибути, или персонализиран изглед на базата на запазен въпрос."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
 msgid "How do you want to filter this table for users in this group?"
-msgstr "Come volete filtrare questa tabella per gli utenti di questo gruppo?"
+msgstr "Как искате да филтрирате тази таблица за потребители в тази група?"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
 msgid "Pick a saved question that returns the custom view of this table that these users should see."
-msgstr "Scegliere una domanda salvata che restituisce la vista personalizzata di questa tabella che questi utenti dovrebbero vedere."
+msgstr "Изберете запазен въпрос, който връща персонализирания изглед на тази таблица, който тези потребители трябва да виждат."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
 msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
-msgstr "Qui si possono aggiungere opzionalmente ulteriori filtri in base agli attributi dell'utente. Questi filtri verranno applicati in aggiunta a quelli già presenti in questa domanda salvata."
+msgstr "По желание можете да добавите допълнителни филтри тук въз основа на потребителските атрибути. Тези филтри ще бъдат приложени върху всички филтри, които вече са в този запазен въпрос."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
 msgid "For this option to work, your users need to have some attributes"
-msgstr "Affinché questa opzione funzioni, i vostri utenti devono avere alcuni attributi"
+msgstr "За да работи тази опция, вашите потребители трябва да имат някои атрибути"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
 msgid "To add additional filters, your users need to have some attributes"
-msgstr "Per aggiungere ulteriori filtri, gli utenti devono avere alcuni attributi"
+msgstr "За да добавите допълнителни филтри, вашите потребители трябва да имат някои атрибути"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
 msgid "No user attributes"
-msgstr "Nessun attributo utente"
+msgstr "Няма потребителски атрибути"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
 msgid "Pick a user attribute"
-msgstr "Scegliere un attributo utente"
+msgstr "Изберете потребителски атрибут"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
 msgid "Pick a parameter"
-msgstr "Scegliere un parametro"
+msgstr "Изберете параметър"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
 msgid "Pick a column"
-msgstr "Scegli una colonna"
+msgstr "Изберете колона"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
 msgid "Users in {0} can view"
-msgstr "Gli utenti in {0} possono visualizzare"
+msgstr "Потребителите в {0} могат да преглеждат"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
 msgid "rows in the {0} question"
-msgstr "righe nella domanda {0}"
+msgstr "редове във въпроса {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
 msgid "rows in the {0} table"
-msgstr "righe nella tabella {0}"
+msgstr "редове в таблицата {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
 msgid "where {0} equals {1}"
-msgstr "dove {0} è uguale a {1}"
+msgstr "където {0} е равно на {1}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
 msgid "and {0} equals {1}"
-msgstr "e {0} è uguale a {1}"
+msgstr "и {0} е равно на {1}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
 msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
-msgstr "È possibile aggiungere automaticamente gli attributi impostando un SSO che utilizza SAML, oppure è possibile inserirli manualmente andando nella sezione Persone e cliccando sul menu ... all'estrema destra."
+msgstr "Можете да добавяте атрибути автоматично, като настроите SSO, който използва SAML, или можете да ги въведете ръчно, като отидете в секцията Хора и щракнете върху менюто ... вдясно."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
 msgid "User attribute"
-msgstr "Attributo utente"
+msgstr "Потребителски атрибут"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
 msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
-msgstr "Possiamo ottenere automaticamente gli attributi dei vostri utenti se avete impostato l'SSO, oppure potete aggiungerli manualmente dal menu \"...\" nella sezione Persone del pannello di amministrazione."
+msgstr "Можем автоматично да получим атрибутите на вашите потребители, ако сте настроили SSO, или можете да ги добавите ръчно от менюто \"...\" в раздела Хора на Администраторския панел."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
 msgid "Parameter or variable"
-msgstr "Parametro o variabile"
+msgstr "Параметър или променлива"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
 msgid "equals"
-msgstr "è uguale a"
+msgstr "се равнява"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
 msgid "Grant sandboxed access"
-msgstr "Concedere l'accesso in sandbox"
+msgstr "Предоставете достъп в пясъчна среда"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
 msgid "Sandboxed access"
-msgstr "Accesso in sandbox"
+msgstr "Достъп в пясъчна среда"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
 msgid "Edit sandboxed access"
-msgstr "Modifica accesso sandboxed"
+msgstr "Редактирайте защитения достъп"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
 msgid "Edit folder details"
-msgstr "Modifica i dettagli della cartella"
+msgstr "Редактиране на подробности за папката"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
 msgid "Change permissions"
-msgstr "Modificare le autorizzazioni"
+msgstr "Промяна на разрешенията"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
 msgid "Create your new folder"
-msgstr "Crea la tua nuova cartella"
+msgstr "Създайте новата си папка"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
 msgid "New folder"
-msgstr "Nuova cartella"
+msgstr "Нова папка"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
 msgid "We're having trouble validating your token"
-msgstr "Abbiamo problemi a convalidare il tuo gettone"
+msgstr "Имаме проблеми с валидирането на маркера ви"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
 msgid "Please double-check that your instance can connect to Metabase's servers"
-msgstr "Si prega di verificare che la vostra istanza possa connettersi ai server di Metabase"
+msgstr "Моля, проверете отново дали вашият екземпляр може да се свърже със сървърите на Metabase"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
 msgid "Get help"
-msgstr "Chiedere aiuto"
+msgstr "Потърси помощ"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
 msgid "Get even more out of Metabase with the Enterprise Edition"
-msgstr "Ottenere ancora di più da Metabase con l'Enterprise Edition"
+msgstr "Вземете още повече от Metabase с Enterprise Edition"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
 msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
-msgstr "Tutti gli strumenti necessari per fornire in modo semplice e veloce i report per i vostri clienti, o per aiutarvi a gestire e monitorare Metabase in una grande organizzazione"
+msgstr "Всички инструменти, от които се нуждаете, за да предоставяте бързо и лесно отчети за вашите клиенти или да ви помагат да стартирате и наблюдавате Metabase в голяма организация"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
 msgid "Activate a license"
-msgstr "Attivare una licenza"
+msgstr "Активирайте лиценз"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
 msgid "Your trial is active with these features"
-msgstr "Il tuo trial è attivo con queste caratteristiche"
+msgstr "Пробният ви период е активен с тези функции"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
 msgid "Trial expires {0}"
-msgstr "Il processo scade {0}"
+msgstr "Пробният период изтича {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
 msgid "Need help? Ready to buy?"
-msgstr "Hai bisogno di aiuto? Pronto per l'acquisto?"
+msgstr "Нужда от помощ? Готови ли сте да купите?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
 msgid "Talk to us"
-msgstr "Parlate con noi"
+msgstr "Говори ни"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
 msgid "Your trial has expired"
-msgstr "Il suo processo è scaduto"
+msgstr "Пробният ви период изтече"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
 msgid "Need more time? Ready to buy?"
-msgstr "Hai bisogno di più tempo? Pronti a comprare?"
+msgstr "Имате нужда от повече време? Готови ли сте да купите?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
 msgid "Your features are active!"
-msgstr "Le tue funzioni sono attive!"
+msgstr "Вашите функции са активни!"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
 msgid "Your licence is valid through {0}"
-msgstr "La sua licenza è valida fino al {0}"
+msgstr "Вашият лиценз е валиден до {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
 msgid "Your license has expired"
-msgstr "La sua licenza è scaduta"
+msgstr "Лицензът ви е изтекъл"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
 msgid "It expired on {0}"
-msgstr "È scaduto il {0}"
+msgstr "Той изтече на {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
 msgid "Want to renew your license?"
-msgstr "Vuoi rinnovare la tua licenza?"
+msgstr "Искате ли да подновите лиценза си?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
 msgid "Learn how to use this"
-msgstr "Imparare ad usarlo"
+msgstr "Научете как да използвате това"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
 msgid "Not included in your current plan"
-msgstr "Non incluso nel vostro piano attuale"
+msgstr "Не е включен в текущия ви план"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
 msgid "Enter the token you recieved from the store"
-msgstr "Inserisci il gettone che hai ricevuto dal negozio"
+msgstr "Въведете символа, който сте получили от магазина"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
 msgid "Activate"
-msgstr "Attivare"
+msgstr "Активирате"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
 msgid "Need help?"
-msgstr "Hai bisogno di aiuto?"
+msgstr "Нужда от помощ?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
 msgid "More info about your problem."
-msgstr "Maggiori informazioni sul vostro problema."
+msgstr "Повече информация за вашия проблем."
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
 msgid "Contact support"
-msgstr "Contatta il supporto"
+msgstr "Свържете се с екипа за поддръжка"
 
 #: enterprise/frontend/src/metabase-enterprise/store/index.js:7
 msgid "Enterprise"
-msgstr "Impresa"
+msgstr "Предприятие"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
 msgid "Data sandboxes"
-msgstr "Dati sandbox"
+msgstr "Пясъчници за данни"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
 msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
-msgstr "Assicuratevi di mostrare alle persone giuste i dati giusti con filtri automatici e sicuri basati sugli attributi dell'utente."
+msgstr "Уверете се, че показвате на правилните хора правилните данни с автоматични и сигурни филтри, базирани на потребителски атрибути."
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
 msgid "White labeling"
-msgstr "Etichettatura bianca"
+msgstr "Бяло етикетиране"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
 msgid "Match Metabase to your brand with custom colors, your own logo and more."
-msgstr "Abbina Metabase al tuo marchio con colori personalizzati, il tuo logo e altro ancora."
+msgstr "Съчетайте Metabase с вашата марка с персонализирани цветове, ваше собствено лого и др."
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
 msgid "Auditing"
-msgstr "Revisione contabile"
+msgstr "Одит"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
 msgid "Keep an eye on performance and behavior with robust auditing tools."
-msgstr "Tenete d'occhio le prestazioni e il comportamento con robusti strumenti di auditing."
+msgstr "Следете производителността и поведението със здрави инструменти за одит."
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
 msgid "Single sign-on"
-msgstr "Singolo accesso"
+msgstr "Единичен вход"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
 msgid "Provide easy login that works with your exisiting authentication infrastructure."
-msgstr "Fornite un login facile che funzioni con la vostra infrastruttura di autenticazione esistente."
+msgstr "Осигурете лесно влизане, което работи с вашата съществуваща инфраструктура за удостоверяване."
 
 #: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
 msgid "Store"
-msgstr "Negozio"
+msgstr "Съхранявайте"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
 msgid "Application Name"
-msgstr "Nome dell'applicazione"
+msgstr "Име на приложението"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
 msgid "Color Palette"
-msgstr "Tavolozza dei colori"
+msgstr "Цветова палитра"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
 msgid "Logo"
-msgstr "Logo"
+msgstr "Лого"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
 msgid "Favicon"
@@ -15785,337 +15780,337 @@ msgstr "Favicon"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
 msgid "Landing Page"
-msgstr "Pagina di atterraggio"
+msgstr "Целева страница"
 
 #: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
 msgid "No groups"
-msgstr "Nessun gruppo"
+msgstr "Няма групи"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
 msgid "Permissions for {0}"
-msgstr "Permessi per {0}"
+msgstr "Разрешения за {0}"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
 msgid "Permissions for this folder"
-msgstr "Autorizzazioni per questa cartella"
+msgstr "Разрешения за тази папка"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:297
 msgid "Grant Edit access"
-msgstr "Concedere l'accesso a Modifica"
+msgstr "Предоставяне на достъп за редактиране"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:298
 msgid "Can modify snippets in this folder"
-msgstr "Può modificare i frammenti in questa cartella"
+msgstr "Може да променя фрагменти в тази папка"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:303
 msgid "Grant View access"
-msgstr "Accesso Grant View"
+msgstr "Предоставяне на достъп за преглед"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:304
 msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
-msgstr "Può inserire e utilizzare gli snippets in questa cartella, ma non può modificare l'SQL che contiene"
+msgstr "Може да вмъква и използва фрагменти в тази папка, но не може да редактира съдържащия се в тях SQL"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:310
 msgid "Can't view or insert snippets in this folder"
-msgstr "Non è possibile visualizzare o inserire frammenti in questa cartella"
+msgstr "Не мога да прегледам или вмъкна фрагменти в тази папка"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:814
 msgid "Also change sub-folders"
-msgstr "Cambiare anche le sottocartelle"
+msgstr "Сменете и подпапки"
 
 #: frontend/src/metabase/admin/settings/selectors.js:238
 msgid "First day of the week"
-msgstr "Primo giorno della settimana"
+msgstr "Първи ден от седмицата"
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:74
 msgid "There was an issue signing in with Google. Please contact an administrator."
-msgstr "C'è stato un problema con l'accesso a Google. Si prega di contattare un amministratore."
+msgstr "Възникна проблем при влизането с Google. Моля, свържете се с администратор."
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:133
 msgid "on the"
-msgstr "sul"
+msgstr "на"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:191
 msgid "at"
-msgstr "all'indirizzo"
+msgstr "в"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
 msgid "Open the Metabase actions menu"
-msgstr "Aprire il menu delle azioni di Metabase"
+msgstr "Отворете менюто за действия на Metabase"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
 #: frontend/src/metabase/lib/click-behavior.js:151
 msgid "Do nothing"
-msgstr "Non fare nulla"
+msgstr "Не правете нищо"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
 msgid "Go to a custom destination"
-msgstr "Vai a una destinazione personalizzata"
+msgstr "Отидете до персонализирана дестинация"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
 msgid "Update a dashboard filter"
-msgstr "Aggiornare il filtro del cruscotto"
+msgstr "Актуализирайте филтър на таблото за управление"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
 msgid "{0} updates {1} filter"
 msgid_plural "{0} updates {1} filters"
-msgstr[0] "{0} aggiornamenti {1} filtro"
-msgstr[1] "{0} aggiorna {1} i filtri"
+msgstr[0] "{0} актуализира {1} филтър"
+msgstr[1] "{0} актуализира {1} филтри"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
 msgid "{0} goes to {1}"
-msgstr "...va a..."
+msgstr "{0} отива на {1}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
 msgid "On-click behavior for each column"
-msgstr "Comportamento on-click per ogni colonna"
+msgstr "Поведение при кликване за всяка колона"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
 msgid "Go to custom destination"
-msgstr "Vai alla destinazione personalizzata"
+msgstr "Отидете до персонализирана дестинация"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
 msgid "Open the actions menu"
-msgstr "Aprire il menu delle azioni"
+msgstr "Отворете менюто за действия"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
 msgid "Click behavior for {0}"
-msgstr "Comportamento dei clic per {0}"
+msgstr "Поведение на кликване за {0}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
 msgid "Pick one or more filters to update"
-msgstr "Scegliere uno o più filtri da aggiornare"
+msgstr "Изберете един или повече филтри за актуализиране"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
 msgid "Saved question"
-msgstr "Domanda salvata"
+msgstr "Запазен въпрос"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
 msgid "Link to"
-msgstr "Collegamento a"
+msgstr "Връзка към"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
 msgid "Enter a URL to link to"
-msgstr "Inserire un URL a cui collegarsi"
+msgstr "Въведете URL адрес, към който да се свържете"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
 msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
-msgstr "È possibile inserire il valore di un filtro di colonna o di cruscotto utilizzando il suo nome, in questo modo: {{qualche_colonna}}}"
+msgstr "Можете да вмъкнете стойността на филтър за колона или табло, като използвате името му, по следния начин: {{some_column}}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
 msgid "e.g. http://acme.com/id/{{user_id}}"
-msgstr "ad esempio http://acme.com/id/{{{{id_utente}}}}."
+msgstr "напр. http://acme.com/id/{{user_id}}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
 msgid "Pick a dashboard..."
-msgstr "Scegli un cruscotto..."
+msgstr "Изберете табло за управление ..."
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
 msgid "Pick a question..."
-msgstr "Scegli una domanda..."
+msgstr "Изберете въпрос ..."
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
 msgid "Pick a dashboard to link to"
-msgstr "Scegliere un cruscotto da collegare a"
+msgstr "Изберете табло за управление, към което да се свържете"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
 msgid "Pick a question to link to"
-msgstr "Scegliere una domanda da collegare a"
+msgstr "Изберете въпрос, към който да се свържете"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
 msgid "Pass values to this dashboard's filters (optional)"
-msgstr "Passa i valori ai filtri di questo cruscotto (opzionale)"
+msgstr "Предавайте стойности на филтрите на това табло (по избор)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
 msgid "Pass values to this question's variables (optional)"
-msgstr "Passare i valori alle variabili di questa domanda (opzionale)"
+msgstr "Предава стойности на променливите на този въпрос (по избор)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
 msgid "Pass values to filter this question (optional)"
-msgstr "Passare i valori per filtrare questa domanda (opzionale)"
+msgstr "Предайте стойности за филтриране на този въпрос (по избор)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
 msgid "Dashboard filters"
-msgstr "Filtri del cruscotto"
+msgstr "Филтри на таблото"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
 msgid "User attributes"
-msgstr "Attributi dell'utente"
+msgstr "Потребителски атрибути"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
 msgid "Customize link text (optional)"
-msgstr "Personalizzare il testo del link (opzionale)"
+msgstr "Персонализиране на текста на връзката (по избор)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
 msgid "E.x. Details for {{Column Name}}"
-msgstr "E.x. Dettagli per {{Nome della colonna}}"
+msgstr "E.x. Подробности за {{Име на колона}}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
 msgid "Values you can reference"
-msgstr "Valori a cui si può fare riferimento"
+msgstr "Стойности, на които можете да се позовете"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
 msgid "No available targets"
-msgstr "Nessun obiettivo disponibile"
+msgstr "Няма налични цели"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
 msgid "filter"
-msgstr "filtro"
+msgstr "филтър"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
 msgid "variable"
-msgstr "variabile"
+msgstr "променлива"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
 msgid "Other available filters"
-msgstr "Altri filtri disponibili"
+msgstr "Други налични филтри"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
 msgid "Avaliable filters"
-msgstr "Filtri disponibili"
+msgstr "Налични филтри"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
 msgid "Other available variables"
-msgstr "Altre variabili disponibili"
+msgstr "Други налични променливи"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
 msgid "Avaliable variables"
-msgstr "Variabili valutabili"
+msgstr "Допустими променливи"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
 msgid "Other available columns"
-msgstr "Altre colonne disponibili"
+msgstr "Други налични колони"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
 msgid "Avaliable columns"
-msgstr "Colonne disponibili"
+msgstr "Достъпни колони"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
 msgid "user attribute"
-msgstr "attributo utente"
+msgstr "потребителски атрибут"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:214
 msgid "Text card"
-msgstr "Scheda di testo"
+msgstr "Текстова карта"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:271
 msgid "Click behavior"
-msgstr "Comportamento dei clic"
+msgstr "Поведение на щракване"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:298
 msgid "Visualization options"
-msgstr "Opzioni di visualizzazione"
+msgstr "Опции за визуализация"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:335
 msgid "Edit series"
-msgstr "Modifica serie"
+msgstr "Редактиране на поредицата"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:335
 msgid "Add series"
-msgstr "Aggiungere serie"
+msgstr "Добавяне на поредица"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:383
 msgid "On click"
-msgstr "Su clic"
+msgstr "При щракване"
 
 #: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
 msgid "Change title and description"
-msgstr "Cambia titolo e descrizione"
+msgstr "Промяна на заглавието и описанието"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
 msgid "You've updated embedded params and will need to update your embed code."
-msgstr "Avete aggiornato i parametri incorporati e dovrete aggiornare il vostro codice incorporato."
+msgstr "Актуализирали сте вградени параметри и ще трябва да актуализирате своя код за вграждане."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
 msgid "Add question"
-msgstr "Aggiungi domanda"
+msgstr "Добавете въпрос"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
 msgid "You're editing this dashboard."
-msgstr "Stai modificando questo cruscotto."
+msgstr "Редактирате това табло за управление."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
 msgid "Column to filter on"
-msgstr "Colonna da filtrare su"
+msgstr "Колона за филтриране"
 
 #: frontend/src/metabase/entities/snippet-collections.js:22
 msgid "snippet collection"
-msgstr "raccolta di frammenti"
+msgstr "колекция от фрагменти"
 
 #: frontend/src/metabase/entities/snippet-collections.js:23
 msgid "snippet collections"
-msgstr "collezioni di frammenti"
+msgstr "колекции от фрагменти"
 
 #: frontend/src/metabase/entities/snippet-collections.js:72
 msgid "Give your folder a name"
-msgstr "Date un nome alla vostra cartella"
+msgstr "Дайте име на вашата папка"
 
 #: frontend/src/metabase/entities/snippet-collections.js:73
 msgid "Something short but sweet"
-msgstr "Qualcosa di breve ma dolce"
+msgstr "Нещо кратко, но сладко"
 
 #: frontend/src/metabase/entities/snippet-collections.js:94
 #: frontend/src/metabase/entities/snippets.js:55
 msgid "Folder this should be in"
-msgstr "Cartella questa dovrebbe essere in"
+msgstr "Папка, в която трябва да бъде"
 
 #: frontend/src/metabase/lib/click-behavior.js:150
 msgid "Open the action menu"
-msgstr "Aprire il menu delle azioni"
+msgstr "Отворете менюто за действие"
 
 #: frontend/src/metabase/lib/click-behavior.js:159
 msgid "{0} column has custom behavior"
 msgid_plural "{0} columns have custom behavior"
-msgstr[0] "{0} colonna ha un comportamento personalizzato"
-msgstr[1] "{0} colonne hanno un comportamento personalizzato"
+msgstr[0] "Колона {0} има персонализирано поведение"
+msgstr[1] "{0} колони имат персонализирано поведение"
 
 #: frontend/src/metabase/lib/click-behavior.js:172
 msgid "Go to..."
-msgstr "Vai a..."
+msgstr "Отидете на ..."
 
 #: frontend/src/metabase/lib/click-behavior.js:174
 msgid "Go to dashboard"
-msgstr "Vai al cruscotto"
+msgstr "Отиди до таблото"
 
 #: frontend/src/metabase/lib/click-behavior.js:176
 msgid "Go to question"
-msgstr "Vai alla domanda"
+msgstr "Отидете на въпрос"
 
 #: frontend/src/metabase/lib/click-behavior.js:177
 msgid "Go to url"
-msgstr "Vai all'url"
+msgstr "Отидете на url"
 
 #: frontend/src/metabase/lib/click-behavior.js:180
 msgid "Filter this dashboard"
-msgstr "Filtrare questo cruscotto"
+msgstr "Филтрирайте това табло за управление"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
 msgid "Returns the count of rows in the selected data."
-msgstr "Restituisce il conteggio delle righe nei dati selezionati."
+msgstr "Връща броя на редовете в избраните данни."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
 msgid "The column or number to sum."
-msgstr "La colonna o il numero da sommare."
+msgstr "Колоната или числото за сумиране."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
 msgid "The numeric column to get standard deviation of."
-msgstr "La colonna numerica di cui ottenere la deviazione standard."
+msgstr "Числовата колона, за да се получи стандартно отклонение на."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "The numeric column whose values to average."
-msgstr "La colonna numerica i cui valori sono in media."
+msgstr "Числовата колона, чиито стойности се осредняват."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
 msgid "Returns the smallest value found in the column"
-msgstr "Restituisce il più piccolo valore trovato nella colonna"
+msgstr "Връща най-малката стойност, намерена в колоната"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Google"
@@ -16123,543 +16118,543 @@ msgstr "Google"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
 msgid "Sums up the specified column only for rows where the condition is true."
-msgstr "Somma la colonna specificata solo per le righe in cui la condizione è vera."
+msgstr "Обобщава посочената колона само за редове, където условието е вярно."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
 msgid "Returns the numeric variance for a given column."
-msgstr "Restituisce la varianza numerica per una data colonna."
+msgstr "Връща числовата дисперсия за дадена колона."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Temperature"
-msgstr "Temperatura"
+msgstr "Температура"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
 msgid "The column or number to get the variance of."
-msgstr "La colonna o il numero di cui ottenere la varianza."
+msgstr "Колоната или числото, за да се получи дисперсията."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
 msgid "Returns the median value of the specified column."
-msgstr "Restituisce il valore mediano della colonna specificata."
+msgstr "Връща средната стойност на посочената колона."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
 msgid "The column or number to get the median of."
-msgstr "La colonna o il numero di cui ottenere la mediana."
+msgstr "Колоната или числото, за да се получи медианата на."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
 msgid "percentile-value"
-msgstr "valore percentile"
+msgstr "процентил-стойност"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
 msgid "Returns the value of the column at the percentile value."
-msgstr "Restituisce il valore della colonna al valore del percentile."
+msgstr "Връща стойността на колоната при процентилна стойност."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The column or number to get the percentile of."
-msgstr "La colonna o il numero di cui ottenere il percentile."
+msgstr "Колоната или числото, за да получите процентила на."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
 msgid "The value of the percentile."
-msgstr "Il valore del percentile."
+msgstr "Стойността на процентила."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 msgid "Returns the string of text in all lower case."
-msgstr "Restituisce la stringa di testo in tutte le minuscole."
+msgstr "Връща низа от текст с малки букви."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The column with values to convert to lower case."
-msgstr "La colonna con i valori da convertire in minuscolo."
+msgstr "Колоната със стойности за преобразуване в малки букви."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the text in all upper case."
-msgstr "Restituisce il testo in tutte le maiuscole."
+msgstr "Връща текста с главни букви."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
 msgid "The column or text to return a portion of."
-msgstr "La colonna o il testo di cui restituire una parte."
+msgstr "Колоната или текстът, за да се върне част от."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
 msgid "The column or text to search through."
-msgstr "La colonna o il testo da cercare."
+msgstr "Колоната или текстът за търсене."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
 msgid "Combine two or more strings of text together."
-msgstr "Combina due o più stringhe di testo insieme."
+msgstr "Комбинирайте два или повече низа от текст заедно."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
 msgid "The column or text to begin with."
-msgstr "La colonna o il testo per iniziare."
+msgstr "Колоната или текстът за начало."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
 msgid "This will be added to the end of value1, and so on."
-msgstr "Questo sarà aggiunto alla fine del valore1 e così via."
+msgstr "Това ще бъде добавено към края на value1 и т.н."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
 msgid "Enormous"
-msgstr "Enorme"
+msgstr "Огромно"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
 msgid "Gigantic"
-msgstr "Gigantesco"
+msgstr "Гигантски"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
 msgid "Returns the number of characters in text."
-msgstr "Restituisce il numero di caratteri nel testo."
+msgstr "Връща броя на символите в текста."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
 msgid "The column or text you want to get the length of."
-msgstr "La colonna o il testo di cui si desidera ottenere la lunghezza."
+msgstr "Колоната или текстът, на който искате да получите дължината."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
 msgid "The column or text you want to trim."
-msgstr "La colonna o il testo da tagliare."
+msgstr "Колоната или текстът, които искате да отрежете."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
 msgid "Returns the absolute (positive) value of the specified column."
-msgstr "Restituisce il valore assoluto (positivo) della colonna specificata."
+msgstr "Връща абсолютната (положителна) стойност на посочената колона."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
 msgid "Debt"
-msgstr "Debito"
+msgstr "Дълг"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 msgid "The column or number to return absolute (positive) value of."
-msgstr "La colonna o il numero di cui restituire il valore assoluto (positivo)."
+msgstr "Колоната или числото, за което се връща абсолютна (положителна) стойност."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "Rounds a decimal number down."
-msgstr "Arrotonda un numero decimale verso il basso."
+msgstr "Закръглява десетично число надолу."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
 msgid "The column or number to round down."
-msgstr "La colonna o il numero da arrotondare per difetto."
+msgstr "Колоната или номерът за закръгляване надолу."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
 msgid "Rounds a decimal number up."
-msgstr "Arrotonda un numero decimale verso l'alto."
+msgstr "Закръглява десетично число нагоре."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "The column or number to round up."
-msgstr "La colonna o il numero da arrotondare."
+msgstr "Колоната или номерът за закръгляване."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
 msgid "Rounds a decimal number either up or down to the nearest integer value."
-msgstr "Arrotonda un numero decimale verso l'alto o verso il basso al valore intero più vicino."
+msgstr "Закръглява десетично число нагоре или надолу до най-близката целочислена стойност."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
 msgid "The column or number to round to nearest integer."
-msgstr "La colonna o il numero da arrotondare al numero intero più vicino."
+msgstr "Колоната или числото, което трябва да се закръгли до най-близкото цяло число."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 msgid "Returns the square root."
-msgstr "Restituisce la radice quadrata."
+msgstr "Връща квадратния корен."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "Hypotenuse"
-msgstr "Ipotenusa"
+msgstr "Хипотенуза"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "The column or number to return square root value of."
-msgstr "La colonna o il numero di cui restituire il valore della radice quadrata."
+msgstr "Колоната или номерът, за които се връща квадратна коренна стойност."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
 msgid "exponent"
-msgstr "Esponente"
+msgstr "експонента"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Raises a number to the power of the exponent value."
-msgstr "Alza un numero al potere del valore dell'esponente."
+msgstr "Повишава число в степен на степенната стойност."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Length"
-msgstr "Lunghezza"
+msgstr "Дължина"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column or number raised to the exponent."
-msgstr "La colonna o il numero elevato all'esponente."
+msgstr "Колоната или номерът, повдигнати до степента."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
 msgid "The value of the exponent."
-msgstr "Il valore dell'esponente."
+msgstr "Стойността на степента."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Returns the base 10 log of the number."
-msgstr "Restituisce il registro di base 10 del numero."
+msgstr "Връща основния дневник 10 на числото."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
 msgid "Value"
-msgstr "Valore"
+msgstr "Стойност"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
 msgid "The column or number to return the natural logarithm value of."
-msgstr "La colonna o il numero di cui restituire il valore logaritmico naturale."
+msgstr "Колоната или номерът за връщане на естествения логаритъм на."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
 msgid "Returns Euler's number, e, raised to the power of the supplied number."
-msgstr "Restituisce il numero di Eulero, e, elevato alla potenza del numero fornito."
+msgstr "Връща числото на Ойлер, e, повишено до степента на предоставеното число."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
 msgid "Interest Months"
-msgstr "Mesi di interesse"
+msgstr "Месеци на лихви"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
 msgid "The column or number to return the exponential value of."
-msgstr "La colonna o il numero di cui restituire il valore esponenziale."
+msgstr "Колоната или числото, за да се върне експоненциалната стойност на."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
 msgid "The column or text to check."
-msgstr "La colonna o il testo da controllare."
+msgstr "Колоната или текстът за проверка."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
 msgid "Checks a date or number column's values to see if they're within the specified range."
-msgstr "Controlla i valori di una data o di una colonna numerica per vedere se sono all'interno dell'intervallo specificato."
+msgstr "Проверява стойностите на колоната за дата или число, за да види дали са в рамките на посочения диапазон."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
 msgid "Created At"
-msgstr "Creato a"
+msgstr "Създаден в"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
 msgid "The date or numeric column that should be within the start and end values."
-msgstr "La data o la colonna numerica che dovrebbe rientrare nei valori iniziali e finali."
+msgstr "Датата или числовата колона, която трябва да бъде в рамките на началната и крайната стойност."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "The beginning of the range."
-msgstr "L'inizio della gamma."
+msgstr "Началото на диапазона."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "The end of the range."
-msgstr "La fine della gamma."
+msgstr "Краят на диапазона."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
 msgid "Checks a date column's values to see if they're within the relative range."
-msgstr "Controlla i valori di una colonna di data per vedere se sono all'interno dell'intervallo relativo."
+msgstr "Проверява стойностите на колона за дата, за да види дали са в относителния диапазон."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
 msgid "The date column to return interval of."
-msgstr "La colonna della data di ritorno dell'intervallo di."
+msgstr "Колоната с дата за връщане на интервал от."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
 msgid "Period of interval, where negative values are back in time."
-msgstr "Periodo di intervallo, in cui i valori negativi sono indietro nel tempo."
+msgstr "Период от интервал, когато отрицателните стойности се връщат във времето."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
 msgid "Type of internal like \"day\", \"month\", \"year\"."
-msgstr "Tipo di interno come \"giorno\", \"mese\", \"anno\"."
+msgstr "Тип вътрешни като \"ден\", \"месец\", \"година\"."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "The column or value to return."
-msgstr "La colonna o il valore da restituire."
+msgstr "Колоната или стойността за връщане."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
 msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
-msgstr "Se il valore1 è vuoto, il valore2 viene restituito se non è vuoto, e così via."
+msgstr "Ако value1 е празно, value2 се връща, ако не е празно и т.н."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
 msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
-msgstr "Testa un'espressione rispetto a una lista di casi e restituisce il valore corrispondente del primo caso corrispondente, con un valore di default opzionale se non viene soddisfatto nient'altro."
+msgstr "Тества израз срещу списък от случаи и връща съответната стойност на първия съвпадащ случай, с незадължителна стойност по подразбиране, ако не е изпълнено нищо друго."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
 msgid "The value that will be returned if the preceding condition is true, and so on."
-msgstr "Il valore che sarà restituito se la condizione precedente è vera, e così via."
+msgstr "Стойността, която ще бъде върната, ако предходното условие е вярно и т.н."
 
 #: frontend/src/metabase/lib/schema_metadata.js:392
 #: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is null"
-msgstr "È nullo"
+msgstr "Е нула"
 
 #: frontend/src/metabase/lib/schema_metadata.js:393
 #: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Not null"
-msgstr "Non nullo"
+msgstr "Не е нула"
 
 #: frontend/src/metabase/lib/schema_metadata.js:544
 msgid "Additive sum of all the values of a column.\n"
 "e.x. total revenue over time."
-msgstr "Somma additiva di tutti i valori di una colonna.\n"
-"e.x. il totale delle entrate nel tempo."
+msgstr "Адитивна сума на всички стойности на колона.\n"
+"напр. общ приход във времето."
 
 #: frontend/src/metabase/lib/schema_metadata.js:553
 msgid "Additive count of the number of rows.\n"
 "e.x. total number of sales over time."
-msgstr "Conteggio additivo del numero di righe.\n"
-"e.x. numero totale di vendite nel tempo."
+msgstr "Брой адитиви на броя редове.\n"
+"напр. общ брой продажби във времето."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
 msgid "Linked filters"
-msgstr "Filtri collegati"
+msgstr "Свързани филтри"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
 msgid "Label"
-msgstr "Etichetta"
+msgstr "Етикет"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
 msgid "Default value"
-msgstr "Valore di default"
+msgstr "Стойност по подразбиране"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
 msgid "No default"
-msgstr "Nessun difetto"
+msgstr "Няма по подразбиране"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
 msgid "To view this, {0} must be connected to at least one field."
-msgstr "Per visualizzare questo, {0} deve essere collegato ad almeno un campo."
+msgstr "За да видите това, {0} трябва да е свързан поне с едно поле."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
 msgid "Limit this filter's choices"
-msgstr "Limitare le scelte di questo filtro"
+msgstr "Ограничете избора на този филтър"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
 msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
-msgstr "Se si dispone di un altro filtro del cruscotto, è possibile limitare le scelte che sono elencate per questo filtro in base alla selezione dell'altro."
+msgstr "Ако имате друг филтър на таблото за управление, можете да ограничите избора, посочен за този филтър, въз основа на избора на другия."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
 msgid "So first, {0}."
-msgstr "Allora, prima di tutto..."
+msgstr "Така че първо, {0}."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
 msgid "add another dashboard filter"
-msgstr "aggiungere un altro filtro per il cruscotto"
+msgstr "добавете друг филтър на таблото за управление"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
 msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
-msgstr "Se si attiva uno di questi filtri del cruscotto, la selezione di un valore per quel filtro limiterà le scelte disponibili per il filtro {0}."
+msgstr "Ако превключите на един от тези филтри на таблото за управление, избирането на стойност за този филтър ще ограничи наличните възможности за избор на филтър {0}."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
 msgid "Filtering column"
-msgstr "Colonna di filtraggio"
+msgstr "Филтрираща колона"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
 msgid "Filtered column"
-msgstr "Colonna filtrata"
+msgstr "Филтрирана колона"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
 msgid "Enter user names or email addresses"
-msgstr "Inserire i nomi utente o gli indirizzi e-mail"
+msgstr "Въведете потребителски имена или имейл адреси"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
 msgid "New snippet"
-msgstr "Nuovo frammento"
+msgstr "Нов фрагмент"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
 msgid "{0}:00 PM"
-msgstr "{0}:00 PM"
+msgstr "{0}: 00 ч"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
 msgid "12:00 AM"
-msgstr "12:00 AM"
+msgstr "00:00 ч"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
 msgid "{0}:00 AM"
-msgstr "{0}:00 AM"
+msgstr "{0}: 00 ч"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
 msgid "Hourly"
-msgstr "Ogni ora"
+msgstr "Почасово"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
 msgid "Daily at {0}"
-msgstr "Ogni giorno a {0}"
+msgstr "Всеки ден в {0}"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
 msgid "Weekly at {0} on {1}"
-msgstr "Settimanale al {0} il {1}"
+msgstr "Седмично в {0} на {1}"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
 msgid "Monthly on the {0} {1} at {2}"
-msgstr "Mensile il {0} {1} a {2} al {0}"
+msgstr "Месечно на {0} {1} в {2}"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
 msgid "Delete this subscription"
-msgstr "Cancella questo abbonamento"
+msgstr "Изтрийте този абонамент"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
 msgid "Subscriptions"
-msgstr "Abbonamenti"
+msgstr "Абонаменти"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
 msgid "Create a dashboard subscription"
-msgstr "Creare un abbonamento al cruscotto"
+msgstr "Създайте абонамент за табло"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
 msgid "Email it"
-msgstr "Invia un'e-mail"
+msgstr "Изпратете го по имейл"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
 msgid "You can send this dashboard regularly to users or email addresses."
-msgstr "È possibile inviare questa dashboard regolarmente agli utenti o agli indirizzi e-mail."
+msgstr "Можете да изпращате това табло за управление редовно до потребители или имейл адреси."
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
 msgid "Send it to Slack"
-msgstr "Invia a Slack"
+msgstr "Изпратете го на Slack"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
 msgid "Pick a channel and a schedule, and Metabase will do the rest."
-msgstr "Scegliete un canale e un programma, e Metabase farà il resto."
+msgstr "Изберете канал и график, а Metabase ще свърши останалото."
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
 msgid "Email this dashboard"
-msgstr "Invia questa dashboard per e-mail"
+msgstr "Изпратете това табло за управление по имейл"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
 msgid "Don't send if there aren't results"
-msgstr "Non inviare se non ci sono risultati"
+msgstr "Не изпращайте, ако няма резултати"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
 msgid "Attach results"
-msgstr "Allega i risultati"
+msgstr "Прикачете резултати"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
 msgid "Attachments can contain up to 2,000 rows of data."
-msgstr "Gli allegati possono contenere fino a 2.000 righe di dati."
+msgstr "Прикачените файлове могат да съдържат до 2000 реда данни."
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
 msgid "Send this dashboard to Slack"
-msgstr "Invia questo cruscotto a Slack"
+msgstr "Изпратете това табло за управление на Slack"
 
 #: src/metabase/api/dashboard.clj
 msgid "Dashboard does not have a parameter with the ID {0}"
-msgstr "Il cruscotto non ha un parametro con l'ID {0}"
+msgstr "Таблото за управление няма параметър с идентификатор {0}"
 
 #: src/metabase/api/dashboard.clj
 msgid "Parameter {0} does not have any Fields associated with it"
-msgstr "Il parametro {0} non ha nessun campo associato"
+msgstr "Параметърът {0} няма свързани полета"
 
 #: src/metabase/api/database.clj
 msgid "include must be either empty or the value 'tables'"
-msgstr "includere deve essere vuoto o il valore \"tabelle\"."
+msgstr "включва трябва да е или празно, или стойността \"таблици\""
 
 #: src/metabase/api/dataset.clj
 msgid "`database` is required for all queries whose type is not `internal`."
-msgstr "Il `database` è richiesto per tutte le query il cui tipo non è `interno`."
+msgstr "„база данни“ се изисква за всички заявки, чийто тип не е „вътрешен“."
 
 #: src/metabase/api/session.clj
 msgid "Password login is disabled for this instance."
-msgstr "In questo caso il login con password è disabilitato."
+msgstr "Входът за парола е деактивиран за този случай."
 
 #: src/metabase/api/session.clj
 msgid "Your account is disabled. Please contact your administrator."
-msgstr "Il tuo account è disabilitato. Contatta il tuo amministratore."
+msgstr "Вашият акаунт е деактивиран. Моля, свържете се с вашия администратор."
 
 #: src/metabase/api/session.clj
 msgid "Your account is disabled."
-msgstr "Il tuo account è disabilitato."
+msgstr "Вашият акаунт е деактивиран."
 
 #: src/metabase/api/slack.clj
 msgid "Invalid Slack token."
-msgstr "Gettone di allentamento non valido."
+msgstr "Невалиден маркер Slack."
 
 #: src/metabase/cmd.clj
 msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
-msgstr "Il comando ''{0}'' è disponibile solo in Metabase Enterprise Edition."
+msgstr "Командата '' {0} '' е налична само в Metabase Enterprise Edition."
 
 #: src/metabase/core.clj
 msgid "Metabase Enterprise Edition extensions are PRESENT."
-msgstr "Le estensioni di Metabase Enterprise Edition sono PRESENTI."
+msgstr "Разширенията на Metabase Enterprise Edition са НАСТОЯЩИ."
 
 #: src/metabase/core.clj
 msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
-msgstr "L'uso delle funzionalità di Metabase Enterprise Edition è soggetto alla licenza commerciale Metabase."
+msgstr "Използването на функциите на Metabase Enterprise Edition е предмет на Търговския лиценз на Metabase."
 
 #: src/metabase/core.clj
 msgid "See {0} for details."
-msgstr "Vedi {0} per i dettagli."
+msgstr "Вижте {0} за подробности."
 
 #: src/metabase/core.clj
 msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
-msgstr "Le estensioni di Metabase Enterprise Edition NON sono PRESENTI."
+msgstr "Разширенията на Metabase Enterprise Edition НЕ СА."
 
 #: src/metabase/email/messages.clj
 msgid "You''re invited to join {0}''s {1}"
-msgstr "Siete invitati ad unirvi a noi."
+msgstr "Поканени сте да се присъедините към {1} на {0}"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a {1} account"
-msgstr "ha creato un conto"
+msgstr "{0} създаде {1} акаунт"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their {1} invite"
-msgstr "...ha accettato il loro invito."
+msgstr "{0} прие тяхната {1} покана"
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Password Reset Request"
-msgstr "Richiesta di reimpostazione della password"
+msgstr "[{0}] Заявка за нулиране на парола"
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Notification"
-msgstr "Notifica"
+msgstr "[{0}] Известие"
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Help make [{1}] better."
-msgstr "Aiuta a migliorare la situazione."
+msgstr "[{0}] Помогнете да подобрите [{1}]."
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Tell us how things are going."
-msgstr "Dicci come vanno le cose."
+msgstr "[{0}] Кажете ни как вървят нещата."
 
 #: src/metabase/events.clj
 msgid "Error starting events listener"
-msgstr "Errore di avvio dell'ascoltatore di eventi"
+msgstr "Грешка при стартиране на слушателя на събития"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Should we sync user attributes when someone logs in via LDAP?"
-msgstr "Dobbiamo sincronizzare gli attributi degli utenti quando qualcuno effettua il login tramite LDAP?"
+msgstr "Трябва ли да синхронизираме потребителски атрибути, когато някой влезе чрез LDAP?"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
-msgstr "Elenco separato da virgole degli attributi degli utenti per saltare la sincronizzazione per gli utenti LDAP."
+msgstr "Списък със потребителски атрибути, разделен със запетая, за да пропуснете синхронизирането за LDAP потребители."
 
 #: src/metabase/integrations/slack.clj
 msgid "Invalid token"
-msgstr "Gettone non valido"
+msgstr "Невалиден Жетон"
 
 #: src/metabase/integrations/slack.clj
 msgid "Slack API error: {0}"
-msgstr "Errore API allentato: {0}"
+msgstr "Грешка в Slack API: {0}"
 
 #: src/metabase/integrations/slack.clj
 msgid "Slack channel named `metabase_files` is missing!"
-msgstr "Manca il canale Slack chiamato `metabase_files`!"
+msgstr "Слаб канал с име `metabase_files` липсва!"
 
 #: src/metabase/integrations/slack.clj
 msgid "Please create or unarchive the channel in order to complete the Slack integration."
-msgstr "Si prega di creare o disarchiviare il canale per completare l'integrazione Slack."
+msgstr "Моля, създайте или деархивирайте канала, за да завършите интеграцията на Slack."
 
 #: src/metabase/integrations/slack.clj
 msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
-msgstr "Il canale viene utilizzato per memorizzare i grafici che sono inclusi nelle risposte di Pulses e MetaBot."
+msgstr "Каналът се използва за съхраняване на графики, които са включени в отговорите на Pulses и MetaBot."
 
 #: src/metabase/integrations/slack.clj
 msgid "Uploaded image"
-msgstr "Immagine caricata"
+msgstr "Качено изображение"
 
 #: src/metabase/integrations/slack.clj
 msgid "Error uploading file to Slack:"
-msgstr "Errore nel caricamento del file su Slack:"
+msgstr "Грешка при качването на файл в Slack:"
 
 #: src/metabase/middleware/session.clj
 msgid "Invalid session. Expected an instance of Session."
-msgstr "Sessione non valida. Prevista un'istanza di Sessione."
+msgstr "Невалидна сесия. Очаква се екземпляр на сесия."
 
 #: src/metabase/middleware/session.clj
 msgid "Session cookie's SameSite is configured to \"None\", but site is"
-msgstr "Il SameSite del cookie di sessione è configurato su \"Nessuno\", ma il sito è"
+msgstr "SameSite на сесийната бисквитка е конфигуриран на \"Няма\", но сайтът е"
 
 #: src/metabase/middleware/session.clj
 msgid "served over an insecure connection. Some browsers will reject "
-msgstr "e' servita per una connessione insicura. Alcuni browser rifiutano "
+msgstr "поднесени по несигурна връзка. Някои браузъри ще отхвърлят "
 
 #: src/metabase/middleware/session.clj
 msgid "cookies under these conditions. "
-msgstr "cookies a queste condizioni. "
+msgstr "бисквитки при тези условия. "
 
 #: src/metabase/middleware/session.clj
 msgid "https://www.chromestatus.com/feature/5633521622188032"
@@ -16667,142 +16662,143 @@ msgstr "https://www.chromestatus.com/feature/5633521622188032"
 
 #: src/metabase/models/collection.clj
 msgid "Top folder"
-msgstr "Cartella in alto"
+msgstr "Най-горната папка"
 
 #: src/metabase/models/dashboard.clj
 msgid ":parameters must be a sequence of maps with String :id keys"
-msgstr ":i parametri devono essere una sequenza di mappe con i tasti String :id"
+msgstr ": параметрите трябва да са последователност от карти с ключове String: id"
 
 #: src/metabase/models/field_values.clj
 msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
-msgstr "Valori non validi leggibili dall'uomo: i valori devono essere una sequenza; ogni elemento deve essere nullo o una stringa"
+msgstr "Невалидни човешки четими стойности: стойностите трябва да са последователност; всеки елемент трябва да е нула или низ"
 
 #: src/metabase/models/field_values.clj
 msgid ":values must be present to fetch :human_readable_values"
-msgstr ":i valori devono essere presenti per recuperare :valori_letturabili_umani"
+msgstr ": стойностите трябва да присъстват за извличане: human_readable_values"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is > {0}."
-msgstr "La lunghezza totale dei valori del campo è > {0}."
+msgstr "Общата дължина на стойностите на полето е> {0}."
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "snippet names cannot include '}' or start with spaces"
-msgstr "i nomi dei frammenti non possono includere '}' o iniziare con degli spazi"
+msgstr "имената на фрагменти не могат да включват '}' или да започват с интервали"
 
 #: src/metabase/models/params/chain_filter.clj
 msgid "Error executing chain filter query"
-msgstr "Errore nell'esecuzione della query del filtro a catena"
+msgstr "Грешка при изпълнение на заявката за верижен филтър"
 
 #: src/metabase/models/params/chain_filter.clj
 msgid "Field {0} does not exist."
-msgstr "Il campo {0} non esiste."
+msgstr "Поле {0} не съществува."
 
 #: src/metabase/models/params/chain_filter.clj
 msgid "Cannot search against non-Text Field {0} {1}"
-msgstr "Non è possibile effettuare ricerche in campi diversi da quello di testo {0} {1}"
+msgstr "Не може да се търси в нетекстово поле {0} {1}"
 
 #: src/metabase/models/permissions.clj
 msgid "Granting permissions for group {0}: {1}"
-msgstr "Concessione di autorizzazioni per il gruppo {0}: {1}"
+msgstr "Предоставяне на разрешения за група {0}: {1}"
 
 #: src/metabase/models/permissions.clj
 msgid "Revoking permissions for group {0}: {1}"
-msgstr "Revocando i permessi per il gruppo {0}: {1}"
+msgstr "Отнемане на разрешения за група {0}: {1}"
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
-msgstr "Autorizzazioni DB non valide: se si dispone di un accesso in scrittura per le query native, è necessario avere un accesso completo ai dati."
+msgstr "Невалидни разрешения на DB: ако имате достъп за запис за собствени заявки, трябва да имате пълен достъп до данни."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
-msgstr "Autorizzazioni DB non valide: se si dispone di un accesso alla query nativa di sola lettura, è necessario avere anche l'accesso ai dati."
+msgstr "Невалидни разрешения на DB: ако имате достъп само за четене само за четене, трябва да имате и достъп до данни."
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions from: {0} to: {1}"
-msgstr "Modifica delle autorizzazioni da: {0} a: {1}"
+msgstr "Промяна на разрешенията от: {0} на: {1}"
 
 #: src/metabase/models/user.clj
 msgid "login attribute keys must be a keyword or string"
-msgstr "le chiavi degli attributi di login devono essere una parola chiave o una stringa"
+msgstr "атрибутите за вход трябва да са ключова дума или низ"
 
 #: src/metabase/public_settings.clj
 msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
-msgstr "Il linguaggio predefinito per tutti gli utenti attraverso l'interfaccia utente di Metabase, le e-mail di sistema, gli impulsi e gli avvisi."
+msgstr "Езикът по подразбиране за всички потребители в потребителския интерфейс на Metabase, системни имейли, импулси и сигнали."
 
 #: src/metabase/public_settings.clj
 msgid "Users can individually override this default language from their own account settings."
-msgstr "Gli utenti possono sovrascrivere individualmente questa lingua predefinita dalle impostazioni del proprio account."
+msgstr "Потребителите могат индивидуално да заменят този език по подразбиране от собствените си настройки на акаунта."
 
 #: src/metabase/public_settings.clj
 msgid "Default page to show the user"
-msgstr "Pagina predefinita per mostrare all'utente"
+msgstr "Страница по подразбиране за показване на потребителя"
 
 #: src/metabase/public_settings.clj
 msgid "Allow this origin to embed the full Metabase application"
-msgstr "Permettere a questa origine di incorporare l'intera applicazione Metabase"
+msgstr "Позволете на този произход да вгражда пълното приложение Metabase"
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {0} ({1}) are not allowed."
-msgstr "Non sono ammessi valori superiori a {0} ({1})."
+msgstr "Стойности, по-големи от {0} ({1}), не са разрешени."
 
 #: src/metabase/public_settings.clj
 msgid "This will replace the word \"Metabase\" wherever it appears."
-msgstr "Questo sostituirà la parola \"Metabase\" ovunque essa appaia."
+msgstr "Това ще замени думата \"Metabase\", където и да се появи."
 
 #: src/metabase/public_settings.clj
 msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
-msgstr "Questi sono i colori primari utilizzati nei grafici e in tutta Metabase. Potrebbe essere necessario aggiornare il vostro browser per vedere i vostri cambiamenti avere effetto."
+msgstr "Това са основните цветове, използвани в диаграмите и в Metabase. Може да се наложи да опресните браузъра си, за да видите вашите промени да влязат в сила."
 
 #: src/metabase/public_settings.clj
 msgid "For best results, use an SVG file with a transparent background."
-msgstr "Per ottenere i migliori risultati, utilizzare un file SVG con uno sfondo trasparente."
+msgstr "За най-добри резултати използвайте SVG файл с прозрачен фон."
 
 #: src/metabase/public_settings.clj
 msgid "The url or image that you want to use as the favicon."
-msgstr "L'url o l'immagine che si vuole usare come favicon."
+msgstr "URL адресът или изображението, които искате да използвате като фавикон."
 
 #: src/metabase/public_settings.clj
 msgid "Allow logging in by email and password."
-msgstr "Consentire l'accesso tramite e-mail e password."
+msgstr "Разрешаване на влизане по имейл и парола."
 
 #: src/metabase/public_settings.clj
 msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
 "  It won''t affect SQL queries."
-msgstr "Questo influenzerà cose come il raggruppamento per settimana o il filtraggio nelle query GUI.\n"
-"  Non influenzerà le query SQL."
+msgstr "Това ще повлияе на неща като групиране по седмици или филтриране в GUI заявки.\n"
+"  Това няма да повлияе на SQL заявките."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token"
-msgstr "Impossibile convalidare il gettone"
+msgstr "Не може да се провери маркера"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid."
-msgstr "Il formato del gettone non è valido."
+msgstr "Форматът на маркера е невалиден."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token"
-msgstr "Gettone di convalida errore"
+msgstr "Грешка при проверка на маркера"
 
 #: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
 msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
-msgstr "Filtraggio di errore contro {0} Campo: non è possibile analizzare la stringa {1} in {2}."
+msgstr "Грешка при филтрирането срещу {0} поле: не може да се анализира низ {1} на {2}"
 
 #: src/metabase/task.clj
 msgid "Error fetching details for Job: {0}"
-msgstr "Errore nel reperire i dettagli di Job: {0}"
+msgstr "Грешка при извличането на подробности за работа: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Starting sync task for Database {0}."
-msgstr "Avvio dell'attività di sincronizzazione per il database {0}."
+msgstr "Стартиране на задача за синхронизиране за база данни {0}."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Cannot sync Database {0}: Database does not exist."
-msgstr "Impossibile sincronizzare il database {0}: Il database non esiste."
+msgstr "Не може да се синхронизира база данни {0}: Базата данни не съществува."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Update Field values task triggered for Database {0}."
-msgstr "Aggiornamento dei valori del campo attività attivata per il database {0}."
+msgstr "Задача за актуализиране на стойности на полета, задействана за база данни {0}."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
-msgstr "Saltando l'aggiornamento, gli aggiornamenti automatici dei valori di campo sono disabilitati per il database {0}."
+msgstr "Пропускане на актуализацията, автоматичните актуализации на стойността на полето са деактивирани за база данни {0}."
+

--- a/locales/ca.po
+++ b/locales/ca.po
@@ -28,15 +28,16 @@ msgstr "Explora aquestes dades"
 msgid "Select a database type"
 msgstr "Selecciona un tipus de base de dades"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Desa"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase necessita analitzar la teva base de dades. S'analitzarà periòdicament per tal de mantenir actualizades les metadades. A continuació, pots definir la periodicitat dels anàlisis."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "S'està sincronitzant"
 
@@ -64,7 +65,7 @@ msgstr "Això es un procès simple que busca actualitzacions a l'esquema de la b
 msgid "Scan"
 msgstr "Escaneja"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Escanejant els valors dels filtres"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase pot analizar els valors presents a cada camp de la base de dades, per tal d'activar filtres als quadres de comandament i les preguntes. Aquest procés pot ser intensiu, en especial si disposes d'una base de dades gran."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Amb quina periodicitat Metabase ha d'analitzar i desar en memoria els valors dels camps?"
 
@@ -133,29 +134,31 @@ msgstr "Elimar"
 msgid "in this box:"
 msgstr "en aquest camp:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -178,9 +181,9 @@ msgstr "Eliminar"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -200,8 +203,9 @@ msgstr "Connexió"
 msgid "Scheduling"
 msgstr "Programació"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -280,10 +284,10 @@ msgstr "Afegeix base de dades"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -318,10 +322,8 @@ msgid "Successfully saved!"
 msgstr "Desat correctament!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Edita"
@@ -400,26 +402,29 @@ msgstr "Seleccioneu un tipus especial"
 msgid "Select a target"
 msgstr "Selecciona una referència"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Columnes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Columna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Visibilitat"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Tipus"
 
@@ -427,7 +432,7 @@ msgstr "Tipus"
 msgid "Current database:"
 msgstr "Base de dades actual"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Mostra l'esquema original"
 
@@ -497,7 +502,7 @@ msgstr "Troba una taula"
 msgid "Schemas"
 msgstr "Esquemes"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -514,7 +519,7 @@ msgstr "Afegir una mètrica"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definició"
 
@@ -582,35 +587,35 @@ msgstr " Historial"
 msgid "Revision History for"
 msgstr "Historial de versions per"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - Configuració dels camps"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "On es mostrara aquest camp al Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrant per aquest camp"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quan aquest camp s'utilitza en un filtre, quins valors ha de poder introduir l'usuari?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "No existeix cap descripció per aquest camp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Valor Original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Valor asignat"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Introduïu valor"
 
@@ -627,31 +632,31 @@ msgid "Custom mapping"
 msgstr "Assignació personalitzada"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Tipus d'assignació no reconeguda"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "El camp actual no es una clau forana o fan falten les metadades de la clau forana a la taula de destí"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "El camp seleccionat no es una clau forana"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Mostra valors"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Escull si vols mostrar el valor original de la base de dades o mostrar informació associada o personalitzada"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Tria un camp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Seleccioneu una columna per mosstrar"
 
@@ -659,16 +664,16 @@ msgstr "Seleccioneu una columna per mosstrar"
 msgid "Tip:"
 msgstr "Consell:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Es possible que vulgueu actualitzar el nom del camp per assegurar-t'he que encara tinguin sentit en funció de les opcions d'assignació."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valors del camp a la memòria cau"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "El metabase pot escanejar els valors d'aquest camp per habilitar els filtres de casella de verificació pels quadres de comandament i preguntes."
 
@@ -695,35 +700,36 @@ msgstr "Neteja iniciada!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Seleccioneu qualsevol taula per veure el seu esquema i afegir o editar les metadades."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "El nom es obligatori"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "La descripció es obligatòria"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "El missatge de revisió es obligatori"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "La agrupació es obligatòria"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Edita la teva mètrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Crea la teva mètrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Feu canvis a la vostra mètrica i deixeu un nota explicativa"
 
@@ -731,46 +737,46 @@ msgstr "Feu canvis a la vostra mètrica i deixeu un nota explicativa"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Pots crear mètriques i guardar-les com un camp calculat en aquesta taula. Les mètriques guardades inclouen el tipus d'agregat, el camp agregat i opcionalment qualsevol filtre que afegeixis. Per exemple, pots fer servir això per definir la forma oficial de calcular el \"Preu mig\" d'una taula de preus."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Resultat: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Doneu-li un nom a la vostra mètrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Doneu-li un nom a la vostra mètrica per ajudar als altres a trobar-la."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Alguna cosa descriptiva però no massa llarga"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Descriu la mètrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Doneu-li una descripció a la vostra mètrica per ajudar als altres a entendre de el seu contingut."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Es un bon lloc per ser més específiques sobre les regles de la mètrica no tan evidents. "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Motiu dels canvis"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deixeu una nota per explicar els canvis que heu fet i per a que són necessaris."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Es mostrarà al historial de revisions de la mètrica per ajudar als altres a entendre perquè han canviat les coses."
 
@@ -823,6 +829,7 @@ msgstr "Això apareixerà al historial de versions d'aquest segment per ajudar a
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -837,8 +844,7 @@ msgid "Re-scan this table"
 msgstr "Tornar a escanejar aquesta taula"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Afegir"
 
@@ -855,7 +861,7 @@ msgid "Last name"
 msgstr "Cognom"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Correu electrònic"
@@ -864,7 +870,7 @@ msgstr "Correu electrònic"
 msgid "Permission Groups"
 msgstr "Grups de permisos"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Feu que aquest usuari sigui administrador"
 
@@ -961,6 +967,8 @@ msgstr "Elimina el grup"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -973,11 +981,12 @@ msgstr "Fet"
 msgid "Group name"
 msgstr "Nom del grup"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Groups"
@@ -1086,7 +1095,7 @@ msgstr "Restableix"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Esteu segur que voleu realitzar aquesta acció?"
 
@@ -1199,7 +1208,7 @@ msgstr "No es faran canvis als permisos."
 msgid "You've made changes to permissions."
 msgstr "Heu fet canvis als permisos."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Permisos d'aquest col·lecció"
 
@@ -1255,6 +1264,7 @@ msgstr "Limitar accés"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Revocar el acces"
 
@@ -1318,23 +1328,23 @@ msgstr "Mima la col·lecció"
 msgid "View collection"
 msgstr "Mostrar la col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Accedir a les dades"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Mostrar taules"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "Consultes SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Mostrar esquemes"
 
@@ -1405,12 +1415,15 @@ msgstr "Enviat!"
 msgid "Clear"
 msgstr "Netejar"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autentificació"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Configuració del servidor"
@@ -1423,6 +1436,7 @@ msgstr "Esquema d'usuaris"
 msgid "Attributes"
 msgstr "Atributs"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Esquema de grups"
@@ -1494,6 +1508,9 @@ msgid "Add a map"
 msgstr "Afegiu un mapa"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1503,19 +1520,19 @@ msgid "Delete custom map"
 msgstr "Elimina el mapa personalitzat"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Elimina"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1613,19 +1630,19 @@ msgstr "Compra un token"
 msgid "Enter a token"
 msgstr "Afegiu un token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Editar assignacions"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Assignacions de grups"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Crea un assignació"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1864,18 +1881,27 @@ msgstr "Filtre d'usuaris"
 msgid "Check your parentheses"
 msgstr "Verifiqueu els parèntesis"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Atribut del correu electrònic"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Atribut del nom"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Atribut dels cognoms"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Sincronitza "
@@ -1904,59 +1930,59 @@ msgstr "Mapes personalitzats"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Afegeix els teus propis fitxers GeoJSON per habilitar diferents visualitzacions de mapes de regió"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Compartir públicament"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Permetre compartir públicament"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Quadres de comandament compartits"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Preguntes compartides"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Incrustar en altres aplicacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar la incrustació del Metabase a altres aplicacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Clau secreta de incrustació"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Quadres de comandament incrustats"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Preguntes incrustades"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Activa la memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Duració mínima de la consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplicador Temps de Vida (TTL) de la memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Mida màxima d'una entrada de la memòria cau"
 
@@ -1998,27 +2024,27 @@ msgstr "Es necessita un administrador per poder crear un compte de Metabase aban
 msgid "Sign in with {0}"
 msgstr "Iniciar sessió amb {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Si us plau, poseu-vos amb contacte amb un administrador per a que us restableixi la contrasenya."
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "No recordo la meva contrasenya"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "El correu electrònic que utilitzes per la teva compta de Metabase"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Enviar el correu electrònic per recuperar la contrasenya"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Consulta el teu correu electrònic per obtenir les instruccions sobre com recuperar la teva contrasenya"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Iniciar sessió al Metabase"
 
@@ -2039,11 +2065,11 @@ msgstr "Accedeix"
 msgid "I seem to have forgotten my password"
 msgstr "Sembla que no recordo la meva contrasenya"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "sol·licitar un nou correu electrònic per recuperar la contrasenya"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Vaja, aquest enllaç ha caducat"
 
@@ -2052,11 +2078,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Per raons de seguretat els enllaços per recuperar la contrasenya caduquen al cap d'un temps. Si encara necessites recuperar la teva contrasenya, pots {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nova contrasenya"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Per mantenir les teves dades segures les contrasenyes {0}"
 
@@ -2079,24 +2105,24 @@ msgstr "Confirma la nova contraseña"
 msgid "Make sure it matches the one you just entered"
 msgstr "Assegureu-vos que coincideix amb la que acabes d'introduir"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "La teva contrasenya ha estat restablerta."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Inicia sessió amb la nova contrasenya"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "No s'ha pogut guardar"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2106,25 +2132,26 @@ msgstr "Guardat"
 msgid "Ok"
 msgstr "D'acord"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Arxiva aquesta col·lecció?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Els cuadres de comandament, les colecions i els polsos d'aquesta col·lecció també s'arxivaran."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Arxiva"
 
@@ -2249,7 +2276,7 @@ msgstr "Contingut fixat"
 msgid "Drag something here to pin it to the top"
 msgstr "Arrasta coses aquí per fixar-les a dalt"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2278,6 +2305,7 @@ msgstr "Moure \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Moure"
@@ -2315,7 +2343,7 @@ msgstr "Algunes instancies de bases de dades només es poden accedir a través d
 "Aquesta configuració també proporcionarà una cap addicional de seguretat quan no es disposi d'una VPN. \n"
 "Aquest configuració normalment es més lenta que una connexió directa."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Aquesta es una base de dades gran. Deixem decidir quan el Metabase es sincronitza i escaneja les dades"
 
@@ -2355,7 +2383,7 @@ msgstr "Per utilitzar el Metabase amb aquestes dades has d'habilitar el accés a
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} per anar a la consola si encara no ho has fet"
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Com t'agradaria anomenar aquesta base de dades?"
 
@@ -2471,35 +2499,35 @@ msgstr "Basat en l'esquema"
 msgid "A look at your"
 msgstr "Una vista als teus"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Busca a la llista"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Buscar per {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " o introdueix un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Introdueix un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Introdueix un número"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Introdueix un text"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "No s'han trobat {0} coincidents"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Incloure totes les opcions al filtre possiblement no servirà de res"
 
@@ -2511,7 +2539,6 @@ msgstr "Ho sentim, alguna cosa no ha sortit bé"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Em trobat un error. Pots intentar refrescar la pàgina o simplement tornar enrere."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2522,12 +2549,12 @@ msgstr "Em trobat un error. Pots intentar refrescar la pàgina o simplement torn
 msgid "No description yet"
 msgstr "Encara sense cap descripció"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Nou {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Preguntat pel {0}"
 
@@ -2548,7 +2575,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertit a una revisió anterior i {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historial de revisións"
@@ -2594,7 +2623,7 @@ msgid "Questions"
 msgstr "Preguntes"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Polsos"
 
@@ -2668,52 +2697,69 @@ msgstr "Ara no"
 msgid "Error:"
 msgstr "Error:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Diumenge"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Dilluns"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Dimarts"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Dimecres"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Dijous"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Divendres"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Dissabte"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Primer"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Últim"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15è (punt mitg)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Dia del calendari"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "La zona horària del Metabase"
 
@@ -2767,11 +2813,11 @@ msgstr "Crea"
 msgid "Create dashboard"
 msgstr "Crea un quadre de comandament"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Taula"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Base de dades"
 
@@ -2846,9 +2892,9 @@ msgstr "Quin es el nom de la teva tarjeta?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2862,15 +2908,16 @@ msgstr "Descripció"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Es opcional, però va tan bé a vegades"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "A quina col·lecció vols guardar-ho?"
 
@@ -2910,11 +2957,11 @@ msgstr "Arxiva el quadre de comandament"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Asegura't de fer una selecció per a cada sèrie sinó el filtre no funcionarà per aquesta targeta."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Sembla que aquest quadre de comandament està buit."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Afegeix una pregunta per a que sigui útil"
 
@@ -2934,7 +2981,7 @@ msgstr "Desactiva la pantalla complerta"
 msgid "Enter fullscreen"
 msgstr "Activa la pantalla complerta"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Guardant..."
@@ -2947,7 +2994,8 @@ msgstr "Afegeix una pregunta"
 msgid "Add a question to this dashboard"
 msgstr "Afegiu una pregunta a aquest quadre de comandament."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Afegeix un filtre"
 
@@ -2955,7 +3003,7 @@ msgstr "Afegeix un filtre"
 msgid "Parameters"
 msgstr "Paràmetres"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Afegeix una caixa de text"
 
@@ -2963,7 +3011,7 @@ msgstr "Afegeix una caixa de text"
 msgid "Move dashboard"
 msgstr "Moure el quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Edita el quadre de comandament"
 
@@ -2987,11 +3035,11 @@ msgstr "Moure el quadre de comandament a..."
 msgid "Dashboard moved to {0}"
 msgstr "El quadre de comandament s'ha mogut a {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Que voleu filtrar?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Quin tipus de filtre?"
 
@@ -3063,20 +3111,22 @@ msgstr "Aquesta targeta no té camps ni paràmetres que coincideixin amb aquest 
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Els valors d'aquest camp no coincideixen amb cap altre camp que hagis escollit"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "No hi ha camps válid"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "El nom ha de tenir com a màxim 100 caràcters"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "El color és obligatori"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Quin es el nom del vostre quadre de comandament?"
 
@@ -3131,7 +3181,7 @@ msgstr "ha rebut les ultimes dades de"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Desconegut"
 
@@ -3256,9 +3306,10 @@ msgstr "No has consultat cap quadre de comandament o pregunta recentment"
 msgid "{0} items selected"
 msgstr "{0} elements seleccionats"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Desarxivar"
 
@@ -3375,7 +3426,7 @@ msgid "Zip Code"
 msgstr "Codi postal"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Quantitat"
 
@@ -3408,11 +3459,13 @@ msgid "User"
 msgstr "Usuari"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Origen"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Preu"
 
@@ -3445,21 +3498,23 @@ msgid "Subscription"
 msgstr "Subscripció"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Puntuació"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Títol"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Comentari"
 
@@ -3513,14 +3568,14 @@ msgstr "El Metabase mai obtindrà aquesta camp. Fes-ho servir per informació se
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Compta"
 
@@ -3528,7 +3583,7 @@ msgstr "Compta"
 msgid "CumulativeCount"
 msgstr "RecompteCumulatiu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3546,19 +3601,19 @@ msgstr "Diferent"
 msgid "StandardDeviation"
 msgstr "DesviacióEstàndard"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Mitja"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Mínim"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3569,13 +3624,13 @@ msgstr "Màxim"
 msgid "sad sad panda, lexing errors detected"
 msgstr "Trist, molt trista: S'han trobat errors lèxics"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} segon"
 msgstr[1] "{0} segons"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minut"
@@ -3616,14 +3671,15 @@ msgstr "Sobre que vols buscar?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dades brutes"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Recompte cumulatiu"
 
@@ -3685,166 +3741,164 @@ msgstr "Verdader"
 msgid "False"
 msgstr "Fals"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Selecciona la longitud del camp"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Introdueix la latitud superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Longitud esquerra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Longitud inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Longitud dreta"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "És"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "No és"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Està buit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "No està buit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Diferent de"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Major que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Menor que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Major o igual que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Menor o igual que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Conté"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "No conté"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Comença amb"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Acaba amb"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Abans"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Després"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Dins"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Només una taula amb files a la a resposta. Sense operacions addicionals."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Nombre de files"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Nombre total de files a la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Suma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Suma tots els valors de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Mitja de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Mitja de tots els valors de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Nombre de valors diferents de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Nombre de valors únics de una columna entre totes les files de la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Suma acumulada de ..."
 
@@ -3852,7 +3906,7 @@ msgstr "Suma acumulada de ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Suma cumulativa de tots els valors de una columan. \\\\n Per exemple: Els ingressos totals al llarg del temps"
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Recompte acumulat de files"
 
@@ -3860,27 +3914,27 @@ msgstr "Recompte acumulat de files"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Recompte acumulat del número de files. \\\\n Per exemple: el nombre total de vendes al llarg del temps"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Desviació estàndard de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Nombre que expressa com varien els valors de una columna entre totes les files de la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Mínim de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Valor mínim de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Màxim de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Valor màxim de una columna"
 
@@ -3896,6 +3950,8 @@ msgstr "lletra en minúscules"
 msgid "upper case letter"
 msgstr "lletra en majúscules"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "número"
@@ -4143,7 +4199,7 @@ msgstr "Com crear mètriques"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Consulta les dades al llarg del temps, com a mapa o en una taula pivotada per ajudar a entendre les tendències o els canvis."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Personalitzat"
 
@@ -4166,7 +4222,7 @@ msgstr "Consulta nativa"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Per a preguntes més complicades pots escriure la teva pròpia consulta SQL o nativa."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Seleccioneu un valor per defecte"
 
@@ -4257,7 +4313,7 @@ msgstr "Aquest mes"
 msgid "This Year"
 msgstr "Aquest any"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Introduïu un valor"
@@ -4267,7 +4323,7 @@ msgid "Enter a default value..."
 msgstr "Introduïu un valor predeterminat"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "S'ha produït un error"
@@ -4525,22 +4581,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Escull les preguntes que t'agradaria enviar en aquest pols"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Correus electrònics"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Missatges de Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Enviat"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} s'enviarà a la les"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Missatges"
 
@@ -4612,30 +4676,30 @@ msgstr "Ajuda a tots els membres del teu equip a mantenir-se sincronitzats amb t
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Els polsos es permeten enviar dades de Metabase en una data planificada per correu electrònic o per Slack."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Desprès de {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Abans de {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Buit"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "No buit"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Tot el temps"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Aplica"
 
@@ -4736,12 +4800,12 @@ msgstr[1] "Veure aquests {0}"
 msgid "Zoom in"
 msgstr "Amplia"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Expressió personalitzada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Mètriques comuns"
 
@@ -4938,7 +5002,7 @@ msgstr "generalment"
 msgid "Pick a segment or table"
 msgstr "Tria un segment o taula"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Selecciona una base de dades"
@@ -4999,7 +5063,7 @@ msgstr "Ordena"
 msgid "Row limit"
 msgstr "Límit de files"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Camp desconegut"
 
@@ -5007,7 +5071,7 @@ msgstr "Camp desconegut"
 msgid "field"
 msgstr "camp"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Coincidències"
 
@@ -5032,11 +5096,11 @@ msgstr "Afegeix una agrupació"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dades"
 
@@ -5053,11 +5117,12 @@ msgstr "Mostra"
 msgid "Grouped By"
 msgstr "Agrupat per"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Cap"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Aquesta pregunta està escrita en {0}"
 
@@ -5069,7 +5134,7 @@ msgstr "Amaga l'editor"
 msgid "Hide Query"
 msgstr "Amaga la consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Obrir l'editor"
 
@@ -5077,7 +5142,7 @@ msgstr "Obrir l'editor"
 msgid "Show Query"
 msgstr "Mostra la consulta"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Aquesta mètrica ha estat retirada. Ja no es està disponible pel seu us."
 
@@ -5278,7 +5343,7 @@ msgstr "Tornar a la última execució"
 msgid "Visualization"
 msgstr "Visualització"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Sense descripció"
 
@@ -5335,7 +5400,7 @@ msgstr "No s'han pogut trobar les metadades de la taula abans de crear una nova 
 msgid "See {0}"
 msgstr "Veure {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Definició de la mètrica"
 
@@ -5353,11 +5418,11 @@ msgstr "Número de {0}"
 msgid "See all {0}"
 msgstr "Veure tots els {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Definició del segment"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "S'ha produït un error al carregar la taula"
 
@@ -5365,7 +5430,7 @@ msgstr "S'ha produït un error al carregar la taula"
 msgid "See the raw data for {0}"
 msgstr "Mostra les dades de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Més"
 
@@ -5385,6 +5450,8 @@ msgstr "Formula del camp"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pensa que això es com escriure una fórmula en un full de càlcul: Pots utilitzar números, camps d'aquesta taula, símbols màtemàtics com + i algunes funcions. Pots escriure alguna cosa com: Subtotal - Cost"
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5452,7 +5519,7 @@ msgstr "fals"
 msgid "Add filter"
 msgstr "Afegir un filtre"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Element"
 
@@ -5571,11 +5638,11 @@ msgstr "Camp per mapejar a"
 msgid "Filter widget type"
 msgstr "Tipus de filtre"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Obligatori?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Valor per defecte el camp de filtre"
 
@@ -5587,7 +5654,7 @@ msgstr "Arxivar aquesta pregunta?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Aquesta pregunta s'eliminarà dels quadres de comandaments o polsos que la utilitzin."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Pregunta"
 
@@ -5634,7 +5701,7 @@ msgstr "Tipus de camp"
 msgid "Select a Foreign Key"
 msgstr "Selecciona una clau forànea"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Mostra la formula de {0}"
 
@@ -6118,22 +6185,24 @@ msgstr "Preguntes sobre aquest segment"
 msgid "X-ray this segment"
 msgstr "Aplica rajos-X a aquest segment"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Inicia sessió"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Cerca"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Quadre de comandament"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nova pregunta"
 
@@ -6205,35 +6274,35 @@ msgstr "Tota la informació obtinguda es totalment anònima"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La recopilació es pot desactivar en qualsevol moment des de la pàgina de configuració."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Si et sents abrumant"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "la nostra guia d'iniciació"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "està a un sol click"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Benvingut/da al Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sembla que tot està funcionant. Ara anem a coneixe't, connectar amb les teves dades i començar a donar respostes a les teves preguntes."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Començem"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Ja està tot llest!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Portam al Metabase"
 
@@ -6485,39 +6554,40 @@ msgstr "Cancel·la el filtre"
 msgid "Pin Map"
 msgstr "Mapa de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Desmarcar"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Files {0}-{1} de {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Les dades s'han truncat a {0} files."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "No s'ha pogut trobar la visualització"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "No s'ha pogut mostrar el gràfic amb aquesta informació."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Sense resultats"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Esperant..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Normalment tarda una mitja de {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(es una mica llarg per a un quadre de comandament)"
 
@@ -6627,7 +6697,7 @@ msgid "Highlight the whole row"
 msgstr "Ressalta tota la fila"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Colors"
 
@@ -6713,24 +6783,50 @@ msgstr "Objectiu"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Les dades de la teva consulta no s'ajusten a la opció de visualització escollida. Aquesta visualització necessita com a mínim {0} {1} de dades."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "columna"
@@ -6762,7 +6858,7 @@ msgid "xValues missing!"
 msgstr "Falten valors per les x!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Eix-X"
 
@@ -6771,7 +6867,7 @@ msgid "Add a series breakout..."
 msgstr "Afegeix un desglòs de series..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Eix-Y"
 
@@ -6784,7 +6880,7 @@ msgid "Bubble size"
 msgstr "Mida de la bombolla"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Línia"
 
@@ -6926,20 +7022,20 @@ msgid "Standard Deviation"
 msgstr "Desviació Estàndard"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Àrea"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "Gràfic de àrea"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "Gràfic de barres"
 
@@ -6953,7 +7049,7 @@ msgid "Funnel"
 msgstr "Embut"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Mesura"
 
@@ -6965,81 +7061,81 @@ msgstr "Tipus d'embut"
 msgid "Bar chart"
 msgstr "Gràfic de barres"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "Gràfic de línies"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Selecciona les columnes de longitud i latitud a la configuració del gràfic."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Si us plau, selecciona un mapa de la regió"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Selecciona les columnes de regió i mètriques a la configuració del gràfic."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Tipus de mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Mapa de la regió"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Mapa de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Tipus de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Rajoles"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Marcados"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Camp latitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Camp longitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Camp mètrica"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Camp regió"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Radi"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Difuminar"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Opacitat mínima"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Zoom Maxim"
 
@@ -7051,7 +7147,7 @@ msgstr "No s'han trobat relacions"
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Està {0} està connectada a:"
 
@@ -7063,31 +7159,31 @@ msgstr "Detall del objecte"
 msgid "object"
 msgstr "objecte"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Quines columnes vols fer servir?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pastís"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimesió"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Mostra la llegenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Mostra percentatges a la llegenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Percentatge mínim de la porció"
 
@@ -7112,7 +7208,8 @@ msgid "Progress"
 msgstr "Progrès"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Color"
@@ -7121,7 +7218,7 @@ msgstr "Color"
 msgid "Row Chart"
 msgstr "Gràfic de files"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "gràfic de files"
 
@@ -7145,15 +7242,15 @@ msgstr "Afegeix un sufix"
 msgid "Multiply by a number"
 msgstr "Multiplica per un nombre"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Dispersió"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "gràfic de dispersió"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Pivota la taula"
 
@@ -7204,13 +7301,13 @@ msgstr "Dreta"
 msgid "Show background"
 msgstr "Mostrar el fons"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} agrupació"
 msgstr[1] "{0} agrupacions"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Agrupació automàtica"
 
@@ -7446,10 +7543,13 @@ msgstr "Tens moltes preguntes guardades a {0}? Crea col·leccions per gestionar-
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7639,7 +7739,7 @@ msgstr "suma acumulativa"
 msgid "{0} and {1}"
 msgstr "{0} i {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
@@ -8952,11 +9052,11 @@ msgstr "Permís d'accés a les dade"
 msgid "Collection permissions"
 msgstr "Permisos d'accés a les col·leccions"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Veure tots els permisos de les col·leccions"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Canviar també les sub-col·leccions"
 
@@ -8968,19 +9068,19 @@ msgstr "Pot editar aquesta col·lecció i els seus continguts"
 msgid "Can view items in this collection"
 msgstr "Pot veure el contingut d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Accés a la col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Aquest grup té permisos per veure com a mínim una sub-col·lecció d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Aquest grup té permisos per editar com a mínim una sub-col·lecció d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Mostra sub col·leccíó"
 
@@ -9036,6 +9136,7 @@ msgstr "Relacionat"
 msgid "More X-rays"
 msgstr "Més rajos-X"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9294,10 +9395,10 @@ msgstr "Compartir"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9380,7 +9481,7 @@ msgstr "Utilitza la zona horària de la màquina virtual de Java (JVM)"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Estem analitzant les taules i els camps per ajudar-te a explorar les teves dades"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Consell: "
 
@@ -9388,7 +9489,7 @@ msgstr "Consell: "
 msgid "Select a currency type"
 msgstr "Selecciona un tipus de moneda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Tipo de camp"
 
@@ -9443,6 +9544,7 @@ msgid "Currency"
 msgstr "Modena"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Escull un usuari o canal"
 
@@ -9604,7 +9706,7 @@ msgstr "En quin eix?"
 msgid "Line + Bar"
 msgstr "Línia + Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "Gràfic de línia i barra"
 
@@ -9624,15 +9726,15 @@ msgstr "Rangs del comptador"
 msgid "Field to show"
 msgstr "Camp a mostrar"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "últim {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} era {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Agrupa per un cap temporal per veure com ha canviat al llarg del temps."
 
@@ -9640,23 +9742,23 @@ msgstr "Agrupa per un cap temporal per veure com ha canviat al llarg del temps."
 msgid "Switch positive / negative colors?"
 msgstr "Mostrar colors positius/negatius"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Columna pivot"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Columna celda"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Columnes visibles"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Format condicional"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Títol de la columna"
 
@@ -10094,10 +10196,10 @@ msgstr "Usuaris per origen"
 msgid "The top external pages that brought users to your site"
 msgstr "Les principals pàgines externes que han portat usuaris al teu lloc web"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Com es distribueix [[this]] i alguna cosa més."
 
@@ -10195,13 +10297,13 @@ msgstr "Esdeveniments per hora del dia"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Primers 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Ultims 5 [[this]]"
 
@@ -10214,10 +10316,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Valors nuls"
 
@@ -10245,8 +10347,8 @@ msgstr "Com es comparen estacionalment"
 msgid "Average income per transaction"
 msgstr "Ingressos mitjos per transacció"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] per país"
 
@@ -10370,10 +10472,10 @@ msgstr "Una visió general del teu [[this]] i com es distribueix amb el temps, l
 msgid "Average income per state"
 msgstr "Ingressos mitjos per província"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] per [[GenericCategoryMedium]]"
 
@@ -10550,13 +10652,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Com es distribueix [[GenericTable]] al llarg del temps i si té algun patró estacional."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Visió general"
 
@@ -10665,8 +10767,8 @@ msgstr "Aquí hi ha una mirada més detallada als teus [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Una mirada detallada del teu camp [[this]]"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Resum"
 
@@ -10730,10 +10832,10 @@ msgstr "Ventes per orígen"
 msgid "Average income per country"
 msgstr "Ingressos mitjos per país"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Com es distribueix [[this]]"
 
@@ -10754,17 +10856,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Nombre de [[GenericCategoryMedium]] per [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Una mirada als teus [[this]]"
 
@@ -10830,10 +10932,10 @@ msgid "Transactions per source over time"
 msgstr "Transaccions per origen al llarg del temps"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Com es distribueix el [[this]]"
 
@@ -10862,9 +10964,9 @@ msgstr "On es produeixen aquests esdeveniments"
 msgid "Which US states are bringing you the most business."
 msgstr "Quin estats dels EEUU aporten més al teu negoci"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Com es comparen al llarg del temps"
 
@@ -10969,8 +11071,8 @@ msgstr "Sessions per pais"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Algunes mètriques interessants sobre les teves estadístiques de GAL per començar."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] per província"
 
@@ -11051,12 +11153,12 @@ msgstr "Com es distribueix aquesta mètrica entre els diferents nombres."
 msgid "Sessions by page where the session began"
 msgstr "Sessions per pàgina on ha començat la sessió"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Valors diferents"
 
@@ -11119,10 +11221,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Esdeveniments per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Com es comparen per distribució"
@@ -11428,6 +11530,7 @@ msgstr "Duplica el quadre de comandaments"
 msgid "Duplicate \"{0}\""
 msgstr "Duplica {0}"
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11525,9 +11628,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre del any"
 msgstr[1] "Trimestres de l'any"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seleccionat"
@@ -11550,11 +11653,11 @@ msgstr "Invàlid"
 msgid "Add a time"
 msgstr "Afegeix una hora"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Res que comprar amb el {0} anterior."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "per {0}."
 
@@ -12042,9 +12145,9 @@ msgstr "Un resum de les persones del teu [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] per trimestre del año"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Com es comparen en diferents ubicaions"
 
@@ -12073,12 +12176,12 @@ msgstr "[[CreateTimestamp]] per dia de la setmana"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Aquí una descripció general de les teves dades [[this]] de Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Una visió general del teu [[this]]"
 
@@ -12156,11 +12259,11 @@ msgstr "col·lecció"
 msgid "collections"
 msgstr "col·leccions"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "quadre de comandament"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "quadres de comandament"
 
@@ -12410,7 +12513,7 @@ msgstr "Temps de finalització desprès de {0} mil·lisegons"
 msgid "Misfire Instruction"
 msgstr "Instruccions de fallada"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Arxivar això?"
 
@@ -12428,7 +12531,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Aquesta opció requereis que el host sigui FQDN. Si es conecta a un clúster Atlar es possibleu que necessiteu habilitar aquesta opció. Si no sabeu el que significa deixa-ho deshbilitat."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Executa les consultes automàticament quan es realitze un sumari o un filtre simple."
 
@@ -12440,7 +12543,7 @@ msgstr "Quan axxò esta actiu el Metabase executarà automaticament les consulte
 msgid "Learn about this database"
 msgstr "Apren d'aquesta base de dades"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Arxivar aquest quadr de comandament?"
 
@@ -12496,11 +12599,11 @@ msgstr "Pregunta personalitzada"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Utilitza l'editor avançat per unir dades, crear columnes personalitzades, fer cálculs matemàtics i més."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Mètriques bàsiques"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Personalitzada..."
 
@@ -12686,15 +12789,15 @@ msgstr "Esculliu una visualització"
 msgid "Filter by"
 msgstr "Filtra per"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Resumit per"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Agrupa per"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Afegeix una mètrica"
 
@@ -12705,15 +12808,15 @@ msgstr "Afegeix una mètrica"
 msgid "Profile"
 msgstr "Perfil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Això normalment es batant ràpid pero sembla que aquesta vegada esta tardant una mica."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Combo"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Fila"
 
@@ -13134,7 +13237,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Esculleix les columnes que vols incloure"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Al activar aquesta opció Metabase executarà automàticamente les consultes quan els usuaris realitzin exploracions simples amb els botóns Resumir i Filtra de taules i gràfiques. Pots desactivar aquesta opció si les consultes a la base de dades son lentes. Aquesta configuració no afecta als detalls ni a les consultes SQL."
 
@@ -13200,7 +13303,7 @@ msgstr "Registrar-se a través del correu electrònic"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Utiltizar aquesta opció requereix que la maquina contingui un FQDN. Si us conecteu a un cluster de Atlas, potseu haureu d'habilitar aquesta opció. Si no sabeu el que vol dir això, millor que ho deixeu desactivat."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Per defecte, Metabase fa un sincronització lleujera cada hora i una sincronització intensiva cada hora dels valors dels camps. Si teniu una base de dades gran, us recomanem activar aquesta opció i revisar quan i amb quina freqüencia s'escanejen els valors dels camps."
 
@@ -13268,11 +13371,11 @@ msgstr "No ho incloguis"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "El camp no sera visible o seleccionable a les preguntes createdes amb la interface d'usuari. Si que es podrà accedir amb consultes SQL/natives."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Suma acumulada"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Desviació estàndard"
 
@@ -13288,19 +13391,19 @@ msgstr "Ha de tenir com a mínim {0} caràcters"
 msgid "Name (required)"
 msgstr "Nom (obligatori)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Execut el text seleccionat"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Executa la consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + intro)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + intro)"
 
@@ -13648,7 +13751,7 @@ msgstr "Dates i hores"
 msgid "Numbers"
 msgstr "Nombres"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "No hi ha grup mapejables"
 
@@ -13688,15 +13791,15 @@ msgstr "avuiesunbondia@email.com"
 msgid "Remember me"
 msgstr "Recorda'm"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Per raons de seguretat els enllaços per restablir la contraseña caduquen al cap d'una estona. Si encara necessiteu restablir la vostra contrasenya podeu {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Guardar la nova contrasenya"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "No s'ha trobat cap coincidencia"
 
@@ -13722,26 +13825,26 @@ msgid "or"
 msgstr "o"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "obligatori"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Tipus de base de dades"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Es tracta d'una process lleuger que comprava les actualitzacions del esquema d'aquesta base de dades. En la majoria de caso es suficient que es sincronitzi cada hora."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "El metabase pot escanejar els valors de cada camp a la base de dades per activar els filtres de casella de verificació als cuadres de comandament i preguntes. Aquest proces pot consumir bastants recursos, especialment si teniu una base de dades gran."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Col·leció"
 
@@ -13788,7 +13891,7 @@ msgstr "Categoric"
 msgid "URLs"
 msgstr "URLs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Retorna la mitjana dels valors de la columna."
 
@@ -13797,11 +13900,13 @@ msgstr "Retorna la mitjana dels valors de la columna."
 msgid "The column whose values to average."
 msgstr "La columna de valors que es vol fer la mitjana."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "inici"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "final"
 
@@ -13813,21 +13918,19 @@ msgstr "Comproba si els valors d'una columna numerica o de tipus data estan dins
 msgid "Rating"
 msgstr "Valoració"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "condició"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "sortida"
 
@@ -13835,27 +13938,27 @@ msgstr "sortida"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Comprova una llista de casos i retorna el valor corresponent al primer valor verdader amb un valor por defecte opcional per quan no es compleix cap condició."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Pes"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Llarg"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Mitja"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Petit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Un valor que s'evalua a verdader o fals"
 
@@ -13863,33 +13966,33 @@ msgstr "Un valor que s'evalua a verdader o fals"
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "El valor que es retornarà si la condició es certa."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "valor1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "valor2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Mira els valors de cada argument en ordre i retorna el primer que no es buit de cada fila."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Comentaris"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notes"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "No comentaris"
 
@@ -13905,12 +14008,12 @@ msgstr "Si el valor1 es buit es retorna el valor2 si no es buit, i així succesi
 msgid "Combines two or more strings of text together."
 msgstr "Combina dos o més cadenes de text juntes."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Cognom"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Nom"
 
@@ -13922,27 +14025,27 @@ msgstr "El valor2 s'afegir al final d'auest."
 msgid "This will be added to the end of value1."
 msgstr "Aquest s'afegir al final del valor1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "cadena1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "cadena2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Comporova si la cadena1 conté la cadena2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Estat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Pass"
 
@@ -13950,7 +14053,7 @@ msgstr "Pass"
 msgid "The contents of this string will be checked."
 msgstr "El continguts de la cadena que es comprovarà."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "El text a buscar."
 
@@ -13958,22 +14061,22 @@ msgstr "El text a buscar."
 msgid "Returns the count of rows in the source data."
 msgstr "Retorna el nombre de files a les dades origen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Només conta les files quan la condició és verdadera."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "El total additiu de les files en un conjunt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "La suma cumulativa d'una columna en un conjunt."
 
@@ -13982,53 +14085,57 @@ msgstr "La suma cumulativa d'una columna en un conjunt."
 msgid "The column to sum."
 msgstr "La columna a sumar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "El nombre de valors diferents d'aquesta columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "La columna a comptar els valors diferents."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "comparació"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retorna verdader si el final de la cadena es correspon amb el text de comparació."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Aptetit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "Gana"
 
@@ -14037,20 +14144,20 @@ msgstr "Gana"
 msgid "A column or string of text to check."
 msgstr "La columan o cadena a comprobar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "El text amb el que ha d'acabar el text original."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "expresió_regular"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extreu les subcadenes concordants segons l'expressió regular."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adreça"
 
@@ -14058,7 +14165,7 @@ msgstr "Adreça"
 msgid "The column or string of text to search though."
 msgstr "La columna o el text on buscar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "L'expressió regular a buscar."
 
@@ -14070,7 +14177,7 @@ msgstr "Retorna el text tot en minúscules."
 msgid "The column with values to convert to lowercase."
 msgstr "La columna amb els valors a convertir a mínuscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Elimina els espais al inici d'un text."
 
@@ -14080,15 +14187,16 @@ msgstr "Elimina els espais al inici d'un text."
 msgid "The column with values you want to trim."
 msgstr "La columna d'on voleu eliminar els espais."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Retorna el valor més gran que es troba a la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Edat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "La columna numèrica a la que voleu buscar el màxim."
 
@@ -14096,21 +14204,21 @@ msgstr "La columna numèrica a la que voleu buscar el màxim."
 msgid "Returns the smallest value found in the column."
 msgstr "Retorna el valor més petit que es troba a la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Salari"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "La columna numèrica a la que voleu buscar el mínim."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "posició"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "longitud"
 
@@ -14119,7 +14227,7 @@ msgstr "longitud"
 msgid "new_text"
 msgstr "nou_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Reemplaça part del text amb el nou text."
 
@@ -14147,35 +14255,35 @@ msgstr "El nombre de caràcters a remplaçar."
 msgid "The text to use in the replacement."
 msgstr "El text que s'utilitzarà per remplaçar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Elimina els espais al final d'un text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Retorna el percentatge de files que compleixen la condició en valor decimal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retorna verdades si l'inic del text es correspon amb el text de comparació."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Nom del curs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Informàtica"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "La cada amb que ha de començar el text original."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcula la desviació estàndard de la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Habitants"
 
@@ -14183,7 +14291,7 @@ msgstr "Habitants"
 msgid "A numeric column."
 msgstr "Una columan numèrica."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Retorna una part del text d'entrada."
 
@@ -14191,19 +14299,19 @@ msgstr "Retorna una part del text d'entrada."
 msgid "The text to return a portion of."
 msgstr "El text a retornar una part."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "La posició on començar a copiar caràcters."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "El número de caràcters a retornar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Afegeix tots els valors de la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "La columna numerica a sumar."
 
@@ -14211,15 +14319,15 @@ msgstr "La columna numerica a sumar."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Suma tots els valors de la columan que compleixen amb la condició."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Estat comanda"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Vàlid"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Elimina els espais al inici i al final d'una text."
 
@@ -14227,47 +14335,47 @@ msgstr "Elimina els espais al inici i al final d'una text."
 msgid "Returns the string of text in all upper case."
 msgstr "Retorna el text to amb majúscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "La columna amb els valors que es volen convertir a majuscules."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "ha de ser {0} i incloure {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "ha de ser {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "ha d'incloure {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "com a mínim {0} caracter de longitud"
 msgstr[1] "com a mínim {0} caracters de longitud"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} lletra en mínuscula"
 msgstr[1] "{0} lletres en mínuscules"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} lletra en majuscula"
 msgstr[1] "{0} lletres en majuscules"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} nombre"
 msgstr[1] "{0} nombres"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} caràcter especial"
@@ -14290,6 +14398,7 @@ msgid "Powered by {0}"
 msgstr "Amb la tecnologia de {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "A:"
 
@@ -14377,7 +14486,7 @@ msgstr "Format dels valors"
 msgid "Full"
 msgstr "Ple"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "No hi han canvis del últim {0}"
 
@@ -14702,7 +14811,7 @@ msgstr "Error al generar l'informaciód de la columna:"
 msgid "Sending abandonment email!"
 msgstr "Enviant correu d'abondonament!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Podeu crear mètriques guardades per afegir una opció de metrica nombrada. Les metriques guaradades inclouen el tipus d'agregació, el camp i els filtres opcionals que s'hagin afegit. Per expmle, podeu utilizar això per crear la manera oficial de calcular el \"Preu mitg\" de la taula de comandes."
 
@@ -14710,15 +14819,15 @@ msgstr "Podeu crear mètriques guardades per afegir una opció de metrica nombra
 msgid "Select and add filters to create your new segment."
 msgstr "Seleccioneu i afegiu filtrer per crear el vostre nou segment."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alfabètic"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Inteligent"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Ordre de la columna: {0}"
 
@@ -14770,7 +14879,7 @@ msgstr "Localització"
 msgid "Instance language"
 msgstr "Idioma de la instància"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Opcions de localització"
 
@@ -14842,19 +14951,20 @@ msgstr "Copieu una cadena de conexió"
 msgid "Fill out individual fields"
 msgstr "Emplena els camps individuals"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Introduiu text SQL per reutilitzarlo despres"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Doneu un nom pel vostre pedaç de codi"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Clients actuals"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Afegiu una descripció"
 
@@ -14862,46 +14972,47 @@ msgstr "Afegiu una descripció"
 msgid "Use site default"
 msgstr "Utilitza el lloc per defecte"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "cerca"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "remplaça"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "El text a buscar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "El text a utilizar com a remplaçament."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Editant {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Creu un nou pedaç de codi"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Pedaços de codi arxivats"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Els pedaços de codi son bits de SQL reutilitzables"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Crea un pedaç de codi"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Pedaços de codi"
 
@@ -15180,3 +15291,1502 @@ msgstr "el valor ha de ser una clau o una cadena"
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "La cadena ha de ser el codi ISO de dos lletres del idioma o el codi idioma-pais. Per exemple: 'ca' or 'ca_ES'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Files {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Auditoria"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Configuració dels atributs d'usuari (opcional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Utilitzant {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Configura SSO basat en SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "Autentificació SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Configura el teu proveïdor d'identitat (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "El teu proveïdor d'identitat necessitara la següent informació de Metabase:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL on el IdP cap a on el IdP ha de redireccionar la respota"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Això sa'niomena Single Sign On URL a Okta, Aplicaction Callback URL amb Auth0, i la ACS (Consumer) URL a OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "Atributs SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "A la majoria de IdPS, heu de poser aquests valors en una caixa d'entrada etiquetada \"Name\" a la secció d'atributs."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Atribut del correu electronic del usuari"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Atribut del nom del usuari"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Atribut del cognom del usuari"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Presenta al Metabase el teu proveïdor d'identitats"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "El Metabase necessita la següent informació del teu proveïdor"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL del proveïdor d'identitat SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Certificat del proveïdor d'identitat SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Nom aplicació SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Signa les peticions SSO  (opcional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Ruta Keystore SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Contraseña del Keystore SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Shht..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Alias del Keystore SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Sincronitza la membersia d'usuaris amb el vostre SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Si ho activeu, haureu de crear mapejos per dirli al metabase a quins grup(s) s'han d'afegir els vostres usuaris en funció del grup SSO al que pertanyen."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Nom del grup"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Attribut nom del grup"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Nota:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Si canvieu alguna d'aquests valors amb una configuració SAML activa heu de reiniciar el Metabase per a que els canvis tinguin efecte."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Permetres als usuaris identificarse a traves del proveïdor d'identitat SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Permetres als usuaris identificarse a traves del proveïdor d'identitat JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Activa l'autentificació per contrasenya"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Quan s'activa, els usuaris també poden autentificar-se amb el email i la contrasenya."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Notifica els administradors dels nous usuaris SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Quan s'activa, els administradors rebran un correu el primer cop que un usuari utilitzi el SSO."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Utiltizeu aquesta secció per configurar el SSO via SAML. Si teniu algun dubte consulte la nostra {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "documentació"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI Proveïdor Identitat SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "Autentificació JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI Proveïdor Identitat JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Cadena utiltizada per la clau de signatura JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Embedint la aplicació Metabase Completament"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Si voleu embedir tot el Metabase introduïu els origens de les webs que voleu permetres que s'embedeixin dins d'un iframe separat per espai. Aqui hi ha els {0} que es poden afegir"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Doneu acces restringuit a aquesta taula"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Quan els usuarid del grupo vegin aquesta taula veuran una versió que esta filtrada pels seus atributs o una vista personalitzada basada en una pregunta guardada."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Com voleu filtrar aquesta taula pels usuaris d'aquest grup."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Selecciona una pregunta guardada qeu retorni la vista d'aquesta taula que voleu que vegin els usuaris"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Aquí podeu afegir filtres opcionals basats en els atributs d'usuari. Aquest filtres s'plicaran abans que els altres filtres que ja s'han guardat en aquesta pregunta."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Per a que aquesta opció funcioni el usuaris han de tenir alguns atributs"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Per afegir filtres adicionals els usuaris han de tenir alguns atributs"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "No hi ha atributs d'usuari"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Seleccioneu un atribut d'usuari"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Seleccioneu un paràmetre"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Seleccioneu una columna"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Els usuaris de {0} poden veure"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "files de la pregunta {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "files de la taula {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "on {0} és igual a {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "i {0} és igual a {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Podeu afegir atributs automaticament configurant el SSO que utilitza SAML, o bé els podeu entrar manualment anant al menu Persone i clicant el menú \"...\" a la dreta del tot."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Atribut d'usuari"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "La longitud total dels valors del camp es > {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Paràmetre o varialbe"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "igual"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Permet acces restringit"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Acces de restringit"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Edita el acces restringit"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Edita els detalls de la carpeta"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Canvia els permisos"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Crea la teva carpeta nova"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nova carpeta"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Tenim problems validant el teu token"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Si us plau, comproveu que la vostra instància es pot conectar amb els servidors de Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Obtenir ajuda"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Obteniu encara més del Metabase amb l'edició Empresarial"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Totes les eines que necessiteu per crear facilment informes per cliets o per ajudar-vos a executar i monitoirtzar el Metabase en una empresa gran"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Activeu la llicencia"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "La prova esta activa amb es següents funcionalitats"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "La prova s'acaba el {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Necessiteu ajuda? Preparat per comprar?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Truca'ns"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "La prova s'ha exhaurit"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Necessiteu més temps? Preparat per comprar?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Les vostres funcionalitats estan actives!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "La llicència es vàlida fins {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "La vostra llicencia ha caducat"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Va caducar el {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Voleu renovar la llicència?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Apreneu com utiiltzar això"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "No inclos en el vostre plà actual"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Introduïu el token que heu rebut de la botiga"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Activa"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Necessiteu ajuda?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Més informació sobre el vostre problema."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Contacteu l'equip de suport"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Empresarial"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Dades restringides"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Permisos de BBDD invalids: Si voleu tenir permisosos per escrireu queries natives heu de ternir permisos per accedir a totes les dades."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Personalizació d'estils"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Adapteu el Metabase a la vostra marca amb colors personalitzats, el vostre logotip i més."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Auditoria"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Permisos de BBDD invalids: Si voleu tenir permisosos per llegir queries natives heu de ternir permisos per accedir a totes les dades."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Identiificació ünica"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Proporciona una forma fàcil d'autentificar-se amb la vostra infrastructura d'usuaris"
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Tenda"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Nom de l'aplicació"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Paleta de colors"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logotip"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Landing Page"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Sense grups"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Permisos per {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Permisos per aquest directori"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Otorga permís d'accés"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Pot modificar pedaços de codi d'aquesta carpeta"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Otorga permis per veure"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "la clau de l'atribut de login ha de ser una keyword o una cadena"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Aquests son els colors primaris que s'utilitzen en grafics i al Metabase. Potser heu de refrescar el vostre navegador per veure els canvis."
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Canvia també les subcarpetes"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Primer dia de la setman"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Hi ha hagut un problema amb l'autentificació amb Google. Contacteu amb l'administrador del sistema."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "al"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "el"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Obrir el menú d'accions del metabase"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "No facis res"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Ves a una destinació personalitzada"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Actualitza el filtre del quadre de comandament"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "Això afecta els agrupats per semana o els filtres de GUI de consultes. No afecta les consultes SQL."
+msgstr[1] "{0} actualitza el filtres {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} va cap a {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Un comportament de clic per cada columna."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Ves a una destinació personalitzada"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Obrir el menú d'accions"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Comportament al clicar a {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Seleccioneu un o més filtres per actualitzar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Pregunta guardada"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Enllaç a"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Entra una URL on enllaçar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Podeu inserir el valor d'una columna o filtre de quadre de comandament utiltizant el seu nom, per exemple: {{una_columna}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "e.g. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Selecciona un quadre de comandament..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Selección una pregunta.."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Seleciona un quadre de comandament on enllaçar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Seleciona una pregunta on enllaçar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Passeu valors als filtres d'aquest quadre de comandament (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Passeu valors a les variables d'aquesta pregunta(opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Passeu valors per filtrar aquesta pregunta(opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filtres del quadre de comandament"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Atributs d'usuari"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Enllaç de text de personalització (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "P. E: Detaill de {{Column Name}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Valors que es poden referenciar"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Sense objectius disponible"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filtre"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "variable"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Altres filtres disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Filtres disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Altres variables disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Variables disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Altres columnes disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Columnes diponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "atribut d'usuari"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Carta de text"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Comportament al clicar"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Mostra les opcions"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Editue les series"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Afegiu series"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Al clickar"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Canviar el títol i la descripció"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Heu actualitzat els parametres d'embicció, heu d'actualitzar el codi"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Afegiu una pregunta"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Esteu editant aquest cuadre de comandament."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Colmna on filtrar"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "collecció de pedaços de codi"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "colleccions de pedaços de codi"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Doneuli un nom a la vostra carpeta"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Alguna cosa curta per dolça"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "La carpeta on s'ha de posar"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Obrir l'acció de menú"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} columna te un comportament personalitzat."
+msgstr[1] "{0} columnes tenen un comportament personalitzat."
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Aneu a..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Aneu al cuadre de comandament"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Anar a la pregunta"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Anar a la URL"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filtra aquest quadre de comandament"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Retorna el nombre de filtes de les dades seleccionades"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "La columan o el nombre a sumar"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "La columna numerica d'on obtenir la desviació estàndard"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "La columna númerica d'on obtenir la mitja"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Returna el valor més petit que es trobi a la columna"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Suma la columna especificada només per les files que compleixen amb la condició."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Retorna la variança numèrica d'una columna. "
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "La columna o nombre d'on obtenir la variança."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Retorna el valor mitja de la columna especificada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "La columna o nombre d'on obtenir la mitjana."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "percentil-valor"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Returna el valor the la columna amb el seu valor percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "La columna o el nombre d'on calcular el percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "El valor del percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Retorna una cadena de text en minúscules."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "La columna que conté els valors per convertir a minúscules."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Retorna una cadena de text en majúscules."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "La columna o text d'on retornar-ne una part."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "La columna o text on buscar"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Combina una o meś cadenes de text"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "La columna o text per on començar"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Això s'afegirà al final del valor1, i a continuació"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Enorme"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gegant"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Retorna el nombre de caràcters al text."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "La columna de la qual voleu obtenir la longitud."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "La columna o text d'on voleu eliminar els espais"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Retorna el valor absolut (positiu) de la columna especificada"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Deute"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "La columna o nombre a retornar el valor abosolt (positiu)"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Arrodoneix un nombre a la baixa"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "La columna o el nombre a arrodonir"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Arrodoneix a l'alça un nombre decimal."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "La columna o nombre a arrodonir a l'alça."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Arrodoneix un nombre decimal amun o avall cap al valor enter més proper"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "El nombre a arrodonir al enter més propoer"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Retorna l'arrel cuadrada"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hipotenusa"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "La columna o nombre de la que retornar l'arrel cuadrada"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Eleva un nombre a la potencia de l'exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Longitud"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "La columna o el nombre per elevar a l'exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "El valor de l'exponent."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Retorna la base 10 del logaritme del nombre"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Valor"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "La columna o el nombre a retornar el valor del logaritme natural"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Retorna el nombre d'Eulre, e, elevat a la potencia del nombre subministrat"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Interes mensual"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "La columna o el nombre a retorna el valor exponencial."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "La columna o el text a comprobar"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Comprova si una columna o data esta entre un rang especificat"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Creat el"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "La data o la columna numèrica que ha d'estar entre els valors d'inici i fi."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "L'inici del rang"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "El final del rang"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Comproba els valors d'una columna de data per comprobar si estan al rang relatiu"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "La columna d'on retornar el interval"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Periode d'interval, on els valors negatius són en el passat."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Tipus intern, com per exemple \"dia\", \"mes\", \"any\""
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "La columna o el valor a retornar"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Si el valor1 es buit es retorna el valor2 si no es buit. I així successivament."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Comprova una expressió contra una llista de clauses i returna el valor corresponent al primer element verdader amb un valor opcional si no es compleix cap condició."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "El valor es retornarà si la condició anterior es verdadera, i així succesivament."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "És null"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "No és null"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Suma aditiva dels valors de la columna:\n"
+"p.e: ingressos totals al cap del temps"
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Recompte aditiiu  dels valors de la columna:\n"
+"p.e: nombre total de ventes al cap del temps"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Filtres relacionats"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Etiqueta"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Valor per defecte"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Sense valor per defecte"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Per a veure això, el {0} ha d'estar conectat com a mínim a un camp."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Limita les opcions d'aquest filtre"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Si teniu una altre filtre al quadre de comandament, podeu limitar les opcions d'aquest filtres basades amb les seleccions d'un altre filtre."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Per començar, {0}"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "afegiex un altre filtre al quadre de comandament"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Si activeu algun d'aquest filtres de quadre de comandament, al seleccionar un valor d'aquest filtre es limitaràn les opcions del filtre {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Columna de filtre"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Columan filtrada"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Introduiu el nom d'usuari o correu electronic"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Nou pedaç de codi"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Cada hora"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Diariament a les {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Semanalment el {0} a les {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Mensualment el {0} {1} a les {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Elimina aquesta subscripció"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Subscripcions"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Creu una subscripció al cuadre de comandament"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Envia'l per correu electrònic"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Podeu enviar aquest quadre de comandament regularment als usuaris o direccions de correu electrònic."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Envia a Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Selecciona un canal i una programació. Metabase farà la resta."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Envia el cuadre de comandament per correu electrònic"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "No ho envis si no hi ha resultats."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Adjunta els resultats"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Els adjunts poden contenir com a màxim 2.000 registres de dades."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Envia el cuadre de comandament a Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "El cuadre de comandament no te cap paràmetre amb ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "El paràmetre {0} no te cap camp associat."
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "el include ha de ser buit o el valor 'tables'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "El `database` és obligatori per les consultes de tipus diferent de `internal`."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "L'autentificació per contrasenya està deshabilitada per aquesta instància."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "El vostre compte s'ha deshabilitat. Contacteu amb l'administrador."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "El vostre compte s'ha deshabilitat."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Token de Slack invàlid."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "La comanda \"{0}\" només esta disponible al Metabase Edició Empresarial."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Les extensions del Metabase Edició empresarial estan PRESENTS."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "L'us de les funcionalitats de l'edició Empresarial de Metabase esta subjecte a la Llicència Comercial de Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Vegeu {0} per més detalls."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "FALTEN les extensions de l'edició empresarial de Metabase."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Us han invitat a unirvos a {1} de {0}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} ha creat {1} compte"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} ha acceptat la invitació de {1}"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Solicituds per restablir la contrasenya"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Notificació"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] ajudans a fer el [{1}] millor."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] explica'ns com va tot."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Error el iniciar el escoltador d'events"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Hem de sincronitzar els atributs d'usuari quan algú s'identifica a través de LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Llista separada per comes d'atributs que no s'han d'ingorar al sicnronitzar usuaris LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Token Invàlid"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Error a l'API de Slack: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "No s'ha trobat el canal de Slack anomenat `metabase_files`."
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Si us plau crea o desarxiva el canal per completar la integració amb Slack."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "El canal s'utiltiza per guardar grafiques que s'inclouen als Pulsos i les respostes de Metabot."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Puja una imatge"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Error al pujar l'imatge a Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Sessió invalida. S'esperava una instancia de Sessió"
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "La galeta de sessió SameSite està configurado a \"Cap\", però el lloc"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "es serveix sobre una conexió insegura. Alguns navegadors ho refusaran."
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "coo"
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Carpeta superior"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parametres ha de ser una sequence de mapes amb claus String :id "
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Utilitzeu la configuració a continuació per configurar el SSO via SAML. Si teniu alguna pregunta comproveu la nostra {0}."
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":values han d'estar presenents per obtenir :human_readable_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "La longitud total dels camps es > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "Els noms dels pedaós de codi no poden incloure '}' o començar per espais"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Error al executar la cadena de filtres de consulta"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "El camp {0} no existeix."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "No es pot buscar en un camp que no es de text {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Otorgant permisos al grup {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Revocant permisos al grup {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Permisos de BBDD invalids: Si teniu access d'escritura per les consultes natives, heu de tenir access total a les dades."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Permisos de BBDD invalids: Si teniu access de lectura per les consultes natives, heu de tenir access a les dades."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Canviant els permisos de {0} a {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "les claus dels atributs de login han de seu una keyword o una cadena"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "El idioma per defecte per a tots els usuaris a la UI de Metabase, els correus de sistema, pulsos i alertes."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Els usuarios poden sobreescriue el seu idioma per defecte a la seva configuració."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Pàgina a mostar a l'usuari per defecte."
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Permet aquest orígen embedir la aplicació Metabase complerta."
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Els valros més grans que {0} ({1}) no es permeten."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Això sobrescriura la paraula cada ocurrència de la paraula \"Metabase\"."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Aquestos son els colors primaris utilitzats pels grafics i al Metabase. Potser heu de reiniciar el vostre navegador per veure els canvis."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Utiiltzeu una fitxer SVG amb fons transparent per obtenir millors resultats."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "La URL o la imatge que voleu utiitzar com a favicon."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Permet l'autentificació per correu electrònic i contrasenya."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Això afecta coses com l'agrupat per setmana o el filtre a les consultes de GUI.\n"
+"NO afecta les consultes SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "No s'ha pogut validar el token."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "El format del token es incorrecte"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Error al validar el token."
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Error al filtra el camp {0}: NO s'ha pogut parsejar la cadena {1} a {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Error al obtenir els detalls del treball: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Començant la tasca de sincronització de la base de dades {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "No es pot sincornitzar la base de dades {0}: La base de dades no existeix"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Executant la tasca per actualitzar els valors dels camps de la base de dades {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Ignorant l'actualitació, l'actualització automàtica de camps esta deshabilitada per la base de dades {0}."

--- a/locales/cs.po
+++ b/locales/cs.po
@@ -18,7 +18,7 @@ msgstr "Prošli jsme Vaše data a vytvořili jsme nějaké automatické průzkum
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "V pořádku, děkuji."
+msgstr "Není potřeba, děkuji."
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
@@ -28,15 +28,16 @@ msgstr "Prozkoumat tyto data"
 msgid "Select a database type"
 msgstr "Zvolte typ databáze"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Uložit"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Aby mohl Metabase předvést svá kouzla, potřebuje si proskenovat Vaši databázi. Tento sken bude prováděn periodicky, aby byla metadata vždy aktuální. Níže můžete nastavit, kdy se budou tyto periodické skeny provádět."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Synchronizace databáze"
 
@@ -57,14 +58,14 @@ msgstr "Synchronizace databáze"
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Toto je odlehčený proces, který zjišťuje aktualizace schématu této databáze. Zpravidla by mělo vyhovovat nechat hodinovou periodu synchronizace."
+msgstr "Toto je nenáročný proces, který zjišťuje aktualizace schématu této databáze. Zpravidla by mělo vyhovovat nechat hodinovou periodu synchronizace."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
 msgstr "Skenovat"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Hledání hodnot filtru"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase může projít hodnoty každého políčka a povolit v dotazech a nástěnkách filtrování pomocí zaškrtávacích políček. Tento proces může znatelně zatížit databázi, především, pokud je velká."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Kdy má Metabase skenovat a uložit hodnoty polí do mezipaměti?"
 
@@ -133,29 +134,31 @@ msgstr "SMAZAT"
 msgid "in this box:"
 msgstr "v tomto boxu:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -178,9 +181,9 @@ msgstr "Smazat"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -200,8 +203,9 @@ msgstr "Připojení"
 msgid "Scheduling"
 msgstr "Plánování"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -280,10 +284,10 @@ msgstr "Přidat databázi"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -318,10 +322,8 @@ msgid "Successfully saved!"
 msgstr "Úspěšně uloženo!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Upravit"
@@ -400,26 +402,29 @@ msgstr "Vybrat typ"
 msgid "Select a target"
 msgstr "Vybrat cíl"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Sloupce"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Sloupec"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Viditelnost"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Typ"
 
@@ -427,7 +432,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Aktuální databáze:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Ukázat původní schéma"
 
@@ -500,7 +505,7 @@ msgstr "Najít tabulku"
 msgid "Schemas"
 msgstr "Schémata"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -517,7 +522,7 @@ msgstr "Přidat metriku"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definice"
 
@@ -585,35 +590,35 @@ msgstr " historie"
 msgid "Revision History for"
 msgstr "Historie revizí pro "
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - Nastavení políčka"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
-msgstr "Kde se toto políčko v Metabase objevi"
+msgstr "Kde se toto políčko v Metabase objeví"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrování nad políčkem"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Jakým způsobem mají uživatelé podle tohoto políčka filtrovat?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Toto políčko zatím nemá popis"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Původní hodnota"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Namapovaná hodnota"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Vložte hodnotu"
 
@@ -630,31 +635,31 @@ msgid "Custom mapping"
 msgstr "Vlastní mapování"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Neznámý typ mapování"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Toto pole buď není cizí klíč nebo chybí metadata cílové tabulky"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Vybrané políčko není cizí klíč"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Zobrazit hodnoty"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Vyberte, zda chcete zobrazit původní hodnotu z databáze, nebo nechat tomuto poli zobrazit přiřazenou nebo vlastní informaci."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Vyberte políčko"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Prosím vyberte sloupec pro zobrazení."
 
@@ -662,16 +667,16 @@ msgstr "Prosím vyberte sloupec pro zobrazení."
 msgid "Tip:"
 msgstr "Tip:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Možná budete chtít aktualizovat název pole, aby dával stále smysl podle výběru přemapování."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Hodnoty v mezipaměti"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase může zjistit hodnoty v tomto políčku pro povolení zaškrtávacích filtrů v nástěnkách a dotazech."
 
@@ -698,35 +703,36 @@ msgstr "Vymazání spuštěno"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Vyberte tabulku pro zobrazení schématu nebo editaci metadat."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Jméno je povinné"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Popis je povinný"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Zpráva revize je povinná"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Je nutné zadat agregaci"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Upravit metriku"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Vytvořit metriku"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Proveďte změny metriky a doplňte vysvětlující poznámku."
 
@@ -734,46 +740,46 @@ msgstr "Proveďte změny metriky a doplňte vysvětlující poznámku."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Můžete vytvořit uložené metriky a přidat je do nabídky této tabulky. Mezi uložené metriky patří typ agregace, agregované pole a případně jakýkoliv filtr, který přidáte. Například, můžete to použít k vytvoření něčeho jako oficiální způsob výpočtu \"průměrné ceny\" pro tabulku Objednávky."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Výsledek: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Pojmenujte metriku"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Dejte metrice jméno, aby ji ostatní nalezli."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Přidejte stručný popis."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Popište metriku"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Díky popisu ostatní lépe porozumí, co metrika vyjadřuje."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Na tomto místě popište méně zjevné aspekty metriky."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Důvod změn"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Přidejte poznámku pro vysvětlení, jaké změny jste udělali a proč."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Toto uvidíte v historii revizí této metriky, aby všichni věděli, proč došlo ke změnám."
 
@@ -826,6 +832,7 @@ msgstr "Toto bude vidět v historii revizí segmentu, aby každý věděl, proč
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -840,8 +847,7 @@ msgid "Re-scan this table"
 msgstr "Znovu prohledat tabulku"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Přidat"
 
@@ -858,7 +864,7 @@ msgid "Last name"
 msgstr "Příjmení"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "E-mail"
@@ -867,9 +873,9 @@ msgstr "E-mail"
 msgid "Permission Groups"
 msgstr "Skupiny oprávnění"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
-msgstr "Učinit uživatele administrátorem"
+msgstr "Učinit uživatele správcem"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
@@ -879,7 +885,7 @@ msgstr "Všichni uživatelé patří do {0} skupiny a nelze je odebrat. Nastaven
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "Toto je speciální skupina, jejíž členové vidí veškerý obsah této instance a mají přístup do administrátorské sekce, včetně nastavení oprávnění! Členy této skupiny vybírejte s rozmyslem."
+msgstr "Toto je speciální skupina, jejíž členové vidí veškerý obsah této instance a mají přístup do správcovské sekce, včetně nastavení oprávnění! Členy této skupiny vybírejte s rozmyslem."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
@@ -907,7 +913,7 @@ msgstr "Skupina je dobrá tak, jako jsou její členové."
 #: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
-msgstr "Správce"
+msgstr "Správa Metabase"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
@@ -966,6 +972,8 @@ msgstr "Odebrat skupinu"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -978,11 +986,12 @@ msgstr "Hotovo"
 msgid "Group name"
 msgstr "Název skupiny"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Skupiny"
@@ -1091,7 +1100,7 @@ msgstr "Resetovat"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Opravdu chcete pokračovat?"
 
@@ -1115,7 +1124,7 @@ msgstr "Aktivní"
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "Deaktivován"
+msgstr "Deaktivovaní"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
@@ -1205,7 +1214,7 @@ msgstr "Nebudou provedeny žádné změny oprávnění."
 msgid "You've made changes to permissions."
 msgstr "Provedli jste změny oprávnění."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Oprávnění pro tuto sbírku"
 
@@ -1223,7 +1232,7 @@ msgstr "Došlo k chybě."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:71
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "Administrátoři mají vždy nejvyšší úroveň přístupu ke všemu v Metabase."
+msgstr "Správci mají vždy nejvyšší úroveň přístupu ke všemu v Metabase."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:73
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
@@ -1261,6 +1270,7 @@ msgstr "Omezit přístup"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Odvolat přístup"
 
@@ -1324,23 +1334,23 @@ msgstr "Uspořádat sbírku"
 msgid "View collection"
 msgstr "Zobrazit sbírku"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Přístup k datům"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Zobrazit tabulky"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL dotazy"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Zobrazit schémata"
 
@@ -1411,12 +1421,15 @@ msgstr "Odesláno!"
 msgid "Clear"
 msgstr "Vymazat"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autentifikace"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Nastavení serveru"
@@ -1429,6 +1442,7 @@ msgstr "Uživatelské schema"
 msgid "Attributes"
 msgstr "Atributy"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Schéma skupiny"
@@ -1439,7 +1453,7 @@ msgstr "Používá "
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "Připravuje se"
+msgstr "Připravte se"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
@@ -1500,6 +1514,9 @@ msgid "Add a map"
 msgstr "Přidat mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1509,19 +1526,19 @@ msgid "Delete custom map"
 msgstr "Smazat mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Odstranit"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1549,11 +1566,12 @@ msgstr "např. Česká republika, Evropa, Mars"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "URL GeoJSON souboru, který chcete použít. Je potřeba aby data byly v souřadnicovém systému WGS 84 a uloženy v UTF-8."
+msgstr "URL GeoJSON souboru. Musí být použit stejný protokol jak má Metabase (http vs https).\n"
+"Je potřeba aby data byly v souřadnicovém systému WGS 84 a uloženy v UTF-8 (i Metabase je nutno spustit v UTF-8 modu)."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "Například htpps://muj-server.cz/moje-mapa.json"
+msgstr "Například https://muj-server.cz/moje-mapa.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
@@ -1619,19 +1637,19 @@ msgstr "Koupit token"
 msgid "Enter a token"
 msgstr "Zadejte token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Upravit mapování"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Skupinové mapování"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Vytvořit mapování"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1788,7 +1806,7 @@ msgstr "Aktualizace"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
-msgstr "Zkontrolovat aktualizace"
+msgstr "Kontrola aktualizací"
 
 #: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
@@ -1833,7 +1851,7 @@ msgstr "Jednotné přihlášení"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:30
 msgid "LDAP Authentication"
-msgstr "Autentifikace LDAP"
+msgstr "LDAP Autentifikace"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:36
 msgid "LDAP Host"
@@ -1871,18 +1889,27 @@ msgstr "Filtr uživatelů"
 msgid "Check your parentheses"
 msgstr "Zkontrolujte závorky"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Atribut pro e-mail"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Atribut pro jméno"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Atribut pro příjmení"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Synchronizovat členství ve skupinách"
@@ -1911,59 +1938,59 @@ msgstr "Vlastní mapy"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Přidejte vlastní soubory GeoJSON, abyste povolili různé vizualizace map regionů"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Veřejné sdílení"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Povolit veřejné sdílení"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Sdílené nástěnky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Sdílené dotazy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Vkládání do ostatních aplikací"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Povolit vkládání do ostatních aplikací"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Klíč pro vkládání"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Vložené nástěnky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Vložené dotazy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Mezipaměť"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Povolit mezipaměť"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Minimální trvání dotazu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Násobitel platnosti mezipaměti"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Maximální velikost mezipaměti"
 
@@ -1999,33 +2026,33 @@ msgstr "Pro tento Google účet neexistuje Metabase účet."
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Před přihlášením přes Google musí administrátor vytvořit odpovídající účet v Metabase."
+msgstr "Před přihlášením přes Google musí správce vytvořit odpovídající účet v Metabase."
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 msgid "Sign in with {0}"
 msgstr "Přihlásit pomocí {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
-msgstr "Kontaktujte administrátora pro reset hesla."
+msgstr "Kontaktujte správce pro reset hesla."
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Zapomenuté heslo"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "E-mail vašeho Metabase účtu"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Poslat e-mail pro reset hesla."
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Instrukce pro reset hesla najdete ve své e-mailové schránce."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Přihlásit do Metabase"
 
@@ -2046,11 +2073,11 @@ msgstr "Přihlásit"
 msgid "I seem to have forgotten my password"
 msgstr "Nepamatuji si své heslo"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "Požádat o nový e-mail pro reset hesla"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Ajaj, tento odkaz již vypršel."
 
@@ -2059,11 +2086,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Z bezpečnostních důvodů odkazy pro reset hesla po chvíli vyprší. Pokud stále potřebujete resetovat heslo, můžete {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nové heslo"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Abyste udrželi svá data v bezpečí, hesla {0}"
 
@@ -2086,24 +2113,24 @@ msgstr "Potvrdit nové heslo"
 msgid "Make sure it matches the one you just entered"
 msgstr "Ujistěte se, že se hesla shodují"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Vaše heslo bylo resetováno."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Přihlaste se svým novým heslem"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Chyba ukládání"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2113,25 +2140,26 @@ msgstr "Uloženo"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Archivovat sbírku?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Nástěnky, sbírky a pulzy v této kolekci budou také archivovány."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Archív"
 
@@ -2209,7 +2237,7 @@ msgstr "So"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "E-mail vašeho administrátora"
+msgstr "E-mail vašeho správce"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
@@ -2222,7 +2250,7 @@ msgstr " nebo "
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "Pro odeslání {0} administrátor musí nastavit integraci s {1}"
+msgstr "Pro odeslání {0} musí správce nastavit integraci s {1}"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
@@ -2256,7 +2284,7 @@ msgstr "Špendlíky"
 msgid "Drag something here to pin it to the top"
 msgstr "Přetáhněte něco sem a připnete to nahoru."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2286,6 +2314,7 @@ msgstr "Přesunout \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Přesunout"
@@ -2322,7 +2351,7 @@ msgid "Some database installations can only be accessed by connecting through an
 msgstr "Přístup k některým instalacím databáze je možný pouze připojením přes SSH prostředníka.\n"
 "Tato volba také poskytuje další úroveň zabezpečení, když není k dispozici síť VPN. Toto je obvykle pomalejší než přímé připojení."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Tato databáze je velká, takže nastavte kdy má Metabase spustit synchronizaci a skenování"
 
@@ -2361,7 +2390,7 @@ msgstr "Pokud chcete používat Metabase s těmito daty, musíte povolit příst
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} přejděte na konzoli, pokud jste tak ještě neučinili."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Jak by jste se chtěli odkazovat na tuto databázi?"
 
@@ -2477,35 +2506,35 @@ msgstr "Založeno na schéma"
 msgid "A look at your"
 msgstr "Podívejte se na svou"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Prohledat seznam"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Hledat podle {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " a nebo zadejte ID "
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Zadejte ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Zadejte číslo"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Zadejte nějaký text"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Žádná shoda pro {0} se nenašla."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Zahrnutí každé možnosti do filtru pravděpodobně moc nepomůže..."
 
@@ -2517,7 +2546,6 @@ msgstr "Něco se pokazilo :("
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Došlo k chybě. Zkuste obnovit stránku, nebo stiskněte tlačítko zpět."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2528,12 +2556,12 @@ msgstr "Došlo k chybě. Zkuste obnovit stránku, nebo stiskněte tlačítko zp�
 msgid "No description yet"
 msgstr "Zatím bez popisu"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Nový {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Ptal se {0}"
 
@@ -2554,7 +2582,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Vráceno na dřívější revizi a {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historie revizí"
@@ -2600,7 +2630,7 @@ msgid "Questions"
 msgstr "Otázky"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Pulzy"
 
@@ -2674,52 +2704,69 @@ msgstr "Teď ne"
 msgid "Error:"
 msgstr "Chyba:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Neděle"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Pondělí"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Úterý"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Středa"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Čtvrtek"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Pátek"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Sobota"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "První"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Poslední"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15. (uprostřed)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Kalendářní den"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "vaše Metabase časové pásmo"
 
@@ -2773,11 +2820,11 @@ msgstr "Vytvořit"
 msgid "Create dashboard"
 msgstr "Vytvořit nástěnku"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabulka"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Databáze"
 
@@ -2852,9 +2899,9 @@ msgstr "Jaký je název vaší karty?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2868,15 +2915,16 @@ msgstr "Popis"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Je to nepovinné, ale užitečné"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Do které sbírky to chcete zařadit?"
 
@@ -2916,11 +2964,11 @@ msgstr "Archivovat nástěnku"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Nezapomeňte udělat výběr pro každou sérii, jinak nebude filtr na této kartě fungovat."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Tato nástěnka vypadá prázdně."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Přidejte otázku a začněte ji používat!"
 
@@ -2940,7 +2988,7 @@ msgstr "Opustit režim celé obrazovky"
 msgid "Enter fullscreen"
 msgstr "Přejít do celoobrazovkového režimu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Ukládám..."
@@ -2953,7 +3001,8 @@ msgstr "Vložit otázku"
 msgid "Add a question to this dashboard"
 msgstr "Vlož otázku do této nástěnky"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Přidat filtr"
 
@@ -2961,7 +3010,7 @@ msgstr "Přidat filtr"
 msgid "Parameters"
 msgstr "Parametry"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Přidat textový blok"
 
@@ -2969,7 +3018,7 @@ msgstr "Přidat textový blok"
 msgid "Move dashboard"
 msgstr "Přesunout nástěnku"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Upravit nástěnku"
 
@@ -2993,11 +3042,11 @@ msgstr "Přesuň nástěnku do..."
 msgid "Dashboard moved to {0}"
 msgstr "Nástěnka přesunuta do {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Co chcete filtrovat?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Jaký druh filtru?"
 
@@ -3069,20 +3118,22 @@ msgstr "Tato karta neobsahuje pole ani parametry, které lze mapovat na tento ty
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Hodnoty v tomto poli se neshodují s hodnotami jiných polí, které jste vybrali."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Žádná platná pole"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Jméno může mít max.100 znaků"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Barva je povinná"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Jaký je název vaší nástěnky?"
 
@@ -3137,7 +3188,7 @@ msgstr "přijal nejnovější data z"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Neznámý"
 
@@ -3262,9 +3313,10 @@ msgstr "Nedávno jste se nedívali na žádné nástěnky nebo otázky"
 msgid "{0} items selected"
 msgstr "{0} položek vybráno"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Zrušit archivaci"
 
@@ -3292,7 +3344,7 @@ msgstr "Celkově řádků"
 
 #: frontend/src/metabase/lib/core.js:10
 msgid "The primary key for this table."
-msgstr "Primární klíč pro tuto tabuli."
+msgstr "Primární klíč pro tuto tabulku."
 
 #: frontend/src/metabase/lib/core.js:14
 msgid "Entity Name"
@@ -3308,7 +3360,7 @@ msgstr "Cizí klíč"
 
 #: frontend/src/metabase/lib/core.js:22
 msgid "Points to another table to make a connection."
-msgstr "Propojení ukazuje na jinou tabulku."
+msgstr "Propojení ukazující na jinou tabulku."
 
 #: frontend/src/metabase/lib/core.js:257
 msgid "Avatar Image URL"
@@ -3381,7 +3433,7 @@ msgid "Zip Code"
 msgstr "PSČ"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Množství"
 
@@ -3395,7 +3447,7 @@ msgstr "Sleva"
 
 #: frontend/src/metabase/lib/core.js:193
 msgid "Creation timestamp"
-msgstr "Zadejte časovou značku"
+msgstr "Časová značka vytvoření"
 
 #: frontend/src/metabase/lib/core.js:188
 msgid "Creation time"
@@ -3414,29 +3466,31 @@ msgid "User"
 msgstr "Uživatel"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Zdroj"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Cena"
 
 #: frontend/src/metabase/lib/core.js:223
 msgid "Join timestamp"
-msgstr "Připojte časovou značku"
+msgstr "Časová značka registrace"
 
 #: frontend/src/metabase/lib/core.js:218
 msgid "Join time"
-msgstr "Připojte čas"
+msgstr "Čas registrace"
 
 #: frontend/src/metabase/lib/core.js:213
 msgid "Join date"
-msgstr "Připojte datum"
+msgstr "Datum registrace"
 
 #: frontend/src/metabase/lib/core.js:129
 msgid "Share"
-msgstr "Sdílet"
+msgstr "Podíl"
 
 #: frontend/src/metabase/lib/core.js:151
 msgid "Owner"
@@ -3451,21 +3505,23 @@ msgid "Subscription"
 msgstr "Předplatné"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Skóre"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Nadpis"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Komentář"
 
@@ -3519,14 +3575,14 @@ msgstr "Metabase toto pole nikdy nezíská. Použijte na citlivé nebo irelevant
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Počet"
 
@@ -3534,7 +3590,7 @@ msgstr "Počet"
 msgid "CumulativeCount"
 msgstr "Kumulovaný počet"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3552,19 +3608,19 @@ msgstr "Jedinečný"
 msgid "StandardDeviation"
 msgstr "Směrodatná odchylka"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Průměr"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3575,14 +3631,14 @@ msgstr "Max"
 msgid "sad sad panda, lexing errors detected"
 msgstr "Byla detekována slovníková chyba"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} sekund"
 msgstr[1] "{0} sekundy"
 msgstr[2] "{0} sekund"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuta"
@@ -3596,7 +3652,7 @@ msgstr "Ahoj"
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "Jak to jde?"
+msgstr "Jak se vede"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
@@ -3624,14 +3680,15 @@ msgstr "Co chcete zjistit?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Surové data"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Kumulativní počet"
 
@@ -3693,166 +3750,164 @@ msgstr "Pravda"
 msgid "False"
 msgstr "Nepravda"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Vyberte pole zeměpisné délky"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Zadejte horní zeměpisnou šířku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Zadejte levou zeměpisnou délku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Zadejte dolní zeměpisnou šířku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Zadejte pravou zeměpisnou délku"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Je"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Není"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Je prázdný"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Není prázdné"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Je roven"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Není roven"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Větší než"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Méně než"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Mezi"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Větší nebo rovno než"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Menší nebo rovno než"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Obsahuje"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Neobsahuje"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Začíná na"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Končí na"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Před"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Uvnitř"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Pouze tabulka s řádky v odpovědi, žádné další operace."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Počet řádků"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Celkový počet řádků v odpovědi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Součet z "
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Součet všech hodnot ze sloupce"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Průměr z..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Průměr všech hodnot ze sloupce"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Počet jedinečných hodnot z "
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Počet jedinečných hodnot ve sloupci napříč všemi řádky v odpovědi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Kumulativní součet z "
 
@@ -3860,7 +3915,7 @@ msgstr "Kumulativní součet z "
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Přídavný součet všech hodnot sloupce. .\\ne.x. celkový příjem v čase."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Kumulativní počet řádků"
 
@@ -3869,27 +3924,27 @@ msgstr "Kumulativní počet řádků"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Přídavný počet řádků. \\ne.x. celkový počet prodejů v čase."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Směrodatná odchylka z..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Číslo, které vyjadřuje, do jaké míry se hodnoty sloupce liší mezi všemi řádky v odpovědi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Minimum z ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Minimální hodnota sloupce"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Maximum z ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Maximální hodnota sloupce"
 
@@ -3905,6 +3960,8 @@ msgstr "malé písmeno"
 msgid "upper case letter"
 msgstr "velké písmeno"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "číslo"
@@ -4071,7 +4128,7 @@ msgstr "Nastavení účtu"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Exit admin"
-msgstr "Opustit administraci"
+msgstr "Opustit správu"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:35
 msgid "Logs"
@@ -4114,7 +4171,7 @@ msgstr "a je sestavený s péčí v San Franciscu v Kalifornii"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:224
 msgid "Metabase Admin"
-msgstr "Administrace Metabase"
+msgstr "Správa Metabase"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
@@ -4152,7 +4209,7 @@ msgstr "Jak vytvořit metriku"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Zobrazte data v průběhu času, aby vám to pomohlo pochopit trendy nebo změny."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Volitelný"
 
@@ -4175,7 +4232,7 @@ msgstr "Nativní dotaz"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Pro složitější otázky můžete napsat svůj vlastní SQL nebo nativní dotaz."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Vyberte výchozí hodnotu..."
 
@@ -4213,9 +4270,9 @@ msgstr "Posledních 30 dní"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "týden"
-msgstr[1] "týdnů"
-msgstr[2] "týdny"
+msgstr[0] "Týden"
+msgstr[1] "Týdnů"
+msgstr[2] "Týdny"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4223,9 +4280,9 @@ msgstr[2] "týdny"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "měsíc"
-msgstr[1] "měsíců"
-msgstr[2] "měsíce"
+msgstr[0] "Měsíc"
+msgstr[1] "Měsíců"
+msgstr[2] "Měsíce"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4233,9 +4290,9 @@ msgstr[2] "měsíce"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "rok"
-msgstr[1] "roků"
-msgstr[2] "roky"
+msgstr[0] "Rok"
+msgstr[1] "Roků"
+msgstr[2] "Roky"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
@@ -4269,7 +4326,7 @@ msgstr "Tento měsíc"
 msgid "This Year"
 msgstr "Tento rok"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Zadejte hodnotu..."
@@ -4279,7 +4336,7 @@ msgid "Enter a default value..."
 msgstr "Zadejte výchozí hodnotu..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Nastala chyba"
@@ -4452,7 +4509,7 @@ msgstr "Tato otázka nebude zahrnuta do vašeho pulzu"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Tento pulz již nebude doručován emailem na adresu {0} {1}"
+msgstr "Tento pulz již nebude doručován emailem na {0} {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
@@ -4538,22 +4595,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Vyberte otázky, které chcete poslat v tomto pulzu"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Emaily"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Zprávy pro Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Odeslat"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} bude odeslaný na"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Zprávy"
 
@@ -4625,30 +4690,30 @@ msgstr "Pomozte všem v týmu aby byli synchronizováni s vašimi daty."
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Pulzy umožňují odesílat data z Metabase na email nebo Slack na základě plánu a podle vašeho výběru."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Po {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Před {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Je prázdný"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Není prázdný"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Vždy"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Aplikovat"
 
@@ -4750,12 +4815,12 @@ msgstr[2] "Zobrazit těchto {0}"
 msgid "Zoom in"
 msgstr "přiblížit"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Vlastní výraz"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Běžné metriky"
 
@@ -4881,11 +4946,11 @@ msgstr "Smazat toto upozornění?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "Upozornit mě, když bude linie..."
+msgstr "Upozornit mě, když..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "Upozornit mě, když bude sloupec..."
+msgstr "Upozornit mě, když..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
@@ -4897,11 +4962,11 @@ msgstr "Dosáhne cíle"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Spadá pod cílovou linii"
+msgstr "Spadne pod cílovou linii"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "Spadá pod cíl"
+msgstr "Spadne pod cíl"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
@@ -4952,7 +5017,7 @@ msgstr "obvykle"
 msgid "Pick a segment or table"
 msgstr "Vyberte segment nebo tabulku"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Vyberte databázi"
@@ -5013,7 +5078,7 @@ msgstr "Seřadit"
 msgid "Row limit"
 msgstr "Limit řádků"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Neznámé pole"
 
@@ -5021,7 +5086,7 @@ msgstr "Neznámé pole"
 msgid "field"
 msgstr "pole"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Shody"
 
@@ -5029,7 +5094,7 @@ msgstr "Shody"
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "Přidejte filtry, abyste zúžily výběr"
+msgstr "Přidejte filtry, abyste zúžili výběr"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
@@ -5046,11 +5111,11 @@ msgstr "Přidat seskupení"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Data"
 
@@ -5067,11 +5132,12 @@ msgstr "Zobrazit"
 msgid "Grouped By"
 msgstr "Seskupeno podle"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Žádné"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Tato otázka je napsána v {0}."
 
@@ -5083,7 +5149,7 @@ msgstr "Skrýt editor"
 msgid "Hide Query"
 msgstr "Skrýt dotaz"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Otevřít editor"
 
@@ -5091,7 +5157,7 @@ msgstr "Otevřít editor"
 msgid "Show Query"
 msgstr "Zobraz dotaz"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Tato metrika již byla zrušena. Již není možno ji použít."
 
@@ -5293,7 +5359,7 @@ msgstr "Zpět na poslední spuštění"
 msgid "Visualization"
 msgstr "Vizualizace"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Popis nenastaven."
 
@@ -5350,7 +5416,7 @@ msgstr "Nelze najít metadata tabulky před vytvořením nové otázky"
 msgid "See {0}"
 msgstr "Zobrazit {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Definice metriky"
 
@@ -5368,11 +5434,11 @@ msgstr "Počet {0}"
 msgid "See all {0}"
 msgstr "Zobrazit všechny {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Definice segmentu"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Chyba při načítání tabulky"
 
@@ -5380,7 +5446,7 @@ msgstr "Chyba při načítání tabulky"
 msgid "See the raw data for {0}"
 msgstr "Ukaž surové data pro {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Více"
 
@@ -5400,6 +5466,8 @@ msgstr "Vzorec pole"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Uvažujte o tom, jakoby to bylo jako psaní vzorce v tabulkovém programu: můžete použít čísla, pole v této tabulce, matematické symboly jako + a některé funkce. Můžete tedy zadat něco jako Mezisoučet - Náklady."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5467,7 +5535,7 @@ msgstr "nepravda"
 msgid "Add filter"
 msgstr "Přidat filtr"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Položka"
 
@@ -5483,7 +5551,7 @@ msgstr "Aktuální"
 #: frontend/src/metabase/visualizations/lib/settings/column.js:257
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "Zapnuté"
+msgstr "Ze dne"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
@@ -5586,11 +5654,11 @@ msgstr "Pole na propojení s"
 msgid "Filter widget type"
 msgstr "Typ filtrovacího widgetu"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Povinné?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Výchozí hodnota filtrovacího widgetu"
 
@@ -5602,7 +5670,7 @@ msgstr "Archivovat tuto otázku?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Tato otázka bude odstraněna ze všech nástěnek nebo pulzů, které ji používají."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Otázka"
 
@@ -5649,7 +5717,7 @@ msgstr "Typ pole"
 msgid "Select a Foreign Key"
 msgstr "Vyberte Cizí klíč"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Prohlédněte si vzorec {0}"
 
@@ -6133,22 +6201,24 @@ msgstr "Otázky týkající se tohoto segmentu"
 msgid "X-ray this segment"
 msgstr "Prozkoumat tento segment"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Přihlásit se"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Hledat"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Nástěnka"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nová otázka"
 
@@ -6220,35 +6290,35 @@ msgstr "Celá sbírka je zcela anonymní."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Sbírky můžete kdykoliv vypnout v nastaveních správce."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Pokud se cítíte zaseknutý"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "náš průvodce pro začátečníky"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "je vzdálen jen na jedno kliknutí."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Vítejte v Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Vypadá to, že všechno funguje. Nyní se s vámi seznámíme, připojíme se k vašim datům a začneme prohledávat data."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Začněme"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Všechno je připraveno!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Ukažte mi Metabase"
 
@@ -6501,39 +6571,40 @@ msgstr "Zrušit filtr"
 msgid "Pin Map"
 msgstr "Připnout mapu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Zrušit"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Řádky {0} - {1} z {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Data byly zkráceny na {0} řádky."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Nelze najít vizualizaci"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Tento graf se nedal zobrazit s těmito daty."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Žádné výsledky!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Stále čekám..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Obvykle to trvá průměrně {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Toto je pro nástěnku poněkud dlouhé)"
 
@@ -6645,7 +6716,7 @@ msgid "Highlight the whole row"
 msgstr "Zvýrazněte celý řádek"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Barvy"
 
@@ -6731,24 +6802,50 @@ msgstr "Cíl"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Data z vašeho dotazu se neshodují s vybranou volbou zobrazení. Tato vizualizace vyžaduje nejméně {0} {1} z dat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "sloupec"
@@ -6781,16 +6878,16 @@ msgid "xValues missing!"
 msgstr "Chybí hodnota pro osu X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "osa X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Přidat konec do série..."
+msgstr "Přidat do série souhrn..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "osa Y"
 
@@ -6803,7 +6900,7 @@ msgid "Bubble size"
 msgstr "Velikost bubliny"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Linie"
 
@@ -6889,7 +6986,7 @@ msgstr "Sloupcový graf"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
-msgstr "Řadový"
+msgstr "Řady"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
@@ -6945,20 +7042,20 @@ msgid "Standard Deviation"
 msgstr "Směrodatná odchylka"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Oblast"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "plošný graf"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Sloupec"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "sloupcový graf"
 
@@ -6972,7 +7069,7 @@ msgid "Funnel"
 msgstr "Trychtýř"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Hodnoty"
 
@@ -6984,81 +7081,81 @@ msgstr "Typ trychtýře"
 msgid "Bar chart"
 msgstr "Sloupcový graf"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "spojnicový graf"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "V nastavení grafu vyberte sloupce zeměpisné délky a šířky."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Vyberte mapu regionu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "V nastavení grafu vyberte sloupce regionů a metrik."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Typ mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Mapa regionu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Připnout mapu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Typ špendlíku"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Dlaždice"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Značky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Pole zeměpisné šířky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Pole zeměpisné délky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Pole metriky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Pole regionu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Úhel"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Rozmazat"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Min. krytí"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Max. přiblížení"
 
@@ -7070,7 +7167,7 @@ msgstr "Nebyly nalezeny žádné vztahy."
 msgid "via {0}"
 msgstr "prostřednictvím {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Toto {0} je spojené s:"
 
@@ -7082,31 +7179,31 @@ msgstr "Detail objektu"
 msgid "object"
 msgstr "objekt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Celkem"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Které sloupce chcete použít?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Koláč"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Rozměr"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Zobrazit legendu"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Zobrazit procenta v legendě"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minimální procento řezů"
 
@@ -7131,7 +7228,8 @@ msgid "Progress"
 msgstr "Postup"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Barva"
@@ -7140,7 +7238,7 @@ msgstr "Barva"
 msgid "Row Chart"
 msgstr "Pruhový graf"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "pruhový graf"
 
@@ -7164,15 +7262,15 @@ msgstr "Přidejte příponu"
 msgid "Multiply by a number"
 msgstr "Vynásobte číslem"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Bodový"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "bodový diagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Kontingenčně"
 
@@ -7222,14 +7320,14 @@ msgstr "Doprava"
 msgid "Show background"
 msgstr "Zobrazit pozadí"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} interval"
 msgstr[1] "{0} intervaly"
 msgstr[2] "{0} intervalů"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Auto hranice tříd"
 
@@ -7465,10 +7563,13 @@ msgstr "Máte spoustu uložených dotazů v {0}? Vytvořte sbírky, které je po
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7662,7 +7763,7 @@ msgstr "kumulativní součet"
 msgid "{0} and {1}"
 msgstr "{0} a {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
@@ -7860,7 +7961,7 @@ msgstr "Metabase se vypíná ..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Vypnutí Metabase bylo úspěšné"
+msgstr "Vypnuti Metabase bylo uspesne"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
@@ -7881,15 +7982,15 @@ msgstr "Vypadá to, že se jedná o novou instalaci ... připravuje se průvodce
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Inicializace Metabase je HOTOVÁ"
+msgstr "Inicializace Metabase je HOTOVA"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "Spuštění vestavěného webového serveru Jetty s konfigurací:"
+msgstr "Spusteni vestaveneho weboveho serveru Jetty s konfiguraci:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "Vypíná se vestavěný webový server Jetty"
+msgstr "Vypina se vestaveny webovy server Jetty"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
@@ -7942,7 +8043,7 @@ msgstr "Ověřuji připojení k databázi... "
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Spouštím migrace databáze..."
+msgstr "Spoustim migraci databaze..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
@@ -8003,7 +8104,7 @@ msgstr "Časové pásmo připojení, které se použije při provádění dotaz�
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "Registrovaný ovladač {0} {1}"
+msgstr "Registrovan ovladac {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
@@ -8367,7 +8468,7 @@ msgstr "Ukládám hodnoty polí pro pole {0}..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabase se může pokusit transformovat názvy tabulek a polí na rozumnější verze čitelné pro člověka. Např. z \"nějakýstašnýnázev\" se stane \"Nějaký Strašný Název\""
+msgstr "Metabase se může pokusit transformovat názvy tabulek a polí na rozumnější verze čitelné pro člověka. Např. z \"nějakýstašnýnázev\" se stane \"Nějaký Strašný Název\"."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
@@ -8618,7 +8719,7 @@ msgstr "Nelze validovat token."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Chyba při zjišťování stavu tokenu:"
+msgstr "Chyba při načítání stavu tokenu:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
@@ -8788,7 +8889,7 @@ msgstr "Dokončený krok ''{0}''"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "Načítám jmenný prostor úloh:"
+msgstr "Nacitam jmenny prostor uloh:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
@@ -8977,11 +9078,11 @@ msgstr "Oprávnění dat"
 msgid "Collection permissions"
 msgstr "Oprávnění sbírek"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Zobrazit všechna oprávnění ke sbírce"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Změnit i podskupiny"
 
@@ -8993,19 +9094,19 @@ msgstr "Může upravovat tuto sbírku a její obsah"
 msgid "Can view items in this collection"
 msgstr "Může zobrazit položky v této kolekci"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Přístup ke sbírce"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Tato skupina má oprávnění k zobrazení alespoň jedné podskupiny této sbírky."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Tato skupina má oprávnění na úpravu alespoň jedné podskupiny této sbírky."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Zobrazit dílčí sbírky"
 
@@ -9061,6 +9162,7 @@ msgstr "Příbuzný"
 msgid "More X-rays"
 msgstr "Více vhledů"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9297,7 +9399,7 @@ msgstr "Všichni uživatelé"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Administrátoři"
+msgstr "Správci"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
@@ -9319,10 +9421,10 @@ msgstr "Sdílení"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9354,7 +9456,7 @@ msgstr "Vyzkoušejte tyto rychlé průzkumy dat."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:38
 msgid "There was a problem displaying this chart."
-msgstr "Nastal problém při zobrazování grafu."
+msgstr "Nastal problém při zobrazování těchto dat."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:39
 msgid "Sorry, you don't have permission to see this card."
@@ -9405,7 +9507,7 @@ msgstr "Použijte časové pásmo JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Momentálně analyzujeme tabulky a pole, které vám pomohou prozkoumat vaše data."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Tip: "
 
@@ -9413,7 +9515,7 @@ msgstr "Tip: "
 msgid "Select a currency type"
 msgstr "Zvol typ měny"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Typ pole"
 
@@ -9468,6 +9570,7 @@ msgid "Currency"
 msgstr "Měna"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Vyberte uživatele nebo kanál ..."
 
@@ -9629,7 +9732,7 @@ msgstr "Která osa?"
 msgid "Line + Bar"
 msgstr "Linie + Sloupec"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "lineární a sloupcový graf"
 
@@ -9649,15 +9752,15 @@ msgstr "Rozsah měřidla"
 msgid "Field to show"
 msgstr "Pole k zobrazení"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "poslední {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} bylo {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Seskupením podle časového pole zjistíte, jak se to časem změnilo"
 
@@ -9665,23 +9768,23 @@ msgstr "Seskupením podle časového pole zjistíte, jak se to časem změnilo"
 msgid "Switch positive / negative colors?"
 msgstr "Přepnout normální / inverzní barvy?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Do sloupce"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Hodnoty sloupce"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Viditelné sloupce"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Podmíněné formátování"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Popisek sloupce"
 
@@ -9806,7 +9909,7 @@ msgstr "UPOZORNĚNÍ: Nevím, jak negovat: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "Třídění s Druidem je povoleno pouze u dotazů, které mají jeden nebo více průrazových sloupců. Ignoruje :order-by klauzuli."
+msgstr "Třídění s Druidem je povoleno pouze u dotazů, které mají jeden nebo více přehledových sloupců. Ignoruje :order-by klauzuli."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
@@ -10121,10 +10224,10 @@ msgstr "Uživatelé podle zdroje"
 msgid "The top external pages that brought users to your site"
 msgstr "Nejlepší externí stránky, které přivedly uživatele na váš web"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Jak je [[this]] distribuováno a další."
 
@@ -10222,13 +10325,13 @@ msgstr "Události za hodinu během dne"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Top 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Spodních 5 [[this]]"
 
@@ -10241,10 +10344,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Za [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Bez hodnoty"
 
@@ -10272,8 +10375,8 @@ msgstr "Jak si vedou podle sezónnosti"
 msgid "Average income per transaction"
 msgstr "Průměrný příjem na transakci"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] podle země"
 
@@ -10397,10 +10500,10 @@ msgstr "Přehled vašeho [[this]] a jeho distribuce v čase, místě a kategori�
 msgid "Average income per state"
 msgstr "Průměrný příjem podle státu"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] podle [[GenericCategoryMedium]]"
 
@@ -10577,13 +10680,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Jako jsou [[GenericTable]] distribuovány v tomto časovém poli a zda má nějaké sezónní vzorce."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Přehled"
 
@@ -10692,8 +10795,8 @@ msgstr "Zde je bližší pohled na vaše [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Zde je bližší pohled na vaše [[this]] pole"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Souhrn"
 
@@ -10757,10 +10860,10 @@ msgstr "Prodeje za jednotlivé zdrojů"
 msgid "Average income per country"
 msgstr "Průměrný příjem podle země"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Jako je [[this]] distribuované"
 
@@ -10781,17 +10884,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Počet [[Generic Category Medium]] podle [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Podívejte se na [[this]]"
 
@@ -10857,10 +10960,10 @@ msgid "Transactions per source over time"
 msgstr "Transakcí podle zdroje v průběhu času"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Jako je [[this]] distribuovaný"
 
@@ -10889,9 +10992,9 @@ msgstr "Kde se tyto události dějí"
 msgid "Which US states are bringing you the most business."
 msgstr "Které státy USA vám přinášejí nejvíce do vašeho podnikání."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Jak si vedou v průběhu času"
 
@@ -10997,8 +11100,8 @@ msgstr "Relace podle zemí"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Několik zajímavých metrik o vašich GA statistikách, které vám pomohou začít."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] na stát"
 
@@ -11079,12 +11182,12 @@ msgstr "Jak je tato metrika rozdělena mezi různá čísla"
 msgid "Sessions by page where the session began"
 msgstr "Relace podle stránky, kde se relace začala"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Jedinečné hodnoty"
 
@@ -11147,10 +11250,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Události za [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Jak si vedou podle distribuce"
@@ -11458,6 +11561,7 @@ msgstr "Duplikovat nástěnku"
 msgid "Duplicate \"{0}\""
 msgstr "Duplikát \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11564,9 +11668,9 @@ msgstr[0] "Kvartál z roku"
 msgstr[1] "Kvartály z roku"
 msgstr[2] "Kvartálů z roku"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} vybraný"
@@ -11590,13 +11694,13 @@ msgstr "Neplatný"
 msgid "Add a time"
 msgstr "Přidat čas"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nic pro srovnání z předchozím {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
-msgstr "do {0}"
+msgstr "podle {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
@@ -11660,7 +11764,7 @@ msgstr "Načíst ovladač {0} "
 
 #: src/metabase/driver/impl.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Ovladač není zaregistrován po načtení: {0}"
+msgstr "Ovladac neni zaregistrovan po nacteni: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
@@ -11668,11 +11772,11 @@ msgstr "Chyba: pokus o změnu vlastnosti {0} `:abstract?` z {1} na {2}."
 
 #: src/metabase/driver/impl.clj
 msgid "Registered abstract driver {0}"
-msgstr "Registrovaný abstraktní ovladač {0}"
+msgstr "Registrovan abstraktni ovladac {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered driver {0}"
-msgstr "Registrovaný ovladač {0}"
+msgstr "Registrovan ovladac {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "(parents: {0})"
@@ -11704,7 +11808,7 @@ msgstr "Chyba při načítání jmenného prostoru"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "Spouštím naslouhač událostí:"
+msgstr "Spoustim naslouhac udalosti:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
@@ -11844,7 +11948,7 @@ msgstr "Zdroj neexistuje."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "Načítám jmenný prostor doplňků {0}..."
+msgstr "Nacitam jmenny prostor doplnku {0}..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
@@ -11852,7 +11956,7 @@ msgstr "Závislosti jsou vyřešeny; tyto doplňky se nyní načtou: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "Probíhá registrace ovladače JDBC proxy pro {0}..."
+msgstr "Probiha registrace ovladace JDBC proxy pro {0}..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
@@ -11966,11 +12070,11 @@ msgstr "Byl přidán komentář pro {0}."
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Zastavuji časový plánovač {0}"
+msgstr "Zastavuji casovy planovac {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Spouštím časový plánovač {0}"
+msgstr "Spoustim casovy planovac {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
@@ -11980,7 +12084,7 @@ msgstr "Při načítání jmenného prostoru úloh se vyskytla chyba {0}"
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "Inicializuji úlohu {0}"
+msgstr "Inicializuji ulohu {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
@@ -11992,7 +12096,7 @@ msgstr "Problém s odesláním e-mailu o opuštění účtu!"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "Posílám anonymní statistiku o používání."
+msgstr "Posilam anonymni statistiku o pouzivani."
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
@@ -12004,7 +12108,7 @@ msgstr "Chyba při posílání pulzu {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "Posílám naplánované pulzy..."
+msgstr "Posilam naplanovane pulzy..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
@@ -12082,9 +12186,9 @@ msgstr "Zde je přehled lidí ve vašem [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] podle kvartálu roku"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Jak si vedou napříč polohou"
 
@@ -12113,12 +12217,12 @@ msgstr "[[CreateTimestamp]] podle dne v týdnu"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Zde je přehled vašich [[this]] dat ze služby Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Zde je přehled vašich [[this]]"
 
@@ -12197,11 +12301,11 @@ msgstr "sbírka"
 msgid "collections"
 msgstr "sbírky"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "nástěnka"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "nástěnky"
 
@@ -12451,7 +12555,7 @@ msgstr "Časový limit vypršel po {0} milisekundách."
 msgid "Misfire Instruction"
 msgstr "Nezdařené instrukce"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Archivovat to?"
 
@@ -12470,7 +12574,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Použití této volby vyžaduje, aby hostitel byl zadán jako FQDN. Pokud se připojujete ke Atlas klustru, možná bude nutné tuto možnost povolit. Pokud nevíte, co to znamená, nechte to vypnuté."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Automaticky spouštět dotazy při jednoduchém filtrování a sumarizaci"
 
@@ -12482,7 +12586,7 @@ msgstr "Když je toto zapnuto, Metabase automaticky spouští dotazy, když uži
 msgid "Learn about this database"
 msgstr "Další informace o této databázi"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Archivovat tuto nástěnku?"
 
@@ -12539,11 +12643,11 @@ msgstr "Vlastní otázka"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Použijte pokročilý editor poznámek na spojení dat, vytváření vlastních sloupců, výpočty a další."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Základní metriky"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Vlastní..."
 
@@ -12598,7 +12702,7 @@ msgstr "Shromáždit"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Průraz"
+msgstr "Přehled"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
@@ -12663,9 +12767,9 @@ msgstr "Získejte upozornění"
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "{0} průraz"
-msgstr[1] "{0} průrazy"
-msgstr[2] "{0} průrazů"
+msgstr[0] "{0} přehled"
+msgstr[1] "{0} přehledů"
+msgstr[2] "{0} přehledů"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Hide filters"
@@ -12731,15 +12835,15 @@ msgstr "Vyberte vizualizaci"
 msgid "Filter by"
 msgstr "Filtrovat podle"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Sumarizovat podle"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Seskupit podle"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Přidejte metriku"
 
@@ -12750,15 +12854,15 @@ msgstr "Přidejte metriku"
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "To je obvykle dost rychlé, ale nyní se zdá, že to chvíli trvá."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Kombinace"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Pruhy"
 
@@ -12829,7 +12933,7 @@ msgstr "Žádost zrušena, ruším budoucí."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "Metabase může přenášet data pouze z H2 do Postgres nebo MySQL / MariaDB."
+msgstr "Metabase muze migrovat data pouze z H2 do Postgres nebo MySQL / MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
@@ -13183,7 +13287,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Vyberte sloupce, které chcete zahrnout"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Když je toto zapnuto, Metabase automaticky spouští dotazy, když uživatelé dělají jednoduché průzkumy pomocí tlačítek Sumarizovat a Filtrovat během prohlížení tabulky nebo grafu. Tuto možnost lze vypnout, pokud je vyhledávání v této databázi pomalé. Toto nastavení nemá vliv na SQL dotazy."
 
@@ -13250,7 +13354,7 @@ msgstr "Přihlásit se pomocí emailu"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Použití této volby vyžaduje, aby hostitel byl zadán jako FQDN. Pokud se připojujete ke Atlas klustru, možná bude nutné tuto možnost povolit. Pokud nevíte, co to znamená, nechte to vypnuté."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Metabase standardně provádí odlehčenou hodinovou synchronizaci a intenzivní denní skenování hodnot polí. Pokud máte rozsáhlou databázi, doporučujeme zapnout skenování a zkontrolovat kdy a jak často se uskuteční kontrola hodnot polí."
 
@@ -13318,11 +13422,11 @@ msgstr "Nezahrnout"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Toto pole nebude viditelné ani volitelné při otázkách vytvořených pomocí grafických rozhraní. Bude stále přístupná v SQL / nativních dotazech."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Kumulativní součet"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Směrodatná odchylka"
 
@@ -13338,19 +13442,19 @@ msgstr "musí mít alespoň {0} znaků"
 msgid "Name (required)"
 msgstr "Jméno (povinné)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Spustit vybraný text"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Spustit dotaz"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13436,7 +13540,7 @@ msgstr "Při spuštění dotazu se vyskytla chyba"
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Output H2 database already exists: %s, removing."
-msgstr "Databáze výstupů H2 již existuje:%s, odstraňuji."
+msgstr "Výstupní H2 databáze již existuje:%s, odstraňuji."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Don't need to migrate, just use the existing H2 file"
@@ -13698,7 +13802,7 @@ msgstr "Data a časy"
 msgid "Numbers"
 msgstr "Čísla"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Žádná mapovatelná skupina"
 
@@ -13738,15 +13842,15 @@ msgstr "dnestitoslusi@email.com"
 msgid "Remember me"
 msgstr "Zapamatovat si mě"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Z bezpečnostních důvodů platnost odkazů na obnovení hesla za chvíli vyprší. Pokud stále potřebujete obnovit své heslo, můžete {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Uložit nové heslo"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Žádný odpovídající výsledek"
 
@@ -13772,26 +13876,26 @@ msgid "or"
 msgstr "nebo"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "povinné"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Typ databáze"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Toto je odlehčený proces, který zjišťuje aktualizace schématu této databáze. Zpravidla by mělo vyhovovat nechat hodinovou periodu synchronizace."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase může skenovat hodnoty přítomné v každém poli v této databázi kvůli povolení fitrů v nástěnkách a otázkách. Může to být proces, který je trochu náročný na prostředky, zejména pokud máte velmi velkou databázi."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Sbírka"
 
@@ -13838,7 +13942,7 @@ msgstr "Kategorické"
 msgid "URLs"
 msgstr "odkaz"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Vrátí průměr hodnot ve sloupci."
 
@@ -13847,11 +13951,13 @@ msgstr "Vrátí průměr hodnot ve sloupci."
 msgid "The column whose values to average."
 msgstr "Sloupec, jehož hodnoty se mají zprůměrovat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "start"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "konec"
 
@@ -13863,21 +13969,19 @@ msgstr "Kontroluje hodnoty data nebo číselného sloupce a zjišťuje, zda se n
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "podmínka"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "výstup"
 
@@ -13885,27 +13989,27 @@ msgstr "výstup"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testuje seznam případů a vrací odpovídající hodnotu prvního shodného případu, s volitelnou výchozí hodnotou pro případ pokud není žádný splněn."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Váha"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Velká"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Střední"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Malá"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Něco, co by se mělo vyhodnocovat jako PRAVDA nebo NEPRAVDA."
 
@@ -13913,33 +14017,33 @@ msgstr "Něco, co by se mělo vyhodnocovat jako PRAVDA nebo NEPRAVDA."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Hodnota, která se vrátí, pokud je předchozí podmínka splněna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "hodnota1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "hodnota2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Projde hodnoty v každém argumentu dle jejich pořadí a vrátí první nenulovou hodnotu pro každý řádek."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Komentáře"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Poznámky"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Žádné komentáře"
 
@@ -13955,44 +14059,44 @@ msgstr "Pokud je hodnota1 prázdná, hodnota2 bude vrácena pokud není prázdn�
 msgid "Combines two or more strings of text together."
 msgstr "Kombinuje dva nebo více řetězců textu dohromady."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Příjmení"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Jméno"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
-msgstr "hodnota2 se připojí na konec."
+msgstr "hodnota1 bude na začátku"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
 msgstr "Toto se připojí na konec hodnoty1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "řetězec1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "řetězec2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Zkontroluje, zda řetězec1 obsahuje řetězec2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Prošlo"
 
@@ -14000,7 +14104,7 @@ msgstr "Prošlo"
 msgid "The contents of this string will be checked."
 msgstr "Obsah tohoto řetězce se zkontroluje."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Řetězec textu, který se má hledat."
 
@@ -14008,77 +14112,81 @@ msgstr "Řetězec textu, který se má hledat."
 msgid "Returns the count of rows in the source data."
 msgstr "Vrátí počet řádků ve zdrojových datech."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Sečte pouze řádky, ve kterém je podmínka splněna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Mezisoučet"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
-msgstr "Aditivní součet řádků napříč průrazem."
+msgstr "Aditivní součet řádků napříč přehledem."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
-msgstr "Postupný součet sloupce napříč průrazem."
+msgstr "Postupný součet sloupce napříč přehledem."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
 msgstr "Sloupec k sečtení"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Počet jedinečných hodnot v tomto sloupci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Sloupec jehož jedinečné hodnoty se mají sečíst."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "porovnání"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Vrátí PRAVDA pokud konec textu souhlasí s porovnávaným textem."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Chuť"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hladový"
 
@@ -14087,20 +14195,20 @@ msgstr "hladový"
 msgid "A column or string of text to check."
 msgstr "Sloupec nebo řetězec textu na kontrolu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Řetězec textu, na který má původní text končit."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "regulární_výraz"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrahuje odpovídající podřetězce dle regulárního výrazu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adresa"
 
@@ -14108,7 +14216,7 @@ msgstr "Adresa"
 msgid "The column or string of text to search though."
 msgstr "Sloupec nebo řetězec textu, který se má prohledávat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Regulární výraz, který se má shodovat."
 
@@ -14120,7 +14228,7 @@ msgstr "Vrátí řetězec textu v malých písmenech."
 msgid "The column with values to convert to lowercase."
 msgstr "Sloupec s hodnotami pro převod na malá písmena."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Odstraní úvodní mezery z textového řetězce."
 
@@ -14130,15 +14238,16 @@ msgstr "Odstraní úvodní mezery z textového řetězce."
 msgid "The column with values you want to trim."
 msgstr "Sloupec s hodnotami, které chcete oříznout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Vrátí největší hodnotu nacházející se ve sloupci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Věk"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Číselný sloupec, jehož maximum chcete najít."
 
@@ -14146,21 +14255,21 @@ msgstr "Číselný sloupec, jehož maximum chcete najít."
 msgid "Returns the smallest value found in the column."
 msgstr "Vrátí nejmenší hodnotu nacházející se ve sloupci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Plat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Číselný sloupec, jehož minimum chcete najít."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "pozice"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "délka"
 
@@ -14169,7 +14278,7 @@ msgstr "délka"
 msgid "new_text"
 msgstr "nový_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Nahradí část vstupního textu novým textem."
 
@@ -14197,35 +14306,35 @@ msgstr "Počet znaků, které se mají nahradit."
 msgid "The text to use in the replacement."
 msgstr "Text, který má být použit jako náhrada."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Odstraní koncové mezery z textového řetězce."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Vrátí procento řádků v datech které odpovídají podmínce, jako desetinné číslo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Vrátí PRAVDA, pokud se začátek textu shoduje se srovnávaným textem."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Název kurzu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Počítačová věda"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Řetězec textu, na který má původní text začínat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Vypočte směrodatnou odchylku sloupce"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Populace"
 
@@ -14233,7 +14342,7 @@ msgstr "Populace"
 msgid "A numeric column."
 msgstr "Číselný sloupec."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Vrátí část zadaného textu."
 
@@ -14241,19 +14350,19 @@ msgstr "Vrátí část zadaného textu."
 msgid "The text to return a portion of."
 msgstr "Text ze kterého se má vrátit část."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Pozice na které se má začít kopírovat znaky."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Počet znaků, které se mají vrátit."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Sčítá všechny hodnoty sloupce."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Číselný sloupec k sečtení"
 
@@ -14261,15 +14370,15 @@ msgstr "Číselný sloupec k sečtení"
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Sčítá hodnoty ve sloupci, jehož řádky odpovídají podmínce."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Stav objednávky"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Platná"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Odstraní úvodní a koncové mezery z textového řetězce."
 
@@ -14277,51 +14386,51 @@ msgstr "Odstraní úvodní a koncové mezery z textového řetězce."
 msgid "Returns the string of text in all upper case."
 msgstr "Vrátí řetězec textu ve velkých písmenech."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Sloupec s hodnotami pro převod na velká písmena."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "musí být {0} a musí obsahovat {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "musí být {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "musí obsahovat {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "nejméně {0} znak"
 msgstr[1] "nejméně {0} znaky"
 msgstr[2] "nejméně {0} znaků"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} malé písmeno"
 msgstr[1] "{0} malé písmena"
 msgstr[2] "{0} malých písmen"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} velké písmeno"
 msgstr[1] "{0} velké písmena"
 msgstr[2] "{0} velkých písmen"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} číslo"
 msgstr[1] "{0} čísla"
 msgstr[2] "{0} čísel"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} speciální znak"
@@ -14345,6 +14454,7 @@ msgid "Powered by {0}"
 msgstr "Běží na {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Pro:"
 
@@ -14432,7 +14542,7 @@ msgstr "Formátování hodnoty"
 msgid "Full"
 msgstr "Plný"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Žádná změna od poslední {0}"
 
@@ -14757,7 +14867,7 @@ msgstr "Chyba při generování statistik pro sloupec:"
 msgid "Sending abandonment email!"
 msgstr "Odesíláme e-mail o opuštění účtu!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Můžete vytvořit uložené metriky a přidat je do nabídky. Mezi uložené metriky patří typ agregace, agregované pole a případně jakýkoliv filtr, který přidáte. Například, můžete to použít k vytvoření něčeho jako oficiální způsob výpočtu \"průměrné ceny\" pro tabulku Objednávky."
 
@@ -14765,15 +14875,15 @@ msgstr "Můžete vytvořit uložené metriky a přidat je do nabídky. Mezi ulo�
 msgid "Select and add filters to create your new segment."
 msgstr "Pro vytvoření Vašeho nového segmentu vyber a přidej filtry."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Abecední"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Chytré"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Pořadí sloupců: {0}"
 
@@ -14825,7 +14935,7 @@ msgstr "Nastavení jazyka"
 msgid "Instance language"
 msgstr "Jazyk rozhraní"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Možnosti jazyka"
 
@@ -14897,19 +15007,20 @@ msgstr "Vložte připojovací řetězec"
 msgid "Fill out individual fields"
 msgstr "Vyplňte individuální pole"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Napiš zde nějaký SQL, který můžeš později znovu použít"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Pojmenujte svůj výstřižek"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Stávající zákazníci"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Přidat popis"
 
@@ -14917,46 +15028,47 @@ msgstr "Přidat popis"
 msgid "Use site default"
 msgstr "Použít výchozí stránku"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "najít"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "nahradit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Text k nalezení."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Text, který se má použít jako náhrada."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Edituji {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Vytvořte nový výstřižek"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Archivované výstřižky"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Výstřižky jsou oblíbené části SQL dotazů"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Vytvořte výstřižek"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Výstřižky kódu"
 
@@ -15070,27 +15182,27 @@ msgstr "ASYNC"
 
 #: src/metabase/middleware/log.clj
 msgid "{0} ({1} DB calls)"
-msgstr "{0} ({1} DB volání)"
+msgstr "{0} ({1} DB volani)"
 
 #: src/metabase/middleware/log.clj
 msgid "App DB connections: {0}/{1}"
-msgstr "Spojení k aplikační DB: {0}/{1}"
+msgstr "Spojeni k aplikacni DB: {0}/{1}"
 
 #: src/metabase/middleware/log.clj
 msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
-msgstr "Vlákna Jetty: {0}/{1} ({2} nečinné, {3} v řadě)"
+msgstr "Vlakna Jetty: {0}/{1} ({2} necinne, {3} v rade)"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} total active threads)"
-msgstr "({0} celkem aktivních vláken)"
+msgstr "({0} celkem aktivnich vlaken)"
 
 #: src/metabase/middleware/log.clj
 msgid "Queries in flight: {0}"
-msgstr "Dotazů v běhu: {0}"
+msgstr "Dotazu v behu: {0}"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} queued)"
-msgstr "({0} v řadě)"
+msgstr "({0} v rade)"
 
 #: src/metabase/models/collection.clj
 msgid "Collection must be in the same namespace as its parent"
@@ -15122,7 +15234,7 @@ msgstr "Nemůžete aktualizovat creator_id z NativeQuerySnippet."
 
 #: src/metabase/models/setting.clj
 msgid "Error fetching value of Setting"
-msgstr "Chyba při vyvolání hodnoty nastavení"
+msgstr "Chyba při načítání hodnoty nastavení"
 
 #: src/metabase/public_settings.clj
 msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
@@ -15235,3 +15347,1504 @@ msgstr "hodnota musí být klíčové slovo nebo řetězec."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Řetězec musí být platné označení jazyka dle ISO např. 'en' nebo 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Řádky {0}-{1} "
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Auditovat"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Nastavení uživatelských atributů (volitelné)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Používá {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Nastavit SSO založené na SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML Autentifikace"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Nastavte Vašeho poskytovatele identity (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Váš poskytovatel identity bude potřebovat znát následující info o Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL pro IdP kam má zpětně odkázat"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Tohle je známo jako Single Sign On URL v Okta, nebo Application Callback URL v Auth0, nebo ACS (Consumer) URL v OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML atributy"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "Ve většině IdP musíte nastavit všechny tyto atributy."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Atribut pro e-mail"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Atribut pro jméno"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Atribut pro příjmení"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Sdělte Metabase něco o Vašem poskytovateli identity"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase potřebuje znát následující informace o vašem poskytovateli."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL pro poskytovatele identity SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Cetrifikát od poskytovatele identity SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Název SAML aplikace"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Podepsat SSO požadavky (volitelné)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Cesta pro SAML trezor"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Heslo pro SAML trezor"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Tiše..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Alias pro SAML trezor"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Synchronizuj členství ve skupině s vaším SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Aby to šlo povolit, musíte nastavit mapování a Metabase vědělo, do kterých skupin mají být na základě SSO přidáni."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Název skupiny"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Atribut skupiny"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Poznámka:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Pokud již máte SAML aktivní a některé z těchto nastavení změníte, pak musíte Metabase restartovat aby se změny projevily."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Umožnit uživatelům přihlásit se pomocí poskytovatele identity SAML."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Umožnit uživatelům přihlásit se pomocí poskytovatele identity JWT."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Povolit přihlášení heslem"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Pokud je povoleno, tak se můžou uživatelé taky přihlásit pomocí mailu a hesla."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Upozorni správce o nových SSO uživatelích"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Pokud je povoleno, správce dostane mail při prvním přihlášení uživatele pomocí SSO."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Nastavení níže slouží ke konfiguraci SSO přes SAML. Pokud máte nějaké dotazy, navštivte {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "dokumentace"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI pro poskytovatele identity SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT Autentifikace"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI pro poskytovatele identity JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Řetězec použitý pro podepisovací klíč JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Vkládání celé Metabase aplikace"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Pokud chce povolit kompletní vkládání pro celou Metabase, vložte původ stránek nebo webových aplikací které chcete vložit do iframe, oddělit čárkou. Zde je přehled {0} toho co lze zadat."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Povolit sandboxový přístup k této tabulce"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Uživatelé v této pohledové skupině pro tuto tabulku můžou vidět to co mají filtrováno na základě jeho uživatelského atributu. Nebo taky vlastní pohled založený na uložené otázce."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Jak chcete uživatelům v této skupině filtrovat tuto tabulku ?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Zvolte uloženou otázku, která vrací vlastní pohled této tabulky, tak aby ji tito uživatelé viděli."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Také zde můžete zadat další filtry na základě uživatelských atributů. Tyto filtry jsou aplikovány jako první, před těmi které jsou v otázce již uloženy."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Aby tahle možnost fungovala, vaši uživatelé musí mít nějaké atributy."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Pro přidání dalších filtrů, vaši uživatelé musí mít nějaké atributy."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Žádné uživatelské atributy."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Zvolte uživatelský atribut."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Zvolte parametr"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Zvolte kolonku"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Uživatelé v {0} můžou vidět"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "řádků v otázce {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "řádků v tabulce {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "kde {0} se rovná {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "a {0} se rovná {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Můžete automaticky přidat atributy konfigurací SSO které používá SAML, nebo je zadat ručně v sekci Lidé a kliknout na menu ... v pravé části obrazovky."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Atribut uživatele"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Můžeme automaticky přidat atributy vašich uživatelů, pokud jste nakonfiguroval SSO, nebo je zadejte ručně ve správcovské sekci Lidé, kliknutím na menu ... v pravé části obrazovky."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parametr nebo proměnná"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "se rovná"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Udělit sandboxový přístup "
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Sandboxový přístup "
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Editovat sandboxový přístup"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Editovat detaily složky"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Změnit oprávnění"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Vytvořte vaši novou složku"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nová složka"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Máme potíže ověřit váš token"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Prosím ověřte, že vaše instance se dokáže připojit serverům Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Získat pomoc"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Získejte více funkcí Metabase s Enterprise Edicí"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Seznam nástrojů, které můžete potřebovat pro rychlé a snadné reporty, nebo pro použití Metabase ve velké organizaci"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Aktivovat licenci"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Vaše zkušební období je aktivováno s těmito funkcemi"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Zkušební období končí {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Potřebuje pomoci? Pomocí placené podpory?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Napište nám"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Vaše zkušební období skončilo"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Potřebujete více času? Připraveni ke koupi?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Vaše funkce jsou aktivní!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Vaše licence je platná do {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Vaše licence expirovala"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Expirovala dne {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Chcete obnovit Vaši licenci?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Prozkoumejte jak to použít"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Není součásti vašeho současného předplatného"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Vložte klíč přijatý z obchodu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Aktivovat"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Potřebuje pomoci?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Více informací o problému."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Kontaktovat podporu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Sandboxy pro data"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Zajistí aby správní lidé viděli správná data. A to pomocí automatických a zabezpečených filtrů, které jsou založeny na atributech uživatele."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Grafické úpravy"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Přizpůsobí Metabase vaší obchodní značce pomocí vlastních barev, loga, atd..."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Auditování"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Sledujte výkonnost a chování pomocí robustních auditovacích nástrojů."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Jednotné přihlášení"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Poskytne jednoduché přihlašování při využití stávajícího přihlašovacího prostředí."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Obchod"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Název aplikace"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Barevná paleta"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Ikona"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Úvodní obrazovka"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Bez skupin"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Oprávnění pro {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Oprávnění pro tuto složku"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Poskytnout práva pro úpravy"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Může editovat výstřižky v této složce"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Poskytnout práva pro zobrazení"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Může vkládat a používat výstřižky v této složce, ale nemůže editovat jejich SQL dotaz"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Nemůže zobrazit nebo vložit výstřižky v této složce"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Může změnit podsložky"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "První den v týdnu"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Vyskytl se problém s přihlášením přes Google. Prosím kontaktujte správce."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "k datu"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "v čase"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Otevřít menu s akcemi"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Nedělat nic"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Přejít na vlastní umístění"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Aktualizovat filtr nástěnky"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} aktualizuje {1} filtr"
+msgstr[1] "{0} aktualizuje {1} filtry"
+msgstr[2] "{0} aktualizuje {1} filtry"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} přejde na {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Chování při kliknutí na každý sloupec"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Přejít na vlastní umístění"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Otevřít menu akcí"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Chování při kliknutí pro {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Zvolte jeden nebo více filtrů k aktualizaci"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Uložená otázka"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Odkaz na"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Vložit URL s odkazem"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Můžete vložit hodnotu ze sloupce nebo filtr nástěnky za použití jeho jména, jako je: {{nějaký_sloupec}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "např. http://firma.cz/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Zvolte nástěnku..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Zvolte otázku..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Zvolte nástěnku k propojení..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Zvolte otázku k propojení..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Předat hodnoty k filtru této nástěnky (volitelné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Předat hodnoty k proměnné této otázky (volitelné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Předat hodnoty k filtru této otázky (volitelné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filtry nástěnky"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Atributy uživatele"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Přizpůsobit text odkazu (volitelné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "Např. detaily pro {{Nazev Sloupce}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Hodnoty na které se možno odkázat"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Nedostupné cíle"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filtr"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "proměnná"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Ostatní dostupné filtry"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Dostupné filtry"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Ostatní dostupné proměnné"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Dostupné proměnné"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Ostatní dostupné sloupce"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Dostupné sloupce"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "atribut uživatele"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Karta s textem"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Akce pro kliknutí"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Možnosti vizualizace"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Upravit série"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Přidat série"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Po kliknutí"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Změnit nadpis a popisek"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Upravil jste vložené parametry a bude muset aktualizovat kód pro vkládání."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Přidat otázku"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Upravujete nástěnku"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Sloupec k filtrování"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "sbírka s části kódu"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "sbírka s části kódů"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Pojmenujte vaši složku"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Něco krátkého ale výstižného"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Složka by měl být v"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Otevřít menu akcí"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} složka má vlastní chování"
+msgstr[1] "{0} složky mají vlastní chování"
+msgstr[2] "{0} složek má vlastní chování"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Jít na..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Jít na nástěnku"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Jít na otázku"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Jít na adresu"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filtruj tuto nástěnku"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Vrátí počet řádků ve vybraných datech."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Sloupec nebo číslo k sečtení."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Číselný sloupec pro získání standardní odchylky."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Číselný sloupec pro vypočtení průměru."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Vrátí nejmenší hodnotu nalezenou ve sloupci"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Sečte určený sloupec pouze pro řádky odpovídající podmínce."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Vrátí číselný rozptyl pro zadaný sloupec."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Teplota"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Sloupec nebo číslo pro vypočtení rozptylu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Vrátí medián pro zadaný sloupec."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Sloupec nebo číslo pro vypočtení mediánu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "hodnota-percentily"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Vrátí percentilu pro zadaný sloupec."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Sloupec nebo číslo pro vypočtení precentilu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Hodnota percentily."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Převede všechna písmena textového řetězce na malá."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Sloupec s textovým řetězcem k převodu na malá."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Převede všechna písmena textového řetězce na velká."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Sloupec nebo text, ze kterého se má část vrátit "
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Sloupec nebo text, který se má prohledat."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Spojí dva a více textových řetězců dohromady."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Sloupec nebo text kde začít."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Toto bude přidáno na konec hodnoty1, a tak dále."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Enormní"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigantický"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Vrátí počet znaků textového řetězce."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Sloupec nebo text, pro který chcete zjistit délku."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Sloupec nebo text, který chcete ořezat."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Pro zadaný sloupec vrátí absolutní (kladnou) hodnotu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Dluh"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Sloupec nebo číslo, pro které se má vrátit absolutní (kladná) hodnota."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Zaokrouhlí desetinné číslo směrem dolů."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Sloupec nebo číslo pro zaokrouhlení směrem dolů."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Zaokrouhlí desetinné číslo směrem nahoru."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Sloupec nebo číslo pro zaokrouhlení směrem nahoru."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Zaokrouhlí desetinné číslo dolů nebo nahoru k nejbližší celé hodnotě."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "Sloupec nebo číslo pro zaokrouhlení k nejbližší celé hodnotě."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Vrátí druhou odmocninu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Přepona"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Sloupec nebo číslo pro zjištění druhé odmocniny."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Umocní číslo na zadaný exponent."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Délka"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Sloupec nebo číslo jako základ mocniny."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Hodnota n-té mocniny."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Vrátí dekadický logaritmus čísla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Hodnota"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Sloupec nebo číslo pro získání logaritmu čísla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Vrátí přirozený logaritmus čísla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Úrokové měsíce"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Sloupec nebo číslo pro získání přirozeného logaritmu čísla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Sloupec nebo číslo k ověření."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Ověří jestli je číslo nebo datum uvnitř zadaného rozsahu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Vytvořeno dne"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Sloupec s číslem nebo datem kde se nachází počáteční a koncové hodnoty."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Počátek rozsahu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Konec rozsahu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Ověří jestli je datum uvnitř relativního rozsahu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Sloupec s datem pro získání relativního intervalu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Doba intervalu, kde záporné hodnoty znamenají návrat v čase."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Typ intervalu jako \"den\", \"měsíc\", \"rok\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Sloupec nebo hodnota k navrácení."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Pokud je hodnota1 prázdná, bude vrácena hodnota2 pokud tato není prázdná, a tak dále."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Otestuje hodnotu oproti seznamu výrazů a vrátí odpovídající hodnotu prvního odpovídajícího výrazu. Volitelně lze nastavit návratovou hodnotu pro případ žádné shody."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Hodnota která bude navrácena, pokud je platná předešlá podmínka, a tak dále."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Nemá hodnotu"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Má hodnotu"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Přídavný součet všech hodnot sloupce. \n"
+"Např. celkový příjem v čase."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Přídavný počet řádků. \n"
+"Např. celkový počet prodejů v čase."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Propojené fitry"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Popis"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Výchozí hodnota"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Bez výchozí hodnoty"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Pro zobrazení, {0} musí být spojeno alespoň s jedním polem."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Omezit možnosti tohoto filtru"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Pokud máte další filtr nástěnky, můžete omezit jeho možnosti na základě výběru jiného filtru."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Jako první, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "přidat další filtr nástěnky"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Když to na některých z těchto filtrech nástěnky povolíte, vybraná hodnota z tohoto filtru omezí možnosti pro filtr {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Filtrovací sloupec."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Filtrovaný sloupec."
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Zadejte jméno uživatele nebo mailovou adresu."
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Nový výstřižek"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 odpoledne"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 v noci"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 dopoledne"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Co hodinu"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Denně v {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Týdně v {0} a v {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Měsíčně v {0} {1} a v {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Zrušit tento odběr"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Odběry"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Vytvořit odběry pro nástěnku"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Poslat mailem"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Tuto nástěnku můžete pravidelně posílat užívatelům nebo na mailovou adresu."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Odeslat na Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Zvolte kanál a termín, Metabase zařídí zbytek."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Odeslat nástěnku mailem"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Neposílat pokud nemá výsledky"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Připojit výsledky"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Příloha může mít až 2000 řádků s daty."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Odeslat nástěnku na Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Nástěnka nemá parametr s ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Parametr {0} k sobě nemá přidružené žádné pole."
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include musí být buď prázdné, nebo s hodnotou 'tabulky'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "`database` je vyžadována pro všechny dotazy jejíž typ není `internal`."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Přihlášení heslem zde není povolené."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Váš účet byl deaktivován. Kontaktujte správce."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Váš účet byl deaktivován."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Neplatný token Slacku."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "Příkaz ''{0}'' je dostupný pouze v Enterprise edici Metabase."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Rozšíření pro Enterprise edici Metabase JSOU dostupné."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Použití funkcí Enterprise edice Metabase je vázané na obchodní licenci Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Pro detaily načti {0}."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Rozšíření pro Enterprise edici Metabase NEJSOU dostupné."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Byl jste pozván připojit se k {1} od {0}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} vytvořil účet {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} přijal pozvání {1}"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Požadavek na změnu hesla"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Oznámení"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Pomoci zlepšit [{1}]"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Sdělit zpětnou vazbu."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Chyba pri spousteni naslouchace udalosti"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Můžeme synchronizovat uživatelské atributy, když se někdo přihlásí přes LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Seznam uživatelských atributů (oddělených čárkou) které se mají při LDAP synchronizování přeskočit."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Neplatný token."
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Chyba Slack API: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Slack kanál pojmenovaný `metabase_files` nebyl nalezen!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Prosím vytvořte nebo obnovte smazaný kanál aby šlo dokončit integraci se Slackem."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Kanál použitý pro zobrazení grafů které jsou součástí Pulzů nebo odpovědí MetaBota."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Nahraný obrázek"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Chyba při nahrání souborů na Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Neplatná relace. Byla očekávana instance Relace."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "cookie relace SameSite byla nastavena na \"None\", ale stránka je"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "obsloužena přes nezabezpečené spojení. Některé prohlížeče odmítnou "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookies za těchto podmínek. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Hlavní složka"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parameters musí být posloupnost map s String :id keys"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Neplatné lidmi-čitelné-hodnoty: hodnoty musí být posloupnost; každá položka musí být \"nil\" nebo textový řetězec"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":values musí být přítomné k načtení pro: lidmi-čitelné-hodnoty"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Celková délka hodnot políček je > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "Název výstřižku nemůže obsahovat '}' nebo začínat mezerou."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Chyba při spouštění dotazu pro zřetězené filtry"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Pole {0} neexistuje."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Nelze vyhledávat oproti netextovému poli {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Uděluji oprávnění pro skupinu {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Odebírám oprávnění pro skupinu {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Neplatné oprávnění k DB: pokud máte možnost zápisu pro nativní dotazy, musíte mít plný přístup k datům."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Neplatné oprávnění k DB: pokud máte možnost čtení nativních dotazů, musíte mít také plný přístup k datům."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Měním oprávnění z {0} na: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "klíčové atributy pro přihlášení musí být klíčové slovo nebo text"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Výchozí jazyk pro všechny uživatele v Metabase, odesílané maily, pulzy a upozornění."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Uživatelé si mohou pro vlastní účet změnit výchozí jazyk."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Výchozí stránka, která se má uživateli zobrazit"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Povolí tomuto zdroji integrovat kód celé Metabase"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Hodnoty větší než {0} ({1}) nejsou povoleny."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Toto nahradí slovo \"Metabase\" kdekoliv se ukáže."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Toto jsou hlavní barvy použité v grafech a naskrz Metabase. Možná bude potřeba v prohlížeči udělat refresh aby šlo vidět změny."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Pro lepší výsledek použijte SVG soubor s průhledným pozadím."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "Adresa nebo obrázek, který chcete použit jako ikonu."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Povolí přihlášení pomocí mailu a hesla."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Toto ovlivní věci jako seskupování podle týdne nebo filtrování v GUI dotazech.\n"
+"Neovlivní to SQL dotazy."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Nelze zkontrolovat token"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Formát tokenu je neplatný."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Chyba při kontrole tokenu"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Chyba při filtrování pole {0} : nelze ověřit řetězec {1} na {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Chyba při načítání detailů pro Úlohu: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Spoustim synchronizacni ulohu pro Databazi {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Nelze synchronizovat Databazi {0}: databaze neexistuje."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Uloha pro aktualizaci hodnot poli byla spustena u Databaze {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Preskakuji aktualizaci, automaticka aktualizace hodnot poli byla deaktivovana pro databazi {0}."

--- a/locales/de.po
+++ b/locales/de.po
@@ -28,15 +28,16 @@ msgstr "Erkunde diese Daten"
 msgid "Select a database type"
 msgstr "Wähle einen Datenbanktyp"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Speichern"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Damit Metabase etwas seiner Magie entfalten kann, muss deine Datenbank untersucht werden. Als dann werden wir sie periodisch prüfen, um die Metadaten aktuell zu halten. Du kannst den Zeitpunkt dieses Scans unten festlegen."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Datenbank-Synchronisierung"
 
@@ -64,7 +65,7 @@ msgstr "Dieser Prozess prüft regelmäßig auf Updates der Schemata. Zumeist kan
 msgid "Scan"
 msgstr "Scannen"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Nach Filterwerten scannen"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase kann Werte eines jeden Feldes der Datenbank prüfen, um Checkboxen in Dashboards und Fragen zu ermöglichen. Dies kann insbesondere für größere Datenbank ein ressourenintensiver Prozess sein."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Wann soll Metabase Felder automatisch prüfen und Werte puffern?"
 
@@ -133,29 +134,31 @@ msgstr "LÖSCHEN"
 msgid "in this box:"
 msgstr "in dieses Eingabefeld:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -178,9 +181,9 @@ msgstr "Löschen"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -200,8 +203,9 @@ msgstr "Verbindung"
 msgid "Scheduling"
 msgstr "Planung"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -281,10 +285,10 @@ msgstr "Datenbank hinzufügen"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -319,10 +323,8 @@ msgid "Successfully saved!"
 msgstr "Erfolgreich gespeichert!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -401,26 +403,29 @@ msgstr "Wähle ein speziellen Typ"
 msgid "Select a target"
 msgstr "Wähle ein Ziel"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Spalten"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Spalte"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Typ"
 
@@ -428,7 +433,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Aktuelle Datenbank:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Originalschema anzeigen"
 
@@ -498,7 +503,7 @@ msgstr "Finde eine Tabelle"
 msgid "Schemas"
 msgstr "Schemata"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -515,7 +520,7 @@ msgstr "Hinzufügen einer Metrik"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definition"
 
@@ -583,35 +588,35 @@ msgstr " Geschichte"
 msgid "Revision History for"
 msgstr "Revisionshistorie für"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - Feldeinstellungen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Wo dieses Feld in Metabase erscheint"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtern des Feldes"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Welche Eingaben sollen Benutzer tätigen, wenn sie das Feld filtern möchten?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Keine Beschreibung für dieses Feld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Originalwert"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Zugeordneter Wert"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Wert eingeben"
 
@@ -628,31 +633,31 @@ msgid "Custom mapping"
 msgstr "Eigene Zuordnung"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Unbestimmter Zuordnungstyp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Aktuelles Feld ist kein Fremdschlüssel oder es fehlen Metadaten der Fremdschlüssel-Zieltabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Das ausgewählte Feld ist kein Fremdschlüssel"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Anzeigewerte"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Wähle diese Option, um den ursprünglichen Wert aus der Datenbank anzuzeigen, oder lasse dir die zugehörigen oder benutzerdefinierten Informationen in diesem Feld anzeigen."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Wähle ein Feld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Bitte wähle eine anzuzeigende Spalte."
 
@@ -660,16 +665,16 @@ msgstr "Bitte wähle eine anzuzeigende Spalte."
 msgid "Tip:"
 msgstr "Hinweis:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Möglicherweise möchtest du den Feldnamen aktualisieren, um sicherzustellen, dass er auf der Grundlage deiner Umstellungen noch sinnvoll ist."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Gepufferte Feldwerte"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kann die Werte für dieses Feld prüfen, um Listenfitler für Dashboards und Fragen zu aktivieren."
 
@@ -696,35 +701,36 @@ msgstr "Verwerfen gestartet!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Wähle eine beliebige Tabelle aus, um ihr Schema anzuzeigen und Metadaten hinzuzufügen oder zu bearbeiten."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Name ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Beschreibung ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Änderungstext ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Aggregation ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Editieren Deiner Metrik"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Erstellen Deiner Metrik"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Nimm Änderungen an deiner Metrik vor und hinterlasse eine Erläuterung."
 
@@ -732,46 +738,46 @@ msgstr "Nimm Änderungen an deiner Metrik vor und hinterlasse eine Erläuterung.
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Du kannst gespeicherte Metriken erstellen, um dieser Tabelle eine benannte Metrikoption hinzuzufügen. Gespeicherte Metriken umfassen den Aggregationstyp, das aggregierte Feld und optional jeden von dir hinzugefügten Filter. Als Beispiel kannst du damit so etwas wie die offizielle Art der Berechnung des \"Durchschnittspreises\" für eine Bestell-Tabelle erstellen."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Ergebnis: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Benenne Deine Metrik"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Benenne Deine Metrik, um anderen zu helfen, sie zu finden."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Eine Beschreibung, aber nicht zu lang"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Beschreibe Deine Metrik"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Gib deiner Metrik eine Beschreibung, damit andere verstehen, worum es geht."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Dies ist ein guter Ort, um genauer auf weniger offensichtliche metrische Regeln einzugehen"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Grund der Änderung"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Hinterlasse eine Notiz, um zu erklären, welche Änderungen du vorgenommen hast und warum sie erforderlich waren."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Dies wird in der Revisionshistorie für diese Metrik angezeigt, damit sich jeder daran erinnern kann, warum sich die Dinge geändert haben"
 
@@ -824,6 +830,7 @@ msgstr "Dies wird in der Revisionshistorie für dieses Segment angezeigt, damit 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -838,8 +845,7 @@ msgid "Re-scan this table"
 msgstr "Diese Tabelle erneut scannen"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -856,7 +862,7 @@ msgid "Last name"
 msgstr "Nachname"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "E-Mail-Adresse"
@@ -865,7 +871,7 @@ msgstr "E-Mail-Adresse"
 msgid "Permission Groups"
 msgstr "Berechtigungsgruppen"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Diesen Benutzer zum Administrator machen"
 
@@ -964,6 +970,8 @@ msgstr "Gruppe löschen"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -976,11 +984,12 @@ msgstr "Fertig"
 msgid "Group name"
 msgstr "Gruppenname"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Gruppen"
@@ -1089,7 +1098,7 @@ msgstr "Zurücksetzen"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Bist du sicher, dass du es tun möchtest?"
 
@@ -1202,7 +1211,7 @@ msgstr "Es werden keine Änderungen an Berechtigungen vorgenommen."
 msgid "You've made changes to permissions."
 msgstr "Du hast Änderungen an Berechtigungen vorgenommen."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Berechtigungen dieser Sammlung"
 
@@ -1258,6 +1267,7 @@ msgstr "Zugriff beschränken"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Zugriff widerrufen"
 
@@ -1321,23 +1331,23 @@ msgstr "Sammlung organisieren"
 msgid "View collection"
 msgstr "Sammlung ansehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Datenzugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Tabellen ansehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Schemas ansehen"
 
@@ -1408,12 +1418,15 @@ msgstr "Gesendet!"
 msgid "Clear"
 msgstr "Löschen"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Authentifizierung"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Servereinstellungen"
@@ -1426,6 +1439,7 @@ msgstr "Benutzerschema"
 msgid "Attributes"
 msgstr "Attribute"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Gruppenschema"
@@ -1497,6 +1511,9 @@ msgid "Add a map"
 msgstr "Karte hinzufügen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1506,19 +1523,19 @@ msgid "Delete custom map"
 msgstr "Lösche individuelle Karte"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Löschen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1616,19 +1633,19 @@ msgstr "Token kaufen"
 msgid "Enter a token"
 msgstr "Token eingeben"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Editiere Zuordnungen"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Gruppenzuordnung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Erstelle eine Zuordnung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1739,9 +1756,10 @@ msgstr "Site URL"
 msgid "Email Address for Help Requests"
 msgstr "E-Mail-Adresse für Hilfeanfragen"
 
+#. Changed to "Abfragen" which matches the context better, I think.
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
-msgstr "Zeitzone der Reporte"
+msgstr "Zeitzone der Abfragen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
@@ -1868,18 +1886,27 @@ msgstr "Benutzerfilter"
 msgid "Check your parentheses"
 msgstr "Überprüfe deine Klammern"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "E-Mail-Attribute"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Vornamen-Attribut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Nachnamen-Attribut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Synchronisiere Gruppen-Mitgliedschaften"
@@ -1908,59 +1935,59 @@ msgstr "Eigene Karten"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Füge deine eigene GeoJSON Datei hinzu, um verschiedene Kartenvisualisierungen zu aktivieren"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Öffentliches Teilen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Aktiviere Öffentliches Teilen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Geteilte Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Geteilte Fragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Einbettung in andere Applikationen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Aktivieren die Einbettung von Metabase in andere Applikationen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Einbetten des geheimen Schlüssels"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Eingebettete Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Eingebettete Fragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Aktiviere Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Minimale Abfragedauer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Cache Time-To-Live (TTL) Multiplikator"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Max Cachegröße"
 
@@ -2002,27 +2029,27 @@ msgstr "Du benötigst einen Administrator, um ein Metabase Konto zu erstellen, b
 msgid "Sign in with {0}"
 msgstr "Anmelden mit {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Kontaktiere einen Administrator, um dein Passwort zurücksetzen zu lassen"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Passwort vergessen"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Deine E-Mail-Adresse für das Metabase-Konto"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Sende E-Mail zur Kennwortzurücksetzung"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Prüfe deine E-Mails, um weitere Informationen zur Kennwortzurücksetzung zu erhalten."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Bei Metabase anmelden"
 
@@ -2043,11 +2070,11 @@ msgstr "Anmelden"
 msgid "I seem to have forgotten my password"
 msgstr "Ich habe mein Passwort vermeintlich vergessen"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "beantrage eine neue E-Mail zur Kennwortzurücksetzung"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Ups, das ist ein abgelaufener Link"
 
@@ -2056,11 +2083,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Aus Sicherheitsgründen laufen E-Mails zur Kennwortzurücksetzung nach einer gewissen Weile ab. Solltest du dein Passwort weiterhin zurücksetzen wollen, kannst du {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Um die Daten sicher zu halten, Passwörter {0}"
 
@@ -2083,24 +2110,24 @@ msgstr "Bestätige neues Passwort"
 msgid "Make sure it matches the one you just entered"
 msgstr "Stelle sicher, dass es dem bereits Eingegebenen entspricht"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Dein Passwort wurde zurückgesetzt."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Melde dich mit deinem neuen Passwort an"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Speichern fehlgeschlagen"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2110,25 +2137,26 @@ msgstr "Gespeichert"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Möchtest du die Sammlung archivieren?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Alle Dashboards, Sammlungen und Pulses in dieser Sammlung werden auch archiviert."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Archiv"
 
@@ -2253,7 +2281,7 @@ msgstr "Pins"
 msgid "Drag something here to pin it to the top"
 msgstr "Ziehe etwas hierher, um es oben anzupinnen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2282,6 +2310,7 @@ msgstr "Bewege \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Verschieben"
@@ -2317,7 +2346,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "Auf einige Datenbanken können nur mittels SSH Bastion Host zugegriffen werden. Diese Option integriert gleichfalls eine höhere Ebenen an Sicherheit, sobald das VPN nicht erreichbar ist. Im Normalfall ist die Verbindung langsamer als eine Direktanbindung."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Dies ist eine große Datenbank. Lasst mich also selbst entscheiden, wann Metabase synchronisiert und prüft"
 
@@ -2358,7 +2387,7 @@ msgstr "Um Metabase mit diesen Daten verwenden zu können, musst du den API-Zugr
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0}, um zur Konsole zu gelangen, insofern du das noch nicht getan hast."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Wie würdest du gerne auf diese Datenbank referenzieren?"
 
@@ -2474,35 +2503,35 @@ msgstr "Basierend auf dem Schema"
 msgid "A look at your"
 msgstr "Ein Blick auf"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Liste durchsuchen"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Suche nach {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " oder gibt eine ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "ID eingeben"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Nummer eingeben"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Text eingeben"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Keine Treffer für {0} gefunden."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Jede Option in deinem Filter zu verwenden wird wahrscheinlich nicht viel bewirken…"
 
@@ -2514,7 +2543,6 @@ msgstr "Etwas ging schief"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Wir sind auf einen Fehler gestoßen. Du kannst versuchen, die Seite zu aktualisieren oder einfach zurücknavigieren."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2525,12 +2553,12 @@ msgstr "Wir sind auf einen Fehler gestoßen. Du kannst versuchen, die Seite zu a
 msgid "No description yet"
 msgstr "Noch keine Beschreibung"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Neue {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Gefragt durch {0}"
 
@@ -2551,7 +2579,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Wiederhergestellt zu einer früheren Version und {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Revisionshistorie"
@@ -2597,7 +2627,7 @@ msgid "Questions"
 msgstr "Fragen"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Pulses"
 
@@ -2671,52 +2701,69 @@ msgstr "Nicht jetzt"
 msgid "Error:"
 msgstr "Fehler:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Sonntag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Montag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Dienstag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Mittwoch"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Donnerstag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Freitag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Samstag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Erster"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Letzter"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15. (Mittelpunkt)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Kalender Tag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "deine Metabase Zeitzone"
 
@@ -2770,11 +2817,11 @@ msgstr "Erstellen"
 msgid "Create dashboard"
 msgstr "Dashboard erstellen"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabelle"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Datenbank"
 
@@ -2849,9 +2896,9 @@ msgstr "Wie lautet der Name deiner Karte?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2865,15 +2912,16 @@ msgstr "Beschreibung"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Es ist optional, aber sehr hilfreich"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "In welche Sammlung soll es gehen?"
 
@@ -2913,11 +2961,11 @@ msgstr "Dashboard archivieren"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Stelle sicher, dass du für jede Serie eine Auswahl triffst, sonst funktioniert der Filter auf dieser Karte nicht."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Dieses Dashboard sieht leer aus."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Füge eine Frage hinzu, um es nützlicher zu machen!"
 
@@ -2937,7 +2985,7 @@ msgstr "Vollbild beenden"
 msgid "Enter fullscreen"
 msgstr "Vollbild anzeigen"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Speichern…"
@@ -2950,7 +2998,8 @@ msgstr "Füge eine Frage hinzu"
 msgid "Add a question to this dashboard"
 msgstr "Füge eine Frage zu diesem Dashboard hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Füge einen Filter hinzu"
 
@@ -2958,7 +3007,7 @@ msgstr "Füge einen Filter hinzu"
 msgid "Parameters"
 msgstr "Parameter"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Füge ein Textfeld hinzu"
 
@@ -2966,7 +3015,7 @@ msgstr "Füge ein Textfeld hinzu"
 msgid "Move dashboard"
 msgstr "Bewege das Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Ändere das Dashboard"
 
@@ -2990,11 +3039,11 @@ msgstr "Bewege das Dashboard nach..."
 msgid "Dashboard moved to {0}"
 msgstr "Dashboard wurde nach {0} verschoben"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Was möchtest du filtern?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Welche Art von Filter?"
 
@@ -3066,20 +3115,22 @@ msgstr "Diese Karte hat keine Felder oder Parameter, die auf diesen Parametertyp
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Die Werte in diesem Feld überschneiden sich nicht mit den Werten anderer Felder, die du ausgewählt hast."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Keine validen Felder"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Name darf maximal 100 Zeichen lang sein"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Farbe ist notwendig"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Wie lautet der Name deines Dashboards?"
 
@@ -3134,7 +3185,7 @@ msgstr "erhielt aktuellste Daten von"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -3259,9 +3310,10 @@ msgstr "Du hast dir in letzter Zeit keine Dashboards oder Fragen angeschaut"
 msgid "{0} items selected"
 msgstr "{0} Elemente ausgewählt"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Stelle aus dem Archiv wieder her"
 
@@ -3379,7 +3431,7 @@ msgid "Zip Code"
 msgstr "PLZ"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Menge"
 
@@ -3412,11 +3464,13 @@ msgid "User"
 msgstr "Benutzer"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Quelle"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Preis"
 
@@ -3449,21 +3503,23 @@ msgid "Subscription"
 msgstr "Abonnement"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Ergebnis"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titel"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -3517,14 +3573,14 @@ msgstr "Metabase wird dieses Feld nie abrufen. Benutze dies für vertrauliche od
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Anzahl"
 
@@ -3532,7 +3588,7 @@ msgstr "Anzahl"
 msgid "CumulativeCount"
 msgstr "Kumulative Zählung"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3550,19 +3606,19 @@ msgstr "Eindeutig"
 msgid "StandardDeviation"
 msgstr "Standardabweichung"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Durchschnitt"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3573,13 +3629,13 @@ msgstr "Max"
 msgid "sad sad panda, lexing errors detected"
 msgstr "trauriger trauriger Panda, Lexing-Fehler entdeckt"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} Sekunde"
 msgstr[1] "{0} Sekunden"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} Minute"
@@ -3620,14 +3676,15 @@ msgstr "Was möchtest du herausfinden?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Rohdaten"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Kumulative Zählung"
 
@@ -3689,166 +3746,164 @@ msgstr "Wahr"
 msgid "False"
 msgstr "Falsch"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Wähle limitierendes Feld aus"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Setze oberes Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Setze linkes Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Setze unteres Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Setze rechtes Limit"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Ist"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Ist nicht"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Ist leer"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Nicht leer"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Gleich zu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Nicht gleich zu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Größer als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Kleiner als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Zwischen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Größer oder gleich als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Kleiner oder gleich als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Enthält"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Enthält nicht"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Startet mit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Endet mit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Vor"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Nach"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Intern"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Nur eine Tabelle mit den Zeilen in der Antwort ohne zusätzlichen Operationen."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Zählen der Zeilen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Gesamtanzahl der Zeilen einer Antwort."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Summe von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Summe aller Werte einer Spalte."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Durchschnitt von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Durchschnitt aller Werte einer Spalte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Anzahl eindeutiger Werte von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Anzahl eindeutiger Werte einer Spalte für die Zeilen einer Antwort."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Kumulative Summe von..."
 
@@ -3856,7 +3911,7 @@ msgstr "Kumulative Summe von..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Additive Summe aller Werte einer Spalte.\\\\ne.x. Gesamtumsatz über die Zeit."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Kumulative Zählung von Zeilen"
 
@@ -3864,27 +3919,27 @@ msgstr "Kumulative Zählung von Zeilen"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Additive Zählung von Reihen.\\\\ne.x. Gesamtanzahl vom Verkauf über die Zeit."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Standardabweichung von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Zahl, die angibt, wie stark die Werte einer Spalte zwischen allen Zeilen der Antwort variieren."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Minimum von ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Minimalwert einer Spalte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Maximum von ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Maximalwert einer Spalte"
 
@@ -3900,6 +3955,8 @@ msgstr "Kleinbuchstabe"
 msgid "upper case letter"
 msgstr "Grossbuchstabe"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "Nummer"
@@ -4147,7 +4204,7 @@ msgstr "Wie du Metriken erstellst"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Betrachte Daten über die Zeit, als Kartendiagramm oder als Pivot, um Trends und Veränderungen besser zu verstehen."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
@@ -4170,7 +4227,7 @@ msgstr "Native Abfrage"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Für kompliziertere Fragen kannst du deine eigenen SQL- bzw. native Abfragen schreiben."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Wähle einen Standardwert…"
 
@@ -4261,7 +4318,7 @@ msgstr "Dieser Monat"
 msgid "This Year"
 msgstr "Dieses Jahr"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Gib einen Wert ein..."
@@ -4271,7 +4328,7 @@ msgid "Enter a default value..."
 msgstr "Trage einen Standardwert ein..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetaucht"
@@ -4530,22 +4587,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Wähle Fragen, die du gerne in diesem Pulse senden möchtest"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "E-Mails"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slack-Nachrichten"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Versendet"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} wird gesendet an"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Nachrichten"
 
@@ -4618,30 +4683,30 @@ msgstr "Helfe jedem in deinem Team, mit deinen Daten synchron zu bleiben."
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Mit Pulses können Daten aus Metabase per E-Mail oder Slack nach einem Zeitplan deiner Wahl versendet werden."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Nach {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Vor {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Ist leer"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Nicht leer"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Allzeit"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Anwenden"
 
@@ -4744,12 +4809,12 @@ msgstr[1] "Siehe diese {0}"
 msgid "Zoom in"
 msgstr "Heranzoomen"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Benutzerdefinierter Ausdruck"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Allgemeine Metriken"
 
@@ -4946,7 +5011,7 @@ msgstr "normalerweise"
 msgid "Pick a segment or table"
 msgstr "Wähle ein Abschnitt oder eine Tabelle"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Wähle eine Datenbank"
@@ -5007,7 +5072,7 @@ msgstr "Sortieren"
 msgid "Row limit"
 msgstr "Zeilenlimit"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Unbekanntes Feld"
 
@@ -5015,7 +5080,7 @@ msgstr "Unbekanntes Feld"
 msgid "field"
 msgstr "Feld"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Stimmt überein"
 
@@ -5040,11 +5105,11 @@ msgstr "Füge eine Gruppierung hinzu"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Daten"
 
@@ -5061,11 +5126,12 @@ msgstr "Ansicht"
 msgid "Grouped By"
 msgstr "Gruppiert nach"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Nichts"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Diese Frage wurde in {0} geschrieben."
 
@@ -5077,7 +5143,7 @@ msgstr "Verberge Editor"
 msgid "Hide Query"
 msgstr "Verberge Abfrage"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Öffne Editor"
 
@@ -5085,7 +5151,7 @@ msgstr "Öffne Editor"
 msgid "Show Query"
 msgstr "Zeige Abfrage"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Diese Metrik ist inaktiv. Sie steht nicht mehr zur Verfügung."
 
@@ -5287,7 +5353,7 @@ msgstr "Zurück zur vorherigen Ausführung"
 msgid "Visualization"
 msgstr "Visualisierung"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Keine Beschreibung hinterlegt."
 
@@ -5344,7 +5410,7 @@ msgstr "Die Metadaten der Tabelle konnten vor dem Erstellen einer neuen Frage ni
 msgid "See {0}"
 msgstr "Siehe {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Metrik-Definition"
 
@@ -5362,11 +5428,11 @@ msgstr "Anzahl von {0}"
 msgid "See all {0}"
 msgstr "Betrachte all {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Abschnitts-Definition"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Beim Laden der Tabelle ist ein Fehler aufgetreten"
 
@@ -5374,7 +5440,7 @@ msgstr "Beim Laden der Tabelle ist ein Fehler aufgetreten"
 msgid "See the raw data for {0}"
 msgstr "Siehe die Rohdaten für {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Mehr"
 
@@ -5394,6 +5460,8 @@ msgstr "Feld-Formel"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Stelle es dir wie das Schreiben einer Formel in einem Tabellenkalkulationsprogramm vor: du kannst Zahlen, Felder und mathematische Symbole wie + und weitere Funktionen für Tabellen verwenden. Du kannst also so etwas wie Zwischensumme eingeben."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5461,7 +5529,7 @@ msgstr "falsch"
 msgid "Add filter"
 msgstr "Füge einen Filter hinzu"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Element"
 
@@ -5580,11 +5648,11 @@ msgstr "Feld soll Folgendes verknüpft werden"
 msgid "Filter widget type"
 msgstr "Feld-Widget-Typ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Wird benötigt?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Standard Filter-Widget-Wert"
 
@@ -5596,7 +5664,7 @@ msgstr "Archivieren dieser Frage?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Diese Frage wird von allen Dashboards oder Pulse, die sie verwenden, entfernt."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Frage"
 
@@ -5643,7 +5711,7 @@ msgstr "Feldtyp"
 msgid "Select a Foreign Key"
 msgstr "Wähle einen Fremdschlüssel"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Betrachte die  {0} Formel"
 
@@ -6128,22 +6196,24 @@ msgstr "Fragen über diesen Abschnitt"
 msgid "X-ray this segment"
 msgstr "X-Ray für diesen Abschnitt"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Anmeldung"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Suche"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Neue Frage"
 
@@ -6213,37 +6283,37 @@ msgstr "Die gesamte Sammlung ist völlig anonym."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "Die Sammlung kann an jeder beliebigen Stelle in den administrativen Einstellungen deaktiviert werden."
+msgstr "Die Sammlung kann zu jedem beliebigen Zeitpunkt in den administrativen Einstellungen deaktiviert werden."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Wenn du feststeckst"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "unsere Startanleitung"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "ist nur einen Klick entfernt."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Willkommen bei Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sieht so aus, als ob alles funktioniert. Lass uns gemeinsam kennenlernen, deine Daten verbinden und anfangen, ein paar Antworten für dich zu finden!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Lass uns loslegen"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Es ist alles eingerichtet!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Führe mich zu Metabase"
 
@@ -6495,40 +6565,41 @@ msgstr "Filter abbrechen"
 msgid "Pin Map"
 msgstr "Pin-Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Nicht gesetzt"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Zeilen {0}-{1} von {2}"
 
 #. Daten auf {0} Zeilen gekürzt.
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Daten auf {0} Zeilen gekürzt."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Konnte keine Visualisierung finden"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Konnte das Diagramm mit diesen Daten nicht anzeigen."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Keine Ergebnisse!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Warte weiterhin..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Das dauert gewöhnlich durchschnittlich {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Das ist ein wenig lange für ein Dashboard)"
 
@@ -6638,7 +6709,7 @@ msgid "Highlight the whole row"
 msgstr "Die gesamte Zeile hervorheben"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Farben"
 
@@ -6724,24 +6795,50 @@ msgstr "Ziel"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Mist! Die Daten aus deiner Abfrage passen nicht zu der gewählten Darstellungs-Wahl. Diese Visualisierung erfordert mindestens {0} {1} der Daten."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "Spalte"
@@ -6773,7 +6870,7 @@ msgid "xValues missing!"
 msgstr "x-Werte fehlen!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X-Achse"
 
@@ -6783,7 +6880,7 @@ msgid "Add a series breakout..."
 msgstr "Sekundärachse hinzufügen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y-Achse"
 
@@ -6796,7 +6893,7 @@ msgid "Bubble size"
 msgstr "Blasengröße"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Linie"
 
@@ -6938,20 +7035,20 @@ msgid "Standard Deviation"
 msgstr "Standardabweichung"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Fläche"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "Flächendiagramm"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Balken"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "Balkendiagramm"
 
@@ -6965,7 +7062,7 @@ msgid "Funnel"
 msgstr "Trichter"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Messen"
 
@@ -6977,81 +7074,81 @@ msgstr "Trichter-Typ"
 msgid "Bar chart"
 msgstr "Balkendiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "Liniendiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Bitte wähle die Längen- und Breitengrad-Spalten in den Diagramm-Einstellungen."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Bitte wähle eine Region-Karte."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Bitte wähle eine Region sowie die metrischen Spalten in den Diagramm-Einstellungen."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Kartentyp"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Region-Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Pin-Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Pin-Typ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Kacheln"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Markierungen"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Breitengrad-Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Längengrad-Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Metrisches Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Region-Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Radius"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Unschärfe"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Min. Transparenz"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Max. Zoom"
 
@@ -7063,7 +7160,7 @@ msgstr "Keine Beziehungen gefunden."
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "{0} ist verbunden mit:"
 
@@ -7075,31 +7172,31 @@ msgstr "Objekt Detail"
 msgid "object"
 msgstr "Objekt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Gesamt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Welche Spalten möchtest du verwenden?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Torte"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimension"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Legende anzeigen"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Zeige Prozentangaben in der Legende"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Mindestanteil"
 
@@ -7124,7 +7221,8 @@ msgid "Progress"
 msgstr "Fortschritt"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Farbe"
@@ -7133,7 +7231,7 @@ msgstr "Farbe"
 msgid "Row Chart"
 msgstr "Balkendiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "Balkendiagramm"
 
@@ -7157,15 +7255,15 @@ msgstr "Ein Suffix hinzufügen"
 msgid "Multiply by a number"
 msgstr "Multiplizieren mit einer Zahl"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Verstreuen"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "Punktdiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Pivottabelle erzeugen"
 
@@ -7215,13 +7313,13 @@ msgstr "Rechts"
 msgid "Show background"
 msgstr "Hintergrund anzeigen"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "Klasse"
 msgstr[1] "Klassen"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 #, fuzzy
 msgid "Auto binned"
 msgstr "Automatische Klassifizierung"
@@ -7461,10 +7559,13 @@ msgstr "Du hast eine Menge Fragen in {0}? Erstelle Sammlungen um sie zu organisi
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7659,7 +7760,7 @@ msgstr "kumulierte Summe"
 msgid "{0} and {1}"
 msgstr "{0} und {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} of {1}"
@@ -9005,11 +9106,11 @@ msgstr "Datenberechtigungen"
 msgid "Collection permissions"
 msgstr "Sammlungsberechtigungen"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Alle Sammlungsberechtigungen sehen"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Auch Untersammlungen ändern"
 
@@ -9021,19 +9122,19 @@ msgstr "Kann diese Sammlung und ihre Inhalte editieren"
 msgid "Can view items in this collection"
 msgstr "Kann Objekte in dieser Sammlung sehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Sammlungszugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Diese Gruppe hat die Erlaubnis, mindestens eine Untersammlung dieser Sammlung zu sehen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Diese Gruppe hat die Erlaubnis, mindestens eine Untersammlung dieser Sammlung zu bearbeiten."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Untersammlungen anzeigen"
 
@@ -9089,6 +9190,7 @@ msgstr "Ähnlich"
 msgid "More X-rays"
 msgstr "Mehr X-Rays"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9349,10 +9451,10 @@ msgstr "Teilen"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9437,7 +9539,7 @@ msgstr "Verwende JVM Zeitzone"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Wir analysieren gerade die Tabellen und Felder, um dir bei der Untersuchung der Daten helfen zu können."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Tipp: "
 
@@ -9445,7 +9547,7 @@ msgstr "Tipp: "
 msgid "Select a currency type"
 msgstr "Wähle einen Währungstypen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Feld-Typ"
 
@@ -9500,6 +9602,7 @@ msgid "Currency"
 msgstr "Währung"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Wähle einen Benutzer oder einen Kanal"
 
@@ -9662,7 +9765,7 @@ msgstr "Welche Achse?"
 msgid "Line + Bar"
 msgstr "Linie + Balken"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "Line- und Bar-Chart"
 
@@ -9682,15 +9785,15 @@ msgstr "Messbereich"
 msgid "Field to show"
 msgstr "Feld zum Anzeigen"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "Letzte {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} war {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Gruppiere nach einem Zeit-Feld, um die Entwicklung über die Zeit zu sehen"
 
@@ -9698,23 +9801,23 @@ msgstr "Gruppiere nach einem Zeit-Feld, um die Entwicklung über die Zeit zu seh
 msgid "Switch positive / negative colors?"
 msgstr "Möchtest du die positiven / negativen Farben wechseln?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Spalte pivotieren"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Zellspalte"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Sichtbare Spalten"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Bedingte Formatierung"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Spalten-Überschrift"
 
@@ -10153,10 +10256,10 @@ msgstr "Benutzer pro Quelle"
 msgid "The top external pages that brought users to your site"
 msgstr "Die führenden externen Seiten, die Anwender auf Ihre Seite geführt haben"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Wie [[this]] verteilt wird und mehr."
 
@@ -10254,13 +10357,13 @@ msgstr "Ereignisse nach Stunde des Tages"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Top 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Untere 5 [[this]]"
 
@@ -10273,10 +10376,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Nullwerte"
 
@@ -10304,8 +10407,8 @@ msgstr "Wie sie im Vergleich zur Saisonalität stehen"
 msgid "Average income per transaction"
 msgstr "Durchschnittseinkommen nach Transaktionen"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] nach Land"
 
@@ -10429,10 +10532,10 @@ msgstr "Eine Übersicht über deine [[this]] und wie sie über Zeit, Ort und Kat
 msgid "Average income per state"
 msgstr "Durchschnittseinkommen pro Bundesland"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] nach [[GenericCategoryMedium]]"
 
@@ -10609,13 +10712,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Wie [[GenericTable]] über dieses Zeitfeld verteilt sind und ob es saisonale Muster hat."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Überblick"
 
@@ -10724,8 +10827,8 @@ msgstr "Anbei ein tieferer Blick auf [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Anbei ein tieferer Blick auf [[this]] Feld"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Zusammenfassung"
 
@@ -10789,10 +10892,10 @@ msgstr "Verkäufe nach Quelle"
 msgid "Average income per country"
 msgstr "Durchschnittseinkommen nach Land"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Wie [[this]] verteilt wird"
 
@@ -10813,17 +10916,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Anzahl der [[GenericCategoryMedium]] von [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Ein Blick auf [[this]]"
 
@@ -10889,10 +10992,10 @@ msgid "Transactions per source over time"
 msgstr "Transaktionen pro Quelle im Laufe der Zeit"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Wie das [[this]] verteilt wird"
 
@@ -10921,9 +11024,9 @@ msgstr "Wo diese Ereignisse stattfinden"
 msgid "Which US states are bringing you the most business."
 msgstr "Welche US-Bundesstaaten bringen Ihnen die meisten Geschäfte."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Wie sie im Zeitvergleich abschneiden"
 
@@ -11029,8 +11132,8 @@ msgstr "Sitzungen nach Ländern"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Einige interessante Kennzahlen über Ihre GA-Statistiken, um Ihnen den Einstieg zu erleichtern."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] pro Zustand"
 
@@ -11111,12 +11214,12 @@ msgstr "Wie diese Kennzahl auf verschiedene Zahlen verteilt ist"
 msgid "Sessions by page where the session began"
 msgstr "Sitzungen nach Seite, auf der die Sitzung begann."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Eindeutige Werte"
 
@@ -11179,10 +11282,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Events pro [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Wie du im Vergleich zur Verteilung stehst"
@@ -11488,6 +11591,7 @@ msgstr "Dashboard duplizieren"
 msgid "Duplicate \"{0}\""
 msgstr "\"{0}\" duplizieren"
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11585,9 +11689,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Quartal im Jahr"
 msgstr[1] "Quartale im Jahr"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} Auswahl"
@@ -11610,11 +11714,11 @@ msgstr "Ungültig"
 msgid "Add a time"
 msgstr "Zeit hinzufügen"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Es gibt nichts zum vorigen {0} zu vergleichen."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "von {0}"
 
@@ -12104,9 +12208,9 @@ msgstr "Hier ist eine Übersicht über die Personen in deiner/-em [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] pro Quartal des Jahres"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Wie sie über Orte verteilt sind"
 
@@ -12135,12 +12239,12 @@ msgstr "[[CreateTimestamp]] nach Wochentag"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Dies ist eine Übersicht über deine Daten von Google Analytics zu [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Dies ist eine Übersicht über deine [[this]]"
 
@@ -12218,11 +12322,11 @@ msgstr "Sammlung"
 msgid "collections"
 msgstr "Sammlungen"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "dashboard"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "dashboards"
 
@@ -12472,7 +12576,7 @@ msgstr "Zeitüberschreitung nach {0} Millisekunden."
 msgid "Misfire Instruction"
 msgstr "Fehlzündungsanweisung"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Archivieren?"
 
@@ -12492,7 +12596,7 @@ msgstr "Die Verwendung dieser Option setzt voraus, dass der angegebene Host ein 
 "einen Atlas-Cluster verbinden, musst du diese Option möglicherweise aktivieren. Wenn du nicht weißt, was das bedeutet,\n"
 "lasse es deaktiviert."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Führe Abfragen bei einfachen Filtern und Zusammenfassen automatisch aus"
 
@@ -12504,7 +12608,7 @@ msgstr "Wenn dies aktiviert ist, führt Metabase automatisch Abfragen aus, wenn 
 msgid "Learn about this database"
 msgstr "Lerne etwas über diese Datenbank"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Dieses Dashboard archivieren?"
 
@@ -12560,11 +12664,11 @@ msgstr "Benutzerdefinierte Frage"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Verwende den erweiterten Notebook-Editor, um Daten zu verknüpfen, benutzerdefinierte Spalten zu erstellen, Berechnungen durchzuführen und vieles mehr."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Einfache Metriken"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Benutzerdefiniert..."
 
@@ -12749,15 +12853,15 @@ msgstr "Wähle eine Darstellung"
 msgid "Filter by"
 msgstr "Filtern nach"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Summiere"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Gruppieren nach"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Metrik hinzufügen"
 
@@ -12768,15 +12872,15 @@ msgstr "Metrik hinzufügen"
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Das geht normalerweise zeimlich schnell aber scheint gerade sehr lange zu dauern."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Combo"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Zeile"
 
@@ -13197,7 +13301,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Wähle die Spalten aus, die Du einbeziehen möchtest."
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Wenn dies aktiviert ist, führt Metabase automatisch Abfragen aus, wenn Benutzer einfache Erkundungen mit den Schaltflächen Zusammenfassen und Filtern durchführen, wenn sie eine Tabelle oder ein Diagramm anzeigen. Sie können dies ausschalten, wenn die Abfrage dieser Datenbank langsam ist. Diese Einstellung hat keinen Einfluss auf Drill-Throughs oder SQL-Abfragen."
 
@@ -13263,7 +13367,7 @@ msgstr "Anmeldung per E-Mail"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Die Auswahl dieser Option erfordert einen Host, der über einen FQDN verfügt. Wenn zu einem Atlas-Cluster verbunden wird, musst Du diese Option eventuell aktivieren. Falls Du nicht weißt, was diese Option bedeutet, lass sie deaktiviert."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Standardmäßig führt Metabase eine leichte stündliche Synchronisierung und eine intensive tägliche Überprüfung der Feldwerte durch. Wenn Du eine große Datenbank hast, empfehlen wir Dir, das hier einzuschalten und zu überprüfen, wann und wie oft die Feldwertüberprüfungen stattfinden."
 
@@ -13331,11 +13435,11 @@ msgstr "Nicht enthalten"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Dieses Feld ist bei Fragen, die mit den GUI-Oberflächen erstellt wurden, nicht sichtbar oder auswählbar. Es wird weiterhin in SQL/nativen Abfragen verfügbar sein."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Kumulierte Summe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Standardabweichung"
 
@@ -13351,19 +13455,19 @@ msgstr "Muss mindestens {0} Zeichen lang sein"
 msgid "Name (required)"
 msgstr "Name (erforderlich)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Führe ausgewählten Text aus"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Führe Abfrage aus"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + Enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(STRG + Enter)"
 
@@ -13712,7 +13816,7 @@ msgstr "Daten und Zeiten"
 msgid "Numbers"
 msgstr "Zahlen"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Keine verknüpfbaren Gruppen"
 
@@ -13752,15 +13856,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "Angemeldet bleiben"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Aus Sicherheitsgründen laufen Links zum Zurücksetzen des Passworts nach einer Zeit ab. Wenn du dein Passwort noch zurücksetzen musst, kannst du {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Speichere neues Passwort"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Kein passendes Ergebnis"
 
@@ -13786,26 +13890,26 @@ msgid "or"
 msgstr "oder"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "erforderlich"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Datenbanktyp"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Dies ist ein leichtgewichtiger Prozess, der auf Aktualisierungen des Datenbank-Schemas prüft. In den meisten Fällen sollte die stündliche Synchronisation in Ordnung sein."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase kann die Werte dieses Feldes in der Datenbank scannen um Checkbox-Filter in den Dashboard und Fragen bereitzustellen. Dies kann ein sehr ressourcen-intensiver Prozess sein, insbesondere wenn Sie eine sehr große Datenbank verwenden."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Sammlung"
 
@@ -13852,7 +13956,7 @@ msgstr "Kategorisch"
 msgid "URLs"
 msgstr "URLs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Gibt den Durchscnitt aller Werte einer Spalte zurück."
 
@@ -13861,11 +13965,13 @@ msgstr "Gibt den Durchscnitt aller Werte einer Spalte zurück."
 msgid "The column whose values to average."
 msgstr "Spalte deren Durchschnitt gebildet werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "Start"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "Ende"
 
@@ -13877,21 +13983,19 @@ msgstr "Überprüft die Werte eines Datums oder einer numerischen Spalte, um fes
 msgid "Rating"
 msgstr "Bewertung"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "Bedingung"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "Ausgabe"
 
@@ -13899,27 +14003,27 @@ msgstr "Ausgabe"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testet eine Liste von Fällen und gibt den Wert des ersten \"True\"-Falls zurück. Ein optionaler Default-Wert kann ebenfalls angegeben werden, wenn kein Fall zutrifft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Gewicht"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Groß"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Mittel"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Klein"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Etwas mit dem Ergebnis wahr oder falsch."
 
@@ -13927,33 +14031,33 @@ msgstr "Etwas mit dem Ergebnis wahr oder falsch."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Der Wert, der zurückgegeben wird, wenn die vorangehende Bedingung wahr ist."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "Wert1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "Wert2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Betrachtet die Werte jedes Parameters in der gegebenen Reihenfolge und gibt den ersten Non-NULL Wert für jede Zeile zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Kommentare"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notizen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Keine Kommentare"
 
@@ -13969,12 +14073,12 @@ msgstr "Wenn Wert1 leer ist, wird Wert2 zurückgegeben falls dieser nicht leer i
 msgid "Combines two or more strings of text together."
 msgstr "Kombiniert zwei oder mehr Textfolgen miteinander."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Nachname"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Vorname"
 
@@ -13986,27 +14090,27 @@ msgstr "Wert2 wird am Ende angefügt."
 msgid "This will be added to the end of value1."
 msgstr "Wird am Ende von Wert1 angefügt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "Zeichenkette1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "Zeichenkette2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Prüft, ob Zeichenfolge1 Zeichenfolge2 enthält."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "In Ordnung"
 
@@ -14014,7 +14118,7 @@ msgstr "In Ordnung"
 msgid "The contents of this string will be checked."
 msgstr "Der Inhalt dieser Zeichenkette wird geprüft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Text, nach dem gesucht werden soll."
 
@@ -14022,22 +14126,22 @@ msgstr "Text, nach dem gesucht werden soll."
 msgid "Returns the count of rows in the source data."
 msgstr "Gibt die Anzahl der Zeilen der Quelldaten zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Zählt Zeilen nur bei erfüllter Bedingung."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Zwischensumme"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Die kumulative Anzahl von Zeilen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "Die kumulative Summe einer Spalte."
 
@@ -14046,53 +14150,57 @@ msgstr "Die kumulative Summe einer Spalte."
 msgid "The column to sum."
 msgstr "Die zu summierende Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Anzahl eindeutiger Werte in dieser Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Spalte deren Werte eindeutig gezählt werden sollen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "Text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "Vergleich"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Gibt bei passendem Vergleich des Text-Endes true zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Appetit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hungrig"
 
@@ -14101,20 +14209,20 @@ msgstr "hungrig"
 msgid "A column or string of text to check."
 msgstr "Eine Spalte oder Zeichenfolge mit zu prüfendem Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Text mit dem der ursprüngliche Text enden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "regulärer Ausdruck"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrahiert Zeichenketten anhand eines regulären Ausdrucks."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adresse"
 
@@ -14122,7 +14230,7 @@ msgstr "Adresse"
 msgid "The column or string of text to search though."
 msgstr "Zu durchsuchende Spalte oder Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Zutreffender regulärer Ausduck."
 
@@ -14134,7 +14242,7 @@ msgstr "Gibt den Text in Kleinbuchstaben zurück."
 msgid "The column with values to convert to lowercase."
 msgstr "Spalten deren Werte in Kleinbuchstaben konvertiert werden sollen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Entfernt vorgestellte Leerzeichen aus einem Text."
 
@@ -14144,15 +14252,16 @@ msgstr "Entfernt vorgestellte Leerzeichen aus einem Text."
 msgid "The column with values you want to trim."
 msgstr "Spalte deren vor- und nachgestellte Leerzeichen entfernt werden sollen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Gibt den größten Wert aus der Spalte zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Alter"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Numerisch Spalte deren Maximalwert gefunden werden soll."
 
@@ -14160,21 +14269,21 @@ msgstr "Numerisch Spalte deren Maximalwert gefunden werden soll."
 msgid "Returns the smallest value found in the column."
 msgstr "Gibt den kleinsten Wert aus der Spalte zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Gehalt"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Numerische Spalte deren Minimalwert gefunden werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "Position"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "Länge"
 
@@ -14183,7 +14292,7 @@ msgstr "Länge"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Ersetzt einen Teil der Eingabe mit neuem Text."
 
@@ -14211,35 +14320,35 @@ msgstr "Anzahl der zu ersetzenden Zeichen."
 msgid "The text to use in the replacement."
 msgstr "Text in dem ersetzt werden soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Entfern nachgestellte Leerzeichen aus einem Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Gibt den prozentualen Anteil der Zeilen als Dezimalzahl zurück, auf welche die Bedingung zutrifft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Gibt bei passendem Vergleich des Text-Anfangs true zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Kursname"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Informatik"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Die Zeichenfolge, mit der der ursprüngliche Text beginnen soll."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Berechnet die Standardabweichung der Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Bevölkerung"
 
@@ -14247,7 +14356,7 @@ msgstr "Bevölkerung"
 msgid "A numeric column."
 msgstr "Eine numerische Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Gibt einen Teil des übergebenen Textes zurück."
 
@@ -14255,19 +14364,19 @@ msgstr "Gibt einen Teil des übergebenen Textes zurück."
 msgid "The text to return a portion of."
 msgstr "Text aus dem ein Teil zurückgegeben wird"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Die Startposition zum Kopieren der Zeichen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Zurückzugebende Anzahl der Zeichen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Addiert alle Werte der Spalte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Die numerische Spalte, deren Summe ermittelt werden soll."
 
@@ -14275,15 +14384,15 @@ msgstr "Die numerische Spalte, deren Summe ermittelt werden soll."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Summiert in einer Spalte alle Werte, auf welche die Bedingung zutrifft."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Bestellstatus"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Gültig"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Entfernt vor- und nachgestellte Leerzeichen aus der Zeichenfolge."
 
@@ -14291,47 +14400,47 @@ msgstr "Entfernt vor- und nachgestellte Leerzeichen aus der Zeichenfolge."
 msgid "Returns the string of text in all upper case."
 msgstr "Gibt den Text in Großbuchstaben zurück."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Die Spalte mit Werten, die in Großbuchstaben umgewandelt werden sollen."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "muss {0} sein und {1} enthalten."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "muss {0} sein."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "muss {0} enthalten."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "mindestens {0} Zeichen lang"
 msgstr[1] "mindestens {0} Zeichen lang"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} kleingeschriebener Buchstabe"
 msgstr[1] "{0} kleingeschriebene Buchstaben"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} Großbuchstabe"
 msgstr[1] "{0} Großbuchstaben"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} Zahl"
 msgstr[1] "{0} Zahlen"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} Spezialzeichen"
@@ -14354,6 +14463,7 @@ msgid "Powered by {0}"
 msgstr "Angetrieben von {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "An:"
 
@@ -14441,7 +14551,7 @@ msgstr "Formatierung des Wertes"
 msgid "Full"
 msgstr "Vollständig"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Keine Änderungen seit dem letzten {0}"
 
@@ -14768,7 +14878,7 @@ msgstr "Fehler bei der Generierung von Einsichten für die Spalte:"
 msgid "Sending abandonment email!"
 msgstr "Sende Verlassensemail!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Sie können Metriken speichern um eine Benannte-Metrik Option hinzuzufügen.\n"
 "Gespeicherte Metriken beinhalten den Aggrgations-Typ, das aggregierte Feld und optional beliebige Filter, die Sie hinzufügen.\n"
@@ -14778,15 +14888,15 @@ msgstr "Sie können Metriken speichern um eine Benannte-Metrik Option hinzuzufü
 msgid "Select and add filters to create your new segment."
 msgstr "Wählen und fügen Sie Filter hinzu, um Ihr neues Segment zu erstellen."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alphabetisch geordnet"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Intelligent"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Reihenfolge der Spalten: {0}"
 
@@ -14838,9 +14948,9 @@ msgstr "Sprache"
 msgid "Instance language"
 msgstr "Instanz-Sprache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
-msgstr "Sprache-Optionen"
+msgstr "Sprach-Optionen"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:51
 msgid "This database doesn't have any tables."
@@ -14910,19 +15020,20 @@ msgstr "Einfügen einer Verbindungszeichenfolge"
 msgid "Fill out individual fields"
 msgstr "Füllen Sie die einzelnen Felder aus"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Geben Sie hier etwas SQL ein, damit Sie es später wiederverwenden können."
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Geben Sie Ihrem Snippet einen Namen"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Aktuelle Kunden"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Eine Beschreibung hinzufügen"
 
@@ -14930,46 +15041,47 @@ msgstr "Eine Beschreibung hinzufügen"
 msgid "Use site default"
 msgstr "Website-Vorgabe verwenden"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "finden"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "ersetzen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Der zu findende Text."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Der als Ersatz zu verwendende Text."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Bearbeiten {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Erstellen Sie Ihr neues Snippet"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Archivierte Schnipsel"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Snippets sind wiederverwendbare Teile von SQL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Ausschnitt erstellen"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Schnipsel"
 
@@ -15248,3 +15360,1499 @@ msgstr "Der Wert muss ein Schlüsselwort oder eine Zeichenkette sein."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Die Zeichenfolge muss ein gültiger zweibuchstabiger ISO-Sprach- oder Sprach-Ländercode sein, z.B. 'de' oder 'de_DE'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Zeilen {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Audit"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Konfiguration von Benutzerattributen (optional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Verwende {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "SAML-basiertes SSO einrichten"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML Authentifizierung"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Konfigurieren Sie ihren Identitäts-Provider (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Ihr Identitäts-Provider wird die folgenden Informationen über Metabase benötigen."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL zu der der IdP zurückleiten soll"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Dies wird in Okta als Single Sign On-URL, in Auth0 als Application Callback-URL und in OneLogin als ACS-URL (Consumer) bezeichnet."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML Attribute"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "In den meisten IdPs müssen Sie diese in ein Eingabefeld mit der Bezeichnung \"Name\" im Abschnitt für Attributsanweisungen einfügen."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "\"E-Mail\" Attribut des Benutzers"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "\"Vorname\" Attribut des Benutzers"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "\"Nachname\" Attribut des Benutzers"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Informieren Sie Metabase über Ihren Identitäts-Provider"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase benötigt die folgenden Informationen über Ihren Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML Identitäts-Provider URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Zertifikat des SAML Identitäts-Providers"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML Anwendungsname"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "SSO Requests signieren (optional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Pfad zum SAML-Keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Passwort zum SAML-Keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Psst..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Alias des SAML-Keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Gruppenzugehörigkeit mit dem SSO synchronisieren"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Um dies zu aktivieren wird eine Zuordnung von SSO Gruppen zu Gruppen in Metabase benötigt. Teile Metabase mit, wie Benutzer aus SSO Gruppen den Gruppen in Metabase zugeordnet werden sollen."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Gruppenname"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Attributsname der Gruppe"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Hinweis:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Wenn du Einstellungen eines aktiven SAML-Setups änderst, muss Metabase neu gestartet werden, damit diese wirksam werden."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Erlaubt Benutzern den Login über einen SAML Identitäts-Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Erlaubt Benutzern den Login über einen JWT Identitäts-Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Passwort-Authentifizierung aktivieren"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Benutzer können sich zusätzlich mit ihrer E-Mail Adresse und einem Passwort anmelden, wenn aktiviert."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Admins über neue SSO Benutzer informieren"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Wenn aktiviert, erhalten Administratoren eine E-Mail wenn ein Benutzer erstmalig SSO verwendet."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Verwenden Sie die nachfolgenden Einstellungen, um Ihr SSO via SAML zu konfigurieren. Wenn Sie Fragen haben, prüfen Sie unser {0]."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "Dokumentation"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML Identitäts-Provider URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT Authentifizierung"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT Identitäts-Provider URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Vom JWT-Signaturschlüssel verwendeter String"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Gesamte Metabase-App einbetten"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Möchtest du Metabase vollständig einbetten, gebe hier die URLs bzw. Origins der Websites oder Webanwendungen ein, in welchen die Einbettung im Iframe ermöglicht werden soll. Mehrere Einträge sind durch space zu trennen. Hier sind die {0} für das, was eingegeben werden kann."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Sandbox-Zugriff auf diese Tabelle erteilen"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Wenn Benutzer in dieser Gruppe diese Tabelle ansehen, sehen sie eine nach ihren Benutzerattributen gefilterte Version, oder eine benutzerdefinierte Ansicht, die auf einer gespeicherten Frage basiert."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Wie möchten Sie diese Tabelle für Benutzer dieser Gruppe filtern?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Gespeicherte Frage auswählen, die die benutzerdefinierte Ansicht dieser Tabelle zurückgibt, die diese Benutzer sehen sollen."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Sie können optional weitere Filter hinzufügen, die auf Benutzerattributen basieren. Diese Filter werden zusätzlich zu allen anderen Filtern angewendet, die in der gespeicherten Frage enthalten sind."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Damit diese Option funktioniert, benötigen Ihre Benutzer einige Attribute"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Um weitere Filter hinzuzufügen müssen Ihre Benutzer einige Attribute besitzen"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Keine Benutzer-Attribute"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Wählen Sie ein Benutzer-Attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Wählen Sie einen Parameter"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Wählen Sie eine Spalte"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Benutzer in {0} können lesen"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "Zeilen in der Frage {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "Zeilen in der Tabelle {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "wo {0} {1} entspricht"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "und {0} entspricht {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Du kannst Attribute automatisch hinzufügen, indem du ein SSO via SAML einrichtest. Alternativ kannst du sie manuell eingeben, indem du zum Abschnitt Mitglieder gehst und ganz rechts auf das \"...\" Menü klickst."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Benutzerattribut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Wir können die Attribute der Benutzer automatisch abrufen, wenn du SSO eingerichtet hast. Alternativ kannst du sie manuell über das Menü \"...\" im Abschnitt \"Mitglieder\" des Admin-Bereichs hinzufügen."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parameter oder Variable"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "entspricht"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Sandboxed Zugriff erteilen"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Sandboxed Zugriff"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Sandboxed Zugriff bearbeiten"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Ordner-Details bearbeiten"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Berechtigungen ändern"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Erstellen Sie einen neuen Ordner"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Neuer Ordner"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Wir können Ihr Token nicht validieren"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Bitte stellen Sie sicher, dass Ihre Instanz die Server von Metabase erreichen kann"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Erhalten Sie Hilfe"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Holen Sie noch mehr aus Metabase mit Hilfe der Enterprise Edition heraus"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Alle notwendigen Tools, um deinen Kunden schnell und einfach Berichte bereitzustellen oder um Metabase in einem großen Unternehmen auszuführen und zu überwachen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Lizenz aktivieren"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Ihre Testphase ist mit folgenden Features aktiv"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Die Testphase läuft ab am {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Benötigen Sie Hilfe? Bereit zum Kauf?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Kontaktieren Sie uns"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Ihre Testphase ist abgelaufen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Benötigen Sie mehr Zeit? Bereit zum Kauf?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Ihre Features sind aktiv!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Ihre Lizenz ist gültig bis {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Ihre Lizenz ist abgelaufen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Es ist abgelaufen am {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Möchten Sie Ihre Lizenz erneuern?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Erfahren Sie, wie dies eingesetzt wird"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Nicht in Ihrem aktuellen Tarif/Lizenzplan enthalten"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Geben Sie hier den Token ein, den Sie aus dem Shop erhalten haben"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Aktivieren"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Benötigen Sie Hilfe?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Mehr Information über Ihr Problem."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Support kontaktieren"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Daten Sandboxen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Stellen Sie sicher, dass die richtigen Leute die korrekten und passenden Daten sehen, indem Sie automatische und sicher Filter einsetzen, die auf Benutzerattributen basieren."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "White Labeling"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Passen Sie Metabase an Ihre Marke an, mit eigenen Farben, dem eigenen Logo und mehr."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Auditing"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Behalten Sie die Performance und das Verhalten im Auge mit robusten Auditing-Tools."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Single Sign-On"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Stellen Sie einen einfachen Login zur Verfügung, der mit Ihrer existierenden Authentifizierungs-Infrastruktur zusammenarbeitet."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Shop"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Anwendungsname"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Farbpalette"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Startseite"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Keine Gruppen"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Berechtigungen für {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Berechtigungen für diesen Ordner"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Schreib-Zugriff erteilen"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Kann Snippets in diesem Ordner ändern"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Lese-Zugriff erteilen"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Kann Snippets in diesen Ordner einfügen und benutzen, jedoch nicht das SQL editieren, das sie beinhalten."
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Kann keine Snippets in diesen Ordner einfügen oder ansehen"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Unterordner ebenfalls ändern"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Erster Tag der Woche"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Es gab ein Problem bei der Anmeldung über Google. Bitte kontaktieren Sie einen Administrator."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "am"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "um"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Das Metabase Aktionsmenü öffnen"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Nichts unternehmen"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Gehe zu einem benutzerdefinierten Ziel"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Dashboard-Filter aktualisieren"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} aktualisiert {1} Filter"
+msgstr[1] "{0} aktualisiert {1} Filter"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} geht nach {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Klick-Verhalten für jede Spalte"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Gehe zu einem benutzerdefinierten Ziel"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Aktionsmenü öffnen"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Click-Verhalten für {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Wählen Sie einen oder mehrere Filter aus, die aktualisiert werden sollen"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Frage gespeichert"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Link zu"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Geben Sie die URL ein, zu der verlinkt werden soll"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Sie können den Wert einer Spalte oder eines Dashboard-Filters über seinen Namen wie folgt einfügen: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "z.B. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Wählen Sie ein Dashboard..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Wählen Sie eine Frage..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Wählen Sie ein Dashboard, auf das verlinkt werden soll"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Wählen Sie die Frage aus, zu der verlinkt werden soll"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Werte an die Filter dieses Dashboards übergeben (optional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Werte an die Variablen dieser Frage übergeben (optional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Werte zum Filtern an diese Frage übergeben (optional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Dashboard-Filter"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Benutzerattribute"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Linktext anpassen (optional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "z.B. Details für {{Column Name}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Werte, die Sie referenzieren können"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Keine verfügbaren Ziele"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "Filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "Variable"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Weitere verfügbare Filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Verfügbare Filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Weitere verfügbare Variablen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Verfügbare Variablen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Weitere verfügbare Spalten"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Verfügbare Spalten"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "Benutzerattribut"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Textkarte"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Klick-Verhalten"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Visualisierungs-Optionen"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Serie bearbeiten"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Serie hinzufügen"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Bei Klick"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Titel und Beschreibung ändern"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Du hast eingebettete Parameter aktualisiert und musst nun den Einbettungscode aktualisieren."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Frage hinzufügen"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Sie bearbeiten dieses Dashboard."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Spalte, auf die gefiltert werden soll"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "Snippet Sammlung"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "Snippet Sammlungen"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Geben Sie ihrem Ordner einen Namen"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Etwas Kurzes und Einprägsames"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Ordner, in dem dies sein sollte"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Aktionsmenü öffnen"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} Spalte hat ein benutzer-definiertes Verhalten"
+msgstr[1] "{0} Spalten haben ein benutzer-definiertes Verhalten"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Gehe zu..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Gehe zum Dashboard"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Gehe zu Frage"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Gehe zu URL"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Dieses Dashboard filtern"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Gibt die Anzahl der Zeilen der ausgewählten Daten zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Spalte oder Zahl, die summiert werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Die Zahlen-Spalte, deren Standard-Abweichung zurückgegeben werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Die Zahlen-Spalte, aus der der Durchschnittswert berechnet werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Gibt den kleinsten Wert aus dieser Spalte zurück"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Summiert die Werte der angegebenen Spalte nur, wo die angegebene Bedindung zutrifft."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Gibt die numerische Varianz für eine bestimmte Spalte zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Temperatur"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Die Spalte oder Zahl, deren Varianz ermittelt werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Gibt den Medianwert der angegebenen Spalte zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Die Spalte oder Zahl, deren Median ermittelt werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "Prozentwert"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Gibt den Wert der Spalte am Perzentilwert zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Die Spalte oder Zahl, deren Perzentil ermittelt werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Der Wert des Perzentils."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Gibt die Textzeichenfolge in Kleinbuchstaben zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Die Spalte mit den Werten, die in Kleinbuchstaben umgewandelt werden sollen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Gibt den Text vollständig in Großbuchstaben zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Die Spalte oder der Text, von dem ein Teil zurückgegeben werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Die Spalte oder der Text, der durchsucht werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Zwei oder mehr Strings vereinen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Die Spalte oder der Text, mit dem begonnen werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Dies wird am Ende von Wert 1 usw. angefügt"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Enorm"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigantisch"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Gibt die Anzahl der Zeichen im Text zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Die Spalte oder der Text, dessen Länge Sie erhalten möchten."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Die Spalte oder der Text, der abgeschnitten werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Gibt den Betrag (positiv) der angegebenen Spalte zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Schuld"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Die Spalte oder Zahl, deren Betrag (positiv) zurückgegeben werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Rundet eine Dezimalzahl ab."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Die Spalte oder Zahl, die abgerundet werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Rundet eine Zahl auf."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Die Spalte oder Zahl, die aufgerundet werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Rundet eine Zahl zur nächsten Ganzzahl auf bzw ab."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "Die Spalte oder Zahl, die auf- bzw. abgerundet werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Gibt die Quadratwurzel zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hypotenuse"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Die Spalte oder Zahl, deren Quadratwurzel zurückgegeben werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "Exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Erhöht eine Zahl um die Potenz des Exponentenwerts."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Länge"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Die Spalte oder Zahl, die um den Exponenten erhöht wird."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Der Wert des Exponenten."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Gibt den Logarithmus zur Basis 10 der Zahl zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Wert"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Die Spalte oder Zahl, deren natürlicher Logarithmuswert zurückgegeben werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Gibt die Eulersche Zahl e, erhöht um die Potenz der angegebenen Zahl, zurück."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Zinsmonate"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Die Spalte oder Zahl, deren Exponentialwert zurückgegeben werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Die zu prüfende Spalte oder der zu prüfende Text."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Prüft, ob die Werte einer Datums- oder Zahlenspalte im angegebenen Bereich liegen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Erzeugt am"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Die Datums- oder Zahlenspalte, die innerhalb der Start- und Endwerte liegen soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Der Beginn des Bereichs."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Das Ende des Bereichs."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Prüft, ob die Werte einer Datumsspalte innerhalb des relativen Bereiches liegen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Die Datumsspalte für das Rückgabeintervall."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Intervallperiode, wobei negative Werte in die Vergangenheit deuten."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Typ des Intervals, wie \"Tag\", \"Monat\", \"Jahr\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Die Spalte oder der Wert, der zurückgegeben werden soll."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Wenn Wert1 leer ist, wird Wert2 zurückgegeben (wenn er nicht leer ist), usw."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Testet einen Ausdruck gegen eine Liste von Werten und gibt den ersten übereinstimmenden Wert zurück. Optional kann ein Standardwert gesetzt werden, welcher zurückgegeben wird falls keiner der Werte übereinstimmt."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Der Wert, der zurückgegeben wird, wenn die vorhergehende Bedingung erfüllt ist, und so weiter."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Ist NULL"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Nicht NULL"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Kumulative Summe aller Werte einer Spalte, z.B. Gesamtprofit über die Zeit."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Kumulative Zeilenanzahl, z.B. Gesamtzahl von Verkäufen über die Zeit."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Verbundene Filter"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Bezeichnung"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Defaultwert"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Kein Default"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Um dies zu sehen, muss {0} mit mindestens einem Feld verbunden sein."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Auswahl dieses Filters begrenzen"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Wenn Sie einen anderen Dashboard-Filter haben, können Sie die Auswahlmöglichkeiten für diesen Filter basierend auf der Auswahl des anderen Filters einschränken."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Zunächst, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "Einen weiteren Dashboard-Filter hinzufügen"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Wenn Sie einen dieser Dashboard-Filter aktivieren, wird durch Auswahl eines Werts für diesen Filter die verfügbare Auswahl für den Filter {0} eingeschränkt."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Filtere Spalte"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Gefilterte Spalte"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Usernamen oder E-Mail Adressen"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Neues Snippet"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 Uhr (nachmittags)"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 Uhr Mittags"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 Uhr (vormittags)"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Stündlich"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Täglich um {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Wöchentlich um {0} am {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Monatlich am {0} {1} um {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Dieses Abonnement löschen"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Abonnements"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Dashboard-Abonnement erstellen"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Per E-Mail senden"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Sie können dieses Dashboard regelmäßig an Benutzer oder Email-Adressen senden."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Sende es an Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Wählen Sie einen Kanal und einen Zeitplan aus, Metabase wird dann den Rest übernehmen."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Dieses Dashboard per E-Mail senden"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Nicht senden, wenn keine Ergebnisse vorliegen"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Ergebnisse anhängen"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Anhänge können bis zu 2000 Zeilen an Daten enthalten."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Dieses Dashboard an Slack senden"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Das Dashboard hat keinen Parameter mit der ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Mit dem Parameter {0}  sind keine Felder verbunden."
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include muss entweder leer sein oder den Wert 'tables' besitzen"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "`database` ist bei allen Abfragen notwendig, die nicht vom Typ `internal` sind."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Passwort-Login ist für diese Instanz deaktiviert."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Ihr Konto ist deaktiviert. Bitte kontaktieren Sie ihren Administrator."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Der Account ist deaktiviert."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Ungültiges Slack-Token"
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "Der Befehl  ''{0}'' ist nur in der Metabase Enterprise Edition verfügbar."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Die Erweiterungen der Metabase Enterprise Edition SIND vorhanden."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Die Verwendung der Metabase Enterprise Edition-Funktionen unterliegt der kommerziellen Metabase-Lizenz."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Siehe {0} für Details."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Die Erweiterungen der Metabase Enterprise Edition sind NICHT vorhanden."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Sie wurden eingeladen, {0}''s {1} beizutreten"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} hat ein {1} Konto erstellt"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} hat die {1} Einladung angenommen"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Password Reset Anfrage"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Benachrichtigung"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Helfen Sie [{1}] zu verbessern."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Erzählen Sie uns, wie die Dinge laufen."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Fehler beim Starten des Ereignis-Listeners"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Sollen wir die Benutzerattribute synchronisieren, wenn sich jemand über LDAP einloggt?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Komma-separierte Liste von Benutzerattributen, die nicht über LDAP synchronisiert werden sollen."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Ungültiger Token"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Slack-API Fehler: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Der Slack-Kanal `metabase_files` fehlt!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Bitte erstellen Sie den Kanal oder holen ihn aus dem Archiv, um die Slack-Integration abzuschließen."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Der Kanal wird zum Speichern von Diagrammen verwendet, die in Pulsen und MetaBot-Antworten enthalten sind."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Bild hochladen"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Fehler beim Hochladen der Datei zu Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Ungültige Sitzung. Es wurde eine \"Session\"-Instanz erwartet."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "Das SameSite-Attribut des Sitzungscookies ist auf \"Keine\" gestellt,"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "die Site wird jedoch über eine unsichere Verbindung erreicht."
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "Einige Browser lehnen Cookies unter diesen Bedingungen ab."
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Hauptordner"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parameters muss eine Folge von Maps mit String :id-Schlüsseln sein"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Ungültige Menschen-lesbare Werte: Werte müssen eine Folge sein; Jedes Element muss null oder eine Zeichenfolge sein"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":values müssen vorhanden sein, um :human_readable_values abzurufen"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Die Gesamtlänge der Feldwerte beträgt> {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "Snippet-Namen dürfen kein '}' enthalten oder mit einem Leerzeichen beginnen."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Fehler beim Ausführen der Filterabfragekette."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Feld {0} existiert nicht."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Das Nicht-Text Feld {0} {1} kann nicht durchsucht werden."
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Erteile Berechtigungen für Gruppe {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Entferne Berechtigungen von Gruppe {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Ungültige DB Berechtigungen: Wenn Sie Schreibzugriff auf native Abfragen haben, benötigen Sie vollen Datenzugriff."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Ungültige DB-Berechtigungen: Wenn Sie schreibgeschützten nativen Abfragezugriff haben, müssen Sie auch über Datenzugriff verfügen."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Ändere Berechtigungen von: {0} zu {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "Anmeldeattributschlüssel müssen ein Schlüsselwort oder eine Zeichenfolge sein"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Die Default-Sprache für alle Benutzer in der Metabase GUI, System-Emails, Pulsen und Alarmen."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Benutzer können individuell eine andere Sprache in ihren Benutzereinstellungen auswählen."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Defaultseite, die dem Benutzer gezeigt werden soll"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Gestattet der Quelle, die gesamte Metabase-Anwendung einzubetten."
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Werte größer als {0} ({1}) sind nicht erlaubt."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Dies wird das Wort \"Metabase\" überall ersetzen."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Dies sind die bevorzugten Farben für Diagramme und in Metabase an sich. Ggfs. müssen Sie Ihren Browser refreshen um die Änderungen zu sehen."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Um die besten Ergebnisse zu erzielen, verwenden Sie eine SVG Datei mit transparentem Hintergrund."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "Die URL oder das Bild, das als Favicon verwendet werden soll."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Login via E-Mail und Passwort gestatten."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Dies wird sich auf Dinge wie Gruppierung nach Wochen oder Filterung in GUI-Abfragen auswirken. Es wird keine SQL Abfragen betreffen."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Konnte Token nicht validieren"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Das Token-Format ist ungültig."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Fehler beim Validieren des Token"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Fehler beim Filtern des Feldes {0}: Der String {1} konnte nicht nach {2} geparst werden."
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Fehler beim Laden der Job-Details: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Starte Synchronisations-Task für Datenbank {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Datenbank {0} kann nicht synchronisiert werden: Die Datenbank existiert nicht."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Die Aufgabe, die Feldwerte der Datenbank {0} zu aktualisieren, wurde gestartet."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Update wird übersprungen, die Updates von Feldwerten sind für die Datenbank {0} deaktiviert."

--- a/locales/es.po
+++ b/locales/es.po
@@ -28,15 +28,16 @@ msgstr "Explora estos datos"
 msgid "Select a database type"
 msgstr "Selecciona un tipo de base de datos"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Guardar"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Para hacer algo de magia, Metabase necesita escanear la base de datos. Lo volveremos a hacer periódicamente para mantener actualizados los metadatos. Puedes controlar cuando se realizan los repasos periódicos a continuación."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Sincronizando base de datos"
 
@@ -66,7 +67,7 @@ msgstr "Este es un proceso rápido que busca \n"
 msgid "Scan"
 msgstr "Explorar"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Buscando valores de filtrado"
 
@@ -80,7 +81,7 @@ msgstr "Metabase puede escanear los valores presentes en cada \n"
 "puede ser un proceso que consume muchos recursos, particularmente si tienes una \n"
 "base de datos grande."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "¿Cuándo debería Metabase escanear y almacenar automáticamente los valores de campo?"
 
@@ -138,29 +139,31 @@ msgstr "ELIMINAR"
 msgid "in this box:"
 msgstr "en esta casilla:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -183,9 +186,9 @@ msgstr "Eliminar"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -205,8 +208,9 @@ msgstr "Conexión"
 msgid "Scheduling"
 msgstr "Programación"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -285,10 +289,10 @@ msgstr "Añadir base de datos"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -324,10 +328,8 @@ msgstr "¡Guardado con éxito!"
 
 #. Editar
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Editar"
@@ -406,27 +408,30 @@ msgstr "Seleccione un tipo especial"
 msgid "Select a target"
 msgstr "Seleccione un objetivo"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Columnas"
 
 #. Campo
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Campo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Visibilidad"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Tipo"
 
@@ -434,7 +439,7 @@ msgstr "Tipo"
 msgid "Current database:"
 msgstr "Base de datos actual:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Mostrar esquema original"
 
@@ -505,7 +510,7 @@ msgstr "Encontrar una tabla"
 msgid "Schemas"
 msgstr "Esquemas"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -522,7 +527,7 @@ msgstr "Añadir una métrica"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definición"
 
@@ -590,35 +595,35 @@ msgstr "Historia"
 msgid "Revision History for"
 msgstr "Historial de Revisiones para"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} – Configuración de campos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Donde aparecerá este campo en Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrando sobre este campo"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Cuando este campo se usa en un filtro, ¿qué valores debería aceptar?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "No hay descripción para este campo todavía"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Valor original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Valor asignado"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Introduce un valor"
 
@@ -635,31 +640,31 @@ msgid "Custom mapping"
 msgstr "Mapeo personalizado"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Tipo de mapeo no reconocido"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "El campo actual no es una clave foránea o faltan los metadatos de clave foránea en la tabla de destino"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "El campo seleccionado no es una clave foránea"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Valores mostrados"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Elige si quieres mostrar el valor original de la base de datos, o mostrar información asociada o personalizada."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Elige un campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Selecciona una columna para mostrar."
 
@@ -667,16 +672,16 @@ msgstr "Selecciona una columna para mostrar."
 msgid "Tip:"
 msgstr "Consejo:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Es posible que quieras actualizar el nombre del campo para asegurarte de que todavía tenga sentidoen función de las opciones de asignación."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valores de campo en caché"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase puede escanear los valores de este campo para habilitar los filtros de casilla de verificación en cuadros de mando y preguntas."
 
@@ -703,35 +708,36 @@ msgstr "¡Limpieza iniciada!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Selecciona cualquier tabla para ver su esquema y añadir o editar metadatos."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Nombre es obligatorio"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Descripción es obligatorio"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Mensaje de la revisión es obligatorio"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Agregación es obligatoria"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Edita tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Crea tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Haz cambios en tu métrica y deja una nota explicativa."
 
@@ -739,46 +745,46 @@ msgstr "Haz cambios en tu métrica y deja una nota explicativa."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Puedes crear métricas y guardarlas como campo calculado en esta tabla.Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas.Por ejemplo, puedes usar esto para definir la forma oficial de calcular el \"Precio promedio\" para una tabla de Pedidos."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Resultado:"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Ponle nombre a tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Dale un nombre a tu métrica para ayudar a otros a encontrarla."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Algo descriptivo pero no demasiado largo"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Describe tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Dale una descripción a tu métrica para ayudar a otros a entender de qué se trata."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Este es un buen lugar para ser más específico sobre las reglas métricas menos obvias"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Motivo de los cambios"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deja una nota para explicar qué cambios has hecho y por qué fueron necesarios."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Esto aparecerá en el historial de revisiones de esta métrica para ayudar a todos a recordar por qué se realizó el cambio"
 
@@ -831,6 +837,7 @@ msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayud
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -845,8 +852,7 @@ msgid "Re-scan this table"
 msgstr "Re-Leer esta tabla"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Añadir"
 
@@ -863,7 +869,7 @@ msgid "Last name"
 msgstr "Apellidos"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Dirección de Email"
@@ -872,7 +878,7 @@ msgstr "Dirección de Email"
 msgid "Permission Groups"
 msgstr "Grupos de Permisos"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Convertir a este usuario en administrador"
 
@@ -970,6 +976,8 @@ msgstr "Borrar Grupo"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -982,11 +990,12 @@ msgstr "Hecho"
 msgid "Group name"
 msgstr "Nombre Grupo"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Grupos"
@@ -1095,7 +1104,7 @@ msgstr "Reiniciar"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "¿Seguro que quieres hacer esto?"
 
@@ -1208,7 +1217,7 @@ msgstr "No se realizarán cambios en los permisos."
 msgid "You've made changes to permissions."
 msgstr "Has realizado cambios en los permisos."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Permisos de esta colección"
 
@@ -1264,6 +1273,7 @@ msgstr "Limitar el acceso"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Revocar el acceso"
 
@@ -1327,23 +1337,23 @@ msgstr "Mima la colección"
 msgid "View collection"
 msgstr "Ver colección"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Acceso a Datos"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Ver tablas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "Consultas SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Ver esquemas"
 
@@ -1414,12 +1424,15 @@ msgstr "¡Enviado!"
 msgid "Clear"
 msgstr "Limpiar"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autenticación"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Configuración Servidor"
@@ -1432,6 +1445,7 @@ msgstr "Esquema de Usuario"
 msgid "Attributes"
 msgstr "Atributos"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Esquema de Grupo"
@@ -1503,6 +1517,9 @@ msgid "Add a map"
 msgstr "Añade un mapa"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1512,19 +1529,19 @@ msgid "Delete custom map"
 msgstr "Elimina mapa personalizado"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Borrar"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1622,19 +1639,19 @@ msgstr "Comprar un token"
 msgid "Enter a token"
 msgstr "Introducir un token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Editar Asignaciones"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Asignaciones de Grupo"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Crear una asignación"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1873,18 +1890,27 @@ msgstr "Filtro de usuario"
 msgid "Check your parentheses"
 msgstr "Verifica los paréntesis"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Atributo de Email"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Atributo de Nombre"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Atributo de Apellidos"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Sincronizar membresías de grupo"
@@ -1913,59 +1939,59 @@ msgstr "Mapas Personalizados"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Añade tus propios archivos GeoJSON para habilitar diferentes visualizaciones de mapas de región"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Uso compartido público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Habilitar el intercambio público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Cuadros de Mando compartidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Preguntas compartidas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Incrustar en otras aplicaciones"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar incrustación de Metabase en otras aplicaciones"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Clave secreta de incrustación"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Cuadros de Mando embebidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Preguntas embebidas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Almacenamiento en caché"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Habilitar caché"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Duración mínima de la consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplicador Time-to-Live (TTL) de caché"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Tamaño máximo de entrada de caché"
 
@@ -2007,27 +2033,27 @@ msgstr "Necesitará un administrador para crear una cuenta Metabase antes de pod
 msgid "Sign in with {0}"
 msgstr "Inicia sesión con {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Por favor, ponte en contacto con un administrador para que restablezca tu contraseña"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Olvidé mi contraseña"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "El correo electrónico que utilizas para tu cuenta Metabase"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Enviar correo electrónico de restablecimiento de contraseña"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Consulta tu correo electrónico para obtener instrucciones sobre cómo restablecer tu contraseña."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Iniciar sesión en Metabase"
 
@@ -2048,11 +2074,11 @@ msgstr "Acceder"
 msgid "I seem to have forgotten my password"
 msgstr "Parece que olvidé mi contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "solicitar un nuevo correo electrónico de reinicio"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Vaya, ese es un enlace caducado"
 
@@ -2062,11 +2088,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo.\n"
 "Si aún necesita restablecer tu contraseña, puedes {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nueva contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Para mantener tus datos seguros, las contraseñas {0}"
 
@@ -2089,24 +2115,24 @@ msgstr "Confirmar nueva contraseña"
 msgid "Make sure it matches the one you just entered"
 msgstr "Tiene que coincidir con la que acabas de poner"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Tu contraseña ha sido restablecida."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Inicia sesión con tu nueva contraseña"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Ha fallado"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2116,25 +2142,26 @@ msgstr "Guardado"
 msgid "Ok"
 msgstr "Vale"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "¿Archivar esta colección?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección también se archivarán."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Archivar"
 
@@ -2259,7 +2286,7 @@ msgstr "Pins"
 msgid "Drag something here to pin it to the top"
 msgstr "Arrastra algo aquí para pegarlo arriba"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2288,6 +2315,7 @@ msgstr "¿Mover \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Mover"
@@ -2325,7 +2353,7 @@ msgstr "Algunas instalaciones de bases de datos solo se pueden acceder conectán
 "Esta opción también proporciona una capa adicional de seguridad cuando no dispones de una VPN.\n"
 "Esto suele ser más lento que una conexión directa."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Esta es una base de datos grande, así que déjame elegir cuándo Metabase sincroniza y escanea"
 
@@ -2365,7 +2393,7 @@ msgstr "Para usar Metabase con estos datos, debes habilitar el acceso a la API e
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} para ir a la consola si aún no lo has hecho."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "¿Cómo te gustaría llamar esta base de datos?"
 
@@ -2481,35 +2509,35 @@ msgstr "Basado en el esquema"
 msgid "A look at your"
 msgstr "Una vista a tus"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Busca la lista"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Buscar por {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr "o introduce un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Introduce un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Introduce un número"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Introduce un texto"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "No se encontraron {0} coincidentes."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Incluir cada opción en tu filtro probablemente no hará mucho…"
 
@@ -2521,7 +2549,6 @@ msgstr "Lo siento. Algo salió mal."
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o simplemente volver atrás"
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2532,12 +2559,12 @@ msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o si
 msgid "No description yet"
 msgstr "Sin descripción todavía"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Nuevo {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Preguntado por {0}"
 
@@ -2558,7 +2585,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertido a una revisión anterior y {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historial de Revisiones"
@@ -2604,7 +2633,7 @@ msgid "Questions"
 msgstr "Preguntas"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Pulsos"
 
@@ -2678,52 +2707,69 @@ msgstr "Ahora no"
 msgid "Error:"
 msgstr "Error:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Domingo"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Lunes"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Martes"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Jueves"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Viernes"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Sábado"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Primero"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Ultimo"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15to (punto medio)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Día Calendario"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "tu zona horaria en Metabase"
 
@@ -2777,11 +2823,11 @@ msgstr "Crea"
 msgid "Create dashboard"
 msgstr "Crea un Cuadro de Mando"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabla"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Base de Datos"
 
@@ -2856,9 +2902,9 @@ msgstr "¿Cuál es el nombre de tu tarjeta?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2872,15 +2918,16 @@ msgstr "Descripción"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Es opcional pero, tan útil"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "¿En qué colección debería ir esto?"
 
@@ -2920,11 +2967,11 @@ msgstr "Archivar Cuadro de Mando"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Asegúrate de hacer una selección para cada serie, o el filtro no funcionará en esta tarjeta."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Este cuadro de mando parece estar vacío."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "¡Añade una pregunta para hacerlo útil!"
 
@@ -2944,7 +2991,7 @@ msgstr "Desactivar Pantalla Completa"
 msgid "Enter fullscreen"
 msgstr "Activar Pantalla Completa"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Guardando…"
@@ -2957,7 +3004,8 @@ msgstr "Añade una pregunta"
 msgid "Add a question to this dashboard"
 msgstr "Añade una pregunta a este cuadro de mando"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Añadir filtro"
 
@@ -2965,7 +3013,7 @@ msgstr "Añadir filtro"
 msgid "Parameters"
 msgstr "Parámetros"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Añade una caja de texto"
 
@@ -2973,7 +3021,7 @@ msgstr "Añade una caja de texto"
 msgid "Move dashboard"
 msgstr "Mover cuadro de mando"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Editar Cuadro de Mando"
 
@@ -2997,11 +3045,11 @@ msgstr "Mover cuadro de mando a..."
 msgid "Dashboard moved to {0}"
 msgstr "Cuadro de Mando movido a {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "¿Qué quieres filtrar?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "¿Qué tipo de filtro?"
 
@@ -3073,20 +3121,22 @@ msgstr "Esta tarjeta no tiene campos ni parámetros que coincidan con este tipo 
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Los valores en este campo no coinciden con los valores de ningún otro campo que hayas elegido."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "No hay campos válidos"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "El nombre debe tener 100 caracteres o menos"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Color es obligatorio"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "¿Cuál es el nombre de tu cuadro de mando?"
 
@@ -3141,7 +3191,7 @@ msgstr "recibido los últimos datos de"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -3266,9 +3316,10 @@ msgstr "No has consultado ningún cuadro de mando o pregunta recientemente"
 msgid "{0} items selected"
 msgstr "{0} elemento(s) seleccionado(s)"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Desarchivar"
 
@@ -3385,7 +3436,7 @@ msgid "Zip Code"
 msgstr "Código Postal"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Cantidad"
 
@@ -3419,11 +3470,13 @@ msgid "User"
 msgstr "Usuario"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Fuente"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Precio"
 
@@ -3456,21 +3509,23 @@ msgid "Subscription"
 msgstr "Suscripción"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Puntuación"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Título"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Comentario"
 
@@ -3524,14 +3579,14 @@ msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Contar"
 
@@ -3539,7 +3594,7 @@ msgstr "Contar"
 msgid "CumulativeCount"
 msgstr "RecuentoAcumulativo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3558,19 +3613,19 @@ msgstr "Distinto"
 msgid "StandardDeviation"
 msgstr "DesviacionEstandar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Media"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Mín"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3581,13 +3636,13 @@ msgstr "Máx"
 msgid "sad sad panda, lexing errors detected"
 msgstr "triste panda triste, errores léxicos detectados"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} segundo"
 msgstr[1] "{0} segundos"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
@@ -3628,14 +3683,15 @@ msgstr "¿Qué quieres saber?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Datos brutos"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Recuento acumulativo"
 
@@ -3697,166 +3753,164 @@ msgstr "Verdadero"
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Selecciona el campo de longitud"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Latitud Superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Longitud Izquierda"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Latitud Inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Longitud Derecha"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Es"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "No es"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Vacío"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "No Vacío"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Distinto a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Mayor que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Menor que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Mayor o igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Menos o igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "No contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Empieza con"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Termina en"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Antes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Después"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Dentro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Solo una tabla con las filas en la respuesta, sin operaciones adicionales."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Número de filas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Número total de filas en la respuesta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Suma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Suma de todos los valores de una columna."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Media de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Promedio de todos los valores de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Número de valores distintos de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Número de valores únicos de una columna entre todas las filas en la respuesta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Suma acumulada de ..."
 
@@ -3865,7 +3919,7 @@ msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over t
 msgstr "Suma aditiva de todos los valores de una columna.\n"
 " e.g. los ingresos totales a lo largo del tiempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Recuento acumulado de filas"
 
@@ -3874,27 +3928,27 @@ msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over
 msgstr "Recuento aditiva del número de filas.\n"
 " e.g. número total de ventas en el tiempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Desviación estándar de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Número que expresa cuánto varían los valores de una columna entre todas las filas en la respuesta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Mínimo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Valor mínimo de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Máximo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Valor máximo de una columna"
 
@@ -3910,6 +3964,8 @@ msgstr "letra en minúsculas"
 msgid "upper case letter"
 msgstr "letra en mayúsculas"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "número"
@@ -4157,7 +4213,7 @@ msgstr "Cómo crear métricas"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Consulta los datos a lo largo del tiempo, como un mapa, o gírelos para ayudarte a comprender las tendencias o los cambios."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -4180,7 +4236,7 @@ msgstr "Consulta nativa"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Para preguntas más complicadas puedes escribir tu propia consulta SQL o nativa."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Selecciona un valor por defecto…"
 
@@ -4271,7 +4327,7 @@ msgstr "Este Mes"
 msgid "This Year"
 msgstr "Este Año"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Introduce un valor..."
@@ -4281,7 +4337,7 @@ msgid "Enter a default value..."
 msgstr "Introduce un valor predeterminado..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ha ocurrido un error"
@@ -4539,22 +4595,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Elige las preguntas que te gustaría enviar en este pulso"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Emails"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Mensajes Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Enviado"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} se enviará a las"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Mensajes"
 
@@ -4626,30 +4690,30 @@ msgstr "Ayuda a todos los de tu equipo a mantenerse sincronizados con tus datos.
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o Slack en el horario que desees."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Después de {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Antes de {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Vacío"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "No Vacío"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Todo el Tiempo"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -4750,12 +4814,12 @@ msgstr[1] "Ver estos {0}"
 msgid "Zoom in"
 msgstr "Ampliar"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Expresión Personalizada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Métricas Comunes"
 
@@ -4952,7 +5016,7 @@ msgstr "generalmente"
 msgid "Pick a segment or table"
 msgstr "Elige un segmento o tabla"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Selecciona una base de datos"
@@ -5013,7 +5077,7 @@ msgstr "Ordenar"
 msgid "Row limit"
 msgstr "Límite de filas"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Campo Desconocido"
 
@@ -5021,7 +5085,7 @@ msgstr "Campo Desconocido"
 msgid "field"
 msgstr "campo"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Conincidencias"
 
@@ -5046,11 +5110,11 @@ msgstr "Añadir una agrupación"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Datos"
 
@@ -5067,11 +5131,12 @@ msgstr "Ver"
 msgid "Grouped By"
 msgstr "Agrupado por"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Ninguno"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Esta pregunta está escrita en {0}"
 
@@ -5083,7 +5148,7 @@ msgstr "Esconder Editor"
 msgid "Hide Query"
 msgstr "Esconder Consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Abrir Editor"
 
@@ -5091,7 +5156,7 @@ msgstr "Abrir Editor"
 msgid "Show Query"
 msgstr "Mostrar Consulta"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Esta métrica ha sido retirada. Ya no está disponible para su uso."
 
@@ -5292,7 +5357,7 @@ msgstr "Volver a la última ejecución"
 msgid "Visualization"
 msgstr "Visualización"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Sin descripción"
 
@@ -5349,7 +5414,7 @@ msgstr "No se pudieron encontrar los metadatos de la tabla antes de crear una nu
 msgid "See {0}"
 msgstr "Ver {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Definición de Métrica"
 
@@ -5367,11 +5432,11 @@ msgstr "Número de {0}"
 msgid "See all {0}"
 msgstr "Ver todos los {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Definición de Segmento"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Se produjo un error al cargar la tabla"
 
@@ -5379,7 +5444,7 @@ msgstr "Se produjo un error al cargar la tabla"
 msgid "See the raw data for {0}"
 msgstr "Ver los datos de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Más"
 
@@ -5399,6 +5464,8 @@ msgstr "Fórmula de campo"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Piensa en esto como algo parecido a escribir una fórmula en un programa de hoja de cálculo: puedes usar números, campos de esta tabla, símbolos matemáticos como + y algunas funciones. Así puedes escribir algo como Subtotal - Cost."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5466,7 +5533,7 @@ msgstr "falso"
 msgid "Add filter"
 msgstr "Añadir filtro"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Elemento"
 
@@ -5585,11 +5652,11 @@ msgstr "Campo para mapear a"
 msgid "Filter widget type"
 msgstr "Tipo de filtro"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "¿Obligatorio?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Valor por defecto del filtro"
 
@@ -5601,7 +5668,7 @@ msgstr "¿Archivar esta pregunta?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Esta pregunta se eliminará de cualquier cuadro de mando o pulso que lo usen."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Pregunta"
 
@@ -5648,7 +5715,7 @@ msgstr "Tipo campo"
 msgid "Select a Foreign Key"
 msgstr "Selecciona una Clabe foránea"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Ver la fórmula de {0}"
 
@@ -6132,22 +6199,24 @@ msgstr "Preguntas sobre este segmento"
 msgid "X-ray this segment"
 msgstr "Aplica rayos-X a este segmento"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Iniciar sesión"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Buscar"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Cuadro de Mando"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nueva Pregunta"
 
@@ -6219,35 +6288,35 @@ msgstr "Toda la información obtenida es completamente anónima."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La recopilación puede desactivarse en cualquier momento en la sección de configuración."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Si te sientes abrumado"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "nuestra guía de inicio"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "esta a un solo click."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Bienvenid@ a Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Parece que todo está funcionando. ¡Ahora vamos a conocerte, conectarte con tus datos y comenzar a encontrarte algunas respuestas!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Empecemos"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "¡Estás listo!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Llévame a Metabase"
 
@@ -6500,39 +6569,40 @@ msgstr "Cancelar Filtro"
 msgid "Pin Map"
 msgstr "Mapa de Pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Desmarcar"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Filas {0}-{1} de {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Datos truncados a {0} filas."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "No se pudo encontrar la visualización"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "No se pudo mostrar este gráfico con esta información."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "¡Sin resultados!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Esperando..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Esto suele tardar unos {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Es un poco largo para un cuadro de mando)"
 
@@ -6643,7 +6713,7 @@ msgid "Highlight the whole row"
 msgstr "Resalta la fila entera"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Colores"
 
@@ -6729,24 +6799,50 @@ msgstr "Objetivo"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Vaya! Los datos de tu consulta no se ajustan a la opción de visualización elegida. Esta visualización requiere al menos {0} {1} de datos."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "columna"
@@ -6778,7 +6874,7 @@ msgid "xValues missing!"
 msgstr "¡Faltan valores x!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Eje-X"
 
@@ -6787,7 +6883,7 @@ msgid "Add a series breakout..."
 msgstr "Añade un desglose de series..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Eje-Y"
 
@@ -6800,7 +6896,7 @@ msgid "Bubble size"
 msgstr "Tamaño de burbuja"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Línea"
 
@@ -6942,20 +7038,20 @@ msgid "Standard Deviation"
 msgstr "Desviación Estándar"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Area"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "Gráfico de área"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "Gráfico de barras"
 
@@ -6969,7 +7065,7 @@ msgid "Funnel"
 msgstr "Embudo"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Medida"
 
@@ -6981,81 +7077,81 @@ msgstr "Tipo Embudo"
 msgid "Bar chart"
 msgstr "Gráfico de barras"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "Gráfico de líneas"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Selecciona las columnas de longitud y latitud en la configuración del gráfico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Por favor, selecciona un mapa de la región."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Selecciona las columnas de región y métricas en la configuración del gráfico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Tipo mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Mapa de la región"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Mapa de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Tipo Pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Baldosas"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Marcadores"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Campo Latitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Campo Longitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Campo Métrica"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Campo Región"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Radio"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Difuminar"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Opacidad Mínima"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Acercamiento Máximo"
 
@@ -7067,7 +7163,7 @@ msgstr "No se encontraron relaciones."
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Esta {0} está conectada a:"
 
@@ -7079,31 +7175,31 @@ msgstr "Detalle del Objeto"
 msgid "object"
 msgstr "objeto"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "¿Qué columnas quieres usar?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pastel"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimensión"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Mostrar Leyenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Mostrar porcentajes en la leyenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Porcentaje mínimo de porción"
 
@@ -7128,7 +7224,8 @@ msgid "Progress"
 msgstr "Progreso"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Color"
@@ -7137,7 +7234,7 @@ msgstr "Color"
 msgid "Row Chart"
 msgstr "Gráfico de Filas"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "gráfico de filas"
 
@@ -7161,15 +7258,15 @@ msgstr "Añade un sufijo"
 msgid "Multiply by a number"
 msgstr "Multiplicar por un número"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Dispersión"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "gráfico de dispersión"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Pivote la tabla"
 
@@ -7219,13 +7316,13 @@ msgstr "Derecho"
 msgid "Show background"
 msgstr "Mostrar fondo"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} agrupación"
 msgstr[1] "{0} agrupaciones"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Agrupación Auto"
 
@@ -7461,10 +7558,13 @@ msgstr "¿Tienes muchas preguntas guardadas en {0}? Crea colecciones para ayudar
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7654,7 +7754,7 @@ msgstr "suma acumulativa"
 msgid "{0} and {1}"
 msgstr "{0} y {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
@@ -8969,11 +9069,11 @@ msgstr "Permisos de acceso de datos"
 msgid "Collection permissions"
 msgstr "Permisos de acceso de colecciones"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Ver todos los permisos de colecciones"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "También cambiar sub-colecciones"
 
@@ -8985,19 +9085,19 @@ msgstr "Puede editar esta colección y sus contenidos"
 msgid "Can view items in this collection"
 msgstr "Puede ver artículos en esta colección"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Acceso a Colección"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Este grupo tiene permiso para ver al menos una subcolección de esta colección."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Este grupo tiene permiso para editar al menos una subcolección de esta colección."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Ver subcolección"
 
@@ -9053,6 +9153,7 @@ msgstr "Relacionado"
 msgid "More X-rays"
 msgstr "Más Rayos-X"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9311,10 +9412,10 @@ msgstr "Compartir"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9398,7 +9499,7 @@ msgstr "Utiliza la zona horaria del JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Estamos analizando las tablas y los campos para ayudarte a explorar tus datos."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Consejo: "
 
@@ -9406,7 +9507,7 @@ msgstr "Consejo: "
 msgid "Select a currency type"
 msgstr "Selecciona un tipo de moneda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Tipo Campo"
 
@@ -9461,6 +9562,7 @@ msgid "Currency"
 msgstr "Moneda"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Elige un usuario o canal..."
 
@@ -9622,7 +9724,7 @@ msgstr "¿En qué eje?"
 msgid "Line + Bar"
 msgstr "Línea + Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "gráfico de línea y barra"
 
@@ -9642,15 +9744,15 @@ msgstr "Rangos del contador"
 msgid "Field to show"
 msgstr "Campo a mostrar"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "último {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} era {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Agrupa por un campo temporal para ver como ha cambiado a lo largo del tiempo"
 
@@ -9658,23 +9760,23 @@ msgstr "Agrupa por un campo temporal para ver como ha cambiado a lo largo del ti
 msgid "Switch positive / negative colors?"
 msgstr "¿Mostrar colores positivos/negativos?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Columna pivote"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Columna celda"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Columnas visibles"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Formato condicional"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Título columna"
 
@@ -10112,10 +10214,10 @@ msgstr "Usuarios por origen"
 msgid "The top external pages that brought users to your site"
 msgstr "Las principales páginas externas que trajeron usuarios a tu sitio."
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Cómo se distribuye [[this]] y algo más."
 
@@ -10213,13 +10315,13 @@ msgstr "Eventos por hora del día"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Primeros 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Ultimos 5 [[this]]"
 
@@ -10232,10 +10334,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Por [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Valores nulos"
 
@@ -10263,8 +10365,8 @@ msgstr "Cómo se comparan por estacionalidad."
 msgid "Average income per transaction"
 msgstr "Ingreso medio por transacción"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] por país"
 
@@ -10388,10 +10490,10 @@ msgstr "Una visión general de tu [[this]] y cómo se distribuye en el tiempo, e
 msgid "Average income per state"
 msgstr "Ingresos medios por provincia"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] por [[GenericCategoryMedium]]"
 
@@ -10568,13 +10670,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Cómo [[GenericTable]] se distribuye en este campo de tiempo, y si tiene algún patrón estacional."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Visión general"
 
@@ -10683,8 +10785,8 @@ msgstr "Aquí hay una mirada más detallada a tus [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Una mirada detallada de tu campo [[this]]"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Resumen"
 
@@ -10748,10 +10850,10 @@ msgstr "Ventas por origen"
 msgid "Average income per country"
 msgstr "Ingreso medio por país"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Como se distribuye [[this]]"
 
@@ -10772,17 +10874,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Cuenta de [[GenericCategoryMedium]] por [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Una mirada a tus [[this]]"
 
@@ -10848,10 +10950,10 @@ msgid "Transactions per source over time"
 msgstr "Transacciones por origen a lo largo del tiempo."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Como se distribuye el [[this]]"
 
@@ -10880,9 +10982,9 @@ msgstr "Donde occuren estos eventos"
 msgid "Which US states are bringing you the most business."
 msgstr "Qué estados de los EEUU te están dando más negocio"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Como se comparan a lo largo del tiempo"
 
@@ -10987,8 +11089,8 @@ msgstr "Sesiones por País"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Algunas métricas interesantes sobre tus estadísticas de GA para empezar."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] por provincia"
 
@@ -11069,12 +11171,12 @@ msgstr "Cómo se distribuye esta métrica entre diferentes números."
 msgid "Sessions by page where the session began"
 msgstr "Sesiones por página donde comenzó la sesión."
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Valores distintos"
 
@@ -11137,10 +11239,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Eventos por [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Cómo se comparan por distribución"
@@ -11446,6 +11548,7 @@ msgstr "Duplicar Cuadro de Mando"
 msgid "Duplicate \"{0}\""
 msgstr "Duplicar \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11543,9 +11646,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre del año"
 msgstr[1] "Trimestres del año"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seleccionado"
@@ -11568,11 +11671,11 @@ msgstr "Inválido"
 msgid "Add a time"
 msgstr "Añade una hora"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nada que comparar en el {0} anterior."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "por {0}."
 
@@ -12060,9 +12163,9 @@ msgstr "Aquí hay un resumen de las personas en tu [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] por trimestre del año"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Cómo se comparan a través de la ubicación"
 
@@ -12091,12 +12194,12 @@ msgstr "[[CreateTimestamp]] por día de la semana"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Aquí hay una descripción general de tus datos [[this]] de Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Aquí hay una visión general de tu [[this]]"
 
@@ -12174,11 +12277,11 @@ msgstr "colección"
 msgid "collections"
 msgstr "colecciones"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "cuadro de mando"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "cuadros de mando"
 
@@ -12428,7 +12531,7 @@ msgstr "Tiempo agotado después de {0} milisegundos."
 msgid "Misfire Instruction"
 msgstr "Instrucciones de fallo"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "¿Archivar esto?"
 
@@ -12446,7 +12549,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Esta opción requiere que el host sea FQDN. Si se conecta a un clúster Atlas, es posible que deba habilitar esta opción. Si no sabe lo que esto significa, deje esto deshabilitado."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Ejecutar consultas automáticamente al realizar un filtrado/resumen simple"
 
@@ -12458,7 +12561,7 @@ msgstr "Cuando esto está activo en Metabase, se ejecutarán consultas automáti
 msgid "Learn about this database"
 msgstr "Aprende cosas sobre esta base de datos"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "¿Archivar este cuadro de mando?"
 
@@ -12514,11 +12617,11 @@ msgstr "Pregunta personalizada"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Utiliza el editor avanzado para unir datos, crear columnas personalizadas, hacer cálculos matemáticos y más."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Indicadores básicos"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Personalizado..."
 
@@ -12703,15 +12806,15 @@ msgstr "Elige una visualización"
 msgid "Filter by"
 msgstr "Filtrar por"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Resumir por"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Agrupar por"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Añadir una métrica"
 
@@ -12722,15 +12825,15 @@ msgstr "Añadir una métrica"
 msgid "Profile"
 msgstr "Perfil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Esto suele ser bastante rápido, pero parece estar tardando un poco en este momento."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Combo"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Fila"
 
@@ -13152,7 +13255,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Elige las columnas que quieres incluir"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Al activar esto, Metabase ejecutará consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar ea tablas o gráficos. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta a los detalles ni a las consultas SQL."
 
@@ -13218,7 +13321,7 @@ msgstr "Entrar con email"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "El uso de esta opción requiere que el host proporcionado sea un FQDN. Si te conectas a un clúster de Atlas, es posible que debas habilitar esta opción. Si no sabes lo que significa esto, dejalo deshabilitado."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "De manera predeterminada, Metabase realiza una sincronización por hora y un escaneo diario intensivo de valores de campo. Si tienes una base de datos grande, recomendamos activar esto y revisar cuándo y con qué frecuencia ocurren los escaneos de valor de campo."
 
@@ -13286,11 +13389,11 @@ msgstr "No incluir"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Este campo no será visible o seleccionable en las preguntas creadas con la aplicación. Todavía será accesible en consultas SQL/nativas."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Suma Acumulada"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Desviacion estandar"
 
@@ -13306,19 +13409,19 @@ msgstr "Debe tener al menos {0} caracteres de longitud"
 msgid "Name (required)"
 msgstr "Nombre (requerido)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Ejecutar texto seleccionado"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Ejecutar consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + intro)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + intro)"
 
@@ -13666,7 +13769,7 @@ msgstr "Fechas y Horas"
 msgid "Numbers"
 msgstr "Números"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "No hay grupos asignables"
 
@@ -13706,15 +13809,15 @@ msgstr "tevesbienhoy@email.com"
 msgid "Remember me"
 msgstr "Recuérdame"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo. Si aún necesitas restablecer tu contraseña, puedes {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Guardar nueva contraseña"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Sin resultados coincidentes"
 
@@ -13740,26 +13843,26 @@ msgid "or"
 msgstr "o"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "obligatorio"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Tipo base de datos"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Este es un proceso ligero que busca actualizaciones para el esquema de esta base de datos. En la mayoría de los casos, debería estar bien dejarlo que sincronice cada hora."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase puede escanear los valores presentes en cada campo en esta base de datos para habilitar filtros de casillas de verificación en paneles y preguntas. Este puede ser un proceso de uso intensivo de recursos, especialmente si tienes una base de datos muy grande."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Colección"
 
@@ -13806,7 +13909,7 @@ msgstr "Categórico"
 msgid "URLs"
 msgstr "URLs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Devuelve el promedio de los valores en la columna."
 
@@ -13815,11 +13918,13 @@ msgstr "Devuelve el promedio de los valores en la columna."
 msgid "The column whose values to average."
 msgstr "La columna cuyos valores promediar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "inicio"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "fin"
 
@@ -13831,21 +13936,19 @@ msgstr "Comprueba los valores de una fecha o columna numérica para ver si está
 msgid "Rating"
 msgstr "Clasificación"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "condición"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "salida"
 
@@ -13853,27 +13956,27 @@ msgstr "salida"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Prueba una lista de casos y devuelve el valor correspondiente del primer caso verdadero, con un valor predeterminado opcional si no se cumple ninguno."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Peso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Grande"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Medio"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Pequeño"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Algo que debería evaluar como verdadero o falso."
 
@@ -13881,33 +13984,33 @@ msgstr "Algo que debería evaluar como verdadero o falso."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "El valor que se devolverá si la condición anterior es verdadera."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "valor1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "valor2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Mira los valores en cada argumento en orden y devuelve el primer valor no nulo para cada fila."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Comentarios"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notas"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Sin comentarios"
 
@@ -13923,12 +14026,12 @@ msgstr "Si valor1 está vacío, devuelve valor2 si no está vacío, y así suces
 msgid "Combines two or more strings of text together."
 msgstr "Combina dos o más cadenas de texto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Apellidos"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Nombre"
 
@@ -13940,27 +14043,27 @@ msgstr "valor2 se añadirá al final de esto."
 msgid "This will be added to the end of value1."
 msgstr "Esto se agregará al final del valor1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "cadena1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "cadena2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Comprueba si string1 contiene string2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Estado"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Pasar"
 
@@ -13968,7 +14071,7 @@ msgstr "Pasar"
 msgid "The contents of this string will be checked."
 msgstr "Se verificará el contenido de esta cadena."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "La cadena de texto a buscar."
 
@@ -13976,22 +14079,22 @@ msgstr "La cadena de texto a buscar."
 msgid "Returns the count of rows in the source data."
 msgstr "Devuelve el número de filas en los datos de origen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Solo cuenta las filas donde la condición es verdadera."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "El total aditivo de filas en una ruptura."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "La suma aditiva de una columna en una ruptura."
 
@@ -14000,53 +14103,57 @@ msgstr "La suma aditiva de una columna en una ruptura."
 msgid "The column to sum."
 msgstr "La columna a sumar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "El número de valores distintos en esta columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "La columna en la que hay que contar los valores distintos."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "texto"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "comparación"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Devuelve verdadero si el final del texto coincide con el texto de comparación."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Apetito"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hambriento"
 
@@ -14055,20 +14162,20 @@ msgstr "hambriento"
 msgid "A column or string of text to check."
 msgstr "Una columna o cadena de texto para verificar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "La cadena de texto con la que debe terminar el texto original."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "expresión_regular"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrae subcadenas coincidentes de acuerdo con una expresión regular."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Dirección"
 
@@ -14076,7 +14183,7 @@ msgstr "Dirección"
 msgid "The column or string of text to search though."
 msgstr "La columna o cadena de texto en la que buscar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "La expresión regular a evaluar."
 
@@ -14088,7 +14195,7 @@ msgstr "Devuelve la cadena de texto en minúsculas."
 msgid "The column with values to convert to lowercase."
 msgstr "La columna con valores para convertir a minúsculas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Elimina los espacios en blanco iniciales de una cadena de texto."
 
@@ -14098,15 +14205,16 @@ msgstr "Elimina los espacios en blanco iniciales de una cadena de texto."
 msgid "The column with values you want to trim."
 msgstr "La columna con los valores que quieres recortar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Devuelve el máximo valor encontrado en la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Edad"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "La columna numérica cuyo máximo quieres encontrar."
 
@@ -14114,21 +14222,21 @@ msgstr "La columna numérica cuyo máximo quieres encontrar."
 msgid "Returns the smallest value found in the column."
 msgstr "Devuelve el valor más pequeño encontrado en la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Salario"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "La columna numérica cuyo mínimo quieres encontrar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "posición"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "longitud"
 
@@ -14137,7 +14245,7 @@ msgstr "longitud"
 msgid "new_text"
 msgstr "texto_nuevo"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Reemplaza una parte del texto de entrada con texto nuevo."
 
@@ -14165,35 +14273,35 @@ msgstr "El número de caracteres a reemplazar."
 msgid "The text to use in the replacement."
 msgstr "El texto a usar en el reemplazo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Elimina los espacios en blanco finales de una cadena de texto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Devuelve el porcentaje de filas en los datos que coinciden con la condición, como un decimal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Devuelve verdadero si el comienzo del texto coincide con el texto de comparación."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Nombre del Curso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Ciencias de la Computación"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "La cadena de texto con la que debe comenzar el texto original."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcula la desviación estándar de la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Población"
 
@@ -14201,7 +14309,7 @@ msgstr "Población"
 msgid "A numeric column."
 msgstr "Una columna numérica"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Devuelve una parte del texto proporcionado."
 
@@ -14209,19 +14317,19 @@ msgstr "Devuelve una parte del texto proporcionado."
 msgid "The text to return a portion of."
 msgstr "El texto del que hay que extraer una parte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "La posición para comenzar a copiar caracteres."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "El número de caracteres a devolver."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Suma todos los valores de la columna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "La columna numérica a sumar."
 
@@ -14229,15 +14337,15 @@ msgstr "La columna numérica a sumar."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Resume valores en una columna donde las filas coinciden con la condición."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Estado Pedido"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Válido"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Elimina los espacios en blanco iniciales y finales de una cadena de texto."
 
@@ -14245,47 +14353,47 @@ msgstr "Elimina los espacios en blanco iniciales y finales de una cadena de text
 msgid "Returns the string of text in all upper case."
 msgstr "Devuelve la cadena de texto en mayúsculas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "La columna con valores para convertir a mayúsculas."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "debe ser {0} e incluir {1}"
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "debe ser {0}"
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "debe incluir {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "al menos {0} carácter"
 msgstr[1] "al menos {0} caracteres"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} letra minúscula"
 msgstr[1] "{0} letras minúsculas"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} letra mayúscula"
 msgstr[1] "{0} letras mayúsculas"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} número"
 msgstr[1] "{0} números"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} carácter especial"
@@ -14308,6 +14416,7 @@ msgid "Powered by {0}"
 msgstr "Impulsado por {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "A:"
 
@@ -14395,7 +14504,7 @@ msgstr "Formato de valor"
 msgid "Full"
 msgstr "Lleno"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Sin cambios desde el último {0}"
 
@@ -14720,7 +14829,7 @@ msgstr "Error al generar información para la columna:"
 msgid "Sending abandonment email!"
 msgstr "Enviando correo electrónico de abandono!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Puedes crear métricas guardadas para agregar una opción de métrica con nombre. Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas. Como ejemplo, puedes usar esto para crear algo así como la forma oficial de calcular el \"Precio promedio\" para una tabla de pedidos."
 
@@ -14728,15 +14837,15 @@ msgstr "Puedes crear métricas guardadas para agregar una opción de métrica co
 msgid "Select and add filters to create your new segment."
 msgstr "Selecciona y añade filtros para crear tu nuevo segmento."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alfabético"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Ingenioso"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Orden de Columna: {0}"
 
@@ -14788,7 +14897,7 @@ msgstr "Localización"
 msgid "Instance language"
 msgstr "Idioma de Aplicación"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Opciones de localización"
 
@@ -14860,19 +14969,20 @@ msgstr "Pegar una cadena de conexión"
 msgid "Fill out individual fields"
 msgstr "Rellena campos individuales"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Añade SQL aquí para que puedas reutilizarlo más tarde"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Dale un nombre a tu fragmento"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Clientes Actuales"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Añadir una descripción"
 
@@ -14880,46 +14990,47 @@ msgstr "Añadir una descripción"
 msgid "Use site default"
 msgstr "Utilizar el valor por defecto del sitio"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "encontrar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "sustituir"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "El texto a encontrar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "El texto a utilizar para sustituir."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Editando {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Crea tu nuevo fragmento"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Fragmentos archivados"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Fragmentos son porciones de SQL reutilizables"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Crea un fragmento"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Fragmentos"
 
@@ -15198,4 +15309,1506 @@ msgstr "El valor debe ser una palabra clave o una cadena."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "La cadena debe ser un idioma ISO válido de dos letras o un código de idioma-país, p.e. 'en' o 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Filas {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Auditoria"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Configuración de atributos de usuario (opcional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Utilizando {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Configura Acceso con SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "Autentificación SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Configura tu proveeedor de identidad (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Su proveedor de identidad necesitará la siguiente información sobre Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL a la que el IdP debe redirigir"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Esto se denomina la URL de inicio de sesión único en Okta, la URL de devolución de llamada de la aplicación en Auth0,\n"
+"y la URL de ACS (consumidor) en OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "atributos SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "En la mayoría de los IdP, deberá colocar cada uno de estos en un cuadro de entrada etiquetado\n"
+"\"Nombre\" en la sección de declaraciones de atributos."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Atributo de correo electrónico del usuario"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Atributo de nombre del usuario"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Atributo de apellido del usuario"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Cuéntele a Metabase sobre tu proveedor de identidad"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase necesitará la siguiente información sobre tu proveedor."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL del proveedor de identidad SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Certificado de proveedor de identidad SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Nombre de la aplicación SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Firmar solicitudes de SSO (opcional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Ruta del almacén de claves SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Contraseña de claves SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Shh..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Alias de claves SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Sincroniza la membresía de grupo con SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Para habilitar esto, deberás crear asignaciones para decirle a Metabase a qué grupo(s) deben unirse tus\n"
+"usuarios en función del grupo de SSO en el que se encuentran."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Nombre Grupo"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Nombre de atributo de grupo"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Nota:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Si cambias alguna de las opciones de una configuración activa SAML, deberás reiniciar Metabase para que surtan efecto."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Permite a los usuarios iniciar sesión a través de un proveedor de identidad SAML."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Permite a los usuarios iniciar sesión a través de un proveedor de identidad JWT."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Habilitar la autenticación de contraseña"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Cuando está habilitado, los usuarios también pueden iniciar sesión con correo electrónico y contraseña."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Notificar a los administradores de nuevos usuarios de SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Cuando está habilitado, los administradores recibirán un correo electrónico la primera vez que un usuario utilice el inicio de sesión único."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Utiliza la siguiente configuración para configurar tu SSO a través de SAML. Si tienes alguna pregunta, consulta {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "documentation"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI del proveedor de identidad de SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "Autenticación JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI del proveedor de identidad de JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Cadena utilizada por la clave de firma JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Incrustar toda la aplicación Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Si quieres incrustar todo Metabase, define los sitios web o aplicaciones web donde quieres permitir la incrustación en un iframe, separados por un espacio. Aquí están los {0} para lo que se puede ingresar."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Otorgar acceso de zona de pruebas a esta tabla"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Cuando los usuarios de este grupo vean esta tabla, verán una versión de la misma filtrada por sus atributos de usuario, o una vista personalizada basada en una pregunta guardada."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "¿Cómo quieres filtrar esta tabla para los usuarios de este grupo?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Elige una pregunta guardada que devuelva la vista personalizada de esta tabla que estos usuarios deberían ver."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Opcionalmente, puedes agregar filtros adicionales aquí según los atributos del usuario. Estos filtros se aplicarán sobre cualquier filtro que ya esté en esta pregunta guardada."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Para que esta opción funcione, tus usuarios deben tener algunos atributos"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Para agregar filtros adicionales, tus usuarios deben tener algunos atributos"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Sin atributos de usuario"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Elija un atributo de usuario"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Elige un parámetro"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Elige una columna"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Las usuarios en {0} pueden ver"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "filas en la pregunta {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "filas en la tabla {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "donde {0} es igual a {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "y {0} es igual a {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Puedes agregar atributos automáticamente configurando un SSO que use SAML, o puedes ingresarlos manualmente yendo a la sección Personas y haciendo clic en el menú … en el extremo derecho."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Atributo de usuario"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Podemos obtener automáticamente los atributos de tus usuarios si has configurado el inicio de sesión único o puede añadirlos manualmente desde el menú \"...\" en la sección Personas del Panel de administración."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parámetro o variable"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "igual a"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Otorgar acceso a la zona de pruebas"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Acceso en la zona de pruebas"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Editar el acceso a la zona de pruebas"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Editar los detalles de la carpeta"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Cambiar permisos"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Crea tu nueva carpeta"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nueva carpeta"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Tenemos problemas validando tu token"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Verifica que tu instancia puede conectarse a los servidores de Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Obtener ayuda"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Aprovecha aún más Metabase con Enterprise Edition"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Todas las herramientas que necesita para proporcionar informes rápida y fácilmente a sus clientes, o para ayudarlo a ejecutar y monitorear Metabase en una organización grande."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Activar una licencia"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Tu prueba está activa con estas funciones"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "La prueba caduca {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "¿Necesitas ayuda? ¿Listo para comprar?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Habla con nosotros"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Tu periodo de prueba ha caducado"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "¿Necesitas mas tiempo? ¿Listo para comprar?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "¡Tus funciones están activas!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Tu licencia es válida hasta {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Tu licencia ha expirado"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Caducó el {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "¿Quieres renovar tu licencia?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Aprende a usar esto"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "No incluido en tu plan actual"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Ingrese el token que recibió de la tienda"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Activar"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "¿Necesitas ayuda?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Más información sobre tu problema."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Contactar con soporte"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Datos en zona de pruebas"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Asegúrate de mostrar los datos correctos a las personas correctas con filtros seguros y automáticos basados en los atributos del usuario."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Etiquetado blanco"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Haz coincidir Metabase con tu marca con colores personalizados, tu propio logotipo y más."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Auditando"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Vigila el rendimiento y el comportamiento con sólidas herramientas de auditoría."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Inicio de sesión único"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Proporciona un inicio de sesión sencillo que funciona con tu infraestructura de autenticación existente."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Tienda"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Nombre de Aplicación"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Paleta de Colores"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Página de destino"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Sin grupos"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Permisos para {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Permisos para esta carpeta"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Conceder acceso de edición"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Puedes modificar fragmentos en esta carpeta"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Conceder acceso para visualizar"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Puedes insertar y usar fragmentos en esta carpeta, pero no puedes editar el SQL que contienen"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "No se pueden ver o insertar fragmentos en esta carpeta"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "También cambiar subcarpetas"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Primer día de la semana"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Hubo un problema al iniciar sesión con Google. Por favor busca ayuda de un administrador."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "en el"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "en"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Abra el menú de acciones de la Metabase"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "No hacer nada"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Ir a un destino personalizado"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Actualizar un filtro de cuadro de mando"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} actualizaciones {1} filtro"
+msgstr[1] "{0} actualizaciones {1} filtros"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} va a {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Comportamiento al hacer clic para cada columna"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Ir a destino personalizado"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Abre el menú de acciones"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Comportamiento del clic para {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Elige uno o más filtros para actualizar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Pregunta guardada"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Enlazar a"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Introduce una URL para enlazar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Puedes insertar el valor de una columna o filtro de cuadro de mando con su nombre, así: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "e.g. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Elige un cuadro de mando..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Elige una pregunta..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Elige un cuadro de mando con el que enlazar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Elige un pregunta con la que enlazar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Pasar valores a los filtros de este cuadro de mando (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Pasar valores a las variables de esta pregunta (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Pasar valores para filtrar esta pregunta (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filtros de cuadro de mando"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Atributos de usuario"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Personalizar el texto del enlace (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "Ex. Detalles de {{Column Name}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Valores a los que puedes hacer referencia"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "No hay objetivos disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filtro"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "variable"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Otros filtros disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Filtros disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Otras variables disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Variables disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Otras columnas disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Columnas disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "atributo de usuario"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Tarjeta de texto"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Comportamiento de clic"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Opciones de visualización"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Editar series"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Añadir series"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Al hacer click"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Cambiar título y descripción"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Has actualizado los parámetros integrados y deberás actualizar tu código de inserción."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Añadir pregunta"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Estás editando este cuadro de mando."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Columna por la que filtrar"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "colección de fragmentos"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "colecciones de fragmentos"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Dale un nombre a tu carpeta"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Algo corto y ameno"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Carpeta en la que debería estar"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Abre el menú de acciones"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} columna tiene un comportamiento personalizado"
+msgstr[1] "{0} columnas tienen un comportamiento personalizado"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Ir a..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Ir a cuadro de mando"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Ir a pregunta"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Ir a URL"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filtrar este cuadro de mando"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Devuelve el recuento de filas en los datos seleccionados."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "La columna o número a sumar"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "La columna numérica de la que se obtendrá la desviación estándar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "La columna numérica cuyos valores promediar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Devuelve el valor más pequeño encontrado en la columna."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Suma la columna especificada solo para las filas donde la condición es verdadera."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Devuelve la varianza numérica de una columna determinada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "La columna o número para obtener la varianza."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Devuelve el valor mediano de la columna especificada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "La columna o el número del que se obtendrá la mediana."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "valor percentil"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Devuelve el valor de la columna en el valor de percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "La columna o número para obtener el percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "El valor del percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Devuelve la cadena de texto en minúsculas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "La columna con valores para convertir a minúsculas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Devuelve el texto en mayúsculas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "La columna o el texto del que se devolverá una parte."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "La columna o texto en la que buscar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Combina dos o más cadenas de texto juntas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "La columna o texto con el que empezar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Esto se agregará al final de value1, y así sucesivamente."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Enorme"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigantesco"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Devuelve el número de caracteres del texto."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "La columna o el texto cuya longitud quieres obtener."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "La columna o el texto que quieres recortar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Devuelve el valor absoluto (positivo) de la columna especificada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Deuda"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "La columna o número del que se devolverá el valor absoluto (positivo)."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Redondea un número decimal hacia abajo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "La columna o número para redondear hacia abajo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Redondea un número decimal hacia arriba."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "La columna o número que se va a redondear."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Redondea un número decimal hacia arriba o hacia abajo al valor entero más cercano."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "La columna o número que se va a redondear al entero más cercano."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Devuelve la raíz cuadrada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hipotenusa"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "La columna o número del que se devolverá el valor de raíz cuadrada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "exponente"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Eleva un número a la potencia del valor del exponente."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Longitud"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "La columna o número elevado al exponente."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "El valor del exponente."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Devuelve el logaritmo en base 10 del número."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Valor"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "La columna o número del que se devolverá el valor en logaritmo natural."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Devuelve el número de Euler, e, elevado a la potencia del número proporcionado."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Meses de interés"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "La columna o número del que se devolverá el valor exponencial."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "La columna o el texto a comprobar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Comprueba los valores de una columna de fecha o número para ver si están dentro del rango especificado."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Creado en"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "La fecha o columna numérica que debe estar dentro de los valores inicial y final."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "El inicio del rango."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "El final del rango."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Comprueba los valores de una columna de fecha para ver si están dentro del rango relativo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "La columna de fecha del intervalo de retorno."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Período de intervalo, donde los valores negativos retroceden en el tiempo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Tipo de interno como \"día\", \"mes\", \"año\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "La columna o valor que se devolverá."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Si value1 está vacío, value2 se devuelve si no está vacío, y así sucesivamente"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Prueba una expresión con una lista de casos y devuelve el valor correspondiente del primer caso coincidente, con un valor predeterminado opcional si no se cumple para ningún caso."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "El valor que se devolverá si la condición anterior es verdadera, y así sucesivamente."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "es nulo"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "no es nulo"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Suma aditiva de todos los valores de una columna.\n"
+"ex. ingresos totales a lo largo del tiempo."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Recuento aditivo del número de filas.\n"
+"ex. número total de ventas a lo largo del tiempo."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Filtros enlazados"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Etiqueta"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Valor por defecto"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Sin valor por defecto"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Para ver esto, {0} debe estar conectado a al menos un campo."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Limita las opciones de este filtro"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Si tienes otro filtro de panel, puede limitar las opciones que se enumeran para este filtro en función de la selección del otro."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Así que primero, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "añade otro filtro de panel"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Si activas uno de estos filtros de panel, la selección de un valor para ese filtro limitará las opciones disponibles para el filtro {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Columna con filtro"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Columna filtrada"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Ingresa nombres de usuario o direcciones de correo electrónico"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Nuevo fragmento"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Cada hora"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Diariamente a las {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Semanalmente en {0} el {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Mensualmente el {0} {1} a las {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Eliminar esta suscripción"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Suscripciones"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Crear una suscripción al panel"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Envíalo por correo electrónico"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Puedes enviar este panel con regularidad a usuarios o direcciones de correo electrónico."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Envíalo a Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Elija un canal y un horario, y Metabase hará el resto."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Enviar este panel por correo electrónico"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "No enviar si no hay resultados"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Adjuntar resultados"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Los archivos adjuntos pueden contener hasta 2000 filas de datos."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Enviar este panel a Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "El panel no tiene un parámetro con el ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "El parámetro {0} no tiene ningún campo asociado."
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "incluir debe estar vacío o el tener el valor 'tables'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "Se requiere `database` para todas las consultas cuyo tipo no sea ʻinternal`."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "El inicio de sesión con contraseña está deshabilitado para esta instancia."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Tu cuenta está desactivada. Pregunta a tu administrador."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Tu cuenta está desactivada."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Token de Slack inválido"
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "El comando ''{0}'' solo está disponible en Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Las extensiones de Metabase Enterprise Edition ESTÁN PRESENTES."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "El uso de las funciones de Metabase Enterprise Edition está sujeto a la licencia comercial de Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Ver {0} para obtener más detalles."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Las extensiones de Metabase Enterprise Edition NO ESTÁN PRESENTES."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Estás invitado a unirte al {0} de {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} creó una cuenta de {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} aceptó su invitación a {1}"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Solicitud de restablecimiento de contraseña"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Notificación"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Ayuda a mejorar [{1}]."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Cuéntanos cómo van las cosas."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Error al iniciar el detector de eventos"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "¿Debemos sincronizar los atributos del usuario cuando alguien inicia sesión a través de LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Una lista de atributos de usuario, separados por comas, a omitir de la sincronización de usuarios de LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Token no válido"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Error de API de Slack: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "¡Falta el canal de Slack llamado `metabase_files`!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Crea o desarchiva el canal para completar la integración con Slack."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "El canal se utiliza para almacenar gráficos que se incluyen en las respuestas de Pulses y MetaBot."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Imagen cargada"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Error al cargar el archivo en Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Sesión inválida. Se esperaba una instancia de Session."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "El cookie de sesión SameSite está configurado en \"Ninguno\", pero el sitio está"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "servido a través de una conexión insegura. Algunos navegadores lo rechazarán "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookies cookies en estas condiciones. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Carpeta superior"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parameters debe ser una secuencia de mapas con String: id keys"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Valores legibles por humanos no válidos: los valores deben ser una secuencia; cada elemento debe ser nulo o una cadena"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":values deben estar presentes para obtener :human_readable_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "La longitud total de los valores de campo es > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "los nombres de los fragmentos no pueden incluir \"}\" ni empezar con espacios"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Error al ejecutar la consulta de filtrado encadenado"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "El campo {0} no existe."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "No se puede buscar en un campo que no sea de texto {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Concesión de permisos para el grupo {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Revocación de permisos para el grupo {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Permisos de base de datos no válidos: si tienes acceso de escritura para consultas nativas, debes tener acceso completo a los datos."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Permisos de base de datos no válidos: si tienes acceso a consultas nativas de solo lectura, también debes tener acceso a datos."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Cambio de permisos de: {0} a: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "las claves de atributo de inicio de sesión deben ser una palabra clave o una cadena"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "El idioma predeterminado para todos los usuarios en la interfaz de usuario de la Metabase, correos electrónicos del sistema, pulsos y alertas."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Los usuarios podrán cambiar individualmente este idioma predeterminado desde la configuración de su propia cuenta."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Página predeterminada para mostrar al usuario"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Permitir que este origen incruste la aplicación completa de Metabase"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "No se permiten valores superiores a {0} ({1})."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Esto reemplazará la palabra \"Metabase\" donde sea que aparezca."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Estos son los colores primarios que se utilizan en los gráficos y en toda Metabase. Es posible que tengas que actualizar tu navegador para que los cambios surtan efecto."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Para obtener los mejores resultados, utiliza un archivo SVG con fondo transparente."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "La URL o imagen que quieres usar como favicon."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Permitir iniciar sesión por correo electrónico y contraseña."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Esto afectará cosas como agrupar por semana o filtrar en las consultas.\n"
+" No afectará las consultas SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "No se puede validar el token"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "El formato del token no es válido."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Error al validar el token"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Error al filtrar por {0}: no se puede analizar la cadena {1} a {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Error al obtener los detalles del trabajo: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Iniciando tarea de sincronización para la base de datos {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "No se puede sincronizar la base de datos {0}: la base de datos no existe."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Tarea de actualización de valores de campo activada para la base de datos {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Omitiendo la actualización, las actualizaciones automáticas de valores de campo están inhabilitadas para la base de datos {0}."
 

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -20,27 +20,28 @@ msgstr "با نگاهی اجمالی به داده های شما، ما یکسر
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 #, fuzzy
 msgid "I'm good thanks"
-msgstr "من خوبم ممنون"
+msgstr "خوبم ممنون"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 #, fuzzy
 msgid "Explore this data"
-msgstr "این داده ها را کاوش و بررسی کن"
+msgstr "این داده ها را بررسی کن"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 #, fuzzy
 msgid "Select a database type"
-msgstr "یک نوع پایگاه داده را انتخاب کن"
+msgstr "یک نوع پایگاه داده را انتخاب کنید"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -53,9 +54,9 @@ msgstr "ذخیره کردن"
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "برای ادامه کار، متابیس نیاز دارد پایگاه داده شما را اسکن کند.\n"
-"همچنان برای آپدیت ماندن متابیس این کار به صورت دوره ای و اتوماتیک نیز انجام میشود، شما میتوانید زمان بازه ها را تنظیم کنید."
+"همچنین برای آپدیت ماندن متابیس این کار به صورت دوره ای و اتوماتیک نیز انجام میشود، شما میتوانید زمان بازه ها را تنظیم کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 #, fuzzy
 msgid "Database syncing"
 msgstr "همگام سازی پایگاه داده"
@@ -64,7 +65,7 @@ msgstr "همگام سازی پایگاه داده"
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "این یک فرایند سبک برای برسی بروز بودن شمای پایگاه داده هست. در بیشتر موارد، بهتر است برای همگام سازی ساعتی صبر نمایید."
+msgstr "این یک فرایند سبک برای بررسی بروز بودن شِمای پایگاه داده هست. در بیشتر موارد، بهتر است برای همگام سازی ساعتی صبر نمایید."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
@@ -72,7 +73,7 @@ msgstr "این یک فرایند سبک برای برسی بروز بودن شم
 msgid "Scan"
 msgstr "بررسی"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 #, fuzzy
 msgid "Scanning for Filter Values"
 msgstr "جستجو برای مقادیر فیلتر"
@@ -82,12 +83,12 @@ msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "متابیس می‌تواند تمامی مقادیر حاضر در هر فید این دیتابیس را اسکن کند تا فیلترهای جعبه چک را در داشبوردها و سؤالات فعّال کند. این می‌تواند تاحدّی یک پردازش با مصرف زیاد از منابع باشد، به‌خصوص اگر شما یک دیتابیس خیلی بزرگ دارید."
+msgstr "متابیس می‌تواند تمامی مقادیر حاضر در هر فیلد این دیتابیس را اسکن کند تا فیلترهای چک باکس  را در داشبوردها و سؤالات فعّال کند. این می‌تواند تاحدّی یک پردازش پر مصرف باشد، به‌خصوص اگر شما یک دیتابیس خیلی بزرگ داشته باشید."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 #, fuzzy
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "چه زمانی باید متابیس به صورت اتوماتیک مقادیر فیلدها را برسی و در حافظه نگه دارد؟"
+msgstr "چه زمانی باید متابیس به صورت اتوماتیک مقادیر فیلدها را بررسی و در حافظه نگه دارد؟"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:25
 msgid "Regularly, on a schedule"
@@ -100,13 +101,13 @@ msgstr "تنها وقتی که یک ویجت فیلتر افزوده شود"
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "هنگامی که یک کاربر یک فیلتر جدید را به یک داشبورد یا سوال SQL اضافه می کند، Metabase خواهد شد\n"
-"اسکن فیلد (ها) به آن فیلتر برای نمایش لیستی از مقادیر انتخاب شده."
+msgstr "هنگامی که یک کاربر،  یک فیلتر جدید را به یک داشبورد یا دستورSQL اضافه می کند، متابیس\n"
+"فیلد هایی را که به آن فیلترها، جهت نمایش لیستی از مقادیر انتخاب شده اند،  اسکن خواهد کرد."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 #, fuzzy
 msgid "Never, I'll do this manually if I need to"
-msgstr "هرگز، اگر لازم داشته باشم به صورت دستی انجام خواهم داد"
+msgstr "خیر، اگر لازم داشته باشم به صورت دستی انجام خواهم داد"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
@@ -129,7 +130,7 @@ msgstr "آیا این پایگاه داده حذف شود؟"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "تمام سوالات ذخیره شده، معیارها و بخش هایی که بر اساس این پایگاه داده تکیه می کنند، از بین می روند."
+msgstr "تمام سوالات و دستورات ذخیره شده، معیارها و بخش هایی که بر اساس این پایگاه داده تنظیم شده اند، از بین می روند."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
@@ -148,29 +149,31 @@ msgstr "حذف کردن"
 msgid "in this box:"
 msgstr "داخل این کادر:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -193,15 +196,15 @@ msgstr "حذف"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "پایگاه داده"
+msgstr "پایگاه های داده"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:148
 msgid "Add Database"
@@ -215,8 +218,9 @@ msgstr "ارتباط"
 msgid "Scheduling"
 msgstr "برنامه ریزی کردن"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -230,11 +234,11 @@ msgstr "ذخیره کردن تغییرات"
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
-msgstr "اقدام"
+msgstr "اکشن ها"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 msgid "Sync database schema now"
-msgstr "در حال همگام سازی شمای دیتابیس"
+msgstr "در حال همگام سازی شِمای دیتابیس"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:212
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
@@ -247,7 +251,7 @@ msgstr "در حال شروع..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:213
 msgid "Failed to sync"
-msgstr "موفق به همگام سازی نشد"
+msgstr "همگام سازی با موفقیت انجام نشد"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:214
 msgid "Sync triggered!"
@@ -277,7 +281,7 @@ msgstr "منطقه خطر"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Discard saved field values"
-msgstr "نادیده گرفتن مقادیر فیلد ذخیره شده"
+msgstr "حذف مقادیر فیلد ذخیره شده"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:257
 msgid "Remove this database"
@@ -295,10 +299,10 @@ msgstr "اضافه کردن پایگاه داده"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -333,29 +337,27 @@ msgid "Successfully saved!"
 msgstr "با موفقیت ذخیره شد!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "ویرایش"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "تاریخچه نسخه گذاری"
+msgstr "تاریخچه بازنگری"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "بازنشستگی این {0}؟"
+msgstr " این {0} را کنار میگذارید؟"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "سوالات ذخیره شده و موارد دیگر که به این {0} بستگی دارد، به کار ادامه خواهد داد، اما این {1} دیگر از سازنده پرس و جو انتخاب نخواهد شد."
+msgstr "سوالات ذخیره شده و موارد دیگر که به این {0} بستگی دارد، به کار ادامه خواهند داد، اما این {1} دیگر از کوئری ساز انتخاب نخواهد شد."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "اگر مطمئن هستید که می خواهید این {0} بازنشسته شود، لطفا یک توضیح سریع از اینکه چرا بازنشسته می شوید، بنویسید:"
+msgstr "اگر مطمئن هستید که می خواهید این {0} کنار گذاشته شود، لطفا یک توضیح سریع از علت این کار بنویسید:"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
@@ -363,11 +365,11 @@ msgstr "این در خوراک فعالیت و در یک ایمیل نشان د�
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "بازنشستگی"
+msgstr "کنار گذاشتن"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "بازنشستگی ..."
+msgstr "کنار گذاشتن..."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 #: frontend/src/metabase/components/form/CustomForm.jsx:188
@@ -377,7 +379,7 @@ msgstr "ناموفق"
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 #: frontend/src/metabase/components/form/CustomForm.jsx:189
 msgid "Success"
-msgstr "موفقیت"
+msgstr "موفق"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
@@ -416,26 +418,29 @@ msgstr "یک نوع خاص را انتخاب کنید"
 msgid "Select a target"
 msgstr "یک هدف را انتخاب کنید"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "ستون‌ها"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "ستون"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
-msgstr "رؤیت"
+msgstr "قابلیت رؤیت"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "نوع"
 
@@ -443,7 +448,7 @@ msgstr "نوع"
 msgid "Current database:"
 msgstr "پایگاه داده فعلی:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "نمایش طرح اولیه"
 
@@ -474,7 +479,7 @@ msgstr "داده های فنی"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
-msgstr "بی ربط / Cruft"
+msgstr "بی ربط "
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
@@ -510,7 +515,7 @@ msgstr "یک جدول را پیدا کنید"
 msgid "Schemas"
 msgstr "طرح ها"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -527,13 +532,13 @@ msgstr "یک سنجش اضافه کن"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "تعریف"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:51
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "ایجاد متریک برای اضافه کردن آنها به نمایش کشویی در سازنده پرس و جو"
+msgstr "ایجاد متریک برای اضافه کردن آنها به نمایش کشویی در کوئری ساز"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
@@ -593,37 +598,37 @@ msgstr "تاریخچه␣"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
-msgstr "تاریخچه نسخه گذاری برای"
+msgstr "تاریخچه بازنگری برای"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - تنظیمات فیلد"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
-msgstr "کجا این فیلد در سراسر Metabase ظاهر می شود"
+msgstr "این فیلد در سراسر متابیس، در چه مکانی ظاهر می گردد"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "فیلتر کردن این فیلد"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "هنگامی که این فیلد در یک فیلتر استفاده می شود، چه افرادی باید برای وارد کردن مقدار مورد نظر برای فیلتر کردن، چه استفاده کنند؟"
+msgstr "هنگامی که این فیلد در یک فیلتر استفاده می شود، افراد برای وارد کردن مقدار مورد نظر شان برای فیلتر کردن، از چه چیز هایی باید استفاده کنند؟"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "هنوز برای این قیلد توضیحی نوشته نشده است"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "مقدار اصلی"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
-msgstr "مقدار Map شده"
+msgstr "مقدار ترسیم شده"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "مقدار را وارد کنید"
 
@@ -637,34 +642,34 @@ msgstr "از کلید خارجی استفاده کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
-msgstr "Map سفارشی"
+msgstr "ترسیم سفارشی"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
-msgstr "نوع Map غیر قابل تشخیص"
+msgstr "نوع ترسیم غیر قابل تشخیص است"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "فیلد جاری دارای کلید خارجی نیست یا متا دیتای جدولی که هدف کلید خارجی است وجود ندارد"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
-msgstr "فیلد انتخابی کلید خارجی نیست"
+msgstr "فیلد انتخابی، کلید خارجی نیست"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "نمایش مقادیر"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "انتخاب کنید که ارزش اصلی را از پایگاه داده نشان می دهد یا این اطلاعات را نمایش داده یا مرتبط کنید."
+msgstr "انتخاب کنید که مقداراصلی را از پایگاه داده نشان بدهد یا این اطلاعات دلخواه  را."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "یک فیلد را انخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "لطفا یک ستون را برای نمایش انتخاب کنید."
 
@@ -672,32 +677,32 @@ msgstr "لطفا یک ستون را برای نمایش انتخاب کنید."
 msgid "Tip:"
 msgstr "نکته:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "شما ممکن است بخواهید نام فیلد را به روز کنید تا مطمئن شوید که هنوز بر اساس گزینه های بازخوانی شما منطقی است."
+msgstr "شما ممکن است بخواهید نام فیلد را به روز کنید تا مطمئن شوید که هنوز بر اساس گزینه های بازخوانی شما، منطقی است."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "مقادیر فیلد ذخیره شده"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabase می تواند مقادیر این فیلد را فعال کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
+msgstr "متابیس می تواند مقادیر این فیلد را فعال کند تا فیلترهای چک باکس را در داشبورد و سوالات فعال کند."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "دوباره این زمینه را اسکن کنید"
+msgstr "دوباره این فیلد را اسکن کن"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
-msgstr "نادیده گرفتن مقادیر فیلد ذخیره شده"
+msgstr "کنار گذاشتن مقادیر فیلد ذخیره شده"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
-msgstr "نادیده گرفتن مقادیر ناموفق بود"
+msgstr "کنار کذاشتن مقادیر، ناموفق بود"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
@@ -706,87 +711,88 @@ msgstr "تغییرات را نادیده بگیر!"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "جدولی را برای مشاهد شما و یا ویرایش متادیتا انتخاب نمایید."
+msgstr "جدولی را برای مشاهد شِما و یا ویرایش متادیتا انتخاب نمایید."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 #, fuzzy
 msgid "Name is required"
-msgstr "نام مورد نیاز است"
+msgstr "وارد کردن نام ضروری است"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
-msgstr "توضیح مورد نیاز است"
+msgstr "وارد کردن توضیحات ضروری است"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
-msgstr "پیام بازبینی مورد نیاز است"
+msgstr "وارد کردن پیام بازبینی ضروری است"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
-msgstr "یکپارچه‌سازی لازم است"
+msgstr "یکپارچه ‌سازی لازم است"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "متریک خود را ویرایش کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "متریک خود را ایجاد کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "تغییر در متریک خود را انجام دهید و یک یادداشت توضیحی را ترک کنید."
+msgstr "تغییر در متریک خود را انجام دهید و یک توضیحی بنویسید."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:145
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "شما می توانید معیارهای ذخیره شده را برای افزودن یک گزینه متریک نام به این جدول ایجاد کنید. معیارهای ذخیره شده شامل نوع تجمع، فیلد جمع شده و به صورت اختیاری هر فیلتر اضافه می شود. به عنوان مثال، شما ممکن است از این برای ایجاد چیزی شبیه روش رسمی محاسبه \"میانگین قیمت\" برای جدول سفارشات استفاده کنید."
+msgstr "شما می توانید معیارهای ذخیره شده را برای افزودن یک گزینه به نام متریک در این جدول ایجاد کنید. معیارهای ذخیره شده شامل نوع تجمع، فیلد جمع شده و به صورت اختیاری هر فیلتر اضافه می شود. به عنوان مثال، شما ممکن است از این برای ایجاد چیزی شبیه روش رسمی محاسبه \"میانگین قیمت\" برای جدول سفارشات استفاده کنید."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "نتیجه:"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
-msgid "Name Your Metric"
-msgstr "نام متریک خود را"
-
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
-msgid "Give your metric a name to help others find it."
-msgstr "نام متریک خود را برای کمک به دیگران پیدا کنید."
+msgid "Name Your Metric"
+msgstr "نام متریک خود را بنویسید"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
+msgid "Give your metric a name to help others find it."
+msgstr "متریک خود را  نام گذاری کنید تا به دیگران جهت یافتن آن  کمک کنید."
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
-msgstr "چیزی توصیفی اما نه خیلی طولانی"
-
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
-msgid "Describe Your Metric"
-msgstr "متریک خود را شرح دهید"
+msgstr "یک توصیف نه چندان طولانی"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+msgid "Describe Your Metric"
+msgstr "متریک خود را توصیف کنید"
+
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "توضیحات متریک خود را برای کمک به دیگران درک کنید."
+msgstr "به متریک خود توضیحاتی را نسبت دهید تا به دیگران جهت درک بهتر آن کمک کنید."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "این مکان بسیار خوبی است که درمورد قوانین متریک کمتر آشکارتر باشد"
+msgstr "این مکان بهتراست که درمورد قوانین متریک، کمتر واضح باشد"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "دلیل تغییرات"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "یک یادداشت را برای توضیح آنچه که تغییراتی ایجاد کرده اید و چرا آنها مورد نیاز بود را ترک کنید."
+msgstr "یک یادداشت برای توضیح  علت تغییرات ایجادشده بنویسید."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "این در تاریخ تجدید نظر برای این متریک نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
+msgstr "این در تاریخچه بازنگری برای این متریک نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشند چرا برخی تغییرات ایجاد شده اند"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
@@ -794,27 +800,27 @@ msgstr "حداقل یک فیلتر مورد نیاز است"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
-msgstr "بخش شما را ویرایش کنید"
+msgstr "بخش شِما را ویرایش کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
-msgstr "ایجاد بخش شما"
+msgstr "بخش مورد نظرتان را ایجاد کنید "
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "تغییرات را در بخش خود انجام دهید و یک یادداشت توضیحی را ترک کنید."
+msgstr "تغییرات را در بخش خود انجام دهید و یک یادداشت جهت توضیح بنویسید."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "برای ایجاد بخش جدید خود برای جدول {0} را انتخاب کنید و فیلترها را اضافه کنید"
+msgstr "برای ایجاد بخش جدید خود برای جدول {0} ، فیلترها را انتخاب و اضافه کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
-msgstr "بخش خود را بنویسید"
+msgstr "نام بخش خود را بنویسید"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
-msgstr "بخش خود را به نام برای کمک به دیگران پیدا کنید."
+msgstr "بخش خود را  نام گذاری کنید تا به دیگران جهت یافتن آن  کمک کنید."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
@@ -822,21 +828,22 @@ msgstr "بخش خود را توصیف کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "شرح خود را به بخش خود بدهید تا دیگران را در درک آنچه در مورد آن هستید کمک کنید."
+msgstr "به بخش خود یک توضیحی اضافه کنید تا به دیگران جهت فهم آن کمک کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "این مکان خوبی است که در مورد قوانین جزئی کمتر آشکار باشد"
+msgstr "این مکان بهتراست که درمورد قوانین بخش ها، کمتر واضح باشد"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "این در تاریخ تجدید نظر برای این بخش نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
+msgstr "این در تاریخچه بازنگری، برای این بخش نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشند چرا برخی چیز ها تغییر کرده است."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
 #: frontend/src/metabase/admin/routes.jsx:137
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -844,21 +851,20 @@ msgstr "تنضیمات"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabase می تواند مقادیر در این جدول را اسکن کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
+msgstr "متابیس می تواند مقادیر در این جدول را اسکن کند تا فیلترهای چک باکس را در داشبورد و سوالات فعال کند."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "دوباره این جدول را اسکن کنید"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "اضافه کردن"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 msgid "Not a valid formatted email address"
-msgstr "یک آدرس ایمیل فرمت معتبر نیست"
+msgstr "فرمت آدرس ایمیل معتبر نیست"
 
 #: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
@@ -869,16 +875,16 @@ msgid "Last name"
 msgstr "نام خانوادگی"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "آدرس ایمیل"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "گروه های مجوز"
+msgstr "مجوز گروه ها"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "این کاربر را admin کنید"
 
@@ -977,6 +983,8 @@ msgstr "حذف گروه"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -989,11 +997,12 @@ msgstr "انجام شد"
 msgid "Group name"
 msgstr "نام گروه"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "گروه‌ها"
@@ -1104,7 +1113,7 @@ msgstr "بارگذازی مجدد"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "آیا مطمئنید که می خواهید این کار را انجام دهید؟"
 
@@ -1216,7 +1225,7 @@ msgstr "هیچ تغییری در مجوز انجام نخواهد شد."
 msgid "You've made changes to permissions."
 msgstr "شما مجوزها را تغییر داده اید."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "مجوزهای این مجموعه"
 
@@ -1272,6 +1281,7 @@ msgstr "محدودیت دسترسی"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "لغو دسترسی"
 
@@ -1335,23 +1345,23 @@ msgstr "مجموعه گردنبند"
 msgid "View collection"
 msgstr "مشاهده مجموعه"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "دسترسی به داده ها"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "مشاهده جداول"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "نمایش طرح ها"
 
@@ -1422,12 +1432,15 @@ msgstr "ارسال شد!"
 msgid "Clear"
 msgstr "پاک کردن"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "احراز هویت"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "تنضیمات سرور"
@@ -1440,6 +1453,7 @@ msgstr "طرحواره کاربر"
 msgid "Attributes"
 msgstr "خصوصیات"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "طرح طرح گروه"
@@ -1511,6 +1525,9 @@ msgid "Add a map"
 msgstr "یک نقشه اضافه کنید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "نشانی اینترنتی"
@@ -1520,19 +1537,19 @@ msgid "Delete custom map"
 msgstr "حذف نقشه سفارشی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "پاک کردن"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1630,19 +1647,19 @@ msgstr "خرید یک علامت"
 msgid "Enter a token"
 msgstr "یک نشانه وارد کنید"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "ویرایش نقشه ها"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "نقشه های گروه"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "ایجاد یک نقشه برداری"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1883,18 +1900,27 @@ msgstr "فیلتر کاربر"
 msgid "Check your parentheses"
 msgstr "پرانتزهای خود را بررسی کنید"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "ویژگی ایمیل"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "نام شناسه اول"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "مولفه‌ی نام خانوادگی"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "همگام سازی اعضای گروه"
@@ -1923,59 +1949,59 @@ msgstr "نقشه های سفارشی"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "فایل های GeoJSON خودتان را برای افزودن تصویر های مختلف نقشه های منطقه اضافه کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "اشتراک عمومی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "اشتراکگذاری عمومی را فعال کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "داشبورد به اشتراک گذاشته شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "سوالات مشترک"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "تعبیه در برنامه های دیگر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Enable Embedage Metabase در برنامه های دیگر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "بستن کلید مخفی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "داشبورد جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "سوالات جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "ذخیره سازی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "فعال کردن ذخیره سازی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "حداقل مدت زمان پرس و جو"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "زمان کشیدن به زمان (TTL) ضرب"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "حداکثر اندازه ورودی کش"
 
@@ -2017,27 +2043,27 @@ msgstr "قبل از اینکه بتوانید از Google برای ورود به
 msgid "Sign in with {0}"
 msgstr "با {0} وارد شوید"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "لطفا با یک سرپرست تماس بگیرید تا رمز عبور خود را بازنشانی کنید"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "فراموشی پسورد / پسورد خود را فراموش کرده اید؟"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "ایمیل شما برای حساب Metabase شما استفاده می شود"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "ارسال ایمیل بازیابی پسورد"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "برای دریافت دستورالعمل در مورد چگونگی بازنشانی گذرواژه خود، ایمیل خود را بررسی کنید."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "به Metabase وارد شوید"
 
@@ -2058,11 +2084,11 @@ msgstr "ورود"
 msgid "I seem to have forgotten my password"
 msgstr "به نظر می رسد رمز عبور من را فراموش کرده ام"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "درخواست یک ایمیل"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "اوه، این یک لینک منقضی شده است"
 
@@ -2072,11 +2098,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 msgstr "به دلایل امنیتی، لینک های بازنشانی رمز عبور بعد از چند لحظه منقضی می شوند. اگر هنوز هم نیاز دارید\n"
 "برای بازنشانی گذرواژه خود، میتوانید {0} را انتخاب کنید."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "رمز عبور جدید"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "برای حفظ اطلاعات خود، گذرواژه {0}"
 
@@ -2099,24 +2125,24 @@ msgstr "تایید پسورد جدید"
 msgid "Make sure it matches the one you just entered"
 msgstr "اطمینان حاصل کنید که آن را با آنکه وارد کردید مطابقت دهید"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "گذرواژه شما تنظیم مجدد شده است"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "با گذرواژه جدید خود وارد شوید"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "ذخیره سازی ناموفق"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2126,25 +2152,26 @@ msgstr "ذخیره شد"
 msgid "Ok"
 msgstr "خوب"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "این مجموعه را بایگانی کنید؟"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "داشبورد، مجموعه ها و پالس ها در این مجموعه نیز بایگانی خواهند شد."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "آرشیو"
 
@@ -2269,7 +2296,7 @@ msgstr "پین"
 msgid "Drag something here to pin it to the top"
 msgstr "چیزی را در اینجا بکشید تا آن را به بالا ببرید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2297,6 +2324,7 @@ msgstr "حرکت \"{0}\"؟"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "انتقال"
@@ -2334,7 +2362,7 @@ msgstr "برخی از تاسیسات پایگاه داده تنها با اتص�
 "این گزینه همچنین یک لایه اضافی امنیتی را هنگامی که یک VPN در دسترس نیست فراهم می کند.\n"
 "فعال کردن این معمولا کمتر از یک اتصال مستقیم است."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "این یک پایگاه داده بزرگ است، بنابراین اجازه دهید زمانی که Metabase همگام سازی و اسکن کند، انتخاب کنم"
 
@@ -2374,7 +2402,7 @@ msgstr "برای استفاده از Metabase با این داده ها باید
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} برای رفتن به کنسول اگر قبلا چنین کاری نکرده اید."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "چگونه می خواهید به این پایگاه داده مراجعه کنید؟"
 
@@ -2490,35 +2518,35 @@ msgstr "بر اساس طرح"
 msgid "A look at your"
 msgstr "یک نگاه به تو"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "جستجو در لیست"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "جستجو توسط {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " یا یک شناسه وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "یک شناسه وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "شماره را وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "بعضی از متن ها را وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "هیچ تطابق {0} یافت نشد"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "از جمله هر گزینه ای در فیلتر شما احتمالا زیاد کار نمی کند ..."
 
@@ -2530,7 +2558,6 @@ msgstr "چیزی اشتباه رفته است"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "ما به خطا رسیده ایم شما می توانید صفحه را تمیز کنید یا فقط به عقب برگردید."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2541,12 +2568,12 @@ msgstr "ما به خطا رسیده ایم شما می توانید صفحه ر�
 msgid "No description yet"
 msgstr "هنوز توضیحی ندارید"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "جدید {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "درخواست شده توسط {0}"
 
@@ -2567,7 +2594,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "بازگشت به یک نسخه پیشین و {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "تاریخچه ویرایشهای"
@@ -2613,7 +2642,7 @@ msgid "Questions"
 msgstr "سوال"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "پالس ها"
 
@@ -2687,52 +2716,69 @@ msgstr "اکنون نه"
 msgid "Error:"
 msgstr "خطا:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "یکشنبه"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "دوشنبه"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "سه شنبه"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "چهارشنبه"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "پنج شنبه"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "جمعه"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "شنبه"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "اولین"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "دومین"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15th (Midpoint)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "روز تقویم"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "منطقه زمانی Metabase شما"
 
@@ -2786,11 +2832,11 @@ msgstr "بسازید"
 msgid "Create dashboard"
 msgstr "ایجاد داشبورد"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "جدول"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "پایگاه داده"
 
@@ -2865,9 +2911,9 @@ msgstr "نام کارت شما چیست؟"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2881,15 +2927,16 @@ msgstr "توضیحات"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "این اختیاری است اما اوه، خیلی مفید است"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "کدام مجموعه باید این باشد؟"
 
@@ -2929,11 +2976,11 @@ msgstr "داشبورد بایگانی"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "اطمینان حاصل کنید که انتخاب برای هر سری، یا فیلتر بر روی این کارت کار نخواهد کرد."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "این داشبورد خالی است."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "یک سوال برای شروع مفید بودن اضافه کنید"
 
@@ -2953,7 +3000,7 @@ msgstr "خروج از تمام صفحه"
 msgid "Enter fullscreen"
 msgstr "ورود به حالت تمام صفحه"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "درحال ذخیره‌ سازی"
@@ -2966,7 +3013,8 @@ msgstr "سوالی اضافه کنید"
 msgid "Add a question to this dashboard"
 msgstr "یک سوال به این داشبورد اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "یک فیلتر اضافه کنید"
 
@@ -2974,7 +3022,7 @@ msgstr "یک فیلتر اضافه کنید"
 msgid "Parameters"
 msgstr "مولفه های"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "یک جعبه متن را اضافه کنید"
 
@@ -2982,7 +3030,7 @@ msgstr "یک جعبه متن را اضافه کنید"
 msgid "Move dashboard"
 msgstr "حرکت داشبورد"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "ویرایش داشبورد"
 
@@ -3006,11 +3054,11 @@ msgstr "حرکت داشبورد به ..."
 msgid "Dashboard moved to {0}"
 msgstr "داشبورد به {0} منتقل شد"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "چه میخواهید فیلتر کنید؟"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "چه نوع فیلتر؟"
 
@@ -3082,20 +3130,22 @@ msgstr "این کارت هیچ فیلدی یا پارامتری ندارد که 
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "مقادیر این فیلد با مقادیر هر فیلد دیگری که انتخاب کرده اید همپوشانی ندارد."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "هیچ فیلد معتبر وجود ندارد"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "نام باید 100 عدد یا کمتر باشد"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "رنگ مورد نیاز است"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "نام داشبورد شما چیست؟"
 
@@ -3150,7 +3200,7 @@ msgstr "آخرین اطلاعات دریافت شده از"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "ناشناخته"
 
@@ -3275,9 +3325,10 @@ msgstr "شما اخیرا به هیچ داشبورد یا سوالی نگاه ن
 msgid "{0} items selected"
 msgstr "{0} مورد انتخاب شده است"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "بازخوانی"
 
@@ -3394,7 +3445,7 @@ msgid "Zip Code"
 msgstr "کد پستی"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "مقدار"
 
@@ -3427,11 +3478,13 @@ msgid "User"
 msgstr "کاربر"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "منبع"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "قیمت"
 
@@ -3464,21 +3517,23 @@ msgid "Subscription"
 msgstr "اشتراک، ابونمان"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "امتیاز"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "عنوان"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "اظهار نظر"
 
@@ -3532,14 +3587,14 @@ msgstr "Metabase هرگز این فیلد را بازیابی نخواهد کر�
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "شمردن"
 
@@ -3547,7 +3602,7 @@ msgstr "شمردن"
 msgid "CumulativeCount"
 msgstr "جمع انباشته"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3565,19 +3620,19 @@ msgstr "متمایز"
 msgid "StandardDeviation"
 msgstr "انحراف معیار"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "میانگین"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "کمترین"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3588,19 +3643,19 @@ msgstr "بیشترین"
 msgid "sad sad panda, lexing errors detected"
 msgstr "غم انگیز غم انگیز پاندا، اشتباهات لایسنس شناسایی شده است"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} ثانیه"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} دقیقه"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "سلام اونجا"
+msgstr "سلام"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
@@ -3633,14 +3688,15 @@ msgstr "چه می خواهید بیرون بیایید؟"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "داده های خام"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "شمارش تجمعی"
 
@@ -3702,166 +3758,164 @@ msgstr "درست است"
 msgid "False"
 msgstr "نادرست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "فیلد طول جغرافیایی را انتخاب کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "طول عرضی بالا را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "طول جغرافیایی را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "عرض پایین را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "طول جغرافیایی را وارد کنید"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "نیست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "خالی است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "خالی نیست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "مساوی با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "برابر نیست با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "بزرگتر از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "کمتر از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "بین"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "بزرگتر یا مساوی با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "کمتر یا برابر است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "شامل"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "شامل نمی شود"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "شروع می شود با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "به پایان می رسد با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "قبل از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "بعد از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "داخل"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "فقط یک جدول با ردیف در پاسخ، هیچ عملیات اضافی."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "تعداد ردیف ها"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "تعداد ردیف ها در پاسخ."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "مجموع ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "مجموع تمام مقادیر یک ستون."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "میانگین ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "میانگین تمام مقادیر یک ستون"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "تعداد مقادیر متمایز ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "تعداد مقادیر منحصر به فرد یک ستون در میان تمام ردیف در پاسخ."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "جمع تجمعی ..."
 
@@ -3869,7 +3923,7 @@ msgstr "جمع تجمعی ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "مجموع افزودنی تمام مقادیر یک ستون. \\\\ ne.x. درآمد کل در طول زمان."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "تعداد تجمعی ردیف"
 
@@ -3877,27 +3931,27 @@ msgstr "تعداد تجمعی ردیف"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "تعداد افزودنی تعداد ردیفها. \\\\ ne.x. تعداد کل فروش در طول زمان."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "انحراف استاندارد ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "شماره ای که بیان می کند مقدار مقادیر یک ستون در میان تمام ردیف ها در جواب متفاوت است."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "حداقل از ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "حداقل مقدار یک ستون"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "حداکثر ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "حداکثر مقدار یک ستون"
 
@@ -3913,6 +3967,8 @@ msgstr "حروف کوچک"
 msgid "upper case letter"
 msgstr "نامه بزرگ"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "عدد"
@@ -4160,7 +4216,7 @@ msgstr "چگونه برای ایجاد معیارهای"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "اطلاعات را در طول زمان مشاهده کنید، به عنوان یک نقشه، و یا چرخش برای کمک به شما در درک روند و یا تغییرات."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "سفارشی"
 
@@ -4183,7 +4239,7 @@ msgstr "پرس و جو بومی"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "برای سوالات پیچیده تر، شما می توانید پرس و جو SQL خود و یا بومی خود را بنویسید."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "یک مقدار پیش فرض را انتخاب کنید ..."
 
@@ -4271,7 +4327,7 @@ msgstr "این ماه"
 msgid "This Year"
 msgstr "امسال"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "یک مقدار را وارد کنید"
@@ -4281,7 +4337,7 @@ msgid "Enter a default value..."
 msgstr "مقدار پیش فرض را وارد کنید ..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "یک خطا رخ داده است"
@@ -4538,22 +4594,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "سؤالاتی را که میخواهید در این پالس ارسال کنید را انتخاب کنید"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "ایمیل ها"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "پیام های خالی"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "ارسال شد"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} فرستاده خواهد شد"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "پیام ها"
 
@@ -4599,7 +4663,7 @@ msgstr "نام پالس خود را"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "نام پالس خود را برای کمک به دیگران درک کنید"
+msgstr "پالس خود را  نام گذاری کنید تا به دیگران جهت یافتن آن  کمک کنید."
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
@@ -4625,30 +4689,30 @@ msgstr "هر کس در تیم خود کمک کند با داده های خود �
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "پالس ها به شما اجازه می دهند اطلاعات را از Metabase به ایمیل یا Slack در برنامه انتخابی خود ارسال کنید."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "پس از {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "قبل از {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "خالی است"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "خالی نیست"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "همیشه"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "درخواست دادن"
 
@@ -4748,12 +4812,12 @@ msgstr[0] "مشاهده این {0}"
 msgid "Zoom in"
 msgstr "بزرگنمایی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "عبارتی سفارشی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "معیارهای معمول"
 
@@ -4950,7 +5014,7 @@ msgstr "معمولا"
 msgid "Pick a segment or table"
 msgstr "یک بخش یا جدول را انتخاب کنید"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "یک پایگاه داده را انتخاب کنید"
@@ -5011,7 +5075,7 @@ msgstr "مرتب سازی"
 msgid "Row limit"
 msgstr "محدودیت ردیف"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "میدان ناشناخته"
 
@@ -5019,7 +5083,7 @@ msgstr "میدان ناشناخته"
 msgid "field"
 msgstr "رشته"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "مسابقات"
 
@@ -5044,11 +5108,11 @@ msgstr "یک گروه را اضافه کنید"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "داده ها"
 
@@ -5065,11 +5129,12 @@ msgstr "چشم انداز"
 msgid "Grouped By"
 msgstr "گروه بندی شده توسط"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "هیچ یک"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "این سوال در {0} نوشته شده است."
 
@@ -5081,7 +5146,7 @@ msgstr "مخفی کردن ویرایشگر"
 msgid "Hide Query"
 msgstr "پنهان کردن پرس و جو"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "بازکردن ویرایشگر"
 
@@ -5089,7 +5154,7 @@ msgstr "بازکردن ویرایشگر"
 msgid "Show Query"
 msgstr "نمایش پرس و جو"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "این متریک بازنشسته شده است. این دیگر برای استفاده در دسترس نیست"
 
@@ -5287,9 +5352,9 @@ msgstr "بازگشت به آخرین اجرا"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:194
 msgid "Visualization"
-msgstr "تجسم"
+msgstr "نمایش دادن"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "بدون شرح"
 
@@ -5346,7 +5411,7 @@ msgstr "قبل از ایجاد یک سوال جدید، ابرداده جدول 
 msgid "See {0}"
 msgstr "{0} را ببینید"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "تعریف متریک"
 
@@ -5364,11 +5429,11 @@ msgstr "تعداد {0}"
 msgid "See all {0}"
 msgstr "مشاهده تمام {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "تعریف بخش"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "هنگام بارگیری جدول خطایی روی داد"
 
@@ -5376,7 +5441,7 @@ msgstr "هنگام بارگیری جدول خطایی روی داد"
 msgid "See the raw data for {0}"
 msgstr "داده های خام برای {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "بیشتر"
 
@@ -5396,6 +5461,8 @@ msgstr "فرمول فیلد"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "از این به عنوان نوعی از نوشتن یک فرمول در یک برنامه صفحه گسترده استفاده کنید. میتوانید از اعداد، فیلدها در این جدول، نمادهای ریاضی مانند + و برخی از توابع استفاده کنید. بنابراین شما می توانید چیزی مانند Subtotal - Cost را تایپ کنید."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5463,7 +5530,7 @@ msgstr "نادرست"
 msgid "Add filter"
 msgstr "اضافه کردن فیلتر"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "مورد"
 
@@ -5582,11 +5649,11 @@ msgstr "فیلد برای نقشه"
 msgid "Filter widget type"
 msgstr "نوع ویجت فیلتر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "ضروری؟"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "مقدار ویجت فیلتر پیش فرض"
 
@@ -5598,7 +5665,7 @@ msgstr "بایگانی این سوال؟"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "این سوال از هر داشبورد یا پالس از آن حذف خواهد شد."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "سوال"
 
@@ -5645,7 +5712,7 @@ msgstr "نوع فیلد"
 msgid "Select a Foreign Key"
 msgstr "یک کلید خارجی را انتخاب کنید"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "فرمول {0} را ببینید"
 
@@ -6129,22 +6196,24 @@ msgstr "سوالات در مورد این بخش"
 msgid "X-ray this segment"
 msgstr "اشعه ایکس این بخش"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "ورود"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "جستجو کردن"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "داشبورد"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "سوال جدید"
 
@@ -6216,35 +6285,35 @@ msgstr "تمام مجموعه کاملا ناشناس است."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "مجموعه را می توانید در هر نقطه از تنظیمات مدیریت خود خاموش کنید."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "اگر احساس می کنید گیر کرده اید"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "راهنمای شروع به کار ما"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "فقط یک کلیک دور است"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "به Metabase خوش آمدید"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "به نظر می رسد همه چیز در حال کار است اکنون اجازه دهید شما را بشناسیم، با داده هایتان ارتباط برقرار کنید و برخی از پاسخ ها را پیدا کنید!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "بیا شروع کنیم"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "همه شما تنظیم شده اند!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "من را به Metabase ببر"
 
@@ -6254,7 +6323,7 @@ msgstr "ما باید با شما تماس بگیریم؟"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "سلام {0} از ملاقات شما خوشبختم!"
+msgstr "سلام {0} از ملاقات با شما خوشبختم!"
 
 #: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
@@ -6394,7 +6463,7 @@ msgstr "شما می توانید نتایج خود را به عنوان یک ن�
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "Everbody نمودار ها را دوست دارد! روی منوی کشویی <strong> تجسم </ strong> کلیک کنید و <strong> خط </ strong> را انتخاب کنید."
+msgstr "اکثر افراد نمودار ها را دوست دارند! روی منوی <strong> نمایش دادن</ strong> کلیک کنید و <strong> خط </ strong> را انتخاب کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
@@ -6497,39 +6566,40 @@ msgstr "لغو فیلتر"
 msgid "Pin Map"
 msgstr "نقشه پین"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "گمشده"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "ردیف {0} - {1} از {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "داده های کوتاه شده به {0} ردیف."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
-msgstr "تجسم یافت نشد"
+msgstr "نمایشی پیدا نشد"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "این نمودار را نمیتوان با این اطلاعات نمایش داد."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "هیچ نتیجه ای!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "هنوز منتظرم..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "این معمولا طول می کشد به طور متوسط ​​{0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(این کمی طولانی برای داشبورد است)"
 
@@ -6640,7 +6710,7 @@ msgid "Highlight the whole row"
 msgstr "تمام سطر را برجسته کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "رنگ ها"
 
@@ -6691,15 +6761,15 @@ msgstr "به روز رسانی قانون"
 
 #: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
-msgstr "تجسم صفر است"
+msgstr "نمایشی وجود ندارد"
 
 #: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "تجسم باید متغیر ایستا 'شناسه' را تعریف کند:"
+msgstr "نمایش داده باید متغیر ثابت 'شناسه' را تعریف کند:"
 
 #: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
-msgstr "تجسم با آن شناسه قبلا ثبت شده است:"
+msgstr "نمایش داده با این شناسه قبلا ثبت شده است:"
 
 #: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
@@ -6724,33 +6794,59 @@ msgstr "هدف"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "دوو! داده های درخواست شما متناسب با انتخاب انتخاب صفحه نمایش نیست. این تجسم نیاز به حداقل {0} {1} داده دارد."
+msgstr "خظا! داده های درخواستی شما متناسب با نوع نمایش انتخاب شده  همخوانی ندارد. این نمایش نیاز به حداقل {0} {1} داده دارد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "ستون"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "بدون تاس. ما {0} داده {1} را برای نشان دادن داریم و برای این تجسم کافی نیست."
+msgstr "عملیات امکان پذیر نمی باشد. ما {0} داده {1} را برای نشان دادن داریم و برای این نمایش کافی نیست."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
@@ -6774,7 +6870,7 @@ msgid "xValues missing!"
 msgstr "xValues ​​گم شده!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "محور X"
 
@@ -6783,7 +6879,7 @@ msgid "Add a series breakout..."
 msgstr "شکستن سریال اضافه کنید ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "محور Y"
 
@@ -6796,7 +6892,7 @@ msgid "Bubble size"
 msgstr "اندازه حباب"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "خط"
 
@@ -6938,20 +7034,20 @@ msgid "Standard Deviation"
 msgstr "انحراف معیار"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "حوزه"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "نمودار منطقه"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "بار"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "نمودار میله ای"
 
@@ -6965,7 +7061,7 @@ msgid "Funnel"
 msgstr "کانال"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "اندازه گرفتن"
 
@@ -6977,81 +7073,81 @@ msgstr "نوع قیف"
 msgid "Bar chart"
 msgstr "نمودار میله ای"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "نمودار خط"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "لطفا ستون طول و عرض جغرافیایی را در تنظیمات نمودار انتخاب کنید."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "لطفا یک نقشه منطقه را انتخاب کنید"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "لطفا ستون های منطقه و متریک را در تنظیمات نمودار انتخاب کنید."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "نقشه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "نوع نقشه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "نقشه منطقه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "نقشه پین"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "نوع پین"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "کاشی"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "نشانگرها"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "زمینه عرض"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "میدان طول جغرافیایی"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "زمینه متریک"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "زمینه منطقه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "شعاع"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "تاری"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "حداقل ابعاد"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "حداکثر زوم"
 
@@ -7063,7 +7159,7 @@ msgstr "هیچ روابطی پیدا نشد"
 msgid "via {0}"
 msgstr "از طریق {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "این {0} به متصل است:"
 
@@ -7075,31 +7171,31 @@ msgstr "جزئیات شیء"
 msgid "object"
 msgstr "هدف - شی"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "جمع"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "کدام ستون ها می خواهید استفاده کنید؟"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "پای"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "بعد، ابعاد، اندازه"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "نمایش افسانه"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "نمایش درصد در افسانه"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "حداقل قطعه قطعه"
 
@@ -7117,14 +7213,15 @@ msgstr "هدف {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "تجسم پیشرفت نیاز به یک عدد دارد"
+msgstr "نوع نمایش پیشرفت نیاز به یک عدد دارد"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
 msgstr "پیش رفتن"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "رنگ"
@@ -7133,7 +7230,7 @@ msgstr "رنگ"
 msgid "Row Chart"
 msgstr "نمودار ردیف"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "نمودار ردیف"
 
@@ -7157,15 +7254,15 @@ msgstr "یک پسوند را اضافه کنید"
 msgid "Multiply by a number"
 msgstr "ضرب به یک عدد"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "پراکنده"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "طرح پراکنده"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "جدول را محکم بگیرید"
 
@@ -7216,12 +7313,12 @@ msgstr "درست"
 msgid "Show background"
 msgstr "نمایش پس زمینه"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} بن"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "خودکار متصل"
 
@@ -7457,10 +7554,13 @@ msgstr "سوالهای ذخیره شده زیادی در {0} دارید؟ ایج
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7646,7 +7746,7 @@ msgstr "جمع تجمعی"
 msgid "{0} and {1}"
 msgstr "{0} و {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} از {1}"
@@ -8637,7 +8737,7 @@ msgstr "نمیتوان مقایسه نتایج را به هدف برای هشد�
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "سوال ID '' {0} '' با تنظیمات تجسم است '' {1} ''"
+msgstr "سوال ID '' {0} '' با تنظیمات نمایش است '' {1} ''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
@@ -8958,11 +9058,11 @@ msgstr "دسترسی‌های داده"
 msgid "Collection permissions"
 msgstr "مجوزهای مجموعه"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "تمام مجوزهای مجموعه را مشاهده کنید"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "همچنین زیر مجموعه ها را تغییر دهید"
 
@@ -8974,19 +9074,19 @@ msgstr "می توانید این مجموعه و محتویات آن را ویر
 msgid "Can view items in this collection"
 msgstr "می توانید آیتم های موجود در این مجموعه را مشاهده کنید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "دسترسی به مجموعه"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "این گروه اجازه می دهد حداقل یک زیر مجموعه از این مجموعه را مشاهده کنید."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "این گروه اجازه ویرایش حداقل یک زیر مجموعه از این مجموعه را دارد."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "مشاهده زیر مجموعه ها"
 
@@ -9042,6 +9142,7 @@ msgstr "مربوط"
 msgid "More X-rays"
 msgstr "اشعه X بیشتر"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9301,10 +9402,10 @@ msgstr "اشتراک گذاری"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9388,7 +9489,7 @@ msgstr "استفاده از منطقه زمانی JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "برای کمک به  در حال تحلیل جداول و "
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "نکته:"
 
@@ -9396,7 +9497,7 @@ msgstr "نکته:"
 msgid "Select a currency type"
 msgstr "یک واحد پول انتخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "نوع فیلد"
 
@@ -9451,6 +9552,7 @@ msgid "Currency"
 msgstr "واحد پول"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "یک کاربر یا کانال را انتخاب کنید..."
 
@@ -9612,13 +9714,13 @@ msgstr "کدام محور؟"
 msgid "Line + Bar"
 msgstr "خط + نوار"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "نمودار خط و نوار"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "تجسم سنج به تعدادی نیاز دارد."
+msgstr "نوع نمایش سنج به عدد نیاز دارد."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
 msgid "Gauge"
@@ -9632,15 +9734,15 @@ msgstr "محدوده سنج"
 msgid "Field to show"
 msgstr "زمینه برای نشان دادن"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "آخرین {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} بود {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "گروهی را با یک فیلد زمانی برای دیدن چگونگی تغییر این موضوع در طول زمان ، گروه بندی کنید"
 
@@ -9648,23 +9750,23 @@ msgstr "گروهی را با یک فیلد زمانی برای دیدن چگون
 msgid "Switch positive / negative colors?"
 msgstr "تغییر رنگ های مثبت / منفی؟"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "ستون محوری"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "ستون سلول"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "ستونهای قابل مشاهده"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "قالب بندی شرطی"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "عنوان ستون"
 
@@ -9830,7 +9932,7 @@ msgstr "فقط یک بخش Google Analytics به طور همزمان مجاز ا
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "MONGO AGGREGATION PIPELINE:"
+msgstr ":خط لوله تجمع مونگو"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
@@ -10105,10 +10207,10 @@ msgstr "کاربران در هر منبع"
 msgid "The top external pages that brought users to your site"
 msgstr "صفحات برتر خارجی که کاربران را به سایت شما رسانده است"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "چگونگی توزیع [[this]] و موارد دیگر."
 
@@ -10206,13 +10308,13 @@ msgstr "رویدادها در هر ساعت از روز"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "5 مورد برتر [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "پایین 5 [[this]]"
 
@@ -10225,10 +10327,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "در هر [[GenericCategorLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "مقادیر تهی"
 
@@ -10256,8 +10358,8 @@ msgstr "چگونگی مقایسه آنها با فصلی"
 msgid "Average income per transaction"
 msgstr "درآمد متوسط در هر تراکنش"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] در هر کشور"
 
@@ -10383,10 +10485,10 @@ msgstr "مروری بر [[this]] شما و نحوه توزیع آن در طول 
 msgid "Average income per state"
 msgstr "درآمد متوسط در هر ایالت"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] توسط [[GenericCategorMedium]]"
 
@@ -10563,13 +10665,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "چگونه [[GenericTable]] در این زمینه زمانی توزیع می شود ، و اگر دارای الگوهای فصلی باشد."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "بررسی اجمالی"
 
@@ -10678,8 +10780,8 @@ msgstr "نگاه دقیق تری به [[this]] شما"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "نگاه دقیق تری به زمینه [[this]] شما دارد"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "خلاصه"
 
@@ -10743,10 +10845,10 @@ msgstr "فروش در هر منبع"
 msgid "Average income per country"
 msgstr "درآمد متوسط در هر کشور"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "چگونه [[this]] توزیع می شود"
 
@@ -10767,17 +10869,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "تعداد [[GenericCategorMedium]] توسط [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "نگاهی به [[this]] شما"
 
@@ -10843,10 +10945,10 @@ msgid "Transactions per source over time"
 msgstr "معاملات در هر منبع با گذشت زمان"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "نحوه توزیع [[this]]"
 
@@ -10875,9 +10977,9 @@ msgstr "جایی که این وقایع اتفاق می افتد"
 msgid "Which US states are bringing you the most business."
 msgstr "کدام کشورهای ایالات متحده بیشترین تجارت را به شما ارائه می دهند."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "چگونه آنها در طول زمان مقایسه می کنند"
 
@@ -10982,8 +11084,8 @@ msgstr "جلسات کشور"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "برخی از معیارهای جالب در مورد آمار GA برای شروع کار."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] در هر ایالت"
 
@@ -11064,12 +11166,12 @@ msgstr "نحوه توزیع این متریک در اعداد مختلف"
 msgid "Sessions by page where the session began"
 msgstr "جلسات براساس صفحه ای که جلسه شروع شده است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "مقادیر متمایز"
 
@@ -11133,10 +11235,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "رویدادها برای [[GenericCategorLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "چگونه آنها با توزیع مقایسه می شوند"
@@ -11442,6 +11544,7 @@ msgstr "داشبورد کپی"
 msgid "Duplicate \"{0}\""
 msgstr "کپی کردن \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11530,9 +11633,9 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "ربع سال"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} انتخاب"
@@ -11554,11 +11657,11 @@ msgstr "بی اعتبار"
 msgid "Add a time"
 msgstr "زمان اضافه کنید"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "هیچ چیز برای مقایسه قبلی نیست {0}"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "توسط {0}"
 
@@ -11740,7 +11843,7 @@ msgstr "بانک اطلاعاتی نمی توانند در دایرکتوری م
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
+msgstr "spark-deps.jar دیگر مورد نیاز Metabase 1.0+ نیست. می توانید آن را از فهرست افزونه ها حذف کنید."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
@@ -12046,9 +12149,9 @@ msgstr "بررسی اجمالی افرادی که در [[this]] شما وجود 
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] تا چهارم سال"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "نحوه مقایسه انها در سراسر مکان یا نحوه مقایه انها بر اساس موقعیت مکانی"
 
@@ -12077,12 +12180,12 @@ msgstr "[[CreateTimestamp]] تا روز هفته"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "در اینجا مروری بر داده های [[this]] شما از Google Analytics ارائه شده است"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "در اینجا مروری بر [[this]] شما"
 
@@ -12160,11 +12263,11 @@ msgstr "مجموعه"
 msgid "collections"
 msgstr "مجموعه ها"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "داشبورد"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "داشبورد"
 
@@ -12223,11 +12326,11 @@ msgstr "{0} به اتمام رسید به {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
+msgstr "DELETE / api / metric /: شناسه منسوخ شده است. در عوض ، مقدار `بایگانی شده` آن را از طریق PUT / api / metric /: id تغییر دهید."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
+msgstr "DELETE / api / segment /: شناسه منسوخ شده است. درعوض ، مقدار `بایگانی شده` آن را از طریق PUT / api / segment /: id تغییر دهید."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
@@ -12414,7 +12517,7 @@ msgstr "به پایان رسید پس از {0} میلی ثانیه."
 msgid "Misfire Instruction"
 msgstr "دستورالعمل سوء استفاده"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "بایگانی این؟"
 
@@ -12434,7 +12537,7 @@ msgstr "استفاده از این گزینه مستلزم آن است که می
 "ممکن است لازم باشد این گزینه را فعال کنید. اگر نمی دانید این به چه معنی است ،\n"
 "این را غیرفعال کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "هنگام انجام فیلتر کردن ساده و جمع بندی ساده ، نمایش داده شد"
 
@@ -12446,7 +12549,7 @@ msgstr "هنگامی که این در Metabase است ، به طور خودکا�
 msgid "Learn about this database"
 msgstr "در مورد این پایگاه داده اطلاعات کسب کنید"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "بایگانی این داشبورد؟"
 
@@ -12479,7 +12582,7 @@ msgstr[0] "رکورد"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:369
 msgid "Browse Data"
-msgstr "مرور داده ها"
+msgstr "مرور داده های من"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:402
 msgid "Write SQL"
@@ -12501,11 +12604,11 @@ msgstr "سوال سفارشی"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "از ویرایشگر نوت بوک پیشرفته برای پیوستن به داده ها ، ایجاد ستون های سفارشی ، انجام ریاضی و موارد دیگر استفاده کنید."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "اندازه گیری های اساسی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "سفارشی…"
 
@@ -12539,7 +12642,7 @@ msgstr "محتویات پایگاه داده ها ، جداول و ستون ها
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "تجسم"
+msgstr "نمایش دادن"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
@@ -12688,15 +12791,15 @@ msgstr "تصویری را انتخاب کنید"
 msgid "Filter by"
 msgstr "محدود شده توسط"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "خلاصه توسط"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "دسته بندی بر اساس"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "متریک اضافه کنید"
 
@@ -12707,15 +12810,15 @@ msgstr "متریک اضافه کنید"
 msgid "Profile"
 msgstr "مشخصات"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "این معمولاً خیلی سریع است اما به نظر می رسد اکنون مدتی طول می کشد."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
-msgstr "ترکیب"
+msgstr "ترکیبی"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "ردیف"
 
@@ -13136,7 +13239,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "ستون هایی را که می خواهید گنجانید انتخاب کنید"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "هنگامی که این کار روشن است ، وقتی کاربر در هنگام مشاهده جدول یا نمودار ، دکمه های خلاصه و فیلتر را با استفاده از کاوش ساده انجام می دهد ، Metabase به صورت خودکار نمایش داده می شود. اگر جستجوی این پایگاه داده کند است ، می توانید این را خاموش کنید. این تنظیم تأثیر نمی گذارد از طریق مته یا سؤالهای SQL."
 
@@ -13202,7 +13305,7 @@ msgstr "ورود با ایمیل"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "استفاده از این گزینه مستلزم آن است که میزبان ارائه شده FQDN باشد. در صورت اتصال به یک خوشه اطلس ، شاید لازم باشد این گزینه را فعال کنید. اگر نمی دانید این به چه معنی است ، این را غیرفعال کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "به طور پیش فرض ، Metabase یک همگام ساعته سبک و یک اسکن روزانه فشرده از مقادیر میدانی را انجام می دهد. اگر یک بانک اطلاعاتی بزرگ دارید ، توصیه می کنیم این مورد را روشن کنید و بررسی کنید چه زمان و چند وقت یکبار بررسی اسکن های مقدار انجام می شود."
 
@@ -13270,11 +13373,11 @@ msgstr "شامل نشود"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "این قسمت در سؤالات ایجاد شده با رابط های رابط کاربری گرافیکی قابل مشاهده یا انتخاب نخواهد بود. همچنان در سؤالات SQL / بومی قابل دسترسی خواهد بود."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "مبلغ تجمعی"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "انحراف معیار"
 
@@ -13290,19 +13393,19 @@ msgstr "طول باید حداقل  {0} کاراکتر باشد"
 msgid "Name (required)"
 msgstr "نام (اجباری)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "متن انتخاب شده را اجرا کن"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "کوئری را اجرا کن"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13503,7 +13606,7 @@ msgstr "به جای آدرس از راه دور ، منبع درخواست ها�
 
 #: src/metabase/public_settings.clj
 msgid "Could not resolve Setting {0}/{1}"
-msgstr "تنظیم {0} / {1 ould حل نشد"
+msgstr "تنظیمات حل نشد {0}/{1}"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid Setting: {0}/{1}"
@@ -13651,7 +13754,7 @@ msgstr "تاریخ و زمان"
 msgid "Numbers"
 msgstr "شماره"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "هیچ گروه قابل جابجایی نیست"
 
@@ -13691,15 +13794,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "مرا به خاطر بسپار"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "به دلایل امنیتی ، پیوندهای تنظیم مجدد گذرواژه پس از مدتی منقضی می شوند. اگر هنوز نیاز به تنظیم مجدد رمز عبور خود دارید ، می توانید {0 {."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "گذرواژه جدید را ذخیره کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "نتیجه مطابقت ندارد"
 
@@ -13725,26 +13828,26 @@ msgid "or"
 msgstr "یا"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "ضروری"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "نوع بانک اطلاعاتی"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "این یک پروسه سبک است که به روزرسانی های طرحواره این پایگاه داده را بررسی می کند. در بیشتر موارد ، شما باید خوب باشید که این مجموعه را ساعتی همگام کنید."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase می تواند مقادیر موجود در هر فیلد را در این پایگاه داده اسکن کند تا فیلترهای جعبه کادر در داشبورد و سؤالات را فعال کند. این می تواند یک فرآیند تا حدی پرانرژی باشد ، به خصوص اگر پایگاه داده ای بسیار بزرگ داشته باشید"
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "مجموعه"
 
@@ -13791,7 +13894,7 @@ msgstr "طبقه ای"
 msgid "URLs"
 msgstr "آدرس های اینترنتی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "میانگین مقادیر موجود در ستون را برمی گرداند."
 
@@ -13800,11 +13903,13 @@ msgstr "میانگین مقادیر موجود در ستون را برمی گر�
 msgid "The column whose values to average."
 msgstr "ستونی که مقادیر آن به طور متوسط است."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "شروع"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "پایان"
 
@@ -13816,21 +13921,19 @@ msgstr "مقادیر ستون تاریخ یا عددی را بررسی می کن
 msgid "Rating"
 msgstr "رتبه بندی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "وضعیت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "خروجی"
 
@@ -13838,27 +13941,27 @@ msgstr "خروجی"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "لیستی از موارد را آزمایش کرده و در صورت برآورده شدن مقدار دیگری ، مقدار مربوط به اولین مورد واقعی را برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "وزن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "بزرگ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "متوسط"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "کوچک"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "چیزی که باید آن را درست یا نادرست ارزیابی کند."
 
@@ -13866,33 +13969,33 @@ msgstr "چیزی که باید آن را درست یا نادرست ارزیاب
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "مقداری که در صورت صحت شرط قبلی برمی گردد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "مقدار۱"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "مقدار۲"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "به ترتیب به مقادیر موجود در هر آرگومان می پردازد و اولین مقدار غیر تهی را برای هر سطر برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "نظرات"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "یادداشت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "بدون نظر"
 
@@ -13908,12 +14011,12 @@ msgstr "اگر مقدار1 خالی باشد ، مقدار خالص 2 اگر خ�
 msgid "Combines two or more strings of text together."
 msgstr "دو یا چند رشته متن را با هم ترکیب می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "نام خانوادگی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "نام"
 
@@ -13925,27 +14028,27 @@ msgstr "مقدار2 به انتهای این اضافه می شود."
 msgid "This will be added to the end of value1."
 msgstr "این به پایان مقدار 1 اضافه می شود."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "رشته۱"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "رشته۲"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "بررسی می کند که آیا رشته۱ شامل رشته۲ است."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "وضعیت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "عبور"
 
@@ -13953,7 +14056,7 @@ msgstr "عبور"
 msgid "The contents of this string will be checked."
 msgstr "محتوای این رشته بررسی خواهد شد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "رشته متن را جستجو کنید."
 
@@ -13961,22 +14064,22 @@ msgstr "رشته متن را جستجو کنید."
 msgid "Returns the count of rows in the source data."
 msgstr "شمارش ردیف ها را در داده های منبع برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "فقط ردیف هایی را که شرایط در آن است صحیح شمرده می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "فرعی"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "مجموع مواد افزودنی ردیفها در یک برک آوت."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "جمع نورد ستون در یک برک آوت."
 
@@ -13985,53 +14088,57 @@ msgstr "جمع نورد ستون در یک برک آوت."
 msgid "The column to sum."
 msgstr "جمع ستون."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "تعداد مقادیر مشخص در این ستون."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "ستونی که مقادیر مشخص آن برای شمارش است."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "متن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "مقایسه"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "اگر انتهای متن متن متن مقایسه باشد مطابقت دارد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "اشتها"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "گرسنه"
 
@@ -14040,20 +14147,20 @@ msgstr "گرسنه"
 msgid "A column or string of text to check."
 msgstr "ستونی یا رشته متن برای بررسی."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "رشته متن که متن اصلی باید با آن پایان یابد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "regular_expression"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "بسترهای مطابق با یک عبارت معمولی را استخراج می کنند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "نشانی"
 
@@ -14061,7 +14168,7 @@ msgstr "نشانی"
 msgid "The column or string of text to search though."
 msgstr "ستون یا رشته متن برای جستجو."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "عبارت منظم برای مطابقت"
 
@@ -14073,7 +14180,7 @@ msgstr "رشته متن را با تمام حروف کوچک برمی گردان
 msgid "The column with values to convert to lowercase."
 msgstr "ستون با مقادیر برای تبدیل به حروف کوچک."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "فضای سفید پیشرو را از متن متن حذف می کند."
 
@@ -14083,15 +14190,16 @@ msgstr "فضای سفید پیشرو را از متن متن حذف می کند.
 msgid "The column with values you want to trim."
 msgstr "ستونی با مقادیر مورد نظر برای ترمیم."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "بزرگترین مقدار یافت شده در ستون را برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "سن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "ستون عددی که حداکثر شما می خواهید آن را پیدا کنید."
 
@@ -14099,21 +14207,21 @@ msgstr "ستون عددی که حداکثر شما می خواهید آن را �
 msgid "Returns the smallest value found in the column."
 msgstr "کمترین مقدار یافت شده در ستون را برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "حقوق"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "ستون عددی که حداقل شما می خواهید آن را پیدا کنید."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "موقعیت"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "طول"
 
@@ -14122,7 +14230,7 @@ msgstr "طول"
 msgid "new_text"
 msgstr "متن جدید"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "بخشی از متن ورودی را با متن جدید جایگزین می کند."
 
@@ -14150,35 +14258,35 @@ msgstr "تعداد کاراکترهای جایگزین"
 msgid "The text to use in the replacement."
 msgstr "متن مورد استفاده در جایگزینی."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "فضای سفید را دنبال می کند از متن."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "درصد ردیف ها را در داده هایی که مطابقت با شرایط دارند ، به صورت اعشاری برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "اگر متن متن با متن مقایسه مطابقت داشته باشد ، برمی گردد."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "نام دوره"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "علوم کامپیوتر"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "رشته متن که متن اصلی باید با آن شروع شود."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "انحراف استاندارد ستون را محاسبه می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "جمعیت"
 
@@ -14186,7 +14294,7 @@ msgstr "جمعیت"
 msgid "A numeric column."
 msgstr "یک ستون عددی."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "بخشی از متن ارائه شده را برمی گرداند."
 
@@ -14194,19 +14302,19 @@ msgstr "بخشی از متن ارائه شده را برمی گرداند."
 msgid "The text to return a portion of."
 msgstr "متن برای برگرداندن بخشی از."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "موقعیت شروع به کپی کردن کاراکترها."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "تعداد کاراکترها برای بازگشت."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "تمام مقادیر ستون را اضافه می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "جمع ستون عددی."
 
@@ -14214,15 +14322,15 @@ msgstr "جمع ستون عددی."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "مقادیر را در ستونی که ردیف ها با شرایط مطابقت دارند ، جمع می کند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "وضعیت سفارش"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "معتبر"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "فضای سفید پیشرو و دنبال کننده را از متن متن حذف می کند."
 
@@ -14230,43 +14338,43 @@ msgstr "فضای سفید پیشرو و دنبال کننده را از متن �
 msgid "Returns the string of text in all upper case."
 msgstr "رشته متن را در تمام موارد بزرگ برمی گرداند."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "ستون با مقادیر برای تبدیل به پرونده بزرگ."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "باید {0} باشد و {1} را شامل شود."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "باید {0} باشد."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "باید {0} باشد."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "حداقل شخصیت {0} شخصیت طولانی"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} حروف کوچک"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} حروف بزرگ"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} شماره"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} شخصیت ویژه"
@@ -14288,6 +14396,7 @@ msgid "Powered by {0}"
 msgstr "طراحی شده توسط {0"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "به:"
 
@@ -14345,7 +14454,7 @@ msgstr "یک کلید خارجی را انتخاب کنید"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:50
 msgid "Hi, {0}. Nice to meet you!"
-msgstr "سلام ، {0 از ملاقات شما خوشبختم!"
+msgstr "سلام ، {0} از ملاقات با شما خوشبختم!"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:270
 msgid "12-hour clock"
@@ -14375,7 +14484,7 @@ msgstr "قالب بندی ارزش"
 msgid "Full"
 msgstr "پر شده"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "تغییری از آخرین {0 last گذشته"
 
@@ -14700,7 +14809,7 @@ msgstr "خطا در ایجاد بینش برای ستون:"
 msgid "Sending abandonment email!"
 msgstr "ارسال ایمیل رها!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "می توانید معیارهای ذخیره شده ایجاد کنید تا گزینه متریک نامگذاری شده اضافه شود. معیارهای ذخیره شده شامل نوع جمع ، میدان جمع شده و هر فیلتر دیگری که اضافه می کنید به صورت اختیاری است. به عنوان نمونه ، شما می توانید از این گزینه برای ایجاد چیزی مانند روش رسمی محاسبه \"قیمت متوسط\" برای جدول سفارشات استفاده کنید."
 
@@ -14708,15 +14817,15 @@ msgstr "می توانید معیارهای ذخیره شده ایجاد کنید
 msgid "Select and add filters to create your new segment."
 msgstr "فیلترها را برای ایجاد بخش جدید خود انتخاب و اضافه کنید."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "الفبایی"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "هوشمندانه"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "سفارش ستون: {0"
 
@@ -14768,7 +14877,7 @@ msgstr "بومی سازی"
 msgid "Instance language"
 msgstr "زبان نمونه"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "گزینه های محلی سازی"
 
@@ -14840,19 +14949,20 @@ msgstr "یک رشته اتصال را بچسبانید"
 msgid "Fill out individual fields"
 msgstr "فیلدهای فردی را پر کنید"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "مقداری SQL را در اینجا وارد کنید تا بعدا بتوانید دوباره از آن استفاده کنید"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
-msgstr "نام قطعه خود را بگذارید"
+msgstr "قطعه خود را نام گذاری کنید"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "مشتریان فعلی"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "توضیحات اضافه کنید"
 
@@ -14860,46 +14970,47 @@ msgstr "توضیحات اضافه کنید"
 msgid "Use site default"
 msgstr "از پیش فرض سایت استفاده کنید"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "پیدا کردن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "جایگزین کردن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "متن برای پیدا کردن"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "متن مورد استفاده به عنوان جایگزین"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "ویرایش {0"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "قطعه جدید خود را ایجاد کنید"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "قطعه های بایگانی شده"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "قطعه قطعه ها قابل استفاده مجدد از SQL هستند"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "یک قطعه قطعه ایجاد کنید"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "قطعه قطعه"
 
@@ -15178,3 +15289,1503 @@ msgstr "مقدار باید یک کلمه کلیدی یا رشته باشد."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "رشته باید یک زبان ISO معتبر دو حرف یا کد کشور-کشور مثلاً باشد. 'en' یا 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "ردیف ها {0} - {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "حسابرسی"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "پیکربندی ویژگی کاربر (اختیاری)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "استفاده از {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "SSO مبتنی بر SAML را تنظیم کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "احراز هویت SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "ارائه دهنده هویت خود را پیکربندی کنید (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "ارائه دهنده هویت شما به اطلاعات زیر در مورد Metabase نیاز دارد."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL که IdP باید به آن هدایت شود"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "به این آدرس Single Sign On URL در Okta ، URL Callback Application در Auth0 ،\n"
+"و URL ACS (Consumer) در OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "ویژگی های SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "در بیشتر IdP ها ، باید هر یک از این موارد را در یک جعبه ورودی با برچسب قرار دهید\n"
+"\"نام\" در بخش عبارات ویژگی."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "ویژگی ایمیل کاربر"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "ویژگی نام کاربر"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "ویژگی نام خانوادگی کاربر"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "درباره ارائه دهنده هویت خود به پایگاه داده بگویید"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase در مورد ارائه دهنده شما به اطلاعات زیر احتیاج دارد."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL ارائه دهنده شناسه SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "گواهی ارائه دهنده هویت SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "نام برنامه SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "ثبت درخواست SSO (اختیاری)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML Keystore Path"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "رمز ورود Keystore SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "خخخخخ"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "نام مستعار Keystore SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "عضویت گروه را با SSO خود هماهنگ کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "برای فعال کردن این مورد ، باید نگاشت هایی را ایجاد کنید تا به Metabase بگویید کاربران شما از چه گروهی استفاده می کنند\n"
+"بر اساس گروه SSO که در آن هستند اضافه شود."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "اسم گروه"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "نام ویژگی گروه"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "توجه داشته باشید:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "اگر هرکدام از تنظیمات یک تنظیم فعال SAML موجود را تغییر دهید ، لازم است Metab را مجدداً راه اندازی کنید تا اعمال شود."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "به کاربران اجازه می دهد تا از طریق یک ارائه دهنده هویت SAML وارد سیستم شوند."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "به کاربران اجازه می دهد تا از طریق ارائه دهنده هویت JWT وارد سیستم شوند."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "تأیید اعتبار گذرواژه را فعال کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "در صورت فعال بودن ، کاربران می توانند با ایمیل و رمز ورود به سیستم وارد شوند."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "به کاربران جدید SSO اطلاع دهید"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "وقتی فعال شود ، برای اولین بار که کاربر از Single Sign-On استفاده می کند ، ایمیلی دریافت می کنند."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "برای پیکربندی SSO خود از طریق SAML از تنظیمات زیر استفاده کنید. اگر س anyالی دارید ، {0} ما را بررسی کنید."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "مستندات"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI ارائه دهنده هویت SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "احراز هویت JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI ارائه دهنده هویت JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "رشته ای که توسط کلید امضای JWT استفاده می شود"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "جاسازی کل برنامه Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "اگر می خواهید همه Metabase را جاسازی کنید ، منشا of وب سایت ها یا برنامه های وب را وارد کنید که می خواهید اجازه قرار دادن آنها را در یک iframe ، جدا شده توسط یک فاصله وارد کنید. در اینجا {0} موارد وارد شده آورده شده است."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "به این جدول اجازه دسترسی به جعبه ماسه را بدهید"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "وقتی کاربران در این گروه این جدول را مشاهده می کنند نسخه ای از آن را که با ویژگی های کاربر آنها فیلتر شده است یا نمای سفارشی از آن را براساس یک سوال ذخیره شده مشاهده می کنند."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "چگونه می خواهید این جدول را برای کاربران این گروه فیلتر کنید؟"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "س savedال ذخیره شده ای را انتخاب کنید که نمای سفارشی این جدول را که این کاربران باید مشاهده کنند ، برمی گرداند."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "بر اساس ویژگی های کاربر می توانید فیلترهای اضافی را به صورت اختیاری در اینجا اضافه کنید. این فیلترها در بالای فیلترهایی که از قبل در این سال ذخیره شده قرار دارند ، اعمال می شوند."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "برای کار کردن این گزینه ، کاربران شما باید برخی از ویژگی ها را داشته باشند"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "برای افزودن فیلترهای اضافی ، کاربران شما باید ویژگی هایی داشته باشند"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "هیچ ویژگی کاربری وجود ندارد"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "ویژگی کاربر را انتخاب کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "یک پارامتر را انتخاب کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "ستونی انتخاب کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "کاربران در {0} می توانند مشاهده کنند"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "ردیف های موجود در {0} سوال"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "ردیف ها در جدول {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "جایی که {0} برابر است با {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "و {0} برابر با {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "با راه اندازی SSO که از SAML استفاده می کند ، می توانید ویژگی ها را به صورت خودکار اضافه کنید یا می توانید با رفتن به بخش افراد و کلیک روی منوی on در سمت راست ، آنها را به صورت دستی وارد کنید."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "ویژگی کاربر"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "اگر SSO را تنظیم کرده باشید ، می توانیم ویژگی های کاربران شما را به طور خودکار دریافت کنیم یا می توانید آنها را به صورت دستی از فهرست \"…\" در بخش افراد در Admin Panel اضافه کنید."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "پارامتر یا متغیر"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "برابر است"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "اجازه دسترسی به جعبه ماسه را بدهید"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "دسترسی جعبه ماسه"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "دسترسی جعبه شن را ویرایش کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "جزئیات پوشه را ویرایش کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "مجوزها را تغییر دهید"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "پوشه جدید خود را ایجاد کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "پوشه جدید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "ما در اعتبار سنجی رمز شما مشکل داریم"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "لطفاً بررسی کنید که نمونه شما می تواند به سرورهای Metabase متصل شود"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "کمک بگیر"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "با Enterprise Edition حتی بیشتر از Metabase بهره مند شوید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "تمام ابزاری که برای تهیه سریع و آسان گزارش برای مشتریان خود یا کمک به شما در اجرای و نظارت بر Metabase در یک سازمان بزرگ به آنها نیاز دارید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "مجوز را فعال کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "نسخه آزمایشی شما با این ویژگی ها فعال است"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "دوره آزمایشی منقضی می شود {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "کمک خواستن؟ آماده خرید هستید؟"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "با ما صحبت کن"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "دوره آزمایشی شما منقضی شده است"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "به زمان بیشتری احتیاج دارید؟ آماده خرید هستید؟"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "ویژگی های شما فعال است!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "مجوز شما از طریق {0} معتبر است"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "پروانه شما منقضی شده است"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "تاریخ انقضا در {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "آیا می خواهید مجوز خود را تمدید کنید؟"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "نحوه استفاده از این را بیاموزید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "در برنامه فعلی شما موجود نیست"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "نشانه ای را که از فروشگاه دریافت کرده اید وارد کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "فعال کنید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "کمک خواستن؟"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "اطلاعات بیشتر در مورد مشکل شما"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "با پشتیبانی تماس بگیرید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "شرکت، پروژه"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "جعبه های شن و ماسه داده"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "اطمینان حاصل کنید که با فیلترهای خودکار و ایمن بر اساس ویژگی های کاربر ، داده های مناسب را به افراد مناسب نشان می دهید."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "برچسب زدن سفید"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Metabase را با رنگ های سفارشی ، آرم شخصی و موارد دیگر با مارک خود مطابقت دهید."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "حسابرسی"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "با ابزارهای حسابرسی قوی ، عملکرد و رفتار را زیر نظر داشته باشید."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "ورود به سیستم تنها"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "ورود به سیستم آسان که با زیرساخت احراز هویت موجود شما کار می کند را ارائه دهید."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "فروشگاه"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "نام نرم افزار"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "پالت رنگ"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "لوگو"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "فاویکون"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "صفحه فرود"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "گروهی وجود ندارد"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "مجوزهای {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "مجوزهای این پوشه"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "اجازه دسترسی به ویرایش را بدهید"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "می توان قطعه های موجود در این پوشه را اصلاح کرد"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "دسترسی مشاهده را اعطا کنید"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "می تواند قطعه هایی را در این پوشه درج و استفاده کند ، اما نمی تواند SQL موجود در آنها را ویرایش کند"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "قطعه ها را نمی توان در این پوشه مشاهده یا درج کرد"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "پوشه های فرعی را نیز تغییر دهید"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "روز اول هفته"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "هنگام ورود به سیستم Google با مشکلی روبرو شد. لطفاً با یک مدیر تماس بگیرید."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "در"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "در"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "منوی اقدامات پایگاه داده را باز کنید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "هیچ کاری نکن"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "به یک مقصد سفارشی بروید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "فیلتر داشبورد را به روز کنید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "فیلتر {0} به روزرسانی ها {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} به {1} می رود"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "رفتار کلیک روی هر ستون"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "به مقصد سفارشی بروید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "منوی عملکردها را باز کنید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "روی رفتار کلیک کنید برای {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "برای به روزرسانی یک یا چند فیلتر انتخاب کنید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "سوال ذخیره شده"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "پیوند به"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "یک URL وارد کنید تا به آن پیوند دهید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "می توانید مقدار ستون یا فیلتر داشبورد را با استفاده از نام آن وارد کنید ، مانند این: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "به عنوان مثال، http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "داشبورد انتخاب کنید ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "سوالی را انتخاب کنید ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "داشبوردی را برای پیوند دادن به آن انتخاب کنید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "س linkالی را انتخاب کنید تا به آن پیوند دهید"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "مقادیر عبور به فیلترهای این داشبورد (اختیاری)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "مقادیر را به متغیرهای این سوال منتقل کنید (اختیاری)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "مقادیر عبور برای فیلتر کردن این سوال (اختیاری)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "فیلترهای داشبورد"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "ویژگی های کاربر"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "متن پیوند را سفارشی کنید (اختیاری)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "سابق. جزئیات مربوط به {{نام ستون}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "مقادیری که می توانید به آنها مراجعه کنید"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "هیچ هدف در دسترس نیست"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "فیلتر کردن"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "متغیر"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "سایر فیلترهای موجود"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "فیلترهای قابل دسترسی"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "سایر متغیرهای موجود"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "متغیرهای قابل دسترسی"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "سایر ستون های موجود"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "ستون های قابل دسترسی"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "ویژگی کاربر"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "کارت پیامک"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "رفتار را کلیک کنید"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "گزینه های تجسم"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "ویرایش مجموعه ها"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "سری اضافه کنید"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "با کلیک"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "عنوان و شرح را تغییر دهید"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "شما پارامی های جاسازی شده را به روز کرده و باید کد جاسازی شده خود را به روز کنید."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "س Addال اضافه کنید"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "شما در حال ویرایش این داشبورد هستید."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "ستون برای فیلتر کردن"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "مجموعه قطعه"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "مجموعه های قطعه"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "به پوشه خود یک نام دهید"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "چیزی کوتاه اما شیرین"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "پوشه باید در این باشد"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "منوی اقدام را باز کنید"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "ستون {0} رفتار سفارشی دارد"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "قابل اعتماد و متخصص..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "رفتن به داشبورد"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "به س Goال بروید"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "به آدرس اینترنتی بروید"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "این داشبورد را فیلتر کنید"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "تعداد ردیف های داده انتخاب شده را برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "ستون یا عددی که جمع می شود."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "ستون عددی برای گرفتن انحراف استاندارد از."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "ستونی عددی که مقادیر آن به طور متوسط است."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "کمترین مقدار یافت شده در ستون را برمی گرداند"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "گوگل"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "ستون مشخص شده را فقط برای سطرهایی که شرط درست است جمع می کند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "واریانس عددی ستون داده شده را برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "درجه حرارت"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "ستون یا شماره برای بدست آوردن واریانس."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "مقدار متوسط ستون مشخص شده را برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "ستون یا عددی که میانه آن را بدست آورید."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "ارزش صدک"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "مقدار ستون را در مقدار صدک برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "ستون یا شماره برای گرفتن صدک."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "مقدار صدک."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "رشته متن را با حروف کوچک برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "ستونی با مقادیر برای تبدیل به حروف کوچک."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "متن را با حروف بزرگ برگرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "ستون یا متن برای برگرداندن بخشی از."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "ستون یا متن برای جستجو از طریق"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "دو یا چند رشته متن را با هم ترکیب کنید."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "ستون یا متن برای شروع."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "این به انتهای مقدار 1 و غیره اضافه می شود."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "عظیم"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "غول پیکر"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "تعداد کاراکترهای متن را برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "ستون یا متنی که می خواهید طول آن را بگیرید."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "ستون یا متنی که می خواهید اصلاح کنید."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "مقدار مطلق (مثبت) ستون مشخص شده را برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "بدهی"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "ستون یا عددی که مقدار مطلق (مثبت) را برگرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "یک عدد اعشاری را به پایین جمع می کند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "ستون یا عددی که به پایین جمع می شود."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "عدد اعشاری را به بالا جمع می کند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "ستون یا شماره جمع بندی."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "یک عدد اعشاری را به بالا یا پایین تا نزدیکترین مقدار صحیح جمع کنید."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "ستون یا عددی که به نزدیکترین عدد صحیح گرد می شود."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "ریشه مربع را برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "هیپوتنوئوس"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "ستون یا عددی که مقدار ریشه مربع آن را برگرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "نماینده"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "یک عدد را به قدرت مقدار نماد بالا می برد."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "طول"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "ستون یا عدد برجسته شده به زبان."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "مقدار توان."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "ورودی پایه 10 عدد را برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "ارزش"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "ستون یا عدد برای برگرداندن مقدار لگاریتم طبیعی از."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "شماره اولر ، e ، را به توان شماره عرضه شده برمی گرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "ماه های علاقه"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "ستون یا عددی که مقدار نمایی آن را برگرداند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "ستون یا متن برای بررسی."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "مقادیر ستون تاریخ یا شماره را بررسی می کند تا ببیند در محدوده مشخص شده هستند یا نه."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "ایجاد شده در"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "تاریخ یا ستون عددی که باید در مقادیر شروع و پایان باشد."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "آغاز دامنه."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "پایان دامنه."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "مقادیر ستون تاریخ را بررسی می کند تا ببیند در محدوده نسبی هستند یا خیر."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "ستون تاریخ برای بازگرداندن فاصله"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "دوره فاصله ، که در آن مقادیر منفی به زمان گذشته باز می گردند."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "نوع داخلی مانند \"روز\" ، \"ماه\" ، \"سال\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "ستون یا مقدار برای بازگشت."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "اگر مقدار 1 خالی باشد ، مقدار 2 اگر خالی نباشد ، بازگردانده می شود و غیره."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "عبارتی را در برابر لیستی از موارد آزمایش می کند و مقدار متناظر اولین مورد منطبق را برمی گرداند ، در صورت برآورده نشدن هیچ چیز دیگری ، با مقدار پیش فرض اختیاری."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "مقداری که در صورت صحت شرط قبلی برگردانده شود و غیره."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "پوچ است"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "تهی نیست"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "مجموع افزودنی تمام مقادیر ستون.\n"
+"سابق. درآمد کل در طول زمان"
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "تعداد افزودنی تعداد ردیف ها.\n"
+"سابق. تعداد کل فروش در طول زمان"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "فیلترهای پیوند خورده"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "برچسب"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "مقدار پیش فرض"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "بدون پیش فرض"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "برای مشاهده این ، {0} باید حداقل به یک قسمت متصل باشد."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "گزینه های این فیلتر را محدود کنید"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "اگر فیلتر داشبورد دیگری دارید ، می توانید انتخاب هایی را که برای این فیلتر درج شده اند بر اساس انتخاب فیلتر دیگر محدود کنید."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "ابتدا ، {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "فیلتر داشبورد دیگری اضافه کنید"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "اگر یکی از این فیلترهای داشبورد را روشن کنید ، با انتخاب یک مقدار برای آن فیلتر گزینه های موجود برای فیلتر {0} محدود می شود."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "ستون فیلتر"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "ستون فیلتر شده"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "نام کاربری یا آدرس های ایمیل را وارد کنید"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "قطعه جدید"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}: 00 بعد از ظهر"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}: 00 صبح"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "ساعتی"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "روزانه در {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "هفتگی ساعت {0} روز {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "ماهانه در {0} {1} ساعت {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "این اشتراک را حذف کنید"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "اشتراک ها"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "اشتراک داشبورد ایجاد کنید"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "برای آن ایمیل ارسال کنید"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "می توانید این داشبورد را به طور مرتب برای کاربران یا آدرس های ایمیل ارسال کنید."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "آن را به Slack ارسال کنید"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "یک کانال و یک برنامه را انتخاب کنید و Metabase بقیه کارها را انجام می دهد."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "ایمیل این داشبورد"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "در صورت عدم نتیجه ، ارسال نکنید"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "پیوست کردن نتایج"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "پیوست ها می توانند حاوی 2000 ردیف داده باشند."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "این داشبورد را به Slack ارسال کنید"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "داشبورد پارامتری با شناسه ندارد {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "پارامتر {0} هیچ فیلدی با آن مرتبط نیست"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "شامل باید خالی باشد یا مقدار \"جداول\""
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "`بانک اطلاعاتی` برای همه درخواستهایی که نوع آنها“ داخلی ”نیست لازم است."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "ورود به سیستم گذرواژه برای این نمونه غیرفعال است."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "حساب شما غیرفعال است لطفاً با سرپرست خود تماس بگیرید."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "حساب شما غیرفعال است"
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "رمز Slack نامعتبر است."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "دستور \"\" {0} \"فقط در نسخه سازمانی Metabase در دسترس است."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "افزونه های نسخه سازمانی Metabase در حال حاضر هستند."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "استفاده از ویژگی های نسخه سازمانی Metabase منوط به مجوز بازرگانی Metabase است."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "برای جزئیات بیشتر به {0} مراجعه کنید."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "برنامه های افزودنی Metabase Enterprise Edition موجود نیستند."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "از شما دعوت شده است به {0} \"{1}\" بپیوندید"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} یک حساب {1} ایجاد کرد"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} دعوت {1} خود را پذیرفت"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] درخواست بازنشانی گذرواژه"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] اعلان"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] به بهتر شدن [{1}] کمک کنید."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] به ما بگویید اوضاع چگونه پیش می رود."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "خطا در شروع شنونده رویدادها"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "آیا وقتی کسی از طریق LDAP وارد سیستم می شود ، باید ویژگی های کاربر را همگام سازی کنیم؟"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "لیستی از ویژگی های کاربر با کاما جدا شده تا از همگام سازی برای کاربران LDAP رد شوید."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "رمز نامعتبر است"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "خطای API اسلک: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "کانال شلی با نام `metabase_files` موجود نیست!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "برای تکمیل ادغام Slack لطفاً کانال را ایجاد یا بایگانی کنید."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "این کانال برای ذخیره نمودارهایی که در پاسخ های Pulses و MetaBot وجود دارد استفاده می شود."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "تصویر بارگذاری شده"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "خطا در بارگذاری پرونده در Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "جلسه نامعتبر است. نمونه ای از جلسه انتظار می رود."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "کوکی جلسه SameSite به \"هیچ\" پیکربندی شده است ، اما سایت اینگونه است"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "از طریق یک اتصال ناامن خدمت کرده است. بعضی از مرورگرها رد می شوند "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "با این شرایط کوکی ها "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "پوشه بالا"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ": پارامترها باید دنباله ای از نقشه ها با کلیدهای String: id باشند"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "مقادیر قابل خواندن توسط انسان نامعتبر است: مقادیر باید یک توالی باشند. هر مورد باید صفر یا رشته ای باشد"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ": برای واکشی: مقادیر_خواننده_ انسانی باید مقادیر وجود داشته باشد"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "مقادیر طول کل> {0} است."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "نام قطعه نمی تواند \"}\" باشد یا با فاصله شروع شود"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "خطا در اجرای درخواست فیلتر زنجیره ای"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "قسمت {0} وجود ندارد."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "نمی توان در برابر فیلد غیر متنی جستجو کرد {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "اعطای مجوزها برای گروه {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "لغو مجوزها برای گروه {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "مجوزهای DB نامعتبر: اگر برای نوشتارهای بومی دسترسی نوشتن دارید ، باید به داده کامل دسترسی داشته باشید."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "مجوزهای DB نامعتبر: اگر فقط به جستجوی بومی دسترسی دارید فقط باید به داده دسترسی داشته باشید."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "تغییر مجوزها از: {0} به: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "کلیدهای ویژگی ورود باید یک کلمه کلیدی یا رشته باشند"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "زبان پیش فرض برای همه کاربران در سراسر رابط کاربری پایگاه داده ، ایمیل های سیستم ، پالس ها و هشدارها."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "کاربران می توانند به صورت جداگانه از تنظیمات حساب خود این زبان پیش فرض را نادیده بگیرند."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "صفحه پیش فرض برای نمایش کاربر"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "اجازه دهید این مبدا برنامه کامل Metabase را در خود جای دهد"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "مقادیر بیشتر از {0} ({1}) مجاز نیستند."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "این هر کجا که ظاهر شود جایگزین کلمه \"Metabase\" می شود."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "اینها رنگهای اصلی هستند که در نمودارها و در کل Metabase استفاده می شوند. برای دیدن تأثیرگذاری ممکن است لازم باشد مرورگر خود را تازه کنید."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "برای بهترین نتیجه ، از یک فایل SVG با پس زمینه شفاف استفاده کنید."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "آدرس اینترنتی یا تصویری که می خواهید به عنوان نماد استفاده کنید."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "ورود به سیستم از طریق ایمیل و گذرواژه را مجاز کنید."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "این موارد مانند گروه بندی براساس هفته یا فیلتر کردن در سeriesالات GUI تأثیر می گذارد.\n"
+"  بر پرسشهای SQL تأثیری نخواهد داشت."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "اعتبار سنجی امکان پذیر نیست"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "قالب رمز نامعتبر است."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "خطا در اعتبار سنجی رمز"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "خطا در فیلتر کردن در برابر {0} فیلد: امکان تجزیه رشته {1} به {2} وجود ندارد"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "خطا در واکشی جزئیات برای Job: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "شروع کار همگام سازی برای پایگاه داده {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "همگام سازی پایگاه داده امکان پذیر نیست {0}: پایگاه داده وجود ندارد."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "وظیفه مقادیر زمینه را که برای پایگاه داده فعال شده به روز کنید."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "رد شدن از به روزرسانی ، به روزرسانی خودکار مقدار فیلد برای پایگاه داده غیرفعال است {0}."

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -30,15 +30,16 @@ msgstr "Explorer ces données"
 msgid "Select a database type"
 msgstr "Sélectionner un type de base de données"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -51,7 +52,7 @@ msgstr "Sauvegarder"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase doit analyser votre base de données. Nous procéderons à une nouvelle analyse périodique pour maintenir les métadonnées à jour. Vous pouvez contrôler ci-dessous le moment où ces analyses périodiques auront lieu."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Synchronisation de la base de données"
 
@@ -67,7 +68,7 @@ msgstr "Ceci est un processus léger qui vérifie les\n"
 msgid "Scan"
 msgstr "Analyser"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Analyse des valeurs de filtre"
 
@@ -78,7 +79,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase peut analyser les champs de cette base de données pour en proposer les valeurs dans les filtres des tableaux de bord et des questions. Cette analyse peut être un processus gourmand en ressources, surtout si vous avez une très grande base de données."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Quand Metabase doit-il automatiquement analyser et mettre en cache les valeurs des champs ?"
 
@@ -136,29 +137,31 @@ msgstr "SUPPRIMER"
 msgid "in this box:"
 msgstr "dans cette case :"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -181,9 +184,9 @@ msgstr "Supprimer"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -203,8 +206,9 @@ msgstr "Connexion"
 msgid "Scheduling"
 msgstr "Planification"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -249,7 +253,7 @@ msgstr "Analyser à nouveau les valeurs des filtres maintenant"
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
-msgstr "Impossible de démarrer l analyse"
+msgstr "Impossible de démarrer l'analyse"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
@@ -260,7 +264,7 @@ msgstr "Analyse déclenchée !"
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:233
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "Zone Dangereuse"
+msgstr "Zone dangereuse"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
@@ -284,10 +288,10 @@ msgstr "Ajouter une base de données"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -299,11 +303,11 @@ msgstr "Moteur"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "Suppression ..."
+msgstr "Suppression..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Chargement ..."
+msgstr "Chargement..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
@@ -315,17 +319,15 @@ msgstr "Impossible de se connecter à la base de données. Veuillez vérifier le
 
 #: frontend/src/metabase/admin/databases/database.js:384
 msgid "Successfully created!"
-msgstr "Création réussie!"
+msgstr "Création réussie !"
 
 #: frontend/src/metabase/admin/databases/database.js:394
 msgid "Successfully saved!"
-msgstr "Sauvegarde réussie!"
+msgstr "Sauvegarde réussie !"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Modifier"
@@ -336,7 +338,7 @@ msgstr "Historique des modifications"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "Retirer ce {0}?"
+msgstr "Retirer ce {0} ?"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
@@ -404,26 +406,29 @@ msgstr "Sélectionner un type"
 msgid "Select a target"
 msgstr "Sélectionner une cible"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Colonnes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Colonne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Visibilité"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Type"
 
@@ -431,7 +436,7 @@ msgstr "Type"
 msgid "Current database:"
 msgstr "Base de données actuelle :"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Montrer le schéma original"
 
@@ -501,7 +506,7 @@ msgstr "Trouver une table"
 msgid "Schemas"
 msgstr "Schémas"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -518,7 +523,7 @@ msgstr "Ajouter une métrique"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Définition"
 
@@ -587,35 +592,35 @@ msgstr " Historique"
 msgid "Revision History for"
 msgstr "Historique de modification pour"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} – Réglages du champ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Où ce champ apparaîtra dans Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrer sur ce champ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "Lorsque ce champ est utilisé dans un filtre, que doivent faire les utilisateurs pour saisir la valeur à filtrer?"
+msgstr "Lorsque ce champ est utilisé dans un filtre, que doivent faire les utilisateurs pour saisir la valeur à filtrer ?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Aucune description pour ce champ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Valeur d'origine"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Valeur correspondante"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Saisir une valeur"
 
@@ -632,48 +637,48 @@ msgid "Custom mapping"
 msgstr "Correspondance personnalisée"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Type de correspondance non reconnu"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Le champ actuel n'est pas une clé étrangère ou les métadonnées de la table cible de la clé étrangère sont manquantes"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Le champ sélectionné n'est pas une clé étrangère"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Afficher les valeurs"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Choisir d'afficher la valeur originale dans la base de données, ou une information associée ou personnalisée."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Choisissez un champ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "S'il vous plaît, sélectionnez une colonne à utiliser pour l'affichage"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "Astuce:"
+msgstr "Astuce :"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "Il se peut que vous vouliez mettre à jour le nom du champ pour s'assurer qu'il est toujours pertinent selon vos choix de mise en corespondance."
+msgstr "Il se peut que vous vouliez mettre à jour le nom du champ pour s'assurer qu'il est toujours pertinent selon vos choix de mise en correspondance."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valeurs des filtres mises en cache"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase peut analyser les valeurs de ce champ pour proposer des filtres dans les tableaux de bord et les questions."
 
@@ -694,41 +699,42 @@ msgstr "Impossible de supprimer les valeurs"
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
-msgstr "Suppression lancée"
+msgstr "Suppression lancée !"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Sélectionner une table pour voir son schéma et enrichir ses métadonnées"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Le nom est requis"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "La description est requise"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Un message d'historique est requis"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Une agrégation est requise."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Éditer votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Créer votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Modifier votre métrique et laisser un commentaire pour ces changements."
 
@@ -736,46 +742,46 @@ msgstr "Modifier votre métrique et laisser un commentaire pour ces changements.
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Sauvegardez des métriques pour les rendre disponibles dans l'option de Vue de cette table. Les métriques se définissent par un type d'agrégation, un champ aggrégé, et optionnellement tous filtres que vous y ajouterez. Par exemple, vous pourriez vouloir créer une métrique pour définir la façon officielle de calculer le \"Prix moyen\" d'une table qui contient des Commandes."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Résultat : "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Nommez votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Donnez un nom à votre métrique pour aider les autres à la retrouver."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Description syntétique"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Décrivez votre métrique"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Donnez une description à votre métrique pour aider les autres à mieux l'utiliser."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "C'est le bon endroit pour expliquer plus précisement à quoi sert votre métrique et comment vous l'avez construite."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Raison des modifications"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Laisser un mot d'explication sur les changements que vous avez fait et pourquoi ils étaient nécessaires."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Sera affiché dans l'historique des révisions de cette métrique afin d'aider tout le monde à se souvenir des changements effectués."
 
@@ -828,6 +834,7 @@ msgstr "Ce sera affiché dans l'historique des révisions pour ce segment, afin 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -842,8 +849,7 @@ msgid "Re-scan this table"
 msgstr "Analyser à nouveau cette table"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Ajouter"
 
@@ -860,7 +866,7 @@ msgid "Last name"
 msgstr "Nom"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Adresse électronique"
@@ -869,7 +875,7 @@ msgstr "Adresse électronique"
 msgid "Permission Groups"
 msgstr "Groupes de permissions"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Faire de cet utilisateur un administrateur"
 
@@ -940,7 +946,7 @@ msgstr "Supprimer ce groupe ?"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "Êtes-vous sûr ? Tous les membres de ce groupe perdront toutes leurs  autorisations basées sur ce groupe.\n"
+msgstr "Êtes-vous sûr ? Tous les membres de ce groupe perdront toutes leurs autorisations basées sur ce groupe.\n"
 "Cette action ne peut pas être annulée."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
@@ -956,7 +962,7 @@ msgstr "Non"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "Modifier le Nom"
+msgstr "Modifier le nom"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
@@ -968,6 +974,8 @@ msgstr "Supprimer le groupe"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -980,11 +988,12 @@ msgstr "Fait"
 msgid "Group name"
 msgstr "Nom du groupe"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Groupes"
@@ -999,7 +1008,7 @@ msgstr "Vous pouvez utiliser des groupes pour contrôler l'accès de vos utilisa
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "Modifier les Détails"
+msgstr "Modifier les détails"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
@@ -1022,7 +1031,7 @@ msgstr "Utilisateurs"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "Que voulez-vous ajouter?"
+msgstr "Que voulez-vous ajouter ?"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
@@ -1065,7 +1074,7 @@ msgstr "Les invitations précédentes, envoyées par courriel, ne fonctionneront
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "Désactiver {0}?"
+msgstr "Désactiver {0} ?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
@@ -1073,7 +1082,7 @@ msgstr "{0} ne pourra plus se connecter."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "Réactiver le compte de {0}?"
+msgstr "Réactiver le compte de {0} ?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
@@ -1093,7 +1102,7 @@ msgstr "Réinitialiser"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Êtes-vous sûr de vouloir faire cela ?"
 
@@ -1206,7 +1215,7 @@ msgstr "Aucune modification ne sera faite aux permissions."
 msgid "You've made changes to permissions."
 msgstr "Vous avez fait des modifications aux permissions."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Permissions pour cette collection"
 
@@ -1252,7 +1261,7 @@ msgstr "Révoquer"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "accéder même si \"{0}\" a accès supérieur?"
+msgstr "accéder même si \"{0}\" possède un accès supérieur ?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
@@ -1262,6 +1271,7 @@ msgstr "Limiter l'accès"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Révoquer l'accès"
 
@@ -1311,7 +1321,7 @@ msgstr "Aucun accès"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "Ecrire des questions brutes"
+msgstr "Écrire des questions brutes"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
@@ -1325,23 +1335,23 @@ msgstr "Organiser une collection"
 msgid "View collection"
 msgstr "Voir le contenu d'une collection"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Accès aux données"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Voir les tables"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "Requêtes SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Voir les schémas"
 
@@ -1389,7 +1399,7 @@ msgstr "Ce n'est pas un entier valide"
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
-msgstr "Modifications sauvegardées!"
+msgstr "Modifications sauvegardées !"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
@@ -1412,12 +1422,15 @@ msgstr "Envoyé !"
 msgid "Clear"
 msgstr "Effacer"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Authentification"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Paramètres serveur"
@@ -1430,6 +1443,7 @@ msgstr "Schéma utilisateur"
 msgid "Attributes"
 msgstr "Attributs"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Schéma de groupe"
@@ -1501,6 +1515,9 @@ msgid "Add a map"
 msgstr "Ajouter une carte"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1510,19 +1527,19 @@ msgid "Delete custom map"
 msgstr "Supprimer une carte personnalisée"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Supprimer"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1530,7 +1547,7 @@ msgstr "Sélectionner..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "Valeurs d'exemple:"
+msgstr "Valeurs d'exemple :"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
@@ -1622,19 +1639,19 @@ msgstr "Acheter un jeton"
 msgid "Enter a token"
 msgstr "Saisir un jeton"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Modifier les correspondances"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Correspondances de groupe"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Créer une correspondance"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1770,7 +1787,7 @@ msgstr "Choisir une langue"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
-msgstr "Tracking anonyme"
+msgstr "Pistage anonyme"
 
 #: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
@@ -1873,18 +1890,27 @@ msgstr "Filtre utilisateur"
 msgid "Check your parentheses"
 msgstr "Vérifier vos parenthèses"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Attribut adresse électronique"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Attribut prénom"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Attribut Nom"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Synchroniser les appartenances de groupe"
@@ -1913,60 +1939,60 @@ msgstr "Cartes personnalisées"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Ajouter vos propres fichiers GeoJSON pour permettre la visualisation sur d'autres régions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Partage public"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Activer le partage public"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Tableaux de bord partagés"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Questions partagées"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Intégration dans d'autres applications"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Autoriser l'intégration de Metabase dans d'autres applications"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Clé secrète d'intégration"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Tableaux de bord intégrés"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Questions intégrées"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Mise en cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Autoriser la mise en cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Durée d'exécution minimum d'une requête"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplicateur de durée de vie en cache (TTL)"
 
 #. Erreur de compréhension dans ma première traduction
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Taille maximum d'une entrée du cache"
 
@@ -2008,27 +2034,27 @@ msgstr "Vous aurez besoin qu'un administrateur Metabase crée un compte avant de
 msgid "Sign in with {0}"
 msgstr "Se connecter avec {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "S'il vous plaît, demandez à un administrateur Metabase de réinitialiser votre mot de passe"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Mot de passe oublié"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "L'adresse électronique que vous utilisez pour votre compte Metabase"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Envoyer un courriel de réinitialisation de mot de passe"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Vérifiez vos courriels pour obtenir les instructions de réinitialisation de votre mot de passe."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Se connecter à Metabase"
 
@@ -2050,11 +2076,11 @@ msgstr "Se connecter"
 msgid "I seem to have forgotten my password"
 msgstr "Je semble avoir oublié mon mot de passe"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "demander un nouveau courriel de réinitialisation"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Oups, ce lien a expiré"
 
@@ -2063,11 +2089,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Pour des raisons de sécurité, les liens de réinitialisation de mot de passe expirent après un petit moment. Si vous avez toujours besoin de réinitialiser votre mot de passe, vous pouvez {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Pour conserver vos données en sécurité, les mots de passe {0}"
 
@@ -2090,24 +2116,24 @@ msgstr "Confirmer le nouveau mot de passe"
 msgid "Make sure it matches the one you just entered"
 msgstr "Assurez-vous qu'il correspond à celui que vous venez de saisir"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Votre mot de passe a été réinitialisé."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Vous connecter avec votre nouveau mot de passe"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "La sauvegarde a échouée"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2117,25 +2143,26 @@ msgstr "Sauvegardé"
 msgid "Ok"
 msgstr "C'est tout bon"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Archiver cette collection ?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Les tableaux de bord, collections et pulses de cette collection seront aussi archivés."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Archiver"
 
@@ -2246,7 +2273,7 @@ msgstr "Les tableaux de bord vous permettent de rassembler et partager la donné
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "Les Pulses vous permettent d'envoyer les plus récentes données à votre équipe de façon planifiée, par courriel ou via slack."
+msgstr "Les Pulses vous permettent d'envoyer les données les plus récentes à votre équipe de façon planifiée, par courriel ou via Slack."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
@@ -2254,13 +2281,13 @@ msgstr "Une question est une vue sauvegardée de vos données."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
-msgstr "Epingles"
+msgstr "Épingles"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Déposer quelque chose ici pour l'épingler en haut"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2279,7 +2306,7 @@ msgstr[1] "{0} éléments sélectionnés"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:517
 msgid "Move {0} items?"
-msgstr "Déplacer {0} éléments"
+msgstr "Déplacer {0} éléments ?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:518
 msgid "Move \"{0}\"?"
@@ -2289,6 +2316,7 @@ msgstr "Déplacer \"{0}\" ?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Déplacer"
@@ -2324,7 +2352,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "Certaines bases de données ne sont accessibles qu'en SSH au travers d'un serveur bastion. Cette option ajoute aussi une couche de sécurité lors d'une connexion hors VPN. L'activer est plus lent qu'une connexion directe."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "C'est une grande base de données, laissez-moi donc choisir quand Metabase lance les synchronisations et les analyses"
 
@@ -2364,7 +2392,7 @@ msgstr "Pour pouvoir utiliser Metabase avec cette donnée, vous devez activer l'
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} pour se rendre dans la console si ce n'est déjà fait."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Sous quel nom souhaitez-vous référencer cette base de données ?"
 
@@ -2386,7 +2414,7 @@ msgstr "Supprimer ce/cette {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "Epingler cet élément"
+msgstr "Épingler cet élément"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
@@ -2480,35 +2508,35 @@ msgstr "Selon le schéma"
 msgid "A look at your"
 msgstr "Jeter un œil à votre"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Recherche dans la liste"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Recherche par {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " ou saisir un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Saisir un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Saisir un nombre"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Saisir du texte"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Aucun(e) {0} correspondant trouvé(e)."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Inclure chaque option dans votre filtre n'apportera probablement pas grand chose..."
 
@@ -2520,7 +2548,6 @@ msgstr "Quelque chose s'est mal passé"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Une erreur est survenue. Vous pouvez essayer de rafraîchir la page, ou juste revenir en arrière."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2531,12 +2558,12 @@ msgstr "Une erreur est survenue. Vous pouvez essayer de rafraîchir la page, ou 
 msgid "No description yet"
 msgstr "Aucune description"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Nouveau/nouvelle {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Demandé par {0}"
 
@@ -2557,7 +2584,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Ramené(e) à une précédente version et {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historique des modifications"
@@ -2603,7 +2632,7 @@ msgid "Questions"
 msgstr "Questions"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Pulses"
 
@@ -2675,54 +2704,71 @@ msgstr "Pas maintenant"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "Erreur:"
+msgstr "Erreur :"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Dimanche"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Lundi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Vendredi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Samedi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Premier"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Dernier"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "Le quinze du mois"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Jour calendaire"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "Fuseau horaire de Metabase"
 
@@ -2776,11 +2822,11 @@ msgstr "Créer"
 msgid "Create dashboard"
 msgstr "Créer un tableau de bord"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Table"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Base de données"
 
@@ -2855,9 +2901,9 @@ msgstr "Quel est le nom de votre carte ?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2871,15 +2917,16 @@ msgstr "Description"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "C'est facultatif, mais ô combien utile"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Dans quelle collection cela devrait-il aller ?"
 
@@ -2919,11 +2966,11 @@ msgstr "Archiver le tableau de bord"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Assurez-vous de faire un choix pour chaque série de données, ou le filtre ne fonctionnera pas avec cette carte."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Ce tableau de bord semble vide."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Ajoutez une question pour commencer à le rendre utile !"
 
@@ -2943,7 +2990,7 @@ msgstr "Sortir du mode plein écran"
 msgid "Enter fullscreen"
 msgstr "Passer en mode plein écran"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Sauvegarde en cours..."
@@ -2956,7 +3003,8 @@ msgstr "Ajouter une question"
 msgid "Add a question to this dashboard"
 msgstr "Ajouter une question à ce tableau de bord"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Ajouter un filtre"
 
@@ -2964,7 +3012,7 @@ msgstr "Ajouter un filtre"
 msgid "Parameters"
 msgstr "Paramètres"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Ajouter une zone de texte"
 
@@ -2972,7 +3020,7 @@ msgstr "Ajouter une zone de texte"
 msgid "Move dashboard"
 msgstr "Déplacer le tableau de bord"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Modifier le tableau de bord"
 
@@ -2996,11 +3044,11 @@ msgstr "Déplacer le tableau de bord vers..."
 msgid "Dashboard moved to {0}"
 msgstr "Tableau de bord déplacé vers {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Que voulez-vous filtrer ?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Quel type de filtre ?"
 
@@ -3072,22 +3120,24 @@ msgstr "Cette carte n'a aucun champ ou paramètre qui pourrait être mis en corr
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Les valeurs de ce champ ne chevauchent les valeurs d'aucun autre champ sélectionné."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Aucun champ valide"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Le nom ne pas contenir plus de 100 caractères"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Une couleur est exigée"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
-msgstr "Quel est le nom de votre tableau de bord"
+msgstr "Quel est le nom de votre tableau de bord ?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:95
 msgid "did some super awesome stuff that's hard to describe"
@@ -3141,7 +3191,7 @@ msgstr "a reçu les dernières données de"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -3195,7 +3245,7 @@ msgstr "a supprimé un pulse"
 #: frontend/src/metabase/home/components/Activity.jsx:350
 #: frontend/src/metabase/home/components/Activity.jsx:381
 msgid "added the filter"
-msgstr "a a jouté le filtre"
+msgstr "a ajouté le filtre"
 
 #: frontend/src/metabase/home/components/Activity.jsx:391
 #: frontend/src/metabase/home/components/Activity.jsx:422
@@ -3266,9 +3316,10 @@ msgstr "Vous n'avez consulté aucun tableau de bord ou question récemment"
 msgid "{0} items selected"
 msgstr "{0} élément(s) sélectionné(s)"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Désarchiver"
 
@@ -3343,7 +3394,7 @@ msgstr "Pays"
 
 #: frontend/src/metabase/lib/core.js:240
 msgid "Enum"
-msgstr "Enumération"
+msgstr "Énumération"
 
 #: frontend/src/metabase/lib/core.js:262
 msgid "Image URL"
@@ -3371,7 +3422,7 @@ msgstr "Numérique"
 #: frontend/src/metabase/lib/core.js:75
 #: frontend/src/metabase/meta/Dashboard.js:70
 msgid "State"
-msgstr "Etat d'un pays"
+msgstr "État d'un pays"
 
 #: frontend/src/metabase/lib/core.js:233
 msgid "UNIX Timestamp (Seconds)"
@@ -3386,7 +3437,7 @@ msgid "Zip Code"
 msgstr "Code postal"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Quantité"
 
@@ -3419,11 +3470,13 @@ msgid "User"
 msgstr "Utilisateur"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Origine"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Prix"
 
@@ -3457,21 +3510,23 @@ msgid "Subscription"
 msgstr "Inscription"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Score"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titre"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -3489,7 +3544,7 @@ msgstr "Date de naissance"
 
 #: frontend/src/metabase/lib/core.js:285
 msgid "Search box"
-msgstr "Zone de recherche avec autocomplétion"
+msgstr "Zone de recherche avec auto-complétion"
 
 #: frontend/src/metabase/lib/core.js:286
 msgid "A list of all values"
@@ -3525,14 +3580,14 @@ msgstr "Metabase ne récupèrera jamais ce champ. Utilisez ce réglage pour les 
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Nombre de lignes"
 
@@ -3540,7 +3595,7 @@ msgstr "Nombre de lignes"
 msgid "CumulativeCount"
 msgstr "Nombre cumulé de lignes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3556,21 +3611,21 @@ msgstr "Nombre de valeurs distinctes"
 
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "Ecart-type"
+msgstr "Écart-type"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Moyenne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Minimum"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3579,15 +3634,15 @@ msgstr "Maximum"
 
 #: frontend/src/metabase/lib/expressions/parser.js:373
 msgid "sad sad panda, lexing errors detected"
-msgstr "Des ereurs syntaxiques ou lexicales ont été détectées"
+msgstr "Des erreurs syntaxiques ou lexicales ont été détectées"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} seconde"
 msgstr[1] "{0} secondes"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minute"
@@ -3595,7 +3650,7 @@ msgstr[1] "{0} minutes"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "Héy"
+msgstr "Hé"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
@@ -3628,14 +3683,15 @@ msgstr "Que voulez-vous déterminer ?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Données brutes"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Nombre cumulé"
 
@@ -3652,7 +3708,7 @@ msgstr "Valeurs distinctes du/de la "
 #: frontend/src/metabase/lib/query/description.js:92
 #: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
-msgstr "Ecart-type du/de la "
+msgstr "Écart-type du/de la "
 
 #: frontend/src/metabase/lib/query/description.js:97
 #: frontend/src/metabase/lib/query/description.js:272
@@ -3697,208 +3753,206 @@ msgstr "Vrai"
 msgid "False"
 msgstr "Faux"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Sélectionner le champ longitude"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Saisir la latitude supérieure"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Saisir la longitude inférieure"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Saisir la latitude inférieure"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Saisir la longitude supérieure"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Est"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "N'est pas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Est vide"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Non vide"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
-msgstr "Egal(e) à"
+msgstr "Égal(e) à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Différent(e) de"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Supérieur à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Inférieur à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Supérieur ou égal à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Inférieur ou égal à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Contient"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Ne contient pas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Commence par"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Finit par"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Avant"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Après"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Dans"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Juste une table avec ces lignes dans la réponse, aucune opération additionnelle."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Nombre de lignes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Nombre total de lignes dans la réponse."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Somme de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Somme de toutes les valeurs d'une colonne."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Moyenne de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Moyenne de toutes les valeurs d'une colonne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Nombre de valeurs distinctes de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Nombre de valeurs uniques d'une colonne parmi toutes les lignes dans la réponse."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Somme cumulée de ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "Somme cumulée de toutes les valeurs d'une colonne. Ex : Gain total au cours du temps."
+msgstr "Somme cumulée de toutes les valeurs d'une colonne. Ex. : gain total au cours du temps."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Nombre cumulé de lignes"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "Nombre cumulé de lignes. Ex : Nombre total de ventes au cours du temps."
+msgstr "Nombre cumulé de lignes. Ex. : nombre total de ventes au cours du temps."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
-msgstr "Ecart-type de ..."
+msgstr "Écart-type de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Nombre qui exprime la dispersion des valeurs d'une colonne parmi toutes les lignes dans la réponse."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Minimum de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Valeur minimum d'une colonne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Maximum de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Valeur maximum d'une colonne"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "Eclater par dimension"
+msgstr "Éclater par dimension"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
@@ -3908,6 +3962,8 @@ msgstr "minuscule"
 msgid "upper case letter"
 msgstr "majuscule"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "nombre"
@@ -4089,7 +4145,7 @@ msgstr "Aide"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:72
 msgid "About Metabase"
-msgstr "A propos de Metabase"
+msgstr "À propos de Metabase"
 
 #. Les items du menu sont tous des noms...
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:78
@@ -4158,7 +4214,7 @@ msgstr "Comment créer des métriques"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Voir la donnée comme série chronologique, carte, ou tableau croisé pour vous aider à comprendre les tendances ou les changements."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Personnalisée"
 
@@ -4181,7 +4237,7 @@ msgstr "Requête native"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Pour des questions plus complexes, vous pouvez écrire votre propre requête SQL"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Choisir une valeur par défaut"
 
@@ -4272,7 +4328,7 @@ msgstr "Ce mois-ci"
 msgid "This Year"
 msgstr "Cette année"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Saisir une valeur..."
@@ -4282,7 +4338,7 @@ msgid "Enter a default value..."
 msgstr "Saisir une valeur par défaut..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Une erreur est survenue"
@@ -4313,7 +4369,7 @@ msgstr "Mis à jour"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "Echec !"
+msgstr "Échec !"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
@@ -4343,7 +4399,7 @@ msgstr "Modifiable"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "Vérouillé"
+msgstr "Verrouillé"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
@@ -4379,11 +4435,11 @@ msgstr "Bordure"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "Pour intégrer ce/cette {0} dans votre application:"
+msgstr "Pour intégrer ce/cette {0} dans votre application :"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "Insérez cet extrait  dans le code de votre serveur pour générer l'URL d'intégration signée ␣"
+msgstr "Insérez cet extrait dans le code de votre serveur pour générer l'URL d'intégration signée ␣"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
@@ -4419,7 +4475,7 @@ msgstr "Lien public"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Partagez ce/cette {0} avec des personnes qui ne possèdent pas de compte Metabase en utilisant l'URL ci-dessous:"
+msgstr "Partagez ce/cette {0} avec des personnes qui ne possèdent pas de compte Metabase en utilisant l'URL ci-dessous :"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
@@ -4427,7 +4483,7 @@ msgstr "Intégration publique"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "Intégrez ce/cette {0} dans les posts de blog ou les pages web en copiant/collant ce bout de code."
+msgstr "Intégrez ce/cette {0} dans les posts de blog ou les pages web en copiant/collant ce bout de code :"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
@@ -4543,22 +4599,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Choisissez les questions que vous voudriez envoyer dans ce pulse"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Courriels"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Messages Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Envoyé"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} sera envoyé à"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Messages"
 
@@ -4628,32 +4692,32 @@ msgstr "Aidez chacun de vos utilisateurs à rester en phase avec vos données."
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:31
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Les Pulses vous permettent d'envoyer vos données de façon planifiée, par e-mail ou via slack."
+msgstr "Les Pulses vous permettent d'envoyer vos données de façon planifiée, par e-mail ou via Slack."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Après {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Avant {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Est vide"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "N'est pas vide"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Tout le temps"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Appliquer les modifications"
 
@@ -4675,7 +4739,7 @@ msgstr "Nombre de lignes au fil du temps"
 
 #: frontend/src/metabase/modes/components/drill/PivotByDrill.jsx:52
 msgid "Break out by {0}"
-msgstr "Eclater par {0}"
+msgstr "Éclater par {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:36
 msgid "Summarize this segment"
@@ -4754,12 +4818,12 @@ msgstr[1] "Visualiser ces {0}"
 msgid "Zoom in"
 msgstr "Agrandir"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Expression personnalisée"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Métriques communes"
 
@@ -4785,7 +4849,7 @@ msgstr "En cours de désinscription..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "Echec de la désinscription"
+msgstr "Échec de la désinscription"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
@@ -4942,7 +5006,7 @@ msgstr "résultats"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0} ce type d'alerte est surtout utile quand votre question sauvegardée ne retourne {1} pas de résutat, mais que vous voulez savoir quand elle en retourne un."
+msgstr "{0} Ce type d'alerte est surtout utile quand votre question sauvegardée ne retourne {1} pas de résultat, mais que vous voulez savoir quand elle en retourne un."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
@@ -4956,7 +5020,7 @@ msgstr "habituellement"
 msgid "Pick a segment or table"
 msgstr "Choisir un segment ou une table"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Sélectionner une base de données"
@@ -5018,7 +5082,7 @@ msgstr "Trier"
 msgid "Row limit"
 msgstr "Nombre de lignes maximum"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Champ inconnu"
 
@@ -5026,7 +5090,7 @@ msgstr "Champ inconnu"
 msgid "field"
 msgstr "champ"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Correspondances"
 
@@ -5051,11 +5115,11 @@ msgstr "Ajouter une agrégation"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Données"
 
@@ -5075,11 +5139,12 @@ msgstr "Vue"
 msgid "Grouped By"
 msgstr "Agrégat"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Aucun"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Cette question est écrite en {0}."
 
@@ -5091,7 +5156,7 @@ msgstr "Masquer l'éditeur"
 msgid "Hide Query"
 msgstr "Masquer la requête"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Ouvrir l'éditeur"
 
@@ -5099,7 +5164,7 @@ msgstr "Ouvrir l'éditeur"
 msgid "Show Query"
 msgstr "Montrer la requête"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "La métrique a été retirée. Elle n'est plus utilisable."
 
@@ -5246,7 +5311,7 @@ msgstr "Rechercher"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "Avancé ..."
+msgstr "Avancé..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
@@ -5300,7 +5365,7 @@ msgstr "Retourner à la dernière exécution"
 msgid "Visualization"
 msgstr "Visualisation"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Aucune description."
 
@@ -5330,7 +5395,7 @@ msgstr "Toutes les valeurs distinctes de {0}"
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "Nombre de {0} aggrégés par {1}"
+msgstr "Nombre de {0} agrégés par {1}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5357,7 +5422,7 @@ msgstr "Impossible de trouver les métadonnées de la table avant de créer une 
 msgid "See {0}"
 msgstr "Voir {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Règles de la métrique"
 
@@ -5375,11 +5440,11 @@ msgstr "Nombre de {0}"
 msgid "See all {0}"
 msgstr "Voir tous les {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Définition du segment"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Une erreur est survenue au chargement de la table"
 
@@ -5387,7 +5452,7 @@ msgstr "Une erreur est survenue au chargement de la table"
 msgid "See the raw data for {0}"
 msgstr "Voir les données brutes de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Plus"
 
@@ -5407,6 +5472,8 @@ msgstr "Formule du champ"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Imaginez cela comme étant une sorte de formule de tableur : vous pouvez utiliser des nombres, champs dans la table, opérations mathématiques comme +, et quelques fonctions. Vous pourriez donc écrire quelque chose comme Soustotal - Cout."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5474,9 +5541,9 @@ msgstr "faux"
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
-msgstr "Elément"
+msgstr "Élément"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
@@ -5529,7 +5596,7 @@ msgstr "L'essayer"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:243
 msgid "What's this for?"
-msgstr "A quoi ça sert ?"
+msgstr "À quoi ça sert ?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:245
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
@@ -5561,7 +5628,7 @@ msgstr "Clauses optionnelles"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "des crochets carrés [] autour d'un(e) {0} rendent optionnelle une clause dans le patron SQL. Si la variable est valuée, alors la clause est insérée dans la requête. Sinon, elle est ignorée."
+msgstr "des crochets carrés [] autour d'un(e) {0} rendent optionnelle une clause dans le patron SQL. Si la variable est définie, alors la clause est insérée dans la requête. Sinon, elle est ignorée."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:283
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
@@ -5599,11 +5666,11 @@ msgstr "Champ lié à"
 msgid "Filter widget type"
 msgstr "Type de filtre"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Obligatoire ?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Valeur du filtre par défaut"
 
@@ -5615,7 +5682,7 @@ msgstr "Archiver cette question?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Cette question sera retirée de tous les tableaux de bords ou pulses qui l'utilisent."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Question"
 
@@ -5662,7 +5729,7 @@ msgstr "Type de champ"
 msgid "Select a Foreign Key"
 msgstr "Choisir une clé étrangère"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Afficher la formule {0}"
 
@@ -5728,7 +5795,7 @@ msgstr "Quoi d'utile ou d'intéressant à propos de ce/cette {0} ?"
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "Ecrivez quelque chose d'utile ici"
+msgstr "Écrivez quelque chose d'utile ici"
 
 #. Je propose "Y a-t-il" à la place de Y a t'il https://www.lalanguefrancaise.com/orthographe/y-a-t-il-orthographe/
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
@@ -5967,7 +6034,7 @@ msgstr "Explorez vos données"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "Avez vous des questions?"
+msgstr "Avez-vous des questions ?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
@@ -6036,7 +6103,7 @@ msgstr "Que devrait savoir un utilisateur de cette donnée avant de commencer à
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "Par exemple : Règles d'usage et de confidentialité, erreurs et malentendus fréquents, temps de réponse de l'entrepôt, mentions légales, etc."
+msgstr "Par exemple : règles d'usage et de confidentialité, erreurs et malentendus fréquents, temps de réponse de l'entrepôt, mentions légales, etc."
 
 #. Y a-t-il ? https://www.lalanguefrancaise.com/orthographe/y-a-t-il-orthographe/
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
@@ -6045,7 +6112,7 @@ msgstr "Y a-t-il une personne que vos utilisateurs pourraient contacter s'ils on
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "A qui les utilisateurs pourraient demander de l'aide s'ils ont besoin d'éclaircissements sur ces données ?"
+msgstr "À qui les utilisateurs pourraient demander de l'aide s'ils ont besoin d'éclaircissements sur ces données ?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:76
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:97
@@ -6054,7 +6121,7 @@ msgstr "Veuillez saisir un commentaire de révision"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "Pourquoi cette métrique est interessante ?"
+msgstr "Pourquoi cette métrique est intéressante ?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
@@ -6150,22 +6217,24 @@ msgstr "Questions sur ce segment"
 msgid "X-ray this segment"
 msgstr "Radiographier ce segment"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Se connecter"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Rechercher"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nouvelle question"
 
@@ -6237,41 +6306,41 @@ msgstr "Toute la collection est complètement anonyme"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La collection peut être désactivée à tout moment dans vos paramètres d'administration."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Si vous vous sentez coincé"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "notre guide de démarrage"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "est à portée de clic."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Bienvenue sur Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Tout semble fonctionner. À présent, dites-nous qui vous êtes, connectez vos données et commencez à trouver des réponses !"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "C'est parti"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Tout est configuré !"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Emmenez-moi dans Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:49
 msgid "What should we call you?"
-msgstr "Comment devez-nous vous appeler ?"
+msgstr "Comment devons-nous vous appeler ?"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
@@ -6342,7 +6411,7 @@ msgstr "Cela semble prendre un certain temps. En attendant, vous pouvez consulte
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "J'ai jeté un coup d'oeil aux données que vous venez de connecter et j'ai des explorations  intéressantes à vous montrer. J'espère que vous les aimerez!"
+msgstr "J'ai jeté un coup d'oeil aux données que vous venez de connecter et j'ai des explorations intéressantes à vous montrer. J'espère que vous les aimerez !"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
@@ -6407,7 +6476,7 @@ msgstr "Exécuter votre requête."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "Vous faites si bien ! Cliquez sur <strong>Lancer la requête</strong> pour obtenir vos résultats !"
+msgstr "Vous vous débrouillez bien ! Cliquez sur <strong>Lancer la requête</strong> pour obtenir vos résultats !"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
@@ -6419,11 +6488,11 @@ msgstr "Tout le monde aime les graphiques ! Cliquez sur le menu déroulant <stro
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "Bien joué!"
+msgstr "Bien joué !"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "C'est tout! Si vous avez encore des questions, consultez notre"
+msgstr "C'est tout ! Si vous avez encore des questions, consultez notre"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
@@ -6443,7 +6512,7 @@ msgstr "Sauvegardez vos questions"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "Par ailleurs, vous pouvez sauvegarder votre question pour la retrouver plus tard. Les questions sauvegardées peuvent aussi être aujoutées aux tableaux de bords ou aux Pulses."
+msgstr "Par ailleurs, vous pouvez sauvegarder votre question pour la retrouver plus tard. Les questions sauvegardées peuvent aussi être ajoutées aux tableaux de bords ou aux Pulses."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
@@ -6451,7 +6520,7 @@ msgstr "Ça m'a l'air bien"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "Oups!"
+msgstr "Oups !"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
@@ -6459,11 +6528,11 @@ msgstr "Désolé, il semble que quelque chose se soit mal passé. Essayez s'il v
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "Mot de passe mis à jour avec succès!"
+msgstr "Mot de passe mis à jour avec succès !"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "Compte mis à jour avec succès!"
+msgstr "Compte mis à jour avec succès !"
 
 #: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
@@ -6516,41 +6585,42 @@ msgstr "Annuler le filtre"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "Carte à épîngles"
+msgstr "Carte à épingles"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Désactiver"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Lignes {0}-{1} parmi {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Données tronquées à {0} lignes."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Impossible de trouver la visualisation"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Impossible d'afficher cet graphique avec ces données."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
-msgstr "Pas de résultat!"
+msgstr "Pas de résultat !"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Toujours en attente..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Cela prend habituellement en moyenne {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(C'est un peu long pour un tableau de bord)"
 
@@ -6659,14 +6729,14 @@ msgstr "Quand une cellule de cette colonne est ..."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "... changer son arrière-plan dans cette couleur :"
+msgstr "...changer son arrière-plan dans cette couleur :"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
 msgstr "Surligner toute la ligne"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Couleurs"
 
@@ -6733,7 +6803,7 @@ msgstr "Aucune visualisation pour {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "\"{0}\" est un champ non agrégé : S'il a plus d'une valeur pour une abscisse donnée, les valeurs seront additionnées."
+msgstr "\"{0}\" est un champ non agrégé : s'il a plus d'une valeur pour une abscisse donnée, les valeurs seront additionnées."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:93
 msgid "This chart type requires at least 2 columns."
@@ -6752,24 +6822,50 @@ msgstr "Objectif"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Le résultat de votre requête n'est pas adapté au rendu choisi. Cette visualisation nécessite au moins {0} {1} de données."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "colonne"
@@ -6801,16 +6897,16 @@ msgid "xValues missing!"
 msgstr "Des valeurs sont manquantes !"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Abscisses"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Eclater en plusieurs séries..."
+msgstr "Éclater en plusieurs séries..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Ordonnées"
 
@@ -6823,7 +6919,7 @@ msgid "Bubble size"
 msgstr "Taille des bulles"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Ligne"
 
@@ -6834,7 +6930,7 @@ msgstr "Courbe"
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "Etape"
+msgstr "Étape"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
@@ -6882,7 +6978,7 @@ msgstr "Interpolation linéaire"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
-msgstr "Echelle des abscisses"
+msgstr "Échelle des abscisses"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
@@ -6913,7 +7009,7 @@ msgstr "Ordinal"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
-msgstr "Echelle des ordonnées"
+msgstr "Échelle des ordonnées"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
@@ -6962,23 +7058,23 @@ msgstr "Libellé des ordonnées"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Standard Deviation"
-msgstr "Ecart-type"
+msgstr "Écart-type"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Surface"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "Histogramme"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Histogramme"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "diagramme en colonnes"
 
@@ -6992,7 +7088,7 @@ msgid "Funnel"
 msgstr "Entonnoir"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Mesure"
 
@@ -7004,81 +7100,81 @@ msgstr "Type d'entonnoir"
 msgid "Bar chart"
 msgstr "Diagramme en colonnes"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "Courbe"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Choisissez s'il vous plaît les colonnes de longitude et latitude."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Choisissez s'il vous plaît une carte régionale."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Choisissez s'il vous plaît les colonnes de métrique et de région."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Carte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Type de carte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Carte régionale"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Carte à épingles"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Type d'épingle"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Tuiles"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Puces"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Champ latitude"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Champ longitude"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Champ de métrique"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Champ de région"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Rayon"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Flouter"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Opacité minimale"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Zoom maximum"
 
@@ -7090,7 +7186,7 @@ msgstr "Aucune relation trouvée."
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Ce/cette {0} est relié(e) à :"
 
@@ -7102,31 +7198,31 @@ msgstr "Détail de l'objet"
 msgid "object"
 msgstr "objet"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Quelles colonnes voulez-vous utiliser ?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pie"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimension"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Montrer la légende"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Montrer les pourcentages en légende"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Pourcentage minimum d'une part"
 
@@ -7144,14 +7240,15 @@ msgstr "Objectif {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "La visualisation en barre de progession nécessite un nombre."
+msgstr "La visualisation en barre de progression nécessite un nombre."
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "Barre de progession"
+msgstr "Barre de progression"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Couleur"
@@ -7160,7 +7257,7 @@ msgstr "Couleur"
 msgid "Row Chart"
 msgstr "Graphique en lignes"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "graphique en lignes"
 
@@ -7184,15 +7281,15 @@ msgstr "Ajouter un suffixe"
 msgid "Multiply by a number"
 msgstr "Coefficient multiplicateur"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Nuage de points"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "nuage de points"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Pivoter cette table"
 
@@ -7242,19 +7339,19 @@ msgstr "Droite"
 msgid "Show background"
 msgstr "Montrer l'arrière plan"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} cellule"
 msgstr[1] "{0} cellules"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Binning automatique"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "l'usage de DELETE /api/alert/:id n'est plus encouragé. A la place, changez sa valeur à `archived` via PUT /api/alert/:id."
+msgstr "L'usage de DELETE /api/alert/:id n'est plus encouragé. À la place, changez sa valeur `archived` via PUT /api/alert/:id."
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
@@ -7286,7 +7383,7 @@ msgstr "Erreur lors de la détermination des métadonnées du résultat de la Ca
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
+msgstr "L'usage de DELETE /api/alert/:id n'est plus encouragé. À la place, changez sa valeur `archived` via PUT /api/alert/:id."
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
@@ -7419,7 +7516,7 @@ msgstr "L' adresse électronique n'est pas vérifié."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Vous aurez besoin qu'un administrateur crée un compte Metabase avant de puvoir utiliser Google pour vous connecter."
+msgstr "Vous aurez besoin qu'un administrateur crée un compte Metabase avant de pouvoir utiliser Google pour vous connecter."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
@@ -7484,10 +7581,13 @@ msgstr "Vous avez beaucoup de questions sauvegardées dans {0} ? Créez des coll
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7663,7 +7763,7 @@ msgstr "Nombre de valeurs distinctes"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "ecart-type"
+msgstr "écart-type"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
@@ -7677,7 +7777,7 @@ msgstr "somme cumulée"
 msgid "{0} and {1}"
 msgstr "{0} et {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} parmi {1}"
@@ -7854,7 +7954,7 @@ msgstr "Vérifiez s'il vous plaît l'orthographe et essayez à nouveau."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "Mot de passe de {0} en cours de réinitialisation .."
+msgstr "Mot de passe de {0} en cours de réinitialisation..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
@@ -7862,7 +7962,7 @@ msgstr "OK [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "ECHEC [[[{0}]]]"
+msgstr "ÉCHEC [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
@@ -7911,7 +8011,7 @@ msgstr "Démarrage de Metabase en mode AUTONOME"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "L'Initialisation de Metabase a ECHOUE"
+msgstr "L'initialisation de Metabase a ÉCHOUÉ"
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has migration lock; cannot run migrations."
@@ -8034,7 +8134,7 @@ msgstr "Pas de connaissance sur la façon d'associer la classe \"{0}\" à un \"b
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "Echec de connexion à la base de données : {0}"
+msgstr "Échec de connexion à la base de données : {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
@@ -8046,7 +8146,7 @@ msgstr "Les instructions BigQuery n'acceptent pas de paramètre !"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "Echec du réglage du fuseau horaire :"
+msgstr "Échec du réglage du fuseau horaire :"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
@@ -8058,7 +8158,7 @@ msgstr "Exécuter des requêtes SQL sur des bases de données H2 en utilisant l'
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "Ereur : metabase.driver.FixedHiveDriver est enregistré, mais JDBC ne semble pas l'utiliser."
+msgstr "Erreur : metabase.driver.FixedHiveDriver est enregistré, mais JDBC ne semble pas l'utiliser."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
@@ -8195,7 +8295,7 @@ msgstr "Je ne sais pas comment {0} `{1}`.n{2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr "Uh oh! : cry:n> {0}"
+msgstr "Oh oh ! :cry:n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
@@ -8203,7 +8303,7 @@ msgstr "Voici vos {0} plus récentes Cartes : n{1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "Pourriez-vous être un peu plus précis ? J'ai trouvé ces cartes au nom correspondant : {0}"
+msgstr "Pourriez-vous être un peu plus précis ? J'ai trouvé ces cartes au nom correspondant : n{0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
@@ -8227,11 +8327,11 @@ msgstr "Chargement des citations de Kanye..."
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "Evaluation de la commande MetaBot :"
+msgstr "Évaluation de la commande MetaBot :"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "Rentre chez toi websocket, tu es saoûle."
+msgstr "Rentre chez toi websocket, tu es saoule."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
@@ -8430,7 +8530,7 @@ msgstr "Un groupe avec ce nom existe déjà."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "Vous ne pouvez pas modifier ou supprimer le groupe d'autorisations '' {0} ''!"
+msgstr "Vous ne pouvez pas modifier ou supprimer le groupe d'autorisations ''{0}'' !"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
@@ -8446,7 +8546,7 @@ msgstr "Vous ne pouvez pas supprimer le dernier membre du groupe 'Admin' !"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "Vous ne pouvez mettre à jour une révision de permissions"
+msgstr "Vous ne pouvez mettre à jour une révision de permissions !"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
@@ -8632,7 +8732,7 @@ msgstr "Impossible de valider le jeton."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Ereur à la récupération du statut du jeton :"
+msgstr "Erreur à la récupération du statut du jeton :"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
@@ -8774,7 +8874,7 @@ msgstr "Champ {0} ''{1}''"
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "Champ '' {0} ''"
+msgstr "Champ ''{0}''"
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
@@ -8798,7 +8898,7 @@ msgstr "Durée : {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "Etape \"{0}\" effectuée"
+msgstr "Étape \"{0}\" effectuée"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
@@ -8991,11 +9091,11 @@ msgstr "Permissions sur les données"
 msgid "Collection permissions"
 msgstr "Permissions sur la collection"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Voir toutes les permissions sur la collection"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Changer aussi les sous-collections"
 
@@ -9007,19 +9107,19 @@ msgstr "Peut modifier cette collection et son contenu"
 msgid "Can view items in this collection"
 msgstr "Peut voir les items de cette collection"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Accès à la collection"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Ce groupe a la permission de voir au moins une sous-collection de cette collection."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "Ce groupe a le droit de modifier au moins une sous-collection de cette colleciton."
+msgstr "Ce groupe a le droit de modifier au moins une sous-collection de cette collection."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Voir les sous-collections"
 
@@ -9075,6 +9175,7 @@ msgstr "En lien"
 msgid "More X-rays"
 msgstr "Plus de radiographies"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9120,7 +9221,7 @@ msgstr "Déplacement des instances de {0} qui ne sont pas dans une collection ve
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "Echec de l'attribution de permissions : {0}"
+msgstr "Échec de l'attribution de permissions : {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
@@ -9144,7 +9245,7 @@ msgstr "Nom utilisateur de la base de données"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "Quel nom d'utilisateur utilisez-vous pour vous connecter à la base de données?"
+msgstr "Quel nom d'utilisateur utilisez-vous pour vous connecter à la base de données ?"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
@@ -9335,10 +9436,10 @@ msgstr "Partage"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9421,15 +9522,15 @@ msgstr "Utiliser le fuseau horaire de la JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Nous sommes en cours d'analyse des tables et champs pour vous aider à explorer vos données."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
-msgstr "Astuce:␣"
+msgstr "Astuce :␣"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
 msgstr "Sélectionnez un type de devise"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Type de champ"
 
@@ -9484,6 +9585,7 @@ msgid "Currency"
 msgstr "Devise"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Choisissez un utilisateur ou un canal ..."
 
@@ -9561,7 +9663,7 @@ msgstr "Lorsqu'une cellule de cette colonne..."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "Cette visualisation requiert une aggrégation sur un des champs."
+msgstr "Cette visualisation requiert une agrégation sur un des champs."
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:184
 msgid "Date style"
@@ -9645,7 +9747,7 @@ msgstr "Quel axe ?"
 msgid "Line + Bar"
 msgstr "Linéaire + À barres"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "graphique linéaire et à barres"
 
@@ -9665,15 +9767,15 @@ msgstr "Intervalle de jauge"
 msgid "Field to show"
 msgstr "Champ à afficher"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "dernier {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} était {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Agréger par un champ temporel pour voir comment cela a changé au fil du temps"
 
@@ -9681,23 +9783,23 @@ msgstr "Agréger par un champ temporel pour voir comment cela a changé au fil d
 msgid "Switch positive / negative colors?"
 msgstr "Changer les couleurs positives / négatives ?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Colonne du pivot"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Cellule de colonne"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Colonnes visibles"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Formatage conditionnel"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Titre de colonne"
 
@@ -9803,7 +9905,7 @@ msgstr "Erreur lors de l'analyse de {0}:n{1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "AVERTISSEMENT: le filtrage ne fonctionne que sur les dimensions! ''{0}'' est une métrique. Le filtre est ignoré."
+msgstr "AVERTISSEMENT : le filtrage ne fonctionne que sur les dimensions ! ''{0}'' est une métrique. Le filtre est ignoré."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
@@ -9826,7 +9928,7 @@ msgstr "Le tri avec Druid n'est autorisé que dans les requêtes comportant une 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "AVERTISSEMENT: il est uniquement utile de spécifier les champs d'une requête sans agrégation. J'ignore la clause."
+msgstr "AVERTISSEMENT : il est uniquement utile de spécifier les champs d'une requête sans agrégation. Clause ignorée."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
@@ -9894,7 +9996,7 @@ msgstr "Aucune expression nommée \"{0}\""
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "Aucun aggregat à l'index : {0}"
+msgstr "Aucun agrégat à l'index : {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
@@ -9967,7 +10069,7 @@ msgstr "Une erreur s'est produite lors de la vérification de la validité de ce
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "Jeton pour les fonctionnalités premium. Allez au \"MetaStore\" pour obtenir le vôtre!"
+msgstr "Jeton pour les fonctionnalités Premium. Allez au \"MetaStore\" pour obtenir le vôtre !"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
@@ -9999,7 +10101,7 @@ msgstr "Erreur générale"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "hachage de requête manquant!"
+msgstr "Hachage de requête manquant !"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
@@ -10069,7 +10171,7 @@ msgstr "Impossible d'exécuter la requête: impossible de trouver la table sourc
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr "Erreur lors de l’enregistrement des métadonnées des résultats pour la requête:"
+msgstr "Erreur lors de l’enregistrement des métadonnées des résultats pour la requête :"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
@@ -10135,10 +10237,10 @@ msgstr "Utilisateurs par source"
 msgid "The top external pages that brought users to your site"
 msgstr "Les principales pages externes qui ont amené les utilisateurs sur votre site"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Comment [[this]] est distribué et plus."
 
@@ -10236,13 +10338,13 @@ msgstr "Événements par heure de la journée"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "[[this]] Top 5"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "5 derniers [[this]]"
 
@@ -10255,10 +10357,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Par [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Valeurs nulles"
 
@@ -10286,8 +10388,8 @@ msgstr "Comment ils se comparent par saisonnalité"
 msgid "Average income per transaction"
 msgstr "Revenu moyen par transaction"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] par pays"
 
@@ -10411,10 +10513,10 @@ msgstr "Un aperçu de votre [[this]] et de sa répartition dans le temps, par li
 msgid "Average income per state"
 msgstr "Revenu moyen par état"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] par [[GenericCategoryMedium]]"
 
@@ -10529,7 +10631,7 @@ msgstr "Transactions par source"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "Où avez-vous acquis vos utilisateurs?"
+msgstr "Où avez-vous acquis vos utilisateurs ?"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
@@ -10591,13 +10693,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Comment les [[GenericTable]] sont répartis dans ce champ temporel et s'il comporte des modèles saisonniers."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
@@ -10706,8 +10808,8 @@ msgstr "Voici un aperçu de votre [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Voici un aperçu de votre champ [[this]]"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Résumé"
 
@@ -10749,7 +10851,7 @@ msgstr "Ventes par état"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "D'où viennent la plupart de vos sessions?"
+msgstr "D'où viennent la plupart de vos sessions ?"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
@@ -10771,10 +10873,10 @@ msgstr "Ventes par source"
 msgid "Average income per country"
 msgstr "Revenu moyen par pays"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Comment [[this]] est distribué"
 
@@ -10795,17 +10897,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Nombre de [[GenericCategoryMedium]] par [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Un coup d'oeil à votre [[this]]"
 
@@ -10871,10 +10973,10 @@ msgid "Transactions per source over time"
 msgstr "Transactions par source au fil du temps"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Comment le [[this]] est réparti"
 
@@ -10901,11 +11003,11 @@ msgstr "Où ces événements se produisent"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "Quels États américains vous apportent le plus d’affaires?"
+msgstr "Quels États américains vous apportent le plus d’affaires ?"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Comment ils se comparent à travers le temps"
 
@@ -11000,7 +11102,7 @@ msgstr "Événements par jour du mois"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "Si vous êtes dans les corrélations, Voici la radiographie pour vous."
+msgstr "Si vous êtes dans les corrélations, voici la radiographie pour vous."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
@@ -11010,8 +11112,8 @@ msgstr "Sessions par pays"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Quelques métriques intéressantes sur vos statistiques de GA pour vous aider à démarrer."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] par état"
 
@@ -11092,12 +11194,12 @@ msgstr "Comment cette métrique est répartie sur différents nombres"
 msgid "Sessions by page where the session began"
 msgstr "Sessions par page où la session a commencé"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Valeurs distinctes"
 
@@ -11160,10 +11262,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Événements par [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Comment ils se comparent par la distribution"
@@ -11282,7 +11384,7 @@ msgstr "Problème de connexion au serveur LDAP, de retour à l’authentificatio
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "Les instructions BigQuery ne peuvent pas être paramétrées!"
+msgstr "Les instructions BigQuery ne peuvent pas être paramétrées !"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
@@ -11302,7 +11404,7 @@ msgstr "Il semblerait que Metabase ne vous convenait pas tout à fait."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "Souhaitez-vous prendre un peu de temps pour répondre à un rapide sondage en 5 questions pour aider l’équipe de Metabase à comprendre pourquoi et à améliorer les choses à l’avenir?"
+msgstr "Souhaitez-vous prendre un peu de temps pour répondre à un rapide sondage en 5 questions pour aider l’équipe de Metabase à comprendre pourquoi et à améliorer les choses à l’avenir ?"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
@@ -11310,7 +11412,7 @@ msgstr "Nous espérons que vous avez apprécié Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "Souhaitez vous prendre un peu de temps pour répondre à un rapide sondage de 6 questions pour nous dire comment ca se passe ?"
+msgstr "Souhaitez-vous prendre un peu de temps pour répondre à un rapide sondage de 6 questions pour nous raconter votre expérience ?"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
@@ -11342,7 +11444,7 @@ msgstr "Erreur: la requête source de la requête n'a pas été résolue. Vous d
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "Je ne sais pas quoi faire avec:"
+msgstr "Je ne sais pas quoi faire avec :"
 
 #. Could someone provide context about this string? I cannot figure out where it's used 🤔
 #: src/metabase/models/params.clj
@@ -11470,6 +11572,7 @@ msgstr "Dupliquer le tableau de bord"
 msgid "Duplicate \"{0}\""
 msgstr "Dupliquer \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11567,9 +11670,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre de l'année"
 msgstr[1] "Trimestres de l'année"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} sélectionné"
@@ -11592,11 +11695,11 @@ msgstr "Invalide"
 msgid "Add a time"
 msgstr "Ajouter une heure"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Rien à comparer pour les {0} précédents."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "par {0}"
 
@@ -11630,7 +11733,7 @@ msgstr "ATTENTION : l'utilisation de base de données H2 n'est pas recommandée 
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "Pour le déploiement en production, nous recommendons vivement l'utilisation de Postgres, MySQL ou MariaDB à la place."
+msgstr "Pour le déploiement en production, nous recommandons vivement l'utilisation de Postgres, MySQL ou MariaDB à la place."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
@@ -11663,7 +11766,7 @@ msgstr "Chargement du pilote {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Pilote non enregistré après le chargement {0}"
+msgstr "Pilote non enregistré après le chargement : {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
@@ -11775,7 +11878,7 @@ msgstr "Retour à un répertoire temporaire pour le moment."
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabase ne peut pas écrire dans le dossier temporaire. Définissez MB_PLUGINS_DIR slvers un dossier accessible en écriture et redémarrez Matebase"
+msgstr "Metabase ne peut pas écrire dans le dossier temporaire. Définissez MB_PLUGINS_DIR vers un dossier accessible en écriture et redémarrez Metabase"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
@@ -11851,7 +11954,7 @@ msgstr "Chargement du namespace du plugin {0}..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "Les dépendances ont été satisfaites ; Ces plug-ins seront désormais chargés : {0}"
+msgstr "Les dépendances ont été satisfaites. Ces plug-ins seront désormais chargés : {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
@@ -11877,7 +11980,7 @@ msgstr "Chargement du driver {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "Impossible d'initialiser le plug-in: propriété requise manquante `driver-name`"
+msgstr "Impossible d'initialiser le plug-in : propriété requise manquante `driver-name`"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
@@ -12040,7 +12143,7 @@ msgstr "Erreur lors de la récupération des informations de version"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "Mémoire maximale disponible pour la JVM: {0}"
+msgstr "Mémoire maximale disponible pour la JVM : {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
@@ -12086,9 +12189,9 @@ msgstr "Voici une vue d'ensemble des personnes dans votre [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] par trimestre de l'année"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Comment ils se comparent par localisation"
 
@@ -12117,12 +12220,12 @@ msgstr "[[CreateTimestamp]] par jour de la semaine"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Voici une vue d'ensemble de vos données [[this]] de Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Voici une vue d'ensemble de votre [[this]]"
 
@@ -12136,7 +12239,7 @@ msgstr "Voici une vue plus précise de votre [[this]] par pays"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "Si vous êtes dans les corrélations, ce sont les x-ray pour vous."
+msgstr "Si vous êtes dans les corrélations, voici la radiographie pour vous."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
@@ -12186,7 +12289,7 @@ msgstr "Désactiver l'utilisateur"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "Réactiver {0}?"
+msgstr "Réactiver {0} ?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
@@ -12200,11 +12303,11 @@ msgstr "collection"
 msgid "collections"
 msgstr "collections"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "tableau de bord"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "tableaux de bord"
 
@@ -12247,7 +12350,7 @@ msgstr "Parcourez le contenu de votre base de données ainsi que les tables et c
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr "Les métadonnées des résultats de la card transmises à l'API sont VALIDES. Merci!"
+msgstr "Les métadonnées des résultats de la card transmises à l'API sont VALIDES. Merci !"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
@@ -12389,7 +12492,7 @@ msgstr "Erreur de déplanification des tâches pour la DB"
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr "{0} Les planifications sync/analyze de la base de données \"{1}\" ont changé!"
+msgstr "{0} Les planifications sync/analyze de la base de données \"{1}\" ont changé !"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
@@ -12417,11 +12520,11 @@ msgstr "Changement des permissions"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr "DE:"
+msgstr "DE :"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr "POUR:"
+msgstr "POUR :"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
@@ -12459,7 +12562,7 @@ msgstr "Expire après {0} millisecondes."
 msgid "Misfire Instruction"
 msgstr "Mauvaise instruction"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Archiver ?"
 
@@ -12477,7 +12580,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "L'utilisation de cette option nécessite que l'hôte fourni soit un FQDN. Si vous vous connectez à un cluster Atlas, vous devrez peut-être activer cette option. Si vous ne savez pas ce que cela signifie, laissez-la désactivée."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Exécuter automatiquement les requêtes lors de filtrages ou de synthèses simples"
 
@@ -12489,9 +12592,9 @@ msgstr "Lorsque cette option est activée, Metabase exécute automatiquement des
 msgid "Learn about this database"
 msgstr "En savoir plus sur cette base de données"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
-msgstr "Archiver ce tableau de bord?"
+msgstr "Archiver ce tableau de bord ?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:112
 msgid "All results"
@@ -12527,7 +12630,7 @@ msgstr "Parcourir les données"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:402
 msgid "Write SQL"
-msgstr "Ecrire le SQL"
+msgstr "Écrire le SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
@@ -12545,11 +12648,11 @@ msgstr "Question personnalisée"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Utilisez l'éditeur de bloc-notes avancé pour joindre des modèles de données, créer des colonnes personnalisées, faire des calculs et bien plus encore."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Métriques de base"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Personnalisé..."
 
@@ -12640,7 +12743,7 @@ msgstr "Des crochets autour d'un {0} créent une clause optionnelle dans le patr
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:290
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "A l'usage d'un Filtre de champ, le nom de colonne ne devrait pas être inclu dans le SQL. A la place, la variable devrait être mise en correspondance avec un champ dans le panneau latéral."
+msgstr "À l'usage d'un Filtre de champ, le nom de colonne ne devrait pas être inclus dans le SQL. À la place, la variable devrait être mise en correspondance avec un champ dans le panneau latéral."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
@@ -12682,7 +12785,7 @@ msgstr "Afficher les filtres"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:18
 msgid "Started from"
-msgstr "A partir de"
+msgstr "À partir de"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
@@ -12734,15 +12837,15 @@ msgstr "Choisissez une représentation"
 msgid "Filter by"
 msgstr "Filtrer par"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Agréger par"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Grouper par"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Ajouter un métrique"
 
@@ -12753,15 +12856,15 @@ msgstr "Ajouter un métrique"
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "C'est habituellement agréablement rapide mais semble prendre un moment désormais."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Menu déroulant"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Ligne"
 
@@ -12807,7 +12910,7 @@ msgstr "Problème à la connexion au serveur LDAP, Repli vers vers l'authentific
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "Incapable de créer la base de données: incapable de trouver le pilote {0}."
+msgstr "Incapable de créer la base de données : incapable de trouver le pilote {0}."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
@@ -12859,7 +12962,7 @@ msgstr "Je ne sais pas comment créer un alias à {0}, j'attendais un identifian
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "Le client a fermé la connection, requête annulée"
+msgstr "Le client a fermé la connexion, requête annulée"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
@@ -12871,7 +12974,7 @@ msgstr "Erreur à l'inscription d'une requête API dans le log"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "Echec lors de la mise en place de site-url"
+msgstr "Échec lors de la mise en place de site-url"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
@@ -12986,7 +13089,7 @@ msgstr "Erreur dans le processeur de requête: le nombre de colonnes retourné p
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "J'attendais {0} colonnes, mais la première ligne de résultats en a  {1}."
+msgstr "J'attendais {0} colonnes, mais la première ligne de résultats en a {1}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
@@ -13006,7 +13109,7 @@ msgstr "Somme de {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "Ecart-type de {0}"
+msgstr "Écart-type de {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
@@ -13067,7 +13170,7 @@ msgstr "Incapable de mettre à jour le champ binné: la requête manque de méta
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ ''{0}''"
+msgstr "Dans l'incapacité de mettre à jour le champ binné : métadonnées correspondantes non trouvées pour le champ ''{0}''"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
@@ -13163,15 +13266,15 @@ msgstr "Erreur à la replanification du job"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "Démarrage de l'exécution du Pulse: {0}"
+msgstr "Démarrage de l'exécution du Pulse : {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "Exécution du Pulse terminée: {0}"
+msgstr "Exécution du Pulse terminée : {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "Echec à la planification des tâches pour la base de données {0}"
+msgstr "Échec à la planification des tâches pour la base de données {0}"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
@@ -13182,7 +13285,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Choisissez les colonnes concernées"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Lorsque cette option est activée, Metabase exécute automatiquement des requêtes lorsque les utilisateurs effectuent des explorations simples à l'aide des boutons Résumer et Filtrer lors de l'affichage d'un tableau ou d'un graphique. Vous pouvez désactiver cette option si l'interrogation de cette base de données est lente. Ce paramètre n’affecte pas les accès au détail ni les requêtes SQL."
 
@@ -13248,7 +13351,7 @@ msgstr "Connectez-vous avec un e-mail"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "L'utilisation de cette option nécessite que l'hôte fourni soit un nom de domaine complet. Si vous vous connectez à un cluster Atlas, vous devrez peut-être activer cette option. Si vous ne savez pas ce que cela signifie, laissez cette option désactivée."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Par défaut, Metabase effectue une synchronisation horaire légère et une analyse quotidienne intensive des valeurs de champ. Si vous avez une grande base de données, nous vous recommandons de l'activer et de vérifier quand et à quelle fréquence les analyses de valeur de champ se produisent."
 
@@ -13316,11 +13419,11 @@ msgstr "N'incluez pas"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Ce champ ne sera ni visible ni sélectionnable dans les questions créées avec le générateur de requêtes. Il sera toujours accessible dans les requêtes SQL / natives."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Somme cumulative"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Déviation standard"
 
@@ -13336,19 +13439,19 @@ msgstr "Doit contenir au moins {0} caractères"
 msgid "Name (required)"
 msgstr "Nom (requis)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Exécuter le texte sélectionné"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Exécuter la requête"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + Entrée)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + Entrée)"
 
@@ -13430,7 +13533,7 @@ msgstr "Ce graphique contient des requêtes exécutées dans plusieurs fuseaux h
 
 #: src/metabase/api/public.clj
 msgid "An error occurred while running the query."
-msgstr "Une erreur s'est produite pendant l'execution de la requête"
+msgstr "Une erreur s'est produite pendant l'exécution de la requête."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Output H2 database already exists: %s, removing."
@@ -13442,7 +13545,7 @@ msgstr "Pas besoin de migrer, utilisez simplement le fichier H2 existant"
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Target DB is already populated!"
-msgstr "La BDD cible est déjà remplie!"
+msgstr "La BDD cible est déjà remplie !"
 
 #: src/metabase/core.clj
 msgid "System info:n {0}"
@@ -13522,7 +13625,7 @@ msgstr "Impossible de définir le fuseau horaire : chaîne de format SQL non val
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Did you implement set-timezone-sql?"
-msgstr "Avez-vous implémenté set-timezone-sql?"
+msgstr "Avez-vous implémenté set-timezone-sql ?"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}''"
@@ -13599,7 +13702,7 @@ msgstr "Impossible de trouver le sélecteur de couleurs JS à ''{0} '"
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attemping to format them as such?"
-msgstr "CORRIGEZMOI: Ce ne sont pas des littéraux temporels valides: {0} {1}. Pourquoi essayons-nous de les formater comme tels?"
+msgstr "À CORRIGER : Ce ne sont pas des littéraux temporels valides : {0} {1}. Pourquoi essayons-nous de les formater comme tels ?"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found for join against Table {0} ''{1}'' on Field {2} ''{3}'' via FK {4} ''{5}''"
@@ -13698,13 +13801,13 @@ msgstr "Dates et heures"
 msgid "Numbers"
 msgstr "Numéros"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Aucun groupe cartographiables"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
-msgstr "Documentation de metabase"
+msgstr "Documentation de Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
@@ -13738,15 +13841,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "Se souvenir de moi"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Pour des raisons de sécurité, les liens de réinitialisation des mots de passe expirent après un certain temps. Si vous avez encore besoin de réinitialiser votre mot de passe, vous pouvez {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Enregistrer un nouveau mot de passe"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Aucun résultat correspondant"
 
@@ -13772,26 +13875,26 @@ msgid "or"
 msgstr "ou"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "requis"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Type de base de données"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Il s'agit d'un processus léger qui vérifie les mises à jour du schéma de cette base de données. Dans la plupart des cas, vous devriez pouvoir laisser ce réglage sur une synchronisation horaire."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase peut analyser les valeurs présentes dans chaque champ de cette base de données pour activer les filtres de cases à cocher dans les tableaux de bord et les questions. Ce processus peut être quelque peu gourmand en ressources, en particulier si vous disposez d'une très grande base de données."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Collection"
 
@@ -13838,7 +13941,7 @@ msgstr "Catégorique"
 msgid "URLs"
 msgstr "URLs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Retourne la moyenne des valeurs de la colonne."
 
@@ -13847,11 +13950,13 @@ msgstr "Retourne la moyenne des valeurs de la colonne."
 msgid "The column whose values to average."
 msgstr "La colonne dont les valeurs à la moyenne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "début"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "fin"
 
@@ -13861,23 +13966,21 @@ msgstr "Vérifie les valeurs d'une date ou d'une colonne numérique pour voir si
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
-msgstr "Evaluation"
+msgstr "Évaluation"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "condition"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "sortie"
 
@@ -13885,27 +13988,27 @@ msgstr "sortie"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Teste une liste de cas et renvoie la valeur correspondante du premier cas avéré, avec une valeur par défaut facultative si rien d'autre n'est satisfait."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Poids"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Large"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Moyen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Petit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Quelque chose qui devrait être évalué comme vrai ou faux."
 
@@ -13913,33 +14016,33 @@ msgstr "Quelque chose qui devrait être évalué comme vrai ou faux."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "La valeur qui sera retournée si la condition précédente est vraie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "valeur1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "valeur2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Examine les valeurs de chaque argument dans l'ordre et renvoie la première valeur non nulle pour chaque ligne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Commentaires"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notes"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Aucun commentaire"
 
@@ -13955,12 +14058,12 @@ msgstr "Si la valeur 1 est vide, la valeur 2 est retournée si elle n'est pas vi
 msgid "Combines two or more strings of text together."
 msgstr "Combine deux ou plusieurs chaînes de texte ensemble."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Nom de famille"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Prénom"
 
@@ -13972,27 +14075,27 @@ msgstr "valeur2 sera ajoutée à la fin."
 msgid "This will be added to the end of value1."
 msgstr "Ceci sera ajouté à la fin de la valeur1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "chaîne1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "chaîne2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Vérifie si la chaîne 1 est composée de la chaîne 2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Statut"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Passe"
 
@@ -14000,7 +14103,7 @@ msgstr "Passe"
 msgid "The contents of this string will be checked."
 msgstr "Le contenu de cette chaîne sera vérifié."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "La chaîne de texte à rechercher."
 
@@ -14008,22 +14111,22 @@ msgstr "La chaîne de texte à rechercher."
 msgid "Returns the count of rows in the source data."
 msgstr "Renvoie le nombre de lignes dans les données sources."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Ne compte que les lignes où la condition est vraie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Sous-total"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Le total cumulé des lignes d'un éclatement."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "La somme glissante d'une colonne dans un éclatement."
 
@@ -14032,53 +14135,57 @@ msgstr "La somme glissante d'une colonne dans un éclatement."
 msgid "The column to sum."
 msgstr "La colonne à additionner."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Le nombre de valeurs distinctes dans cette colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "La colonne dont les valeurs distinctes doivent être comptées."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "texte"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "comparaison"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retourne vrai si la fin du texte correspond au texte de comparaison."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Appétit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "affamé"
 
@@ -14087,20 +14194,20 @@ msgstr "affamé"
 msgid "A column or string of text to check."
 msgstr "Une colonne ou une chaîne de texte à vérifier."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "La chaîne de texte avec laquelle le texte original doit se terminer."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "expression_régulière"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrait les sous-chaînes de caractères correspondantes à une expression régulière."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adresse"
 
@@ -14108,7 +14215,7 @@ msgstr "Adresse"
 msgid "The column or string of text to search though."
 msgstr "La colonne ou la chaîne de texte à rechercher."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "L'expression régulière à faire correspondre."
 
@@ -14120,7 +14227,7 @@ msgstr "Retourne la chaîne de texte en minuscules."
 msgid "The column with values to convert to lowercase."
 msgstr "La colonne avec les valeurs à convertir en minuscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Supprime les espaces en début de chaîne de texte."
 
@@ -14130,15 +14237,16 @@ msgstr "Supprime les espaces en début de chaîne de texte."
 msgid "The column with values you want to trim."
 msgstr "La colonne avec les valeurs que vous voulez rogner."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Retourne la plus grande valeur trouvée dans la colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Âge"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "La colonne numérique dont vous voulez trouver le maximum."
 
@@ -14146,21 +14254,21 @@ msgstr "La colonne numérique dont vous voulez trouver le maximum."
 msgid "Returns the smallest value found in the column."
 msgstr "Retourne la plus petite valeur trouvée dans la colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Salaire"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "La colonne numérique dont vous voulez trouver le minimum."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "position"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "longueur"
 
@@ -14169,7 +14277,7 @@ msgstr "longueur"
 msgid "new_text"
 msgstr "nouveau_texte"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Remplace une partie du texte d'entrée par un nouveau texte."
 
@@ -14197,35 +14305,35 @@ msgstr "Le nombre de caractères à remplacer."
 msgid "The text to use in the replacement."
 msgstr "Le texte à utiliser dans le remplacement."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Supprime les espaces à la fin d'une chaîne de texte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Renvoie le pourcentage de lignes dans les données qui correspondent à la condition, sous forme décimale."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retourne vrai si le début du texte correspond au texte de comparaison."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Nom du stage"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Informatique"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "La chaîne de caractères par laquelle le texte d'origine devrait commencer"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcule l'écart-type de la colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Population"
 
@@ -14233,7 +14341,7 @@ msgstr "Population"
 msgid "A numeric column."
 msgstr "Une colonne numérique."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Renvoie une portion du texte fourni."
 
@@ -14241,19 +14349,19 @@ msgstr "Renvoie une portion du texte fourni."
 msgid "The text to return a portion of."
 msgstr "Retourne une partie du texte fourni."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "La position pour démarrer la copie des caractères."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Le nombre de caractères à retourner."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
-msgstr "Adds up all the values of the column."
+msgstr "Additionne toutes les valeurs de la colonne."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "La colonne numérique à additionner."
 
@@ -14261,15 +14369,15 @@ msgstr "La colonne numérique à additionner."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Additionne les valeurs dans une colonne où les lignes correspondent à la condition."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Statut de la commande"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Valide"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Supprime les espaces de début et de fin d'une chaîne de texte."
 
@@ -14277,47 +14385,47 @@ msgstr "Supprime les espaces de début et de fin d'une chaîne de texte."
 msgid "Returns the string of text in all upper case."
 msgstr "Retourne la chaîne de texte en majuscules."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "La colonne avec les valeurs à convertir en majuscules."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "doit être {0} et inclure {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "doit être {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "doit inclure {0}"
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "au moins {0} caractère"
 msgstr[1] "au moins {0} caractères"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} lettre minuscule"
 msgstr[1] "{0} lettres minuscules"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} lettre majuscule"
 msgstr[1] "{0} lettres majuscules"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} nombre"
 msgstr[1] "{0} nombres"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} caractère spécial"
@@ -14340,6 +14448,7 @@ msgid "Powered by {0}"
 msgstr "Propulsé par {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Pour :"
 
@@ -14369,7 +14478,7 @@ msgstr "Question n°..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "Question no{0}."
+msgstr "Question n°{0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
@@ -14427,7 +14536,7 @@ msgstr "Formatage de la valeur"
 msgid "Full"
 msgstr "Complet"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Pas de changement par rapport au dernier {0}"
 
@@ -14568,7 +14677,7 @@ msgstr "Erreur de paramétrage de la connexion en lecture-écriture"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}'' for {1} database"
-msgstr "Echec de définition du fuseau horaire \"{0}\" pour la base de données {1}"
+msgstr "Échec de définition du fuseau horaire \"{0}\" pour la base de données {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting transaction isolation level for {0} database to {1}"
@@ -14637,7 +14746,7 @@ msgstr "Rendu de la carte du pulse avec le type de graphique {0} et le type de r
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "ÀCORRIGER : Ce ne sont pas des littéraux temporels valables : {0} {1}. Pourquoi tentons-nous de les formater en tant que tels ?"
+msgstr "À CORRIGER : Ce ne sont pas des littéraux temporels valables : {0} {1}. Pourquoi tentons-nous de les formater en tant que tels ?"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
@@ -14752,7 +14861,7 @@ msgstr "Erreur lors de la génération des aperçus pour la colonne :"
 msgid "Sending abandonment email!"
 msgstr "Envoi d'un courriel d'abandon !"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Vous pouvez créer des métriques enregistrées pour ajouter une option de métrique nommée. Les métriques sauvegardées comprennent le type d'agrégation, le champ agrégé et, en option, tout filtre que vous ajoutez. Par exemple, vous pouvez l'utiliser pour créer une méthode officielle de calcul du \"prix moyen\" pour une table de commandes."
 
@@ -14760,15 +14869,15 @@ msgstr "Vous pouvez créer des métriques enregistrées pour ajouter une option 
 msgid "Select and add filters to create your new segment."
 msgstr "Sélectionnez et ajoutez des filtres pour créer votre nouveau segment."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alphabétique"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Intelligent"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Ordre des colonnes : {0}"
 
@@ -14820,7 +14929,7 @@ msgstr "Localisation"
 msgid "Instance language"
 msgstr "Langue de l'instance"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Options de localisation"
 
@@ -14892,19 +15001,20 @@ msgstr "Coller une chaîne de connexion"
 msgid "Fill out individual fields"
 msgstr "Remplir les différents champs"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Saisissez ici un peu de SQL pour pouvoir le réutiliser plus tard"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Donnez un nom à votre snippet"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Clients actuels"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Ajouter une description"
 
@@ -14912,46 +15022,47 @@ msgstr "Ajouter une description"
 msgid "Use site default"
 msgstr "Utiliser le défaut du site"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "Trouver"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "Remplacer"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Le texte à trouver"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Le texte à utiliser en remplacement."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
-msgstr "Edition de {0}"
+msgstr "Édition de {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Créez votre nouveau snippet"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Snippets archivés"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Les Snippets sont des bits de SQL réutilisables"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Créer un snippet"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Snippets"
 
@@ -15230,3 +15341,1506 @@ msgstr "La valeur doit être un mot-clef ou une chaîne"
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "La chaîne doit être une langue ISO valide à deux lettres ou un code langue-pays, par exemple \"en\" ou \"en_US\"."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Lignes {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Audit"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Configuration des attributs de l'utilisateur (facultatif)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "En utilisant {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Mettre en place un SSO basé sur SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "Authentification SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Configurer votre fournisseur d'identité (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Votre fournisseur d'identité aura besoin des infos suivantes concernant Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL vers laquelle l'IdP devrait rediriger"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Ceci est appellé \"Single Sign On URL\" dans Okta, \" Application Callback URL\" dans Auth0,\n"
+"et \"ACS URL (Consumer)\" dans OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "Attributs SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "Dans la plupart des fournisseurs d'identité, vous devrez placer chacun d'entre eux dans une case de saisie intitulée\n"
+"\"Nom\" dans la section des déclarations d'attributs."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Attribut email de l'utilisateur"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Attribut prénom de l'utilisateur"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Attribut nom de l'utilisateur"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Indiquez à Metabase votre fournisseur d'identité"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase aura besoin des infos suivantes sur votre fournisseur"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL du fournisseur d'identité SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Certificat du fournisseur d'identité SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Nom de l'application SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Signer les demandes de SSO (facultatif)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "chemin du stockage des clefs SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "mot de passe du stockage des clefs SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Shh..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Alias du stockage de clefs SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Synchroniser l'appartenance à un groupe avec votre SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Pour cela, vous devez créer des correspondances pour indiquer à Metabase quel(s) groupe(s) vos utilisateurs doivent\n"
+"ajouter en fonction du groupe SSO dans lequel ils se trouvent."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Nom du groupe"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Nom de l'attribut de groupe"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Note:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Si vous modifiez l'un des paramètres d'une configuration SAML active, vous devrez alors redémarrer Metabase pour qu'ils prennent effet."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Autoriser les utilisateurs à se connecter via un fournisseur d'identité SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Autoriser les utilisateurs à se connecter via un fournisseur d'identité JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Autoriser l'authentification par mot de passe"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Si activé, les utilisateurs peuvent aussi se connecter avec un email et un mot de passe"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Notifier les admins des nouveaux utilisateurs SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Si activé, les administrateurs recevront un email la première fois qu'un utilisateur utilise SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Utilisez les paramètres ci-dessous pour configurer votre SSO via SAML. Si vous avez des questions, jetez un oeil à notre {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "documentation"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI du fournisseur d'identité SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "Authentification JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI du fournisseur d'identité JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Chaîne utilisée par la clé de signature JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Intégrer l'ensemble de l'application Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Si vous souhaitez intégrer l'ensemble de Metabase, entrez les origines des sites web ou des applications web pour lesquels vous souhaitez autoriser l'intégration dans une iframe, séparées par un espace. Voici les {0} pour ce qui peut être saisi."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Accorder l'accès au bac à sable pour cette table "
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Lorsque les utilisateurs de ce groupe consultent ce tableau, ils en voient une version filtrée par leurs attributs utilisateur, ou une vue personnalisée basée sur une question enregistrée."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Comment voulez-vous filtrer cette table pour les utilisateurs de ce groupe ?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Choisissez une question sauvegardée qui renvoie la vue personnalisée de ce tableau que ces utilisateurs devraient voir."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Vous pouvez éventuellement ajouter ici des filtres supplémentaires basés sur les attributs de l'utilisateur. Ces filtres seront appliqués en plus des filtres déjà présents dans cette question sauvegardée."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Pour que cette option fonctionne, vos utilisateurs doivent disposer de certains attributs"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Pour ajouter des filtres supplémentaires, vos utilisateurs doivent disposer de certains attributs"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Pas d'attributs utilisateur"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Choisissez un attribut d'utilisateur"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Choisissez un paramètre"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Choisissez une colonne"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Les utilisateurs de {0} peuvent consulter"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "lignes de la question {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "lignes de la table {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "où {0} est égal à {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "et {0} est égal à {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Vous pouvez ajouter automatiquement  des attributs en créant un SSO qui utilise SAML, ou vous pouvez les saisir manuellement en allant dans la section Personnes et en cliquant sur le menu ... à l'extrémité droite."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Attribut utilisateur"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Nous pouvons obtenir automatiquement les attributs de vos utilisateurs si vous avez configuré le SSO, ou vous pouvez les ajouter manuellement à partir du menu \"...\" dans la section \"Personnes\" du panneau d'administration."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Paramètre ou variable"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "est égal à"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Accorder un accès au bac à sable"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Accès au bac à sable"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Modifier l'accès au bac à sable"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Editer les détails du dossier"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Changer les permissions"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Créer votre nouveau dossier"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nouveau dossier"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Nous avons des difficultés à valider votre jeton"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Veuillez vérifier que votre instance peut se connecter aux serveurs de Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Obtenir de l'aide"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Profitez encore plus de Metabase avec l'édition Entreprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Tous les outils dont vous avez besoin pour fournir rapidement et facilement des rapports à vos clients, ou pour vous aider à gérer et à surveiller Metabase dans une grande organisation"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Activer une licence"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Votre essai est actif avec ces fonctionnalités"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "la période d'essai expire {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Besoin d'aide ? Prêt à acheter ?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Contactez-nous"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Votre période d'essai a expiré"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Besoin de plus de temps ? Prêt à acheter ?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Vos fonctionnalités sont activées !"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Votre licence est valable jusqu'au {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Votre licence a expiré"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Elle a expiré le {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Vous voulez renouveler votre licence ?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Apprenez comment l'utiliser"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Non inclus dans votre plan actuel"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Entrez le jeton que vous avez reçu du magasin"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Activer"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Besoin d'aide ?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Plus d'informations sur votre problème"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Contacter le support"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Entreprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Les données du bac à sable"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Assurez-vous de montrer aux bonnes personnes les bonnes données grâce à des filtres automatiques et sécurisés basés sur les attributs de l'utilisateur."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Marque blanche"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Faites correspondre Metabase à votre marque avec des couleurs personnalisées, votre propre logo et bien plus encore."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Audit"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Gardez un œil sur les performances et les comportements grâce à de solides outils d'audit."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Connexion unique (SSO)"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Fournit une connexion facile qui fonctionne avec votre infrastructure d'authentification existante."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Magasin"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Nom de l'application"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Palette de couleurs"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Page d'atterrissage"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Aucun groupe"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Autorisations pour {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Autorisations pour ce dossier"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Accorder un accès en écriture"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Peut modifier des fragments dans ce dossier"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Accorder un accès en lecture"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Peut insérer et utiliser des fragments dans ce dossier, mais ne peut pas modifier le SQL qu'ils contiennent"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Impossible de visualiser ou d'insérer des fragments dans ce dossier"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Changer aussi les sous-dossiers"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Premier jour de la semaine"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Il y a eu un problème avec l'authentification Google. Merci de contacter un administrateur."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "au dessus de"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "sur"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Ouvrez le menu des actions de Metabase"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Ne rien faire"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Se rendre à une destination personnalisée"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Mettre à jour un filtre de tableau de bord"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} mise à jour {1} filtre"
+msgstr[1] "{0} mises à jour {1} filtres"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} va à {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Comportement au clic pour chaque colonne"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Se rendre à une destination personnalisée"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Ouvrir le menu des actions"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Comportement au clic sur {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Sélectionnez un ou plusieurs filtres à mettre à jour"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Question sauvegardée"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Lien vers"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Entrez l'URL du lien"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Vous pouvez insérer la valeur d'un filtre de colonne ou de tableau de bord en utilisant son nom, comme ceci : {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "ex : http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Choisissez un tableau de bord..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Choisissez une question..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Choisissez un tableau de bord à relier à"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Choisissez une question à relier à"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Passez les valeurs aux filtres de ce tableau de bord (facultatif)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Passez les valeurs aux variables de cette question (facultatif)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Passez les valeurs pour filtrer cette question (facultatif)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filtres du tableau de bord"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Attributs utilisateur"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Personnaliser le texte du lien (facultatif)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. Détails pour {{Column Name}}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Valeurs que vous pouvez référencer"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Pas de cibles disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filtre"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "variable"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Autres filtres disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Filtres disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Autres variables disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Variables disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Autres colonnes disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Colonnes disponibles"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "attribut utilisateur"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Texte de la carte"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Comportement du clic"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Options de visualisation"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Editer une série"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Ajouter une série"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Sur clic"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Changez le titre et la description"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Vous avez mis à jour les paramètres intégrés et vous devrez mettre à jour votre code intégré."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Ajoutez une question"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Vous êtes en train d'éditer ce tableau de bord."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Colonne sur laquelle filtrer"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "Collection de fragments"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "Collections de fragments"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Donnez un nom à votre dossier"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Quelque chose de court mais sympa"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Dossier dans lequel il doit se trouver"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Ouvrir le menu d'action"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "La colonne {0} a un comportement personnalisé"
+msgstr[1] "Les colonnes {0} ont un comportement personnalisé"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Allez à..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Aller au tableau de bord"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Aller à la question"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Aller à l'url"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filtrer ce tableau de bord"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Renvoie le nombre de lignes de données sélectionnées"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "La colonne ou le nombre à additionner"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "La colonne numérique pour obtenir l'écart type."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Colonne numérique dont les valeurs où la moyenne doit être trouvée."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Renvoie la plus petite valeur trouvée dans la colonne"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "additionne la colonne spécifiée uniquement pour les lignes où la condition est vraie."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Renvoie la variance numérique pour une colonne donnée."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Température"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "La colonne ou le numéro où obtenir la variance."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Renvoie la valeur médiane de la colonne spécifiée"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "La colonne ou le nombre où  obtenir la médiane."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "valeur centile"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Renvoie la valeur de la colonne à la valeur du centile."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "La colonne ou le nombre dont vous souhaitez obtenir le centile."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "La valeur du centile."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Renvoie la chaîne de caractères tout en minuscules "
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "La colonne à convertir en minuscules"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Renvoie le texte en majuscules"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Colonne ou texte où il faut renvoyer une partie."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "La colonne ou le texte à parcourir."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Combinez deux ou plusieurs chaînes de texte ensemble."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "La colonne ou le texte par lequel commencer."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Ceci sera ajouté à la fin de value1, et ainsi de suite."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Énorme"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigantesque"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Renvoie le nombre de caractères dans le texte."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "La colonne ou le texte dont vous souhaitez obtenir la longueur."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "La colonne ou le texte que vous souhaitez rogner."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Renvoie la valeur absolue (positive) de la colonne spécifiée."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Dette"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "La colonne ou le nombre dont la valeur absolue (positive) doit être renvoyée."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Fait l'arrondi inférieur d'un nombre"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "La colonne ou le nombre à arrondir vers le bas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Fait l'arrondi supérieur d'un nombre"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "La colonne ou le nombre à arrondir vers le haut."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Arrondit un nombre décimal vers le haut ou vers le bas à la valeur entière la plus proche."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "La colonne ou le nombre à arrondir vers l'entier le plus proche."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Renvoie la racine carrée"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hypoténus"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Colonne ou nombre où retourner une racine carrée."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "exponant"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Augmente un nombre à la puissance de la valeur de l'exposant."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Longueur"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "La colonne ou le chiffre élevé à l'exposant."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "La valeur de l'exponant"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Renvoie le logarithme en base 10 du nombre."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Valeur"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Colonne ou nombre où renvoyer la valeur du logarithme naturel."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Renvoie le nombre d'Euler, e, élevé à la puissance du nombre fourni."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Mois d'intérêt"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Colonne ou nombre où renvoyer la valeur exponentielle."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "La colonne ou le texte à vérifier."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Vérifie les valeurs d'une colonne de date ou numérique pour voir si elles sont comprises dans la plage spécifiée."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Créé à"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "La date ou la colonne numérique qui doit être comprise entre les valeurs de début et de fin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Le début de la plage."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "La fin de la plage."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Vérifie les valeurs d'une colonne de date pour voir si elles sont dans la plage relative."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "La colonne de date pour laquelle retourner l'intervalle."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Période d'intervalle, où les valeurs négatives sont dans le passé."
+
+#. It should be "type of interval" and not "internal", no ?
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Type intervalle, comme \"jour\", \"mois\", \"année\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "La colonne ou valeur à renvoyer."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Si valeur1 est vide, valeur2 est renvoyée si non vide, etc."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Teste une expression par rapport à une liste de cas et renvoie la valeur correspondante du premier cas correspondant, avec une valeur par défaut facultative si rien d'autre n'est respecté."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "La valeur qui sera renvoyée si la condition précédente est vraie, et ainsi de suite."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Est NULL"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "N'est pas NULL"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Somme de toutes les valeurs d'une colonne.\n"
+"e.g : revenu total"
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Comptage additif du nombre de lignes.\n"
+"ex. nombre total de ventes au fil du temps."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Filtres liés"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Étiquette"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Valeur par défaut"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Aucun défaut"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Pour le voir, {0} doit être connecté à au moins un champ."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Limiter les choix de ce filtre"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Si vous disposez d'un autre filtre de tableau de bord, vous pouvez limiter les choix qui sont répertoriés pour ce filtre en fonction de la sélection de l'autre."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Donc d'abord, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "add another dashboard filter"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Si vous basculez sur l'un de ces filtres du tableau de bord, la sélection d'une valeur pour ce filtre limitera les choix disponibles pour le filtre {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Colonne de filtrage"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Colonne filtrée"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Saisissez les noms d'utilisateur ou les adresses email"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Nouveau fragment"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Toutes les heures"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Quotidiennement à {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Toutes les semaines à {0} le {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Tous les mois le {0} {1} à {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Supprimer cet abonnement"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Abonnements"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Créer un abonnement au tableau de bord"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Envoyer par email"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Vous pouvez envoyer régulièrement ce tableau de bord aux utilisateurs ou aux adresses électroniques."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Envoyer vers Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Choisissez un canal et un horaire, et Metabase fera le reste."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Envoyez ce tableau de bord par email"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Ne pas envoyer s'il n'y a aucun résultat"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Joindre les résultats"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Les pièces jointes peuvent contenir jusqu'à 2 000 lignes de données."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Envoyer ce tableau de bord vers Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Le tableau de bord n'a pas de paramètre avec l'ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Aucun champ n'est associé au paramètre {0}."
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "\"Inclure\" doit soit être vide soit contenir la valeur 'tables'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "La \"base de données\" est requise pour toutes les requêtes dont le type n'est pas \"interne\"."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Le mot de passe de connexion est désactivé dans ce cas."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Votre compte est désactivé. Veuillez contacter votre administrateur."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Votre compte est désactivé."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Jeton Slack invalide."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "La commande ''{0}'' n'est disponible que dans Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Les extensions de Metabase Enterprise Edition sont PRÉSENTES."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "L'utilisation des fonctionnalités de Metabase Enterprise Edition est soumise à la licence commerciale de Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Voir {0} pour plus de détails."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Les extensions de Metabase Enterprise Edition ne sont PAS PRÉSENTES."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Vous êtes invités à rejoindre les {0} {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} a créé un compte {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} a accepté son invitation {1}"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Demande de réinitialisation de mot de passe"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Notification"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Aide à rendre [{1}] meilleur."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Dites-nous comment les choses se passent."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Erreur lors du démarrage de l'écouteur d'événements"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Devrions-nous synchroniser les attributs utilisateurs quand quelqu'un se connecte via LDAP ?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Liste des attributs utilisateur séparés par des virgules afin d'ignorer la synchronisation pour les utilisateurs LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Jeton invalide"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Erreur d'API Slack: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Le canal Slack nommé `metabase_files` est manquant!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Veuillez créer ou désarchiver le canal afin de terminer l'intégration Slack."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Le canal est utilisé pour stocker les graphiques inclus dans les réponses Pulses et MetaBot."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Image envoyée"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Erreur lors de l'envoi du fichier vers Slack :"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Session invalide. Attendu une instance de Session."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "Le cookie de session \"SameSite\" est configuré sur \"Aucun\", mais le site est"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "servi sur une connexion non sécurisée. Certains navigateurs rejetteront "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookies dans ces conditions. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Top dossier"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parameters doivent être dans une séquence de cartes avec les clefs :id"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Valeurs lisibles par un humain non valides: les valeurs doivent être une séquence; chaque élément doit être nul ou une chaîne"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":values doivent être présentes pour aller chercher les valeurs :human_readable_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "La longueur totale des valeurs des champs est > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "Les noms des fragments ne peuvent pas inclure \"}\" ou commencer par des espaces"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Erreur d'exécution d'une requête de chaîne de filtre"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Le champ {0} n'existe pas"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Impossible d'effectuer une recherche sur un champ non textuel {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Accord de permissions pour le groupe {0} : {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Révocation de permissions pour le groupe {0} : {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Autorisations de la base de données invalides : si vous disposez d'un accès en écriture pour les requêtes natives, vous devez avoir un accès complet aux données."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Autorisations de la base de données invalides : si vous disposez d'un accès en lecture seule en mode natif, vous devez également avoir accès aux données."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Modification des permissions de : {0} à : {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "les clés d'attribut de connexion doivent être un mot-clé ou une chaîne"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Langue par défaut pour tous les utilisateurs de l'interface utilisateur de la métabase, des e-mails système, des \"pulses\" et des alertes."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Les utilisateurs peuvent remplacer individuellement cette langue par défaut à partir de leurs propres paramètres de compte."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Page par défaut à afficher à l'utilisateur"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Autoriser cette origine à intégrer l'application Metabase complète"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Les valeurs supérieures à {0} ({1}) ne sont pas autorisées."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Cela remplacera le mot \"Metabase\" partout où il apparaît."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Ce sont les couleurs primaires utilisées dans les graphiques et dans tout Metabase. Vous devrez peut-être rafraîchir votre navigateur pour voir les changements apportés."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Pour de meilleurs résultats, utilisez un fichier SVG avec un fond transparent."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "L'url ou l'image que vous voulez utiliser comme favicon."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Autoriser la connexion par email et mot de passe."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Cela aura des effets sur le regroupement par semaine ou le filtrage des requêtes de l'interface graphique.\n"
+"  Cela n'affectera pas les requêtes SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Impossible de valider le jeton"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Le format du jeton n'est pas valide."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Erreur de validation du jeton"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Erreur lors du filtrage sur le champ {0} : impossible d'analyser la chaîne {1} en un {2}."
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Erreur de recherche de détails pour le Job : {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Lancement de la tâche de synchronisation pour la base de données {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Impossible de synchroniser la base de données {0} : la base de données n'existe pas."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Tâche de mise à jour des valeurs des champs déclenchée pour la base de données {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Sauter la mise à jour, les mises à jour automatiques des valeurs de champ sont désactivées pour la base de données {0}."

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -29,15 +29,16 @@ msgstr "このデータを詳しく見る"
 msgid "Select a database type"
 msgstr "データベースタイプを選択する"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -50,7 +51,7 @@ msgstr "保存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "効果的に使用するため、Metabaseはデータベースをスキャンします。また、メタデータを最新に保つために定期的に再スキャンします。以下から再スキャンの頻度を設定することができます。"
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "データベース同期中"
 
@@ -65,7 +66,7 @@ msgstr "データベーススキーマの更新チェックは軽量なプロセ
 msgid "Scan"
 msgstr "スキャン"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "フィルター値をスキャン中"
 
@@ -77,7 +78,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabaseは、このデータベースの各フィールドの値をスキャンして、ダッシュボードや質問のチェックボックスフィルターを有効にすることができます。 データベースが非常に大きい場合は、ややリソースに負荷がかかる処理となります。"
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "フィールド値のスキャンとキャッシュをいつ行いますか？"
 
@@ -135,29 +136,31 @@ msgstr "削除"
 msgid "in this box:"
 msgstr "このテキストボックスに:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -180,9 +183,9 @@ msgstr "削除"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -202,8 +205,9 @@ msgstr "接続"
 msgid "Scheduling"
 msgstr "スケジューリング"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -282,10 +286,10 @@ msgstr "データベースを追加"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -320,10 +324,8 @@ msgid "Successfully saved!"
 msgstr "保存されました！"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "編集"
@@ -402,26 +404,29 @@ msgstr "特別タイプを選択する"
 msgid "Select a target"
 msgstr "ターゲットを選択する"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "列"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "列"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "表示・非表示"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "タイプ"
 
@@ -429,7 +434,7 @@ msgstr "タイプ"
 msgid "Current database:"
 msgstr "現在のデータベース:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "元のスキーマを表示する"
 
@@ -496,7 +501,7 @@ msgstr "テーブルを探す"
 msgid "Schemas"
 msgstr "スキーマ"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -513,7 +518,7 @@ msgstr "メトリクスを追加する"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "定義"
 
@@ -581,35 +586,35 @@ msgstr "履歴"
 msgid "Revision History for"
 msgstr "履歴"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - フィールド設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Metabase上でフィールドが表示される箇所"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "このフィールドでフィルター設定しています"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "このフィールドでフィルター設定がされている場合、他ユーザーがフィルター設定したい値をどのように入力すればよいですか？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "このフィールドには説明がまだありません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "元の値"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "マップされた値"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "値を入力する"
 
@@ -626,31 +631,31 @@ msgid "Custom mapping"
 msgstr "カスタムマッピング"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "マッピングタイプを識別できません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "現在のフィールドは外部キーではないか、FKターゲットテーブルのメタデータがありません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "選択されたフィールドは外部キーではありません"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "値を表示する"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "データベースから元の値を表示するか、このフィールドに関連する情報またはカスタム情報を表示するかを選択します。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "フィールドを選択"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "表示に使用する列を選択してください。"
 
@@ -658,16 +663,16 @@ msgstr "表示に使用する列を選択してください。"
 msgid "Tip:"
 msgstr "ヒント:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "再マッピングの選択と内容が合うようにフィールド名を更新すると良いでしょう。"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "フィールド値をキャッシュする"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このフィールドの値をスキャンします"
 
@@ -694,35 +699,36 @@ msgstr "削除されました！"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "テーブルを選択し、スキーマを見てメタデータを追加・編集する"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "名前が必要です"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "説明が必要です"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "履歴メッセージが必要です"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "アグリゲーションが必要です"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "メトリクスを編集する"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "メトリクスを作成する"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "メトリクスを変更し注釈を加える"
 
@@ -730,46 +736,46 @@ msgstr "メトリクスを変更し注釈を加える"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "保存されたメトリクスを使用して、このテーブルに名前付きメトリックオプションを追加することができます。 保存されたメトリクスには、集約タイプ、集約フィールド、およびオプションで追加するフィルターが含まれます。 たとえば、これを使用してOrdersテーブルの「平均価格」の公式な計算方法を作成することができます。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "結果: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "メトリックに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "他ユーザーのためにメトリックに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "簡単な説明"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "メトリックを説明する"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "他ユーザーのためにメトリックに説明を加える"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "分かりにくいメトリクスのルールについてより詳細な情報をこちらに記入してください"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "変更理由"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "変更箇所と変更理由を記入する"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "他ユーザーにも変更理由がわかるよう、このメトリクスの履歴に表示されます"
 
@@ -822,6 +828,7 @@ msgstr "他ユーザーにも変更理由がわかるよう、このセグメン
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -836,8 +843,7 @@ msgid "Re-scan this table"
 msgstr "このテーブルを再スキャンする"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "追加"
 
@@ -854,7 +860,7 @@ msgid "Last name"
 msgstr "姓"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "メールアドレス"
@@ -863,7 +869,7 @@ msgstr "メールアドレス"
 msgid "Permission Groups"
 msgstr "権限グループ"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "このユーザーを管理者にする"
 
@@ -960,6 +966,8 @@ msgstr "グループを削除する"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -972,11 +980,12 @@ msgstr "完了"
 msgid "Group name"
 msgstr "グループ名"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "グループ"
@@ -1085,7 +1094,7 @@ msgstr "リセットする"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "よろしいですか？"
 
@@ -1197,7 +1206,7 @@ msgstr "権限は変更されません"
 msgid "You've made changes to permissions."
 msgstr "権限が変更されました"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "このコレクションの権限"
 
@@ -1253,6 +1262,7 @@ msgstr "アクセスを制限する"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "アクセスを取り消す"
 
@@ -1316,23 +1326,23 @@ msgstr "コレクションを公開する"
 msgid "View collection"
 msgstr "コレクションを見る"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "データアクセス"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "テーブルを見る"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQLクエリ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "スキーマを見る"
 
@@ -1403,12 +1413,15 @@ msgstr "送信しました！"
 msgid "Clear"
 msgstr "クリア"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "認証"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "サーバー設定"
@@ -1421,6 +1434,7 @@ msgstr "ユーザースキーマ"
 msgid "Attributes"
 msgstr "属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "グループスキーマ"
@@ -1492,6 +1506,9 @@ msgid "Add a map"
 msgstr "マップを追加する"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1501,19 +1518,19 @@ msgid "Delete custom map"
 msgstr "カスタムマップを削除する"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "削除する"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1611,19 +1628,19 @@ msgstr "トークンを購入する"
 msgid "Enter a token"
 msgstr "トークンを入力する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "マッピングを編集する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "グループマッピング"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "マッピングを作成する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1862,18 +1879,27 @@ msgstr "ユーザーフィルター"
 msgid "Check your parentheses"
 msgstr "かっこを確認する"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "メール属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "名の属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "姓の属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "グループメンバーを同期する"
@@ -1902,59 +1928,59 @@ msgstr "カスタムマップ"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "独自のGeoJSONファイルを追加して、異なるリージョンマップのビジュアライゼーションを可能にする"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "公開"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "公開を有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "公開されたダッシュボード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "公開された質問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "他アプリケーションに埋め込む"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "他アプリケーションへのMetabaseの埋め込みを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "秘密キーを埋め込む"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "埋め込みダッシュボード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "埋め込み質問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "キャッシュ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "キャッシュを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "最低クエリ期間"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "キャッシュTTL乗数"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "最大キャッシュエントリーサイズ"
 
@@ -1996,27 +2022,27 @@ msgstr "Googleを利用してログインするには、管理者からMetabase�
 msgid "Sign in with {0}"
 msgstr "{0}を利用してサインインする"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "パスワードをリセットするには管理者へお問い合わせください"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "パスワードをお忘れの場合"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Metabaseアカウントのメールアドレス"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "パスワードリセットのメールを送信する"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "パスワードのリセット方法についてはメールをご確認ください"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Metabaseにサインインする"
 
@@ -2037,11 +2063,11 @@ msgstr "サインイン"
 msgid "I seem to have forgotten my password"
 msgstr "パスワードを忘れてしまいました"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "パスワードリセットのメールをリクエストする"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "このリンクは有効期限切れです"
 
@@ -2050,11 +2076,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "セキュリティの理由により、パスワードリセットのリンクは一定期間を過ぎると無効となります。パスワードリセットが必要な場合は、{0}ができます"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "新しいパスワード"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "データを安全に保つため、パスワードは{0}"
 
@@ -2077,24 +2103,24 @@ msgstr "新しいパスワードの確認"
 msgid "Make sure it matches the one you just entered"
 msgstr "上記で入力したパスワードと同じものを入力してください"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "パスワードがリセットされました"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "新しいパスワードでサインインする"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "保存が失敗しました"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2104,25 +2130,26 @@ msgstr "保存されました"
 msgid "Ok"
 msgstr "確認しました"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "このコレクションをアーカイブしますか？"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "このコレクション内のダッシュボード、コレクション、パルスもアーカイブされます"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "アーカイブ"
 
@@ -2247,7 +2274,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "ドラッグしてトップに固定してください"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2275,6 +2302,7 @@ msgstr "{0}を移動しますか？"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "移動する"
@@ -2310,7 +2338,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "一部のデータベースインストールは、SSHホストを介して接続することによってのみアクセスできます。VPNが利用できない場合、このオプションを使用することでセキュリティーレベルを高めることができます。この機能を有効にすると直接接続するよりも動作が遅くなりことがあります。"
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "データベースが大きいため、Metabaseの同期とスキャンのタイミングを選択します"
 
@@ -2349,7 +2377,7 @@ msgstr "このデータでMetabaseを利用するには、Google Developers Cons
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "有効化していない場合は、Consoleで{0}してください"
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "どのようにこのデータベースを参照しますか？"
 
@@ -2465,35 +2493,35 @@ msgstr "スキーマに基づく"
 msgid "A look at your"
 msgstr "見てみる"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "一覧を検索する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "{0}で検索する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr "␣またはIDを入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "IDを入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "番号を入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "テキストを入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "一致する{0}が見つかりませんでした"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "フィルターに全てのオプションを含めてしまうと、効果的な結果が得られない場合があります"
 
@@ -2505,7 +2533,6 @@ msgstr "問題が発生しました"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "エラーが発生しました。このページを更新するか、前のページにお戻りください"
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2516,12 +2543,12 @@ msgstr "エラーが発生しました。このページを更新するか、前
 msgid "No description yet"
 msgstr "まだ説明がありません"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "新しい{0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "{0}により質問された"
 
@@ -2542,7 +2569,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "以前の履歴と{0}に戻しました"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "履歴"
@@ -2588,7 +2617,7 @@ msgid "Questions"
 msgstr "質問"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "パルス"
 
@@ -2662,52 +2691,69 @@ msgstr "今はしない"
 msgid "Error:"
 msgstr "エラー:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "日曜日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "月曜日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "火曜日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "水曜日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "木曜日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "金曜日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "土曜日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "最初"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "最後"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15日（中日）"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "カレンダー日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "Metabaseのタイムゾーン"
 
@@ -2761,11 +2807,11 @@ msgstr "作成する"
 msgid "Create dashboard"
 msgstr "ダッシュボードを作成する"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "テーブル"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "ダッシュボード"
 
@@ -2840,9 +2886,9 @@ msgstr "カードの名前は？"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2856,15 +2902,16 @@ msgstr "説明"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "任意ですが、入力しておくととても便利です"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "これはどのコレクションに保存しますか？"
 
@@ -2904,11 +2951,11 @@ msgstr "ダッシュボードをアーカイブする"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "各シリーズを必ず選択してください。選択しない場合、このカードでフィルターは機能しません。"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "このダッシュボードは空です"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "質問を追加して使い易くしましょう！"
 
@@ -2928,7 +2975,7 @@ msgstr "フルスクリーンを解除する"
 msgid "Enter fullscreen"
 msgstr "フルスクリーン"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "保存中..."
@@ -2941,7 +2988,8 @@ msgstr "質問を追加する"
 msgid "Add a question to this dashboard"
 msgstr "このダッシュボードに質問を追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "フィルターを追加する"
 
@@ -2949,7 +2997,7 @@ msgstr "フィルターを追加する"
 msgid "Parameters"
 msgstr "パラメーター"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "テキストボックスを追加する"
 
@@ -2957,7 +3005,7 @@ msgstr "テキストボックスを追加する"
 msgid "Move dashboard"
 msgstr "ダッシュボードを移動する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "ダッシュボードを編集する"
 
@@ -2981,11 +3029,11 @@ msgstr "ダッシュボードを移動する..."
 msgid "Dashboard moved to {0}"
 msgstr "{0}にダッシュボードを移動しました"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "何をフィルターしますか？"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "どのようなフィルター？"
 
@@ -3057,20 +3105,22 @@ msgstr "このパラメータータイプにマップできるフィールドや
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "このフィールドの値は、選択した他のフィールドの値と重複しません。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "有効なフィールドがありません"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "名前は100文字以下で入力してください"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "色が必要です"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "このダッシュボードの名前は？"
 
@@ -3125,7 +3175,7 @@ msgstr "から最新のデータを受信しました"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "不明"
 
@@ -3250,9 +3300,10 @@ msgstr "最近ダッシュボードや質問を見ていないようです"
 msgid "{0} items selected"
 msgstr "{0}アイテムが選択されました"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "アーカイブを取り消す"
 
@@ -3369,7 +3420,7 @@ msgid "Zip Code"
 msgstr "郵便番号"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "量"
 
@@ -3402,11 +3453,13 @@ msgid "User"
 msgstr "ユーザー"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "ソース"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "料金"
 
@@ -3439,21 +3492,23 @@ msgid "Subscription"
 msgstr "購読"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "スコア"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "タイトル"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "コメント"
 
@@ -3507,14 +3562,14 @@ msgstr "Metabaseはこのフィールドを取得しなくなります。取得�
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "カウント"
 
@@ -3522,7 +3577,7 @@ msgstr "カウント"
 msgid "CumulativeCount"
 msgstr "累積カウント"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3540,19 +3595,19 @@ msgstr "ディスティンクト"
 msgid "StandardDeviation"
 msgstr "標準偏差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最低"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3563,12 +3618,12 @@ msgstr "最高"
 msgid "sad sad panda, lexing errors detected"
 msgstr "字句エラーが検出されました"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0}秒"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0}分"
@@ -3608,14 +3663,15 @@ msgstr "何を調べますか？"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "ローデータ"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "累積カウント"
 
@@ -3677,166 +3733,164 @@ msgstr "正"
 msgid "False"
 msgstr "誤"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "経度フィールドを選択する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "もっと上の緯度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "もっと左の経度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "もっと下の緯度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "もっと右の経度を入力する"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "である"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "空ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "同等"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "同等ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "より大きい"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "より小さい"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "以上"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "以下"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "含む"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "含まない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "で始まる"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "で終わる"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "前"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "後"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "中"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "回答内の行を含むテーブルのみ、他操作なし"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "行のカウント"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "回答の全行数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "の合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "列の全値の合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "の平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "列の全値の平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "...の異なる値の数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "回答の全行のうちユニーク値の列数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "累積合計"
 
@@ -3844,7 +3898,7 @@ msgstr "累積合計"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "列の全値の合計\\\\ne.x. 経年の全収入"
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "行の累積カウント"
 
@@ -3852,27 +3906,27 @@ msgstr "行の累積カウント"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "行数の合計\\\\ne.x.経年の販売数合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "...の標準偏差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "回答の全行の間で列の値がどれくらい異なるかを表す数値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "...の最低"
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "列の最低値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "...の最高"
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "列の最高値"
 
@@ -3888,6 +3942,8 @@ msgstr "小文字"
 msgid "upper case letter"
 msgstr "大文字"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "番号"
@@ -4135,7 +4191,7 @@ msgstr "メトリクスの作成方法"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "経時的なデータをマップとして表示したり、傾向や変化を理解するのに役立つようにピボットしたりできます。"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "カスタム"
 
@@ -4158,7 +4214,7 @@ msgstr "ネイティブクエリ"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "複雑な質問については、独自のSQLまたはネイティブクエリを記述することができます。"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "デフォルト値を選択する"
 
@@ -4249,7 +4305,7 @@ msgstr "今月"
 msgid "This Year"
 msgstr "今年"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "値を入力する..."
@@ -4259,7 +4315,7 @@ msgid "Enter a default value..."
 msgstr "デフォルト値を入力する..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "エラーが発生しました"
@@ -4516,22 +4572,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "このパルス内で送信したい質問を選択する"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "メール"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slackメッセージ"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "送信しました"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0}が送信されます"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "メッセージ"
 
@@ -4603,30 +4667,30 @@ msgstr "チームが常にあなたのデータと同期されるよう心がけ
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Metabaseのデータをご自身で設定した予定通りにメールまたはSlackで送信することができます"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "{0}後"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "{0}前"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "空"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "空ではない"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "全期間"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "適用する"
 
@@ -4726,12 +4790,12 @@ msgstr[0] "この{0}を見る"
 msgid "Zoom in"
 msgstr "拡大する"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "カスタムエクスプレッション"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "共通のメトリクス"
 
@@ -4928,7 +4992,7 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "セグメントまたはテーブルを選ぶ"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "データベースを選択する"
@@ -4989,7 +5053,7 @@ msgstr "ソート"
 msgid "Row limit"
 msgstr "行数制限"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "不明なフィールド"
 
@@ -4997,7 +5061,7 @@ msgstr "不明なフィールド"
 msgid "field"
 msgstr "フィールド"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "一致"
 
@@ -5022,11 +5086,11 @@ msgstr "グルーピングを追加する"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "データ"
 
@@ -5043,11 +5107,12 @@ msgstr "閲覧"
 msgid "Grouped By"
 msgstr "グループ化された"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "なし"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "この質問は{0}で書かれました"
 
@@ -5059,7 +5124,7 @@ msgstr "エディターを非表示にする"
 msgid "Hide Query"
 msgstr "クエリを非表示にする"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "エディターを表示する"
 
@@ -5067,7 +5132,7 @@ msgstr "エディターを表示する"
 msgid "Show Query"
 msgstr "クエリを表示する"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "このメトリクスは放棄されており、使用することができません"
 
@@ -5183,9 +5248,11 @@ msgstr "最初の{0} {1}を表示する"
 msgid "Showing {0} {1}"
 msgstr "{0} {1}を表示する"
 
+#. 実験中という表現より実行中という表現のほうが近いかと思いました。
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
+#, fuzzy
 msgid "Doing science"
-msgstr "実験中"
+msgstr "実行中"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
@@ -5267,7 +5334,7 @@ msgstr "最後の実行に戻る"
 msgid "Visualization"
 msgstr "ビジュアライゼーション"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "まだ説明がありません"
 
@@ -5324,7 +5391,7 @@ msgstr "質問作成前にテーブルメタデータが見つかりませんで
 msgid "See {0}"
 msgstr "{0}を見る"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "メトリクスの定義"
 
@@ -5342,11 +5409,11 @@ msgstr "{0}の数"
 msgid "See all {0}"
 msgstr "全ての{0}を見る"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "セグメントの定義"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "テーブルの読み込み中にエラーが発生しました"
 
@@ -5354,7 +5421,7 @@ msgstr "テーブルの読み込み中にエラーが発生しました"
 msgid "See the raw data for {0}"
 msgstr "{0}のローデータを見る"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "さらに"
 
@@ -5374,6 +5441,8 @@ msgstr "フィールド計算式"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "これは、スプレッドシートプログラムで数式を書くようなものだとお考えください。数値、この表のフィールド、+などの数学記号、その他一部の機能を使用できます。そのため、Subtotal - Costのようなものを入力することができます。"
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5441,7 +5510,7 @@ msgstr "誤"
 msgid "Add filter"
 msgstr "フィルターを追加する"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "アイテム"
 
@@ -5560,11 +5629,11 @@ msgstr "マップするためのフィールド"
 msgid "Filter widget type"
 msgstr "フィルターウィジェットタイプ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "必要ですか？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "デフォルトのフィルターウィジェット値"
 
@@ -5576,7 +5645,7 @@ msgstr "この質問をアーカイブしますか？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "この質問は関連したダッシュボードやパルスから削除されます"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "質問"
 
@@ -5623,7 +5692,7 @@ msgstr "フィールドタイプ"
 msgid "Select a Foreign Key"
 msgstr "外部キーを選択する"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "{0}計算式を見る"
 
@@ -5718,9 +5787,10 @@ msgstr "変更理由"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "変更箇所と変更理由を記入してください"
 
+#. 直訳で少し意味が違うような気がしましたので意訳してみました。
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:170
 msgid "Why this database is interesting"
-msgstr "なぜこのデータベースは興味深いですか？"
+msgstr "このデータベースの特徴"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:180
 msgid "Things to be aware of about this database"
@@ -6107,22 +6177,24 @@ msgstr "このセグメントに関する質問"
 msgid "X-ray this segment"
 msgstr "このセグメントを自動探査(X-ray)する"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "ログイン"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "検索"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "新しい条件"
 
@@ -6194,35 +6266,35 @@ msgstr "情報収集は全て匿名です"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "情報収集による設定は管理者設定からいつでも変更することができます"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "お困りの場合"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "スタートガイド"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "クリックするだけ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Metabaseへようこそ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "すべて正常に動作しています。使用を開始し、データを接続して回答を探しましょう。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "開始しましょう"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "準備ができました！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Metabaseを使い始める"
 
@@ -6474,39 +6546,40 @@ msgstr "フィルターをキャンセルする"
 msgid "Pin Map"
 msgstr "マップを固定する"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "解除する"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "{2}の行{0}〜{1}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "{0}行に切り捨てされたデータ"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "ビジュアライゼーションが見つかりませんでした"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "このデータではチャートが表示できません"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "結果が見つかりませんでした"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "待機中..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "通常約{0}かかります"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "（通常のダッシュボード処理より時間がかかっています）"
 
@@ -6616,7 +6689,7 @@ msgid "Highlight the whole row"
 msgstr "全行をハイライトする"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "色"
 
@@ -6702,24 +6775,50 @@ msgstr "目標値"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "クエリのデータが、選択した表示選択に適合しません。 このビジュアライゼーションには少なくとも{0} {1}のデータが必要です。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "列"
@@ -6750,7 +6849,7 @@ msgid "xValues missing!"
 msgstr "x値がありません"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X軸"
 
@@ -6759,7 +6858,7 @@ msgid "Add a series breakout..."
 msgstr "ブレークアウトのシリーズを追加する..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y軸"
 
@@ -6772,7 +6871,7 @@ msgid "Bubble size"
 msgstr "吹き出しサイズ"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "線"
 
@@ -6914,20 +7013,20 @@ msgid "Standard Deviation"
 msgstr "標準偏差"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "範囲"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "範囲図"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "棒"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "棒グラフ"
 
@@ -6941,7 +7040,7 @@ msgid "Funnel"
 msgstr "ファネル"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "測定"
 
@@ -6953,81 +7052,81 @@ msgstr "ファネルタイプ"
 msgid "Bar chart"
 msgstr "棒グラフ"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "折れ線グラフ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "チャート設定で緯度と経度を選択してください"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "地域マップを選択してください"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "チャート設定で地域とメトリクス列を選択してください"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "マップ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "マップタイプ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "地域マップ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "ピンマップ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "ピンタイプ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "タイル"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "マーカー"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "緯度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "経度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "メトリクスフィールド"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "地域フィールド"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "半径"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "ぼかし"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "最小不透明度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "最大ズーム"
 
@@ -7039,7 +7138,7 @@ msgstr "関係は見つかりませんでした"
 msgid "via {0}"
 msgstr "{0}経由"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "この{0}は接続していません:"
 
@@ -7051,31 +7150,31 @@ msgstr "オブジェクト詳細"
 msgid "object"
 msgstr "オブジェクト"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "合計"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "どの列を使用しますか？"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "円"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "ディメンション"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "凡例"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "凡例にパーセンテージを表示する"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "最小パーセンテージ"
 
@@ -7100,7 +7199,8 @@ msgid "Progress"
 msgstr "プログレス"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "色"
@@ -7109,7 +7209,7 @@ msgstr "色"
 msgid "Row Chart"
 msgstr "行グラフ"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "行グラフ"
 
@@ -7133,15 +7233,15 @@ msgstr "接尾辞をつける"
 msgid "Multiply by a number"
 msgstr "掛ける"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "散布"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "散布図"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "テーブルをピボットする"
 
@@ -7191,12 +7291,12 @@ msgstr "右"
 msgid "Show background"
 msgstr "背景を表示する"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0}ビン"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "自動ビニングされた"
 
@@ -7432,10 +7532,13 @@ msgstr "{0}に保存された質問が多数ありますか？整理するのに
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7624,7 +7727,7 @@ msgstr "累積和"
 msgid "{0} and {1}"
 msgstr "{0}と{1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{1}の{0}"
@@ -8936,11 +9039,11 @@ msgstr "データ権限"
 msgid "Collection permissions"
 msgstr "コレクション権限"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "全てのコレクション権限を見る"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "サブコレクションを変更することもできます"
 
@@ -8952,19 +9055,19 @@ msgstr "このコレクションとコンテンツを編集することができ
 msgid "Can view items in this collection"
 msgstr "このコレクション内のアイテムを見ることができます"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "コレクションアクセス"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "このグループには、コレクション内の最低一つのサブコレクションの閲覧権限があります"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "このグループは、このコレクションの最低1つのサブコレクションを編集する権限があります"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "サブコレクションを見る"
 
@@ -9020,6 +9123,7 @@ msgstr "関連"
 msgid "More X-rays"
 msgstr "さらに自動探査(X-ray)"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9278,10 +9382,10 @@ msgstr "共有"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9364,7 +9468,7 @@ msgstr "JVMのタイムゾーンを使う"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "あなたがデータ分析を簡単にできるようテーブルとフィールドを解析中です・・"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "ヒント: "
 
@@ -9372,7 +9476,7 @@ msgstr "ヒント: "
 msgid "Select a currency type"
 msgstr "通貨単位を選択"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "フィールドタイプ"
 
@@ -9427,6 +9531,7 @@ msgid "Currency"
 msgstr "通貨"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "ユーザーかチャンネルを選ぶ..."
 
@@ -9588,7 +9693,7 @@ msgstr "どちらの軸？"
 msgid "Line + Bar"
 msgstr "折れ線＋棒"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "折れ線＋棒グラフ"
 
@@ -9609,15 +9714,15 @@ msgid "Field to show"
 msgstr "表示するフィールド"
 
 #. 「前{0}」はどうでしょう。前日、前月、…
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "前{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} は {1} {2}でした"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "時間経過と共にどのように変化したか見るため時間のフィールドでグルーピング"
 
@@ -9625,23 +9730,23 @@ msgstr "時間経過と共にどのように変化したか見るため時間の
 msgid "Switch positive / negative colors?"
 msgstr "＋/ーの色を入れ替える？"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "ピボット項目"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "セル項目"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "表示列"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "条件付き書式"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "項目名"
 
@@ -10079,10 +10184,10 @@ msgstr "ソースごとのユーザー"
 msgid "The top external pages that brought users to your site"
 msgstr "ユーザーを最も呼び込んでいる外部ページ"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "[[this]]がどのように分布しているのかなど。"
 
@@ -10180,13 +10285,13 @@ msgstr "時間帯ごとのイベント"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "[[this]] の上位5つ"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "[[this]] の下位5つ"
 
@@ -10199,10 +10304,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "[[GenericCategoryLarge]] ごと"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Null値"
 
@@ -10230,8 +10335,8 @@ msgstr "季節ごとの比較"
 msgid "Average income per transaction"
 msgstr "トランザクションごとの平均収益"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "国ごとの [[this]]"
 
@@ -10355,10 +10460,10 @@ msgstr "[[this]]の概要とそれが時間、場所、カテゴリの違いに�
 msgid "Average income per state"
 msgstr "州ごとの平均収益"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[GenericCategoryMedium]] 別の [[this]]"
 
@@ -10535,13 +10640,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "[[GenericTable]]がこの時間フィールドに対してどのように分布しているのか、そして何らかの季節性があるのか。"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "概要"
 
@@ -10650,8 +10755,8 @@ msgstr "[[this]] を詳しく見てみましょう"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "[[this]] フィールドを詳しく見てみましょう"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "要約"
 
@@ -10715,10 +10820,10 @@ msgstr "ソースごとの売上"
 msgid "Average income per country"
 msgstr "国別の平均収益"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "どのように[[this]]が分布しているか"
 
@@ -10739,17 +10844,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "[[this]]による[[GenericCategoryMedium]]の数"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "あなたの[[this]]の概要"
 
@@ -10815,10 +10920,10 @@ msgid "Transactions per source over time"
 msgstr "ソースごとのトランザクション推移"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "[[this]]がどのように分布しているか"
 
@@ -10847,9 +10952,9 @@ msgstr "これらのイベントがどこで起きているか"
 msgid "Which US states are bringing you the most business."
 msgstr "どの米国州が最も大きな業績をもたらしているか"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "時間をかけて比較する方法"
 
@@ -10954,8 +11059,8 @@ msgstr "国別セッション"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "開始するためのGA統計に関する興味深いメトリクス。"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "州ごとの [[this]]"
 
@@ -11036,12 +11141,12 @@ msgstr "このメトリックが異なる数値にどのように分布してい
 msgid "Sessions by page where the session began"
 msgstr "ページ別の開始されたセッション"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "重複のない値"
 
@@ -11104,10 +11209,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "[[GenericCategoryLarge]]ごとのイベント"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "分布による比較"
@@ -11413,6 +11518,7 @@ msgstr "ダッシュボードを複製する"
 msgid "Duplicate \"{0}\""
 msgstr "“{0}”を複製"
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11510,9 +11616,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "年間四半期数\n"
 "年間四半期数"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0}個の選択\n"
@@ -11535,11 +11641,11 @@ msgstr "無効"
 msgid "Add a time"
 msgstr "時間を追加する"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "前の{0}と比較するものはありません。"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "{0}"
 
@@ -12027,9 +12133,9 @@ msgstr "これが[[this]]の人々の概要です"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "四半期別の [[CreateTimestamp]]"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "場所を超えて比較する方法"
 
@@ -12058,12 +12164,12 @@ msgstr "曜日別の [[CreateTimestamp]]"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Google Analyticsから得られた[[this]]のデータの概要です"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "[[this]]の概要です"
 
@@ -12141,11 +12247,11 @@ msgstr "コレクション"
 msgid "collections"
 msgstr "コレクション"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "ダッシュボード"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "ダッシュボード"
 
@@ -12395,7 +12501,7 @@ msgstr "{0} ミリ秒後にタイムアウトしました。"
 msgid "Misfire Instruction"
 msgstr "ジョブが実行できなかった場合の戦略"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "これをアーカイブしますか？"
 
@@ -12413,7 +12519,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "このオプションを使用するには、提供されたホストがFQDNである必要があります。 Atlasクラスターに接続する場合は、このオプションを有効にする必要があります。 これが何を意味するのかわからない場合は、これを無効のままにします。"
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "簡単なフィルタリングと要約を行うときに自動的にクエリを実行する"
 
@@ -12425,7 +12531,7 @@ msgstr "これを有効にすることにより、ユーザ―がテーブルや
 msgid "Learn about this database"
 msgstr "このデータベースについて詳細を見る"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "このダッシュボードをアーカイブしますか？"
 
@@ -12480,11 +12586,11 @@ msgstr "カスタム質問"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "高度なノートブックエディターを使用して、データの結合、カスタム列の作成、計算などを行います。"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "基本的なメトリクス"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "カスタム…"
 
@@ -12668,15 +12774,15 @@ msgstr "可視化方法を選択する"
 msgid "Filter by"
 msgstr "フィルター項目"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "集約方法"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "集約キー"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "メトリクスを追加する"
 
@@ -12687,15 +12793,15 @@ msgstr "メトリクスを追加する"
 msgid "Profile"
 msgstr "プロフィール"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "これはたいていの場合はとても速いですが、現在は時間がかかっているようです。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "コンボ"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "行"
 
@@ -13116,7 +13222,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "含めたい列を選ぶ"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "これを有効にすることにより、ユーザーがチャートやテーブルを見るときに要約やフィルターボタンを利用して簡単な探索を行った場合に、Metabaseが自動的にクエリを実行するようになります。このデータベースへのクエリが遅い場合は、この設定を無効にすることができます。この設定によってドリルスルーやSQLクエリが影響を受けることはありません。"
 
@@ -13182,7 +13288,7 @@ msgstr "メールアドレスでサインインする"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "このオプションを使うには与えられたホスト名がFQDNである必要があります。Atlasクラスタに接続する場合、このオプションを有効にする必要があるでしょう。もしもこれが意味するところが分からない場合は、無効のままにしてください。"
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "デフォルトでMetabaseはフィールド値を毎時の軽量なバッチと日次の重いスキャンで同期しています。大きなデータベースと接続する場合はこの機能をONとし、いつどのくらいの頻度でフィールド値がスキャンされるのかを確認することをオススメします。"
 
@@ -13250,11 +13356,11 @@ msgstr "含めないでください"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "このフィールドはGUIのインターフェースで作られた質問では見ることも選択することもできません。SQLやネイティブクエリではアクセスすることができます。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "累積和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "標準偏差"
 
@@ -13270,19 +13376,19 @@ msgstr "最低{0}文字でなければなりません"
 msgid "Name (required)"
 msgstr "名前（必須）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "選択されたテキストを実行する"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "クエリを実行する"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13630,7 +13736,7 @@ msgstr "日付と時間"
 msgid "Numbers"
 msgstr "数字"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "マッピング可能なグループはありません"
 
@@ -13670,15 +13776,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "ログイン情報を記憶する"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "セキュリティ上の理由で、パスワードリセットのリンクはしばらくすると無効になります。もしもまだパスワードをリセットする必要がある場合、{0}をすることができます。"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "新しいパスワードを保存する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "合致する結果がありません"
 
@@ -13704,26 +13810,26 @@ msgid "or"
 msgstr "か"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "必須"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "データベースのタイプ"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "これはこのデータベースのスキーマの更新をチェックする軽量なプロセスです。ほとんどの場合この設定を毎時同期のままにしておいて問題がないはずです。"
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabaseはこのデータベースの各フィールドの値をスキャンし、ダッシュボードや質問にチェックボックスのフィルタを有効にすることができます。特にとても大きなデータベースと接続する場合、これはある程度リソースを食う処理になる可能性があります。"
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "コレクション"
 
@@ -13770,7 +13876,7 @@ msgstr "カテゴリ値"
 msgid "URLs"
 msgstr "URL"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "コラムの値の平均値を返す。"
 
@@ -13779,11 +13885,13 @@ msgstr "コラムの値の平均値を返す。"
 msgid "The column whose values to average."
 msgstr "平均値を計算するコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "開始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "終わり"
 
@@ -13795,21 +13903,19 @@ msgstr "日付や数値型コラムの値が特定の範囲内にあるかをチ
 msgid "Rating"
 msgstr "評価"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "条件"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "出力"
 
@@ -13817,27 +13923,27 @@ msgstr "出力"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "ケースのリストをテストし、最初の真のケースの対応する値を返します。他に何も満たされない場合は、オプションのデフォルト値を使用します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "重さ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "中"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "真または偽に評価されるべきもの。"
 
@@ -13845,33 +13951,33 @@ msgstr "真または偽に評価されるべきもの。"
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "前の条件が真であれば返ってくる値"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "値1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "値2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "各引数の値を順番に調べ、各行の最初のnull以外の値を返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "コメント"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "注意"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "コメントなし"
 
@@ -13887,12 +13993,12 @@ msgstr "値1が空であれば、それが空でない場合には値2を返し�
 msgid "Combines two or more strings of text together."
 msgstr "テキストの2つ以上の文字列を結合する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "苗字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "名前"
 
@@ -13904,27 +14010,27 @@ msgstr "この末尾に値2が追加されます。"
 msgid "This will be added to the end of value1."
 msgstr "これは値1の末尾に付け足されます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "文字列1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "文字列2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "文字列1が内部に文字列2を含むかを確かめる。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "状態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "パス"
 
@@ -13932,7 +14038,7 @@ msgstr "パス"
 msgid "The contents of this string will be checked."
 msgstr "この文字列の内容がチェックされます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "探している文字列"
 
@@ -13940,22 +14046,22 @@ msgstr "探している文字列"
 msgid "Returns the count of rows in the source data."
 msgstr "ソースのデータにある行数を返す。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "条件がTrueとなる行のみを数える。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "小計"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "ブレークアウト間の行の累積和。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "ブレークアウト間のカラムの累積和。"
 
@@ -13964,53 +14070,57 @@ msgstr "ブレークアウト間のカラムの累積和。"
 msgid "The column to sum."
 msgstr "合計処理をするコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "このコラムの重複のない値の数。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "重複のない値をカウントするコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "テキスト"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "比較"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "テキストの末尾が比較対象のテキストと一致する場合にTrueを返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "興味"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "空腹"
 
@@ -14019,20 +14129,20 @@ msgstr "空腹"
 msgid "A column or string of text to check."
 msgstr "チェックするテキストの列または文字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "元々のテキストの末端にあるべき文字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "正規表現"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "正規表現に従って合致する部分文字列を抽出する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "住所"
 
@@ -14040,7 +14150,7 @@ msgstr "住所"
 msgid "The column or string of text to search though."
 msgstr "ただし、検索するテキストの列または文字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "合致する正規表現。"
 
@@ -14052,7 +14162,7 @@ msgstr "全て小文字であるテキストの文字列を返す。"
 msgid "The column with values to convert to lowercase."
 msgstr "小文字に変換する値のあるコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "文字列やテキストから頭の空白を取り除く。"
 
@@ -14062,15 +14172,16 @@ msgstr "文字列やテキストから頭の空白を取り除く。"
 msgid "The column with values you want to trim."
 msgstr "取り除きたい値の入ったコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "そのコラムで見つかった最大値を返す。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "年齢"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "最大値を見つけ出したい数値型のコラム。"
 
@@ -14078,21 +14189,21 @@ msgstr "最大値を見つけ出したい数値型のコラム。"
 msgid "Returns the smallest value found in the column."
 msgstr "そのコラムで見つかった最小値を返す。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "給与"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "最小値を見つけ出したい数値型のコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "長さ"
 
@@ -14101,7 +14212,7 @@ msgstr "長さ"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "入力されたテキストの一部を新しいテキストに置換します"
 
@@ -14129,35 +14240,35 @@ msgstr "置換される文字数"
 msgid "The text to use in the replacement."
 msgstr "置換で使用するテキスト。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "テキストの文字列から末尾の空白を取り除きます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "条件を満たすデータの行数の割合を小数で返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "テキストの頭が比較対象のテキストと一致している場合に真を返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "講座名"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "コンピュータ科学"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "元のテキストの頭にあるべきテキストの文字列"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "コラム値の標準偏差を計算する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "人口"
 
@@ -14165,7 +14276,7 @@ msgstr "人口"
 msgid "A numeric column."
 msgstr "数値型のコラム。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "与えられたテキストの一部を返します。"
 
@@ -14173,19 +14284,19 @@ msgstr "与えられたテキストの一部を返します。"
 msgid "The text to return a portion of."
 msgstr "一部を返されるテキスト"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "文字列のコピーを始める位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "返すべき文字の数"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "そのカラムの全ての値を足し上げます。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "合計対象の数値型カラム"
 
@@ -14193,15 +14304,15 @@ msgstr "合計対象の数値型カラム"
 msgid "Sums up values in a column where rows match the condition."
 msgstr "条件に合う行に対して、コラムの値を合計する。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "そのほかの状態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "有効"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "テキストの文字列から先頭と末尾の空白を削除する。"
 
@@ -14209,45 +14320,45 @@ msgstr "テキストの文字列から先頭と末尾の空白を削除する。
 msgid "Returns the string of text in all upper case."
 msgstr "テキストの文字列をすべて大文字で返します。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "大文字に変換する値のあるコラム。"
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "{0}でありかつ{1}を含めなければならない。"
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "{0}でなければならない。"
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "{0}を含めなければならない。"
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "最低{0}文字"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0}個の小文字\n"
 "{0}個の小文字"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0}個の大文字\n"
 "{0}個の大文字"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0}個の数"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0}個の特殊文字\n"
@@ -14270,6 +14381,7 @@ msgid "Powered by {0}"
 msgstr "{0}提供"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "To:"
 
@@ -14357,7 +14469,7 @@ msgstr "値のフォーマティング"
 msgid "Full"
 msgstr "いっぱい"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "前回の{0}から変化なし"
 
@@ -14682,7 +14794,7 @@ msgstr "コラムに対してインサイトを生成することに失敗しま
 msgid "Sending abandonment email!"
 msgstr "アカウントの剥奪メールを送っています"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "保存されたメトリクスを作成して、名前付きメトリックオプションを追加できます。 保存されたメトリクスには、集計タイプ、集計フィールド、およびオプションで追加したフィルターが含まれます。 例として、これを使用して、Ordersテーブルの「平均価格」を計算する公式の方法のようなものを作成できます。"
 
@@ -14690,15 +14802,15 @@ msgstr "保存されたメトリクスを作成して、名前付きメトリッ
 msgid "Select and add filters to create your new segment."
 msgstr "フィルターを選択して追加し、新しいセグメントを作成します。"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "アルファベット順"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "スマート"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "列の順番"
 
@@ -14750,7 +14862,7 @@ msgstr "ローカライゼーション"
 msgid "Instance language"
 msgstr "インスタンス言語"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "ローカライゼーションオプション"
 
@@ -14822,19 +14934,20 @@ msgstr "接続文字列を貼り付けます"
 msgid "Fill out individual fields"
 msgstr "個々のフィールドに入力します"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "ここにSQLを入力して、後で再利用できるようにします"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "スニペットに名前を付けます"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "現在の顧客"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "説明を追加"
 
@@ -14842,46 +14955,47 @@ msgstr "説明を追加"
 msgid "Use site default"
 msgstr "サイトのデフォルトを使用"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "検索"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "置換"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "検索する文字列"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "置換する文字列"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "編集中{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "新しいスニペットを作成する"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "アーカイブされたスニペット"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "スニペットは再利用可能なSQLの断片です"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "スニペットを作成する"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "スニペット"
 
@@ -15160,3 +15274,1497 @@ msgstr "値はキーワードまたは文字列でなければなりません。
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "文字列は、有効な2文字のISO言語または言語の国コードである必要があります。例えば'en'または'en_US'。"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "{0}-{1}行目"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "監査"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "ユーザ属性設定（任意）"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "0}を使用して"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "SAMLベースのSSOを設定する"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML認証"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "認証情報プロバイダ（IdP）を設定してください"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "あなたの設定した認証情報プロバイダはMetabaseについての以下の情報を要求します"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "IdPがリダイレクトして戻すURL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "これはOktaではSingle Sign On URL、Auth0ではApplication Callback URL、OneLoginはACS (Consumer) URLと呼ばれているものです。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML属性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "ほとんどのIdPでは、属性ステートメントセクションの「名前」というラベルの付いた入力ボックスにこれらをそれぞれ入力する必要があります。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "ユーザのメールアドレス"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "ユーザの名"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "ユーザの姓"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Metabaseにあなたの利用する認証情報プロバイダを教えてください"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabaseはあなたの認証情報プロバイダに関する以下の情報が必要です"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML認証情報プロバイダのURL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "SAML認証情報プロバイダ証明書"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAMLアプリケーション名"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "サインSSOリクエスト（オプション"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML Keystore Path"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "SAML Keystore Password"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "静かに。。。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML Keystore Alias"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "SSOとグループメンバー情報を同期する"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "これを有効にするためには、ユーザが所属するSSOグループに基づきどのグループに追加されるべきなのかをMetabaseに伝えるためのマッピングを作る必要があります。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "グループ名"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "グループ属性名"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "注意："
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "既存の有効なSAMLの設定を変更する場合、設定を有効化するためにMetabaseを再起動する必要があります。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "ユーザにSAML認証情報プロバイダを通してログインすることを許可する。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "ユーザにJWT認証情報プロバイダを通してログインすることを許可する。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "パスワード認証を有効にする"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "有効にされた場合、ユーザはメールアドレスとパスワードでログインすることもできます。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "管理者に新しいSSOユーザを通知する"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "有効にされた場合、ユーザが初めてシングルサインオンを利用したときに管理者がメールを受け取ることになります。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "SAML経由でのSSOの設定をするためには以下の設定を利用してください。何か疑問点があれば {0} を確認してください。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "ドキュメント"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML認証情報プロバイダURI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT認証"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT認証情報プロバイダURI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "JWT 署名鍵で使用される文字列"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Metabaseアプリ全体を埋め込んでいます"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Metabaseの全てを埋め込みたい場合は、埋め込みを許可したいWebサイトやWebアプリの出典をスペースで区切ってiframeに入力します。ここでは、入力できるものの{0}を示しています。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "このテーブルへのサンドボックス化されたアクセス権を付与する"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "このグループに所属するユーザがこのテーブルを見るとき、自分のユーザ属性によってフィルタされたバージョン、または保存された質問に基づくカスタマイズされたビューが見えることになります。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "このグループに所属するユーザにたいして、このテーブルをどのようにフィルタしたいですか。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "これらのユーザーに表示されるこのテーブルのカスタムビューを返す保存済みの質問を選択します。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "ユーザ属性に応じてここに追加のフィルタを設定することもできます。これらのフィルタは保存された質問に既に設定されているいかなるフィルタよりも先に適用されます。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "このオプションを有効にするには、ユーザがいくつかの属性を持つ必要があります"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "さらなるフィルタを追加するためには、ユーザがいくつかの属性を持つ必要があります"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "ユーザー属性なし"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "ユーザ属性を選択してください"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "パラメタを選択してください"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "カラムを選択してください"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "{0}に属するユーザは見ることができます"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "{0}質問の行"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "{0}テーブルの行"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "{0}が{1}と等しいとき"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "かつ{0}と{1}が等しい"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "SAMLを使用するSSOを設定することで属性を自動的に追加することも、Peopleセクションに移動して右端の[…]メニューをクリックして手動で属性を入力することもできます。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "ユーザ属性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "SSOをセットアップしている場合は自動的にユーザ属性を取得することができ、また、管理者パネルのPeopleセクションの[...]メニューから手動で追加することもできます。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "パラメタまたは変数"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "一致する"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "サンドボックスアクセスを付与する"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "サンドボックスアクセス"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "サンドボックスアクセスを編集する"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "フォルダの詳細を編集"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "権限の変更"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "新しいフォルダを作成"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "新しいフォルダ"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "トークン検証時に問題が発生しています"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "あなたのインスタンスからMetabaseサーバへ接続できるかを再確認してください"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "ヘルプを得る"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Enterprise Edition で Metabase をさらに活用する"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "顧客に素早く簡単にレポートを提供したり、大規模な組織でMetabaseを実行して監視するために必要なすべてのツールが用意されています。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "ライセンスを有効化する"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "これらの機能が有効化されたトライアル期間中です"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "試用期間は {0} に終わります"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "助けが必要？それとも買う準備ができてる？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "コンタクトを取る"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "試用期間は終わりました"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "まだ検討に時間が必要？それとももう買う準備はできている？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "あなたの機能はアクティブです！"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "{0}を通してあなたのライセンスは有効です"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "あなたのライセンスは期限切れです"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "{0}に期限が切れました"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "ライセンスを更新したい？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "この使い方を学ぶ"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "あなたの現状のプランには含まれていません"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "ストアから受け取ったトークンを入力してください"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "アクティベート"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "支援が必要？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "問題に関する詳細情報。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "コンタクトサポート"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "商用版"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "データサンドボックス"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "ユーザ属性に基づいた自動かつ安全なフィルタを利用し、正しいデータを正しい人に開示していることを確認してください。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "ホワイトラベリング"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Metabaseをカスタマイズされた色、ロゴなどのあなたのブランドに合わせる。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "監査"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "堅牢な監査ツールでパフォーマンスと行動を監視します。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "シングルサインオン"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "既存の認証インフラストラクチャで機能する簡単なログインを提供します。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "保存する"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "アプリケーション名"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "カラーパレット"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "ロゴ"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "ファビコン"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "ランディングページ"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "グループはありません。"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "{0}に対するパーミッション"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "このフォルダの権限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "編集権限を付与する"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "このフォルダのスニペットを変更できます"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "閲覧権限を付与する"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "このフォルダにスニペットを挿入して使用することはできますが、スニペットに含まれるSQLを編集することはできません"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "このフォルダにスニペットを表示または挿入できません"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "サブフォルダも変更する"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "週の最初の曜日"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Googleでのサインインに問題がありました。管理者に連絡してください。"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "上で"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "に"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Metabaseアクションメニューを開く"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "何もしない"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "カスタムの目的地に移動する"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "ダッシュボードのフィルタを更新する"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "0} 更新 {1} フィルタ"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0}は{1}に移動します"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "各カラムにおけるon-click時の挙動"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "カスタム目的地に移動"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "アクションメニューを開く"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "0}のクリック動作"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "更新する1つ以上のフィルターを選択します"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "保存された質問"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "リンク"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "リンク先のURLを入力してください"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "カラムまたはダッシュボードのフィルタへの値はその名前を利用して入れることができます（例：{{some_column}}）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "すなわち、http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "ダッシュボードを選んでください..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "質問を選んでください..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "リンクを貼るダッシュボードを選んでください"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "リンクする質問を選択してください"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "このダッシュボードのフィルタに値を渡してください（任意）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "この質問の変数に値を渡してください（任意）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "この質問に値を渡してください（任意）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "ダッシュボードフィルタ"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "ユーザ属性"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "リンクテキストのカスタマイズ（任意）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. {{Column Name}}の詳細"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "参照できる値"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "入手可能なターゲットはありません"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "フィルタ"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "変数"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "他の利用可能なフィルタ"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "利用可能なフィルタ"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "他の利用可能な変数"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "利用可能な変数"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "他の利用可能なカラム"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "利用可能なカラム"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "ユーザ属性"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "テキストカード"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "挙動をクリックします。"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "可視化のオプション"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "系列の編集"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "系列の追加"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "クリック時"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "タイトルと説明を変更する"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "埋め込みパラメータを更新したので、埋め込みコードを更新する必要があります。"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "質問を追加する"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "あなたはこのダッシュボードを編集中です。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "フィルタをかけるカラム"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "スニペットコレクション"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "スニペットコレクション"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "あなたのフォルダに名前をつけてください"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "短く楽しい何か"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "これが入っているはずのフォルダ"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "アクションメニューを開く"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "0} カラムのカスタム動作"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "進め..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "ダッシュボードを見る"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "質問を見る"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "urlに移動します。"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "このダッシュボードをフィルタする"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "選択されたデータの行数を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "加算するカラムまたは数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "標準偏差を計算する数値型カラム。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "平均を計算する数値型カラム。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "カラム内で見つかった最小の値を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "条件が真である行についてのみ、指定された列を合計します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "与えられたカラムに対する分散を返します"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "温度"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "分散を取得するカラムや数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "指定されたカラムの中央値を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "中央値を取得するカラムや数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "パーセンタイル値"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "カラムの中でそのパーセンタイルである値を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "パーセンタイル値を計算するカラムや数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "パーセンタイル値"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "テキストの文字列を全て小文字で返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "小文字に変換するカラム。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "テキストを全て大文字で返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "一部を戻すカラムやテキスト"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "検索をするカラムまたはテキスト。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "２つ以上のテキストの文字を結合します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "始めるカラムやテキスト"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "これはvalue1の末尾に追加されます。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "膨大な"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "巨大な"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "テキスト内の文字数を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "長さを取得したいカラムまたはテキスト。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "トリミングしたいカラムやテキスト"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "指定されたカラムの絶対値を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "債務"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "絶対値を計算するカラムまたは数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "小数値を切り下げます。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "切り下げを行うカラムまたは数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "小数値を切り上げます。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "切り上げを行うカラムまたは数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "小数値を最も近い整数へ丸めます。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "最も近い整数に丸めるカラムや数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "平方根を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "斜辺"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "平方根の値を計算するカラムや数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "指数"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "数値を指数値の累乗で累乗します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "長さ"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "指数まで上げられた列または数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "指数の値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "数値の常用対数値を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "値"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "自然対数を計算するカラムや数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "オイラー数eを、指定された数の累乗で返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "利子月"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "指数値を返す列または数値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "チェックしたいカラムやテキスト"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "日付または数値の列の値をチェックして、指定された範囲内にあるかどうかを確認します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "作成場所"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "始点と終点の間にある日付や数値のカラム。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "範囲の始点。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "範囲の終端。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "日付列の値をチェックして、相対的な範囲内にあるかどうかを確認します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "間隔を返す日付欄。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "マイナスの値が戻ってくるインターバルの期間。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "日」「月」「年」のような内部のタイプ。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "返すカラムまたは値。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "value1が空の場合、もしvalue2が空でなければそれが返る、もしvalue3が...というような形になります。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "式をケースのリストに対してテストし、最初にマッチしたケースの対応する値を返します。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "前述の条件が真の場合に返される値など。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "ヌル値である"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "ヌル値でない"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "カラム値の累積和。（例）時間経過に対する累積売上額。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "行数の累積カウント。（例）時間経過に対する累積売上回数。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "リンクフィルタ"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "ラベル"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "デフォルト値"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "デフォルトではありません。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "これを表示するには、{0}が少なくとも1つのフィールドに接続されている必要があります。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "フィルタの選択肢を制限する"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "別のダッシュボードフィルターがある場合は、他のフィルターの選択に基づいて、このフィルターにリストされる選択肢を制限できます。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "なので最初は{0}。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "他のダッシュボードフィルタを追加する"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "これらのダッシュボード・フィルタのいずれかをトグルすると、そのフィルタの値を選択すると、{0}フィルタの選択肢が制限されます。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "カラムをフィルタリングしています"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "フィルタされたカラム"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "ユーザ名またはメールアドレスを入力してください"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "新しいスニペット"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "午後{0}:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "午前12:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "午前{0}:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "毎時"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "{0}に毎日"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "{1}の{0}に週次"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "{0} {1}の{2}に月次"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "この購読を削除する"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "購読"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "ダッシュボードの購読を作成する"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "メールで送る"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "このダッシュボードは、ユーザーまたは電子メールアドレスに定期的に送信できます。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Slackに送信"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "チャネルとスケジュールを選択すると、残りは Metabase が行います。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "このダッシュボードにメールを送信"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "結果がない場合は送信しないでください"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "結果を付ける"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "添付ファイルには、最大2,000行のデータを含めることができます。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "このダッシュボードをSlackに送る"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "ダッシュボードには ID {0} のパラメータがありません。"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "パラメタ {0} はそれに関連づく如何なるフィールドも持っていません"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include は空か値 'tables' のいずれかでなければなりません。"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "型が `internal` ではないすべてのクエリに `database` が必要である。"
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "このインスタンスでは、パスワードログインは無効になっています。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "あなたのアカウントは無効になりました。管理者に連絡してください。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "あなたのアカウントは無効になりました。"
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "無効なSlackトークン。"
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "''{0}''コマンドは商用版Metabaseでのみで利用可能です"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Metabase Enterprise Editionの拡張機能はPRESENTです。"
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Metabase Enterprise Editionの機能の利用はMetabase Commercial Licenseに従います。"
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "詳細は{0}で確認してください。"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Metabase Enterprise Editionの拡張機能は存在しません。"
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "{0}の{1}に招待されました"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0}は{1}アカウントを作成しました"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "0}が{1}の招待を受け入れた"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] パスワードリセット申請"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] 通知"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] [{1}]をより良くすることに協力する"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] どうなっているのか教えてください。"
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "イベントリスナ開始時のエラー"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "LDAPを通してログインが行われた場合にユーザ属性情報を同期するべきですか？"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "LDAPユーザの同期をスキップするためのカンマ切りされたユーザ属性情報のリスト。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "無効なトークン"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Slack APIエラー：{0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "`metabase_files`という名前のSlackチャネルがありません！"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Slackの統合を完了するには、チャネルを作成またはアーカイブ解除してください。"
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "このチャネルは、PulseおよびMetaBotの回答に含まれるグラフを保存するために使用されます。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "アップロードされた画像"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Slackへのファイルアップロードエラー："
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "無効なセッションです。セッションのインスタンスを期待しています。"
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "セッションクッキーのSameSiteは \"None \"に設定されていますが、サイトは"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "安全でない接続を通してサーブしています。ブラウザにより拒否される場合があります "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "これらの条件の下でクッキーを使用しています。 "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "トップフォルダ"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr "parameters は、String :id キーを持つマップのシーケンスでなければなりません。"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "無効な人間が読める値: 値はシーケンスである必要があります。各項目はnilまたは文字列である必要があります"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr "human_readable_values を取得するには :values が存在しなければなりません。"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "フィールド値の合計長さは> {0}です。"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "スニペット名は'}'を含んだりスペースから始めたりすることはできません"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "チェーンフィルタクエリの実行エラー"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "フィールド{0}は存在しません。"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "非テキストフィールド {0} {1} に対して検索できません。"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "グループ{0}へのパーミッションを与える：{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "グループ{0}へのパーミッションを取り消す：{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "無効なDB権限：ネイティブクエリの書き込みアクセス権がある場合、完全なデータアクセス権が必要です。"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "無効なDBアクセス許可：読み取り専用のネイティブクエリアクセス権がある場合、データアクセス権も必要です。"
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "パーミッションを{0}から{1}へ変更する"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "ログイン属性のキーはキーワードか文字列でなければなりません。"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Metabase UI、システムメール、パルス、アラート全てにわたって全ユーザに適用されるデフォルト言語。"
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "ユーザは、自分のアカウント設定からこのデフォルト言語を個別に上書きできます。"
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "ユーザに見せるデフォルトページ"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "このオリジンが完全な Metabase アプリケーションを埋め込むことを許可する"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "{0}より大きな値（{1}）は許可されていません。"
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "これにより、\"Metabase\"という単語が表示される場所が置き換えられます。"
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "これらがMetabase全体とチャートで用いられる主な色です。変更が適用されたことを確認するにはブラウザを更新する必要がある場合があります。"
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "最良の結果を得るには、背景が透明なSVGファイルを使用してください。"
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "ファビコンとして使用するURLまたは画像。"
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "電子メールとパスワードによるログインを許可します。"
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "これは、週ごとのグループ化やGUIクエリでのフィルタリングなどに影響します。 SQLクエリには影響しません。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "トークンの検証ができません"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "トークンの形式が無効です。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "トークン検証エラー"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "{0}フィールドに対するフィルタリングエラー：文字列{1}を{2}にパースできません"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "ジョブの詳細を取得するのに失敗しました：{0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "データベース {0}との同期タスクを開始しています。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "データベース {0}と同期できません：データベースが存在しません。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "データベース{0}に対するフィールド値アップデートタスクが発動されました"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "アップデートをスキップしています：データベース{0}の自動フィールド値アップデートは無効化されています。"

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -5,28 +5,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: it\n"
+"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "Il database è stato aggiunto!"
+msgstr "Databasen din har blitt lagt til!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "Stiamo dando uno sguardo ai tuoi dati e abbiamo alcune esplorazioni automatiche che possiamo mostrarti!"
+msgstr "Vi har analysert dine data, og vi har noen automatiske utforskninger vi vil vise deg!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "A posto così, grazie"
+msgstr "Jeg har det fint, takk"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "Analizza questi dati"
+msgstr "Utforsk disse dataene"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
-msgstr "Selezionare il tipo di database"
+msgstr "Velg en databasetype"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
@@ -44,95 +44,96 @@ msgstr "Selezionare il tipo di database"
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:30
 msgid "Save"
-msgstr "Salva"
+msgstr "Lagre"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Per fare qualcosa di magico, Metabase ha bisogno di esplorare il tuo database. L'esplorazione viene periodicamente rieseguita. Di seguito puoi controllare quando avverrà la prossima esplorazione."
+msgstr "For at Metabase skal klare å gjøre magi, trenger den å skanne databasen din. Vi kommer til å skanne denne periodisk for og holde metadata oppdatert.\n"
+"Du kan kontrollere når dette skal forekomme."
 
 #: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
-msgstr "Database sincronizzato"
+msgstr "Synkroniserer database"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Questo è un processo leggero che controlla aggiornamenti allo schema del database. Nella maggior parte dei casi, andrá bene impostarlo ad ogni ora."
+msgstr "Dette er en lett prosess som sjekker for oppdatering i database skjemaet. I de fleste tilfeller holder det med synkronisering hver time."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:42
 #: frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx:22
 msgid "Scan"
-msgstr "Scansione"
+msgstr "Skann"
 
 #: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
-msgstr "Ricerca di Valori Filtro"
+msgstr "Skanner etter filtreringsverdier"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase può cercare i valori presenti in ogni campo di questo database per abilitare i checkbox dei filtri nelle dashboard e questions. Questo processo puó essere intensivo, in particolare se hai un database molto grande."
+msgstr "Metabase kan skanne verdiene i hvert felt i denne databasen for og aktivere sjekkboks filtere i infotavler og spørsmål. Dette er en ressurs krevende prosess, spesielt for veldig store databaser"
 
 #: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "Quando Metabase dovrebbe automaticamente scansionare e fare cache dei valori?"
+msgstr "Når skal Metabase automatisk skanne og mellomlagre feltverdier?"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:25
 msgid "Regularly, on a schedule"
-msgstr "Regolarmente secondo schedulazione"
+msgstr "Regelmessig, etter en tidsplan"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:50
 msgid "Only when adding a new filter widget"
-msgstr "Solo quando si aggiunge un nuovo filtro nel widget"
+msgstr "Bare når du legger til en ny filter-widget"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Quando un utente aggiunge un nuovo filtro a una Dashboard o Question, Metabase cercherá nei campi mappati dal filtro per mostrare la lista dei valori selezionabili."
+msgstr "Når en bruker legger til nye filter på en infotavle eller et SQL spørsmål, vil Metabase skanne feltene som er tilknyttet til det filteret for å vise liste over mulige filterverdier."
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
-msgstr "Mai, lo farò manualmente se necessario"
+msgstr "Aldri, jeg vil gjøre det manuelt hvis jeg trenger"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:29
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:229
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 msgid "Saving..."
-msgstr "Salvataggio..."
+msgstr "Lagrer..."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 msgid "Server error encountered"
-msgstr "Errore nel server"
+msgstr "En tjenerfeil har oppstått"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "Cancellare il database?"
+msgstr "Slett denne databasen?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Tutte le Questions, Metriche e segmenti salvati per questo database andranno persi."
+msgstr "Alle dine lagrede spørsmål, beregninger og segmenter"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "Questo non può essere ripristinato"
+msgstr "Dette kan ikke angres"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "Se sei sicuro digita"
+msgstr "Hvis du er sikker, vennligst skriv"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "CANCELLA"
+msgstr "SLETT"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "in questa casella:"
+msgstr "i denne boksen:"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
@@ -170,14 +171,14 @@ msgstr "in questa casella:"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:328
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "Annulla"
+msgstr "Avbryt"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Elimina"
+msgstr "Slett"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -189,19 +190,19 @@ msgstr "Elimina"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "Database"
+msgstr "Databaser"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:148
 msgid "Add Database"
-msgstr "Aggiungi un Database"
+msgstr "Legg til database"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:73
 msgid "Connection"
-msgstr "Connessione"
+msgstr "Tilkobling"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:77
 msgid "Scheduling"
-msgstr "Schedulazione"
+msgstr "Planlegging"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
@@ -213,17 +214,17 @@ msgstr "Schedulazione"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "Salva i cambiamenti"
+msgstr "Lagre endringer"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:203
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:30
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:30
 msgid "Actions"
-msgstr "Azioni"
+msgstr "Handlinger"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 msgid "Sync database schema now"
-msgstr "Sincronizza lo schema database ora"
+msgstr "Synkroniser database skjemaer nå"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:212
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
@@ -232,49 +233,49 @@ msgstr "Sincronizza lo schema database ora"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:90
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:98
 msgid "Starting…"
-msgstr "Avvio..."
+msgstr "Starter..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:213
 msgid "Failed to sync"
-msgstr "Sync fallito"
+msgstr "Feilet ved synkronsering"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:214
 msgid "Sync triggered!"
-msgstr "Sync azionato!"
+msgstr "Synkronisering utløst!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:223
 msgid "Re-scan field values now"
-msgstr "Ri-scansiona i valori dei campi adesso"
+msgstr "Skanne felter verdier på nytt"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:91
 msgid "Failed to start scan"
-msgstr "Inizio della scansione fallito"
+msgstr "Skanning feilet ved start"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:226
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:92
 msgid "Scan triggered!"
-msgstr "Scan azionato!"
+msgstr "Skanning påbegynt!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:233
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "Zona Pericolosa"
+msgstr "Faresone"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Discard saved field values"
-msgstr "Scarta valori campo salvati"
+msgstr "Forkast lagrede feltverdier"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:257
 msgid "Remove this database"
-msgstr "Rimuovere questo database"
+msgstr "Fjern denne databasen"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "Aggiungi un database"
+msgstr "Legg til database"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:28
@@ -291,99 +292,99 @@ msgstr "Aggiungi un database"
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
-msgstr "Nome"
+msgstr "Navn"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "Motore"
+msgstr "Motor"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "In cancellazione..."
+msgstr "Sletter..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Caricamento..."
+msgstr "Laster..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "Ripristinare i dati d'esempio"
+msgstr "Hent eksempel-datasettet tilbake"
 
 #: frontend/src/metabase/admin/databases/database.js:167
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "Impossibile collegarsi al database. Controlla i parametri connessione"
+msgstr "Kunne ikke koble til databasen. Vennligst sjekk tilkoblingen."
 
 #: frontend/src/metabase/admin/databases/database.js:384
 msgid "Successfully created!"
-msgstr "Creazione riuscita!"
+msgstr "Opprettelse vellykket!"
 
 #: frontend/src/metabase/admin/databases/database.js:394
 msgid "Successfully saved!"
-msgstr "Salvataggio riuscito!"
+msgstr "Lagring vellykket!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
-msgstr "Edita"
+msgstr "Rediger"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "Storico Revisioni"
+msgstr "Revisjonshistorikk"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "Rimuovere questo {0}?"
+msgstr "Arkiver denne {0}?"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Le domande salvate e altre cose che dipendono da questo {0} continueranno a funzionare, ma questo {1} non sarà più selezionabile dal generatore di query."
+msgstr "Lagrede spørsmål og andre ting som avhenger av denne {0} vil fortsette å virke, men denne {1} vil ikke lenger være mulig å velge fra spørrings-byggeren."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "Se sei sicuro di voler rimuovere questo {0}, ti preghiamo di scrivere una rapida spiegazione del motivo per cui è stato rimosso:"
+msgstr "Hvis du er usikker på om du vil arkivere denne {0}, vennligst skriv en kort forklaring på hvorfor den blir arkivert:"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "Questo verrà visualizzato nel feed di attività e in un'email che verrà inviata a chiunque nel tuo team che ha creato qualcosa che utilizza questo {0}."
+msgstr "Dette vil vises i aktivitetsstrømmen og i en e-post som vil bli sendt til alle på ditt lag som lager noe som bruker denne {0}."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "Rimuovi"
+msgstr "Arkiver"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "Rimozione..."
+msgstr "Kaster..."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 #: frontend/src/metabase/components/form/CustomForm.jsx:188
 msgid "Failed"
-msgstr "Fallito"
+msgstr "Feilet"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 #: frontend/src/metabase/components/form/CustomForm.jsx:189
 msgid "Success"
-msgstr "Riuscito"
+msgstr "Suksess"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:129
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:185
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
-msgstr "Anteprima"
+msgstr "Forhåndsvisning"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:93
 msgid "No column description yet"
-msgstr "Ancora nessuna descrizione della colonna"
+msgstr "Ingen kolonnebeskrivelse enda"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:126
 msgid "Select a field visibility"
-msgstr "Selezionare la visibilità del campo"
+msgstr "Velg en feltsynlighet"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:187
 msgid "No special type"
-msgstr "Nessun tipo speciale"
+msgstr "Ingen spesiell type"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:188
 #: frontend/src/metabase/lib/core.js:275
@@ -391,16 +392,16 @@ msgstr "Nessun tipo speciale"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:37
 msgid "Other"
-msgstr "Altri"
+msgstr "Andre"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "Seleziona uno speciale tipo"
+msgstr "Velg en spesiell type"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:262
 #: frontend/src/metabase/reference/components/Field.jsx:99
 msgid "Select a target"
-msgstr "Seleziona una destinazione"
+msgstr "Velg ett mål"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
@@ -410,97 +411,97 @@ msgstr "Seleziona una destinazione"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
-msgstr "Colonne"
+msgstr "Kolonner"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "Colonna"
+msgstr "Kolonne"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
-msgstr "Visibilità"
+msgstr "Synlighet"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
-msgstr "Tipo"
+msgstr "Type"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "Database corrente:"
+msgstr "Nåværende database:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
-msgstr "Mostra lo schema originale"
+msgstr "Vis opprinnelige skjema"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "Tipo dei dati"
+msgstr "Datatype"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "Informazioni addizionali"
+msgstr "Tillegsinfo"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "Trova uno schema"
+msgstr "Fins ett skjema"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "{0} schema"
-msgstr[1] "{0} schemi"
+msgstr[0] "{0} skjema"
+msgstr[1] "{0} skjemaer"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:99
 msgid "Why Hide?"
-msgstr "Perché nasconderlo?"
+msgstr "Hvorfor skjule?"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:100
 msgid "Technical Data"
-msgstr "Dati Tecnici"
+msgstr "Teknisk data"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:101
 msgid "Irrelevant/Cruft"
-msgstr "Irrilevante/Mal progettato"
+msgstr "Irrelevant"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:107
 msgid "Queryable"
-msgstr "Interrogabile"
+msgstr "Spørbar"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:108
 msgid "Hidden"
-msgstr "Nascosto"
+msgstr "Skjul"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:136
 msgid "No table description yet"
-msgstr "Nessuna descrizione della tabella ancora"
+msgstr "Ingen tabell beskrivelse enda"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "Forza del metadata"
+msgstr "Metadata styrke"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "Tabella interrogabile"
-msgstr[1] "Tabelle interrogabili"
+msgstr[0] "[0} Spørbar Tabell"
+msgstr[1] "[0} Spørbare Tabeller"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:91
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "Tabella nascosta"
-msgstr[1] "Tabelle nascoste"
+msgstr[0] "{0} skjult tabell"
+msgstr[1] "{0} skjulte tabeller"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:115
 msgid "Find a table"
-msgstr "Trova una tabella"
+msgstr "Find en tabell"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:128
 msgid "Schemas"
-msgstr "Schemi"
+msgstr "Skjemaer"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
@@ -511,21 +512,21 @@ msgstr "Schemi"
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:62
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 msgid "Metrics"
-msgstr "Metriche"
+msgstr "Indikatorer"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:27
 msgid "Add a Metric"
-msgstr "Aggiungi una metrica"
+msgstr "Legg til en indikator"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
-msgstr "Definizione"
+msgstr "Definisjon"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:51
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "Crea metriche per aggiungerle al menu a discesa dela Vista nel generatore di query"
+msgstr "Lag indikatorer som vises i nedtrekksmenyen i spørsmålsbyggeren"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:38
@@ -535,294 +536,294 @@ msgstr "Crea metriche per aggiungerle al menu a discesa dela Vista nel generator
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:61
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "Segmenti"
+msgstr "Segmenter"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:27
 msgid "Add a Segment"
-msgstr "Aggiungi un segmento"
+msgstr "Legg til segment"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:45
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "Crea segmenti per aggiungerle nel menu a discesa dei Filtri nel generatore di query"
+msgstr "Lag segmenter som vises i nedfelsmenyen i spørsmål byggeren"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:21
 msgid "created"
-msgstr "creato"
+msgstr "laget"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "reverted to a previous version"
-msgstr "ritornare alla versione precedente"
+msgstr "vendte tilbake til en tidligere versjon"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:30
 msgid "edited the title"
-msgstr "titolo modificato"
+msgstr "endret tittelen"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:32
 msgid "edited the description"
-msgstr "Modificato la descrizione"
+msgstr "endret beskrivelsen"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:34
 msgid "edited the "
-msgstr "Modificato il␣"
+msgstr "edited the "
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "made some changes"
-msgstr "fatte alcune modifiche"
+msgstr "gjorde noen endringer"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
 #: frontend/src/metabase/home/components/Activity.jsx:83
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "Tu"
+msgstr "Du"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "Modello dei dati"
+msgstr "Datamodell"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:41
 msgid " History"
-msgstr "Storico"
+msgstr " Historie"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:46
 msgid "Revision History for"
-msgstr "Cronologia delle revisioni per"
+msgstr "Revisjons historie for"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
-msgstr "{0} – Impostazioni dei campi"
+msgstr "{0} - felt instillinger"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
-msgstr "Dove questo campo apparirà in tutto Metabase"
+msgstr "Hvor dette feltet vil dukke opp i Metabase"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
-msgstr "Filtra per questo campo"
+msgstr "Filtrering på dette feltet"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "Quando questo campo é usato in un filtro, cosa dovrebbero usare le persone per inserire il valore per il quale vogliono filtrare?"
+msgstr "Når dette feltet brukes i ett filter, hvilken metode skal brukes for å legge inn filtreringsverdi?"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
-msgstr "Nessuna descrizione per questo campo fino ad ora"
+msgstr "Ingen beskrivelse for dette feltet enda"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
-msgstr "Valore originale"
+msgstr "Opprinnelig verdi"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
-msgstr "Valore mappato"
+msgstr "Kartlagt verdi"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
-msgstr "Inserire valore"
+msgstr "Legg inn verdi"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use original value"
-msgstr "Usa il valore originale"
+msgstr "Bruk opprinnelig verdi"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Use foreign key"
-msgstr "Usa la chiave esterna"
+msgstr "Bruk fremmednøkkel"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:28
 msgid "Custom mapping"
-msgstr "Mapping personalizzato"
+msgstr "Tilpasset kartlegging"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
-msgstr "Tipo mapping non riconosciuto"
+msgstr "Ukjent kartleggingstype"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "Il campo corrente non é una Foreign Key o il metadata della tabella target della FK é mancante"
+msgstr "Det gjeldende feltet er ikke en fremmednøkkel eller måltabellen mangler FK-metadata."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
-msgstr "Il campo selezionato non é una foreign key"
+msgstr "Valgt felt er ikke en fremmednøkkel"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
-msgstr "Visualizza valori"
+msgstr "Vis verdier"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "Scegli se mostrare il valore originale dal database o se visualizzare questo campo associato o informazioni personalizzate."
+msgstr "Velg å vise originalverdien fra databasen, eller å vise tilhørende eller egendefinert informasjon."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
-msgstr "Scegli un campo"
+msgstr "Velg ett felt"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
-msgstr "Prego selezionare una colonna da usare per visualizzazione"
+msgstr "Vennligst velg en kolonne til visning"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "Suggerimento:"
+msgstr "Tips:"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "Potresti voler aggiornare il nome del campo per assicurarti che abbia ancora senso in base alle tue scelte di rimappatura."
+msgstr "Du vil kanskje oppdatere feltnavnet sånn at det fortsatt gir mening dersom du har valgt å bruke verdien fra et annet felt."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
-msgstr "Valori del campo memorizzato nella cache"
+msgstr "Mellomlagret felt verdier"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabase può analizzare i valori per questo campo in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'."
+msgstr "Metabase kan skanne verdiene for dette feltet for å aktivere avhukingsfilter i infotavler og spørsmål."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "Ri-scansiona questo campo"
+msgstr "Skan feltet på nytt"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard cached field values"
-msgstr "Scarta la cache dei valori"
+msgstr "Kast mellomlagrede feltverdier"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:99
 msgid "Failed to discard values"
-msgstr "Errore durante la cancellazione del valore"
+msgstr "Mislyktes å kaste verdier"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:100
 msgid "Discard triggered!"
-msgstr "Cancellazione avviata"
+msgstr "Kasting utløst!"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:114
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "Seleziona una qualsiasi tabella per vederne lo schema o cambiarne i metadati"
+msgstr "Velg en hvilken som helst tabell for å se tabellens skjema og for å legge til eller endre metadata."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
 #: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
-msgstr "Nome è obbligatorio"
+msgstr "Navn er påkrevd"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
-msgstr "Descrizione è obbligatorio"
+msgstr "Beskrivelse er påkrevd"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
-msgstr "Sono richieste le informazioni di revisione"
+msgstr "Revisjonsmelding er påkrevd"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
-msgstr "E' richiesta un' aggregazione"
+msgstr "Aggregering er påkrevd"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
-msgstr "Modifica la tua Metrica"
+msgstr "Rediger din indikator"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
-msgstr "Crea la tua metrica"
+msgstr "Opprett din indikator"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "Cambia le tue metriche e aggiungi una nota esplicativa"
+msgstr "Gjør endringer i din indikator og legg igjen en forklaring."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:145
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "È possibile creare metriche salvate per aggiungere un'opzione metrica con nome a questa tabella. Le metriche salvate includono il tipo di aggregazione, il campo aggregato e, facoltativamente, qualsiasi filtro aggiunto. Ad esempio, è possibile utilizzarlo per creare qualcosa come il modo ufficiale di calcolare 'Prezzo medio' per una tabella Ordini."
+msgstr "Du kan lage lagrede indikatorer for å legge til en navngitt indikator i denne tabellen. Lagrede indikatorer inkluderer den aggregerte typen, det aggregerte feltet, og alternativt alle filtre du velger å legge til. Som et eksempel; du vil kanskje bruke dette for å lage noe sånt som den offisielle måten å beregne \"gjennomsnittlig pris\" for en ordre-tabell."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
-msgstr "Risultato:"
+msgstr "Resultat: "
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
-msgstr "Dai un nome alla tua Metrica"
+msgstr "Gi navn til din indikator"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
-msgstr "Dai un nome alla tua Metrica per aiutare gli altri a trovarla."
+msgstr "Gi indikatoren din et navn for å hjelpe andre med å finne den."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
-msgstr "Qualcosa di descrittivo ma non troppo dettagliato"
+msgstr "Noe beskrivende men ikke for langt"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
-msgstr "Descrivi la tua Metrica"
+msgstr "Beskriv din indikator"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "Dai alla tua Metrica una descrizione per aiutare gli altri a capire di cosa tratta"
+msgstr "Gi din indikator en beskrivelse for å hjelpe andre med å forså hva den handler om."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "Questo é un buon posto per essere piú specifici riguardo le metriche meno ovvie"
+msgstr "Dette er et bra sted å være mer spesifikk om mindre åpenbare indikator-regler."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
-msgstr "Motivo per le modifiche"
+msgstr "Grunn Til Endringer"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "Lascia un commento per spiegare quali cambiamenti hai fatto e perché li ritenevi necessari."
+msgstr "Legg igjen en beskjed for å forklare hva slags endringer du gjorde og hvorfor de måtte gjøres."
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "Questo verrá mostrato nello storico revisioni di questa metrica per aiutare tutti a ricordarsi perché le cose sono cambiate"
+msgstr "Dette vil vises i revisjonshistorikken for denne indikatoren for å hjelpe alle med å huske hvorfor ting ble forandret."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:45
 msgid "At least one filter is required"
-msgstr "Al meno uno filtro è obbligatorio"
+msgstr "Minst ett filter er påkrevd"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Edit Your Segment"
-msgstr "Modifica il tuo Segmento"
+msgstr "Rediger ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:102
 msgid "Create Your Segment"
-msgstr "Crea il tuo Segmento"
+msgstr "Opprett ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:106
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "Cambia il tuo segmento e aggiungi una nota esplicativa"
+msgstr "Gjør endringer i ditt segment og legg igjen en forklaring."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "Seleziona un filtro da aggiungere per creare un nuovo segmento sulla tabella {0}"
+msgstr "Velg og legg til filtere for å lage ditt nye segment for {0}-tabellen"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:125
 msgid "Name Your Segment"
-msgstr "Dai un nome al tuo Segmento"
+msgstr "Navngi ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:126
 msgid "Give your segment a name to help others find it."
-msgstr "Dai un nome al tuo segmento per aiutare gli altri a trovarlo"
+msgstr "Gi segmentet ditt et navn for å gjøre det enklere for andre å finne det"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:134
 msgid "Describe Your Segment"
-msgstr "Discrivi il tuo segmento"
+msgstr "Beskriv ditt segment"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:135
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "Dai una descrizione al tuo segmento per aiutare gli altri a capire di cosa si tratta."
+msgstr "Gi ditt segment en beskrivelse for å hjelpe andre med å forstå hva det dreier seg om."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:139
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "questo e' un buon posto per essere precisi nel descrivere le regole di segmento meno ovvie"
+msgstr "Dette er et bra sted å være mer spesifikk om mindre åpenbare segmenteringsregler"
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:149
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "Questo verrà visualizzato nella cronologia delle revisioni di questo segmento per aiutare tutti a ricordare perché le cose sono cambiate"
+msgstr "Dette vil vises i revisjonshistorikken for dette segmentet for å hjelpe alle å huske hvorfor ting ble endret"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:69
 #: frontend/src/metabase/admin/routes.jsx:137
@@ -833,67 +834,65 @@ msgstr "Questo verrà visualizzato nella cronologia delle revisioni di questo se
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
-msgstr "Impostazioni"
+msgstr "Innstillinger"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabase può analizzare i valori per questa tabella in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'. "
+msgstr "Metabase kan skanne verdiene i denne tabellen for å lage avkrysningsboks-filtere på infotavlene og i spørsmålene."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
-msgstr "Riscansiona questa tabella"
+msgstr "Skan denne tabellen på nytt"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
-msgstr "Aggiungi"
+msgstr "Legg til"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 msgid "Not a valid formatted email address"
-msgstr "Indirizzo email formattato non correttamente"
+msgstr "Ikke ett gyldig format på e-post adresse"
 
 #: frontend/src/metabase/entities/users/forms.js:14
 msgid "First name"
-msgstr "Nome"
+msgstr "Fornavn"
 
 #: frontend/src/metabase/entities/users/forms.js:20
 msgid "Last name"
-msgstr "Cognome"
+msgstr "Etternavn"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
-msgstr "Indirizzo email"
+msgstr "E-post adresse"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "Gruppi di Sicurezza"
+msgstr "Tillatelsesgrupper"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
-msgstr "Rendi admin questo user"
+msgstr "Gjør denne bruker til administrator"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "Tutti gli utenti appartengono al gruppo {0} e non possono essere rimossi da esso. L'impostazione dei permessi per questo gruppo è un ottimo modo per \n"
-"assicurarti di sapere quali nuovi utenti di Metabase saranno in grado di vedere."
+msgstr "Alle brukere tilhører {0}-gruppen og kan ikke fjernes fra den. Innstilling av rettigheter for denne gruppen er en bra måte å være sikker på at du vet hva nye Metabase-brukere i denne gruppen har lov til å se."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "Questo è un gruppo speciale i cui membri possono vedere tutto dell'istanza di Metabase e chi vi accede può apportare modifiche alle\n"
-"impostazioni nel Pannello di amministrazione, compresi i permessi di modifica! Quindi, aggiungi le persone a questo gruppo con cura."
+msgstr "Dette er en spesiell gruppe, og dens medlemmer kan se alt i denne Metabase-instansen. Medlemmer av denne gruppen kan også gjøre endringer i Administrasjonspanelet, inkludert endring av tillatelser! Så, vær forsiktig når du legger til brukere i denne gruppen."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Per essere sicuro di non restare bloccato da Metabase, deve sempre esserci almeno un utente in questo gruppo."
+msgstr "For å sikre at du ikke blir låst ute av Metabase, må det alltid være igjen en bruker i denne gruppen."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "Utenti"
+msgstr "Medlemmer"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -902,66 +901,67 @@ msgstr "Utenti"
 #: frontend/src/metabase/lib/core.js:146
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:298
 msgid "Email"
-msgstr "Email"
+msgstr "E-post"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "Un gruppo é tanto buono quanto lo sono i suoi membri."
+msgstr "En gruppe er kun like bra som sine medlemmer."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:55
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Admin"
-msgstr "Admin"
+msgstr "Administrator"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:230
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:288
 msgid "and"
-msgstr "e"
+msgstr "og"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} altro gruppo"
-msgstr[1] "{0} altri gruppi"
+msgstr[0] "{0} annen gruppe"
+msgstr[1] "{0} andre grupper"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "Default"
+msgstr "Standard"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "Qualcosa simile a \"marketing\""
+msgstr "Noe sånt som \"markedsføring\""
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "Rimuovere questo gruppo?"
+msgstr "Fjern denne gruppen?"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "Sei sicuro? Tutti i membri di questo gruppo perderanno tutti i permessi basati su di esso. Operazione irreversibile."
+msgstr "Er du sikker? Alle medlemmer av denne gruppen vil miste tilganger fra denne gruppen.\n"
+"Denne kan ikke bli gjennopprettet."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "Sì"
+msgstr "Ja"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "No"
+msgstr "Nei"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "Modifica nome"
+msgstr "Rediger navn"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "Rimuovi gruppo"
+msgstr "Fjern gruppe"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -977,11 +977,11 @@ msgstr "Rimuovi gruppo"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:334
 msgid "Done"
-msgstr "Fatto"
+msgstr "Ferdig"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "Nome del gruppo"
+msgstr "Gruppenavn"
 
 #: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
@@ -991,386 +991,384 @@ msgstr "Nome del gruppo"
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
-msgstr "Gruppi"
+msgstr "Grupper"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "Crea un gruppo"
+msgstr "Opprett en gruppe"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "Puoi utilizzare i gruppi per controllare l'accesso dei tuoi utenti ai tuoi dati. Metti gli utenti in gruppi e poi vai alla sezione Permessi per controllare l'accesso di ciascun gruppo. I gruppi 'Amministratori' (Administrators) e 'Tutti gli utenti' (All Uses) sono gruppi predefiniti speciali che non possono essere rimossi."
+msgstr "Du kan bruke grupper for og kontrollere din brukers tilgang til dataene. Putt brukere i grupper og endre hver gruppes tilgang under tilgangseksjonen. Gruppene \"Administratorer\" og \"Alle brukere\" er spesielle grupper som ikke kan slettes."
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "Modifica dettagli"
+msgstr "Rediger detaljer"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "Rimanda invito"
+msgstr "Send invitasjon på nytt"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "Password dimenticata"
+msgstr "Tilbakestill passord"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "Disattiva"
+msgstr "Deaktiver"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:21
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:93
 #: frontend/src/metabase/nav/containers/Navbar.jsx:235
 msgid "People"
-msgstr "Persone"
+msgstr "Folk"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "Chi vuoi aggiungere?"
+msgstr "Hvem vil du legge til?"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "Modifica i dettagli di  {0}"
+msgstr "Rediger {0}s detaljer"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "{0} è stato aggiunto"
+msgstr "{0} har blitt lagt til"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "Aggiungi un'altra persona"
+msgstr "Legg til enda en person"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "Non è stato possibile inviare agli utenti un invito via email, \n"
-"assicurati di comunicare di accedere utilizzando {0} \n"
-"e questa password che abbiamo generato:"
+msgstr "Vi klarte ikke å sende dem en e-post invitasjon, vennligst sørg for at du forklarer at de logger inn med {0} og dette passordet vi har generert for dem:"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "Se vuoi essere in grado di inviare inviti e-mail, vai alla pagina {0}."
+msgstr "Hvis du vil ha muligheten til å sende e-post invitasjoner, gå til denne siden {0}."
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "Abbiamo inviato un invito a {0} con le istruzioni per impostare la password."
+msgstr "Vi har sendt ut en invitasjon til {0} med instruksjoner om å sette passordet sitt."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "Sono stati inviati gli inviti di {0}"
+msgstr "Vi har sendt ut invitasjon på nytt til {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:24
 msgid "Okay"
-msgstr "Ok"
+msgstr "Okei"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr " Qualsiasi email precedente inviti non funzionerà più."
+msgstr "Tidligere sendte invitasjoner vil ikke fungere lenger."
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "Disattiva {0}?"
+msgstr "Deaktiver {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0} non sarà più in grado di accedere."
+msgstr "{0} vil ikke kunne logge inn lenger."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "Vuoi riattivare l'account di {0}?"
+msgstr "Reaktiver {0} sin konto?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "Riattivare"
+msgstr "Reaktiver"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "Saranno in grado di accedere di nuovo e verranno reinseriti nei gruppi in cui si trovavano prima che il loro account fosse disattivato."
+msgstr "De vil kunne logge inn igjen, de vil da bli plassert tilbake i gruppene de var i før de ble deaktiverte."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "Reimposta la password di {0}?"
+msgstr "Tilbakestill {0} sitt passord?"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:76
 msgid "Reset"
-msgstr "Reset"
+msgstr "Tilbakestill"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
-msgstr "Sei sicuro di volerlo fare?"
+msgstr "Er du sikker du vil gjøre dette?"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "La password di {0} è stata ripristinata"
+msgstr "{0} sitt passord har blitt nullstilt"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "Ecco una password temporanea si può utilizzare per accedere ,sucessivamente modificare la password"
+msgstr "Her er ett midlertidig passord de kan bruke for å logge inn og bytte passordet."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "Abbiamo spedito una email con le istruzioni per creare una nuova password"
+msgstr "Vi har sendt dem en e-post med instruksjoner for å lage ett nytt passord."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:15
 msgid "Active"
-msgstr "Attivo"
+msgstr "Aktiv"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "Deattivato"
+msgstr "Deaktivert"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "Aggiungi qualcuno"
+msgstr "Legg til noen"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "Ultimo Login"
+msgstr "Siste innlogging"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:154
 msgid "Signed up via Google"
-msgstr "Iscritto  tramite  Google"
+msgstr "Meldt inn via Google"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:159
 msgid "Signed up via LDAP"
-msgstr "Accesso con LDAP"
+msgstr "Meldt inn via LDAP"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:171
 msgid "Reactivate this account"
-msgstr "Riattivare questo account"
+msgstr "Reaktiver denne kontoen"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:195
 msgid "Never"
-msgstr "Mai"
+msgstr "Aldri"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0} tabella"
-msgstr[1] "{0} tabelle"
+msgstr[0] "{0} tabell"
+msgstr[1] "{0} tabeller"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr " sarà "
+msgstr " vil bli "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "Accesso permesso a"
+msgstr "gitt tilgang til"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr " e "
+msgstr " og "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "Accesso proibito a"
+msgstr "nektet tilgang til"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr " non sarà più in grado di "
+msgstr " vil ikke lenger kunne "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr " non sarà in grado di "
+msgstr "vil nå kunne "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr " query native per "
+msgstr " lokal spørring for "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:14
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Permissions"
-msgstr "Permessi"
+msgstr "Tillatelser"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "Salvare i permessi?"
+msgstr "Lagre tillatelser?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 msgid "Save Changes"
-msgstr "Salva le modifiche"
+msgstr "Lagre endringer"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "Scartare le modifiche?"
+msgstr "Forkast endringer?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "Nessun cambiamento ai permessi sará fatto"
+msgstr "Ingen endringer i tillatelser vil bli gjort."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "Hai cambiato i permessi"
+msgstr "Du har gjort endringer med tilganger"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
-msgstr "Permessi per questa collection"
+msgstr "Tilganger for denne samlingen"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:81
 msgid "You have unsaved changes"
-msgstr "Hai modifiche non salvate"
+msgstr "Du har ulagrede endringer"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:82
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "Vuoi lasciare questa pagina e scartare le tue modifiche?"
+msgstr "Vil du gå bort fra siden uten å lagre endringene?"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:129
 msgid "Sorry, an error occurred."
-msgstr "Spiacenti, si é verificato un errore"
+msgstr "Beklager, en feil oppstod."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:71
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "Gli amministratori hanno sempre il più alto livello di accesso a tutto Metabase."
+msgstr "Administratorer har alltid høyeste tilgangsnivå til alt i Metabase."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:73
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "Ogni utente di Metabase appartiene al gruppo 'Tutti gli utenti' (All Users). Se si desidera limitare o limitare l'accesso di un gruppo a qualcosa, assicurarsi che il gruppo 'Tutti gli utenti' abbia un livello di accesso uguale o inferiore."
+msgstr "Hver Metabase bruker tilhører i \"alle brukere\" gruppen. Hvis du vil begrense gruppe tilgang til noe, valider om \"alle brukere\" gruppen har samme eller mindre nivå med tilganger."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:75
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBot è il bot Slack di Metabase. Puoi scegliere a cosa può accedere qui."
+msgstr "MetaBot er Metabase sin Slack-bot. Du kan velge hva den skal ha tilgang til her."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:128
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "Il \"{0}\" gruppo può avere accesso a un diverso insieme di {1} rispetto a questo gruppo, che può dare a questo gruppo ulteriore accesso ad alcune {2}."
+msgstr "Gruppen {0} kan ha tilgang til et annet sett av {1} enn denne gruppen, som kan gi gruppen tilgang til noe av {2}"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:131
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "Il gruppo \"{0}\" ha un livello di accesso superiore a questo, per cui sarà sostutuita questa impostazione. Devi limitare o revocare l'accesso del gruppo \"{1}\" a questo elemento."
+msgstr "\"{0}\"-gruppen har et høyere nivå av adgang enn dette, det vil overstyre denne innstillingen. Du bør begrense eller fjerne \"{1}\"-gruppens tilgang til denne ressursen."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "Limita"
+msgstr "Grense"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "Revoca"
+msgstr "Fjern"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "accesso anche se \"{0}\" ha un accesso maggiore?"
+msgstr "tilgang selv om \"{0}\" har høyere tilgangsnivå?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "Limita l'accesso"
+msgstr "Tilgangsgrense"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 #: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
-msgstr "Revoca L'accesso"
+msgstr "Fjern tilgang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "Modificare l'accesso a questo database a limitato?"
+msgstr "Bytt tilgang til denne databasen til begrenset?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "Cambia"
+msgstr "Bytt"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "Consenti scrittura di query?"
+msgstr "Tillatt direkte spørringer?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "Questo cambierà anche l'accesso ai dati di questo gruppo a 'Non ristretto' (Unrestricted) per questo database."
+msgstr "Dette vil også endre denne gruppens data tilgang til ubegrenset for denne databasen."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "Permetto"
+msgstr "Tillatt"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "Revocare l'accesso a tutte le tabelle?"
+msgstr "Fjern tilgang til alle tabeller?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "Questo revocherà anche l'accesso di questo gruppo alle query per questo database."
+msgstr "Dette vil også fjerne denne gruppens tilgang til rå spørringer for denne databasen."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "Concedere l'accesso illimitato"
+msgstr "Gi ubegrenset tilgang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "Accesso Illimitato"
+msgstr "Ubegrenset tilgang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "Acceso limitato"
+msgstr "Begrenset tilgang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "Accesso Negato"
+msgstr "Ingen tilgang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "Scrivi Query"
+msgstr "Skriv rå spørringer"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "Puoi scrivere query brutali"
+msgstr "Kan skrive direkte spørringer"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "Cura la collezione"
+msgstr "Organiser samlingen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "Vedi collezione"
+msgstr "Vis samling"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:352
 #: frontend/src/metabase/admin/permissions/selectors.js:463
 #: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
-msgstr "Accesso ai dati"
+msgstr "Tilgang til data"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:528
 #: frontend/src/metabase/admin/permissions/selectors.js:683
 #: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
-msgstr "Vedi tabelle"
+msgstr "Vis tabeller"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
-msgstr "SQL query"
+msgstr "SQL spørsmål"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
-msgstr "Vedi schemi"
+msgstr "Vis skjemaer"
 
 #: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
-msgstr "Modello dei dati"
+msgstr "Datamodell"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 #: frontend/src/metabase/plugins/builtin/auth/google.js:31
 msgid "Sign in with Google"
-msgstr "Accesso con Google"
+msgstr "Loginn med Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 #: frontend/src/metabase/plugins/builtin/auth/google.js:32
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Consente agli utenti con account Metabase esistenti di accedere con un account Google che corrisponda al loro indirizzo email oltre al nome utente e alla password di Metabase."
+msgstr "Tillat brukere med eksisterende Metabase konto å logge inn med en Google konto som tilsvarer deres e-postadresse i tillegg til Metabase brukernavn og passord."
 
 #: frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx:24
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "Configurare"
+msgstr "Konfigurer"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:20
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:15
@@ -1378,46 +1376,47 @@ msgid "LDAP"
 msgstr "LDAP"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:16
+#, fuzzy
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "Consente agli utenti all'interno della directory LDAP di accedere a Metabase con le proprie credenziali LDAP e consente la mappatura automatica dei gruppi LDAP ai gruppi di metabase."
+msgstr "Tillat brukere innenfor din LDAP katalog til å logge inn på Metabase med deres LDAP konto, i tillegg til at Metabase kan tildele Metabase grupper som tilsvarer LDAP grupper."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
 #: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
-msgstr "Email non valida"
+msgstr "Det er ikke en gyldig e-postadresse"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
-msgstr "Intero non valido"
+msgstr "Det er ikke ett heltall"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:230
 msgid "Changes saved!"
-msgstr "Modifiche Salvate!"
+msgstr "Endringer lagret!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:180
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:139
 msgid "Looks like we ran into some problems"
-msgstr "Mi"
+msgstr "Ser ut som det har oppstått noen problemer"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:19
 msgid "Send test email"
-msgstr "Spedisci email di test"
+msgstr "Send test e-post"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:20
 msgid "Sending..."
-msgstr "Invio..."
+msgstr "Sender..."
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:21
 msgid "Sent!"
-msgstr "Inviato!"
+msgstr "Sendt!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:93
 msgid "Clear"
-msgstr "Pulisci"
+msgstr "Rens"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
@@ -1425,91 +1424,92 @@ msgstr "Pulisci"
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
-msgstr "Autenticazione"
+msgstr "Autentisering"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
-msgstr "Parametri Server"
+msgstr "Tjenerinstillinger"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:36
 msgid "User Schema"
-msgstr "Schema Utente"
+msgstr "Bruker skjema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:40
 msgid "Attributes"
-msgstr "Attributi"
+msgstr "Attributter"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
-msgstr "Schema Gruppo"
+msgstr "Gruppe skjema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:33
 msgid "Using "
-msgstr "Usando "
+msgstr "Bruker "
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "Prepararsi"
+msgstr "Blir satt opp"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Alcune cose che puoi fare per ottenere il massimo da Metabase."
+msgstr "Ett par ting du kan gjøre for å få mest mulig ut av Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "Prossimo passo (raccomandato)"
+msgstr "Anbefalt neste steg"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "Google Sign-In"
+msgstr "Google innlogging"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "Per consentire agli utenti di accedere con Google, devi fornire a Metabase un ID client dell'applicazione Google Developers Console. Ci vogliono solo pochi passi e le istruzioni su come creare una chiave possono essere trovate {0}"
+msgstr "For å tillate at brukere logger på via Google må du gi Metabase en Google Developers console application client ID. Det tar kun noen få steg og instruksjoner for å lage en nøkkel kan finnes {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:140
 msgid "Your Google client ID"
-msgstr "il tuo Google ID"
+msgstr "Din Google klient ID"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:145
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Consenti agli utenti di registrarsi da soli se il loro indirizzo email dell'account Google proviene da:"
+msgstr "Tillatt brukere å registrere seg hvis Google-kontoen kommer fra:"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:249
 msgid "Answers sent right to your Slack #channels"
-msgstr "Le risposte vengono inviate direttamente ai tuoi #channels di Slack"
+msgstr "Svar er sendt direkte til din Slack #kanaler"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:258
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "Crea un Utente Bot Slack per MetaBot"
+msgstr "Lag en Slack Bot bruker for MetaBot"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:268
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "Una volta che sei lì, dagli un nome e fai clicca {0}. Quindi copia e incolla il token API Bot nel campo sottostante. Una volta terminato, crea un canale \"metabase_files\" in Slack. Metabase ha bisogno di questo per caricare grafici."
+msgstr "Når du er der, gi den ett navn og klikk på {0}.\n"
+"Kopier og lim inn Bot API nøkkel i understående felt. Når du er ferdig, lag en \"metabase_files\" kanal i Slack. Metabase trenger denne til å laste opp grafer."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:17
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "Stai usando Metabase {0} che é l'ultimo e il migliore!"
+msgstr "Du bruker Metabase {0} som er den siste og beste!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "É disponibile Metabase {0}. La versione in uso é la {1}."
+msgstr "Metabase {0} er tilgjengelig. Du bruker {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:41
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:113
 msgid "Update"
-msgstr "Aggiornare"
+msgstr "Oppdater"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:46
 msgid "What's Changed:"
-msgstr "Cos'è cambiato:"
+msgstr "Hva som blir endret:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "Aggiungi una mappa"
+msgstr "Legg til kart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
@@ -1517,11 +1517,11 @@ msgstr "Aggiungi una mappa"
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
-msgstr "URL"
+msgstr "Nettlink"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "Cancellare mappa personalizzata"
+msgstr "Slett tilpasset kart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
@@ -1532,7 +1532,7 @@ msgstr "Cancellare mappa personalizzata"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
-msgstr "Rimuovere"
+msgstr "Slett"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
@@ -1540,332 +1540,331 @@ msgstr "Rimuovere"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
-msgstr "Seleziona..."
+msgstr "Velg..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "Valori di esempio:"
+msgstr "Prøve verdier:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "Aggiungi una nuova mappa"
+msgstr "Legg til nytt kart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "Modifica mappa"
+msgstr "Endre kart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "Come vuoi chiamare questa mappa?"
+msgstr "Hva vil du kalle dette kartet?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "p.es. United Kingdom, Brazil, Mars"
+msgstr "Eksempel Norge, Europa, Månen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "URL per il file GeoJSON che vuoi usare"
+msgstr "Nettlink for GeoJSON fil du vil bruke"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "Come https://my-mb-server.com/maps/my-map.json"
+msgstr "Eksempel https://min-mb-tjener.no/kart/mitt-kart.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "Aggiorna"
+msgstr "Oppdater"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "Carica"
+msgstr "Last inn"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "Quale proprietà specifica l'identificativo della regione?"
+msgstr "Hvilken verdi spesifiserer regionale identifikatorer?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "Quale proprietà specifica il nome da mostrare della regione?"
+msgstr "Hvilken verdi spesifiserer regionens visningsnavn?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "Carica un file GeoJSON per vedere l'anteprima"
+msgstr "Last inn en GeoJSON-fil for å se en forhåndsvisning"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "Salva mappa"
+msgstr "Lagre kart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "Aggiungi mappa"
+msgstr "Legg til kart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "Usa la modalità \"embedded\""
+msgstr "Bruk innebygging"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "Abilitando l'incorporamento accetti la licenza di incorporamento situata in"
+msgstr "Ved å aktivere innebygging er du enig med innebygging lisensen som fins her"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "In italiano semplice, quando si incorporano grafici o 'dashboard' da Metabase nella propria applicazione, tale applicazione non è soggetta alla 'Affero General Public License' che copre il resto di Metabase, purché si mantenga visibile il logo della metabase e il \"Powered by Metabase\" su quegli elementi inclusi. Tuttavia, dovresti leggere il testo della licenza linkato in alto, poiché questa è la licenza effettiva a cui dovrai accettare abilitando questa funzione."
+msgstr "Kort oppsummert, når du bygger inn grafer eller infotavler fra Metabase i din egen applikasjon, så blir ikke den applikasjonen underlagt \"Affero General Publicus Lovende\" som dekker resten av Metabase, så lenge Metabase-logoen og teksten \"Powered by Metabase\" er synlig på alle innbygginger. Du burde uansett lese selve lisensen lenket til ovenfor ettersom det er den faktiske lisensen som du godtar ved å aktivere denne funksjonen."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "Abilita"
+msgstr "Aktiver"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "Abilitazione Premium \"embedding \" attivata"
+msgstr "Premium innebygging aktivert"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Inserisci il token che hai comprato dal negozio Metabase"
+msgstr "Legg inn nøkkelen du kjøpte fra Metabase butikken"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "il Premium ti consente di disattivare 'Powered by Metabase' nelle dashboard e domande embeddate"
+msgstr "Premium innebygging lar deg inaktiveres \"Powered by Metabase\" på innebygde infotavler og spørsmål."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "Acquista un token"
+msgstr "Kjøp en nøkkel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "Inserisci un Token"
+msgstr "Legg inn en nøkkel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
-msgstr "Modifica Mapping"
+msgstr "Rediger tilordninger"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
-msgstr "Raggruppa Mapping"
+msgstr "Grupper tilordninger"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
-msgstr "Crea Mapping"
+msgstr "Lag en tilordning"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "I mapping consentono a Metabase di aggiungere e rimuovere automaticamente utenti dai gruppi in base alle informazioni sull'appartenenza fornite dal server di directory \n"
-". L'appartenenza al gruppo di amministrazione può essere concessa tramite associazioni, ma non verrà automaticamente rimossa come misura \n"
-"failsafe."
+msgstr "Tilordninger tillater Metabase å automatisk legge til og fjerne brukere fra grupper basert på medlemsinformasjonen i LDAP-tjeneren. Medlemskap i Admin-gruppen kan gies gjennom tilordningene, men vil ikke automatisk fjernes som sikring mot å bli låst ute."
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:107
 msgid "Distinguished Name"
-msgstr "Nome distinto"
+msgstr "Unikt navn"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "Link Pubblico"
+msgstr "Offentlig link"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "Revoca Link"
+msgstr "Tilbakekall linken"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "Vuoi disabilitare questo link"
+msgstr "Deaktiver nettlinken?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "Non funzioneranno più e non possono essere ripristinati, ma puoi creare nuovi collegamenti."
+msgstr "De vil ikke fungere lenger, og de kan ikke tilbakekalles, men du kan lage nye nettlinker."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
+#, fuzzy
 msgid "Public Dashboard Listing"
-msgstr "Lista delle 'dashboard' pubbliche"
+msgstr "Offentlig oppføring av infotavle"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "Nessuna dashboard è stato ancora pubblicamente condivisa."
+msgstr "Ingen infotavler har blitt offentlig publisert enda."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "Lista delle card pubbliche"
+msgstr "Offentlig kortvisning"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "Nessuna domanda è stato ancora pubblicamente condivisa."
+msgstr "Ingen spørsmål har blitt offentlig publisert enda "
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "Lista delle  'dashboard'  inserite"
+msgstr "Innebygd visning av infotavle"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "Nessuna 'dashboard' è stata ancora inserita"
+msgstr "Ingen infotavler har blitt bygget inn som en del av en annen side enda."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "Lista delle card incorporate"
+msgstr "Innebygd kortvisning"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "Nessuna domanda è stata ancora incorporata."
+msgstr "Ingen spørsmål har blitt innebygd enda."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "Rigenerare la chiave incorporata?"
+msgstr "Lag ny innebyggingsnøkkel?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "Ciò causerà l'interruzione del funzionamento delle parti incorporate esistenti finché non vengono aggiornati con la nuova chiave"
+msgstr "Dette vil få eksisterende innebygginger til å stoppe å virke til de er oppdatert med ny nøkkel."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "Chiave rigenerata"
+msgstr "Lag nøkkel på nytt"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "Chiave generata"
+msgstr "Lag nøkkel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enabled"
-msgstr "Abilitata"
+msgstr "Aktivert"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:93
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "Disabilitato"
+msgstr "Deaktivert"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:113
 msgid "Unknown setting {0}"
-msgstr "Impostazione sconosciuta {0}"
+msgstr "Ukjent innstilling {0}"
 
 #: frontend/src/metabase/admin/settings/selectors.js:37
 msgid "Setup"
-msgstr "Imposta"
+msgstr "Oppsett"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:214
 #: frontend/src/metabase/admin/settings/selectors.js:42
 msgid "General"
-msgstr "Generale"
+msgstr "Generelt"
 
 #: frontend/src/metabase/admin/settings/selectors.js:46
 msgid "Site Name"
-msgstr "Nome del Sito"
+msgstr "Sidenavn"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Site URL"
-msgstr "URL del sito"
+msgstr "Side nettlink"
 
 #: frontend/src/metabase/admin/settings/selectors.js:64
 msgid "Email Address for Help Requests"
-msgstr "Indirizzo email per richieste di assistenza"
+msgstr "E-postadresse for hjelp"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
-msgstr "Segnala fuso orario"
+msgstr "Rapportering tidssone"
 
 #: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
-msgstr "Database predefinito"
+msgstr "Database standard"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "Seleziona una timezone"
+msgstr "Velg en tidssone"
 
 #: frontend/src/metabase/admin/settings/selectors.js:75
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "Non tutti i database supportano i fusi orari, nel qual caso questa impostazione non avrà effetto."
+msgstr "Ikke alle databaser støtter tidssoner, hvilket gjør at denne innstillingen ikke vil ta effekt."
 
 #: frontend/src/metabase/entities/users/forms.js:34
 msgid "Language"
-msgstr "Lingua"
+msgstr "Språk"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "Seleziona una lingua"
+msgstr "Velg ett språk"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Anonymous Tracking"
-msgstr "Tracciamento Anonimo"
+msgstr "Anonym sporing"
 
 #: frontend/src/metabase/admin/settings/selectors.js:85
 msgid "Friendly Table and Field Names"
-msgstr "Nomi tabelle e campi amichevoli"
+msgstr "Vennlig tabell og feltnavn"
 
 #: frontend/src/metabase/admin/settings/selectors.js:91
 msgid "Only replace underscores and dashes with spaces"
-msgstr "Sostituisci solo caratteri di sottolineatura e trattini con spazi"
+msgstr "Erstatt understrek og bindestreker med mellomrom"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Enable Nested Queries"
-msgstr "Abilita le query annidate"
+msgstr "Aktiver nøstede spørringer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:110
 msgid "Updates"
-msgstr "Aggiornamenti"
+msgstr "Oppdateringer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "Check for updates"
-msgstr "Controlla Aggiornamenti"
+msgstr "Sjekk etter oppdateringer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:126
 msgid "SMTP Host"
-msgstr "Host SMTP"
+msgstr "SMTP vert"
 
 #: frontend/src/metabase/admin/settings/selectors.js:134
 msgid "SMTP Port"
-msgstr "Porta SMTP"
+msgstr "SMTP port"
 
 #: frontend/src/metabase/admin/settings/selectors.js:138
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:47
 msgid "That's not a valid port number"
-msgstr "Questo non e' un numero diporta valido"
+msgstr "Det er ikke ett gyldig port nummer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:142
 msgid "SMTP Security"
-msgstr "Tipo sicurezza SMTP"
+msgstr "SMTP sikkerhet"
 
 #: frontend/src/metabase/admin/settings/selectors.js:150
 msgid "SMTP Username"
-msgstr "SMTP Username"
+msgstr "SMTP brukernavn"
 
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "SMTP Password"
-msgstr "SMTP Password"
+msgstr "SMTP passord"
 
 #: frontend/src/metabase/admin/settings/selectors.js:164
 msgid "From Address"
-msgstr "\"Da\" Indirizzo"
+msgstr "Fra e-postadresse"
 
 #: frontend/src/metabase/admin/settings/selectors.js:178
 msgid "Slack API Token"
-msgstr "Slack API Token"
+msgstr "Slack API nøkkel"
 
 #: frontend/src/metabase/admin/settings/selectors.js:180
 msgid "Enter the token you received from Slack"
-msgstr "Inserisci il token di slack"
+msgstr "Legg inn nøkkelen du fikk fra Slack"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "Single Sign-On"
+msgstr "Singel innlogging"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:30
 msgid "LDAP Authentication"
-msgstr "Autenticazione LDAP"
+msgstr "LDAP autorisering"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:36
 msgid "LDAP Host"
-msgstr "LDAP Host"
+msgstr "LDAP vert"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:44
 msgid "LDAP Port"
-msgstr "Porta LDAP"
+msgstr "LDAP port"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:51
 msgid "LDAP Security"
-msgstr "Sicurezza LDAP"
+msgstr "LDAP sikkerhet"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:59
 msgid "Username or DN"
-msgstr "Username o DN"
+msgstr "Brukernavn eller DN"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:43
 #: frontend/src/metabase/entities/databases/forms.js:61
@@ -1873,259 +1872,260 @@ msgstr "Username o DN"
 #: frontend/src/metabase/user/components/UserSettings.jsx:66
 #: src/metabase/driver/common.clj
 msgid "Password"
-msgstr "Password"
+msgstr "Passord"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:69
+#, fuzzy
 msgid "User search base"
-msgstr "Base di ricerca degli utenti"
+msgstr "Bruker søkebase"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:75
 msgid "User filter"
-msgstr "Filtro utente"
+msgstr "Brukerfilter"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:81
 msgid "Check your parentheses"
-msgstr "Controlla le tue parentesi"
+msgstr "Sjekk dine parenteser"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
-msgstr "Attributo email"
+msgstr "E-post attributter"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
-msgstr "Attributo nome"
+msgstr "Fornavn attributter"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
-msgstr "Attributo cognome"
+msgstr "Etternavn attributter"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
-msgstr "Sincronizza le appartenenze ai gruppi"
+msgstr "Synkroniser gruppe medlemskap"
 
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:113
 msgid "Group search base"
-msgstr "Ricerca base gruppo"
+msgstr "Gruppesøkebase"
 
 #: frontend/src/metabase/admin/settings/selectors.js:201
 msgid "Maps"
-msgstr "Mappe"
+msgstr "Kart"
 
 #: frontend/src/metabase/admin/settings/selectors.js:205
 msgid "Map tile server URL"
-msgstr "URL del MAP TILE SERVER"
+msgstr "URL til tjener for kartfliser"
 
 #: frontend/src/metabase/admin/settings/selectors.js:206
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabase utilizza OpenStreetMaps per impostazione predefinita."
+msgstr "Metabase bruker OpenStreetMaps som standard"
 
 #: frontend/src/metabase/admin/settings/selectors.js:211
 msgid "Custom Maps"
-msgstr "Mappe personalizzate"
+msgstr "Egendefinerte kart"
 
 #: frontend/src/metabase/admin/settings/selectors.js:212
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "Aggiungi i tuoi file GeoJSON per abilitare visualizzazioni di mappe di regioni diverse"
+msgstr "Legg til din egen GeoJSON fil for å aktivere forskjellige regionale kartvisualiseringer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
-msgstr "Condivisione pubblica"
+msgstr "Offentlig deling"
 
 #: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
-msgstr "Abilita la condivisione pubblica"
+msgstr "Aktiver offentlig deling"
 
 #: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
-msgstr "'Dashboard' condivise"
+msgstr "Delte infotavler"
 
 #: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
-msgstr "Question condivise"
+msgstr "Delte spørsmål"
 
 #: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
-msgstr "Incorporamento in altre applicazioni"
+msgstr "Innebygd i andre applikasjoner"
 
 #: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "Abilita incorporamento di Metabase in altre applicazioni"
+msgstr "Aktiver innebygging av Metabase i andre applikasjoner"
 
 #: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
-msgstr "Chiave segreta incorporata"
+msgstr "Hemmelig innebyggingsnøkkel"
 
 #: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
-msgstr "'Dashboard' incorporate"
+msgstr "Innebygde infotavler"
 
 #: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
-msgstr "Question incorporate"
+msgstr "Innebygde spørsmål"
 
 #: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
-msgstr "Caching"
+msgstr "Mellomlagring"
 
 #: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
-msgstr "Abilita caching"
+msgstr "Aktiver mellomlagring"
 
 #: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
-msgstr "Durata minima Query"
+msgstr "Minimum spørringstid"
 
 #: frontend/src/metabase/admin/settings/selectors.js:353
+#, fuzzy
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "Moltiplicatore Time-To-Live (TTL) della cache"
+msgstr "Mellomlagre Time-To-Live (TTL) multiplikator"
 
 #: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
-msgstr "Dimensione massima della cache"
+msgstr "Maks mellomlagrings oppføringsstørrelse"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "Il tuo avviso è tutto configurato."
+msgstr "Dine varsel er satt opp."
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "L'avviso è stato aggiornato."
+msgstr "Dine varsler er oppdatert."
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "L'avviso è stato cancellato con successo."
+msgstr "Varselen ble vellykket slettet."
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "Per piacere inserisci un indirizzo email valido"
+msgstr "Vennligst skriv inn en gyldig e-postadresse."
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "La password non corrisponde"
+msgstr "Passordene er ikke like"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "Torna alla login"
+msgstr "Tilbake til innlogging"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "Nessun account Metabase esiste per questo account Google."
+msgstr "Ingen Metabase konto eksisterer for denne Google kontoen."
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Avrai bisogno di un amministratore per creare un account Metabase prima di poter utilizzare Google per accedere."
+msgstr "Du må ha en administrator for og lage en Metabase konto før du kan logge inn med Google kontoen."
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 msgid "Sign in with {0}"
-msgstr "Accedi con {0}"
+msgstr "Logg inn med {0}"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
-msgstr "Contatta un amministratore per fare in modo che reimposti la password"
+msgstr "Vennligst kontakt en administrator som kan tilbakestille passordet ditt"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
-msgstr "Password dimenticata"
+msgstr "Glemt passord"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
-msgstr "L'email che usi per il tuo account Metabase"
+msgstr "E-postadresse du bruker til din Metabase konto"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
-msgstr "Invia email di reimpostazione della password"
+msgstr "Send e-post for tilbskestilling av passord"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
-msgstr "Controlla la tua e-mail per le istruzioni su come reimpostare la password."
+msgstr "Sjekk din e-post konto for instruksjoner på hvordan du skal tilbakestille passordet."
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
-msgstr "Accedi a Metabase"
+msgstr "Logg inn på Metabase"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:165
 msgid "OR"
-msgstr "O"
+msgstr "ELLER"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
 msgid "Username or email address"
-msgstr "Username e indirizzo email"
+msgstr "Brukernavn eller e-postadresse"
 
 #: frontend/src/metabase/auth/components/AuthProviderButton.jsx:23
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:56
 msgid "Sign in"
-msgstr "Accedi"
+msgstr "Logg inn"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:79
 msgid "I seem to have forgotten my password"
-msgstr "Mi sembra di aver dimenticato la mia password"
+msgstr "Jeg har dessverre glemt passordet mitt"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
-msgstr "richiedi una nuova email di ripristino"
+msgstr "Be om en ny tilbakestillingsepost"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
-msgstr "Ops, questo è un link scaduto"
+msgstr "Oops, nettlinken har utløpt"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "Per motivi di sicurezza, i link di reimpostazione password scadono dopo un po 'di tempo. Se hai ancora bisogno\n"
-"per resettare la tua password, puoi {0}."
+msgstr "På grunn av sikkerhetsmessige grunner, passord tilbakestillingslinker utgår etter en liten stund. Hvis du fortsatt trenger å tilbakestille passordet, kan du {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
-msgstr "Nuova password"
+msgstr "Nytt passord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
-msgstr "Per proteggere i dati, password {0}"
+msgstr "For å holde dataen trygg er passordet {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "Crea una nuova password"
+msgstr "Lag ett nytt passord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:135
 msgid "Make sure its secure like the instructions above"
-msgstr "Assicurati che sia sicuro come le istruzioni sopra"
+msgstr "Forsikre deg om at det er sikkert som instruksjonene over"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:186
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:143
 msgid "Confirm new password"
-msgstr "Conferma la nuova password"
+msgstr "Bekreft nytt passord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:193
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:152
 msgid "Make sure it matches the one you just entered"
-msgstr "Assicurati che corrisponda a quello che hai appena inserito"
+msgstr "Forsikre deg om at det er likt som det du akkurat skrev inn"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
-msgstr "La tua password è stata appena reimpostata"
+msgstr "Passordet ditt har blitt tilbakestilt."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
-msgstr "Accedi con la tua nuova password"
+msgstr "Logg inn med ditt nye passord"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "salvataggio fallito"
+msgstr "Lagring feilet"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2133,7 +2133,7 @@ msgstr "salvataggio fallito"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "Salvato"
+msgstr "Lagret"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
@@ -2141,11 +2141,11 @@ msgstr "Ok"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
-msgstr "Archiviare questa collezione"
+msgstr "Arkiver denne samlingen?"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "Anche le 'dashboard', le collezioni, e i 'pulse' in questa collezione saranno archiviati"
+msgstr "Infotavlene, samlingene og pulsene i denne samlingen vil også bli arkivert."
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
 #: frontend/src/metabase/components/ArchiveModal.jsx:40
@@ -2160,19 +2160,19 @@ msgstr "Anche le 'dashboard', le collezioni, e i 'pulse' in questa collezione sa
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
 #: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
-msgstr "Archivia"
+msgstr "Arkiv"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:65
 msgid "This {0} has been archived"
-msgstr "Questo {0} è stato archiviato"
+msgstr "{0} har blitt arkiverr"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:710
 msgid "View the archive"
-msgstr "Vedi l'archivio"
+msgstr "Se arkivet"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "Annulla questo {0}"
+msgstr "Dearkiver {0}"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:46
 #: frontend/src/metabase/components/BrowseApp.jsx:112
@@ -2181,132 +2181,134 @@ msgstr "Annulla questo {0}"
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
-msgstr "I tuoi dati"
+msgstr "Vår data"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
 msgid "X-ray this table"
-msgstr "Verifica questa tabella"
+msgstr "Kjør X-ray på denne tabellen"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:171
 msgid "Learn about this table"
-msgstr "Ulteriori informazioni su questa tabella"
+msgstr "Lær mer om denne tabellen"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "click ripetuti"
+msgstr "Klikkende klikk"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "salvato!"
+msgstr "Lagret!"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "Salvataggio fallito."
+msgstr "Lagring feilet."
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Su"
-msgstr "Do"
+msgstr "Sø"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Mo"
-msgstr "Lu"
-
-#: frontend/src/metabase/components/Calendar.jsx:112
-msgid "Tu"
 msgstr "Ma"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
+msgid "Tu"
+msgstr "Ti"
+
+#: frontend/src/metabase/components/Calendar.jsx:112
 msgid "We"
-msgstr "Me"
+msgstr "On"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Th"
-msgstr "Gio"
+msgstr "To"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Fr"
-msgstr "Ve"
+msgstr "Fr"
 
 #: frontend/src/metabase/components/Calendar.jsx:112
 msgid "Sa"
-msgstr "Sa"
+msgstr "Lø"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "La tua email d'amministratore"
+msgstr "Din administrator e-postadresse"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "Per inviare {0},  devi {1} integrare."
+msgstr "For og sende {0} må du sette opp {1} integrasjonen."
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr " oppure "
+msgstr " eller "
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "Per inviare {0}, un amministratore deve impostare l'integrazione {1}."
+msgstr "For og sende {0} må en administrator sette opp {1} integrasjonen."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "Questa collezione è vuota, come una tela bianca"
+msgstr "Denne samlingen er tom, som ett tomt lerret"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "Puoi utilizzare le raccolte per organizzare e raggruppare dashboard, domande e spunti per la tua squadra o per te stesso"
+msgstr "Du kan bruke samlinger for å organisere og gruppere infotavler, spørsmål og pulser for ditt lag eller deg selv."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "Crea una nuova collezione"
+msgstr "Lag en ny samling"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "Le dashboard ti consentono di raccogliere e condividere i dati in un'unica posizione."
+msgstr "Infotavler lar deg samle og dele data fra ett sted."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "Le pulsazioni ti consentono di inviare gli ultimi dati al tuo team in base a una temporizzazione via email o slack."
+msgstr "Pulser lar deg sende ut de siste dataene til ditt lag regelmessig via e-post eller Slack."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
+#, fuzzy
 msgid "Questions are a saved look at your data."
-msgstr "Le richieste (question) sono una vista salvata dei tuoi dati."
+msgstr "Spørsmål er en lagret visning av dataene dine."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
+#, fuzzy
 msgid "Pins"
-msgstr "Fissa"
+msgstr "Festet"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "Trascina qualcosa qui per fissarlo in cima"
+msgstr "Dra noe hit for og feste det til toppen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
-msgstr "Collezioni"
+msgstr "Samlinger"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:452
 msgid "Drag here to un-pin"
-msgstr "Trascian qui per sbloccare"
+msgstr "Dra hit for og fjerne festet"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:487
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0} elemento selezionato"
-msgstr[1] "{0} elementi selezionati"
+msgstr[0] "{0} element valgt"
+msgstr[1] "{0} elementer valgt"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:517
 msgid "Move {0} items?"
-msgstr "Vuoi spostare {0} elementi"
+msgstr "Flytt {0} elementer"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:518
 msgid "Move \"{0}\"?"
-msgstr "Vuoi spostare \"{0}\"?"
+msgstr "Flytt \"{0}\"?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:623
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2315,84 +2317,84 @@ msgstr "Vuoi spostare \"{0}\"?"
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
-msgstr "Sposta"
+msgstr "Flytt"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:687
 msgid "Edit this collection"
-msgstr "Modifica la collezione"
+msgstr "Rediger denne samlingen"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:695
 msgid "Archive this collection"
-msgstr "Archivia questa collezione"
+msgstr "Arkiver denne samlingen"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "La mia collezione personale"
+msgstr "Min personlige samling"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "Nuova collezione"
+msgstr "Ny samling"
 
 #: frontend/src/metabase/components/CopyButton.jsx:36
 msgid "Copied!"
-msgstr "Copiato!"
+msgstr "Kopiert!"
 
 #: frontend/src/metabase/entities/databases/forms.js:14
 msgid "Use an SSH-tunnel for database connections"
-msgstr "Usa un tunnel-SSH per le connessioni col database"
+msgstr "Bruk en SSH-tunnel for database tilkoblinger"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "È possibile accedere ad alcune installazioni di database solo collegandosi tramite un host protetto SSH.\n"
-"Questa opzione fornisce anche un ulteriore livello di sicurezza quando una VPN non è disponibile.\n"
-"Abilitare ciò è di solito più lento rispetto ad una connessione diretta."
+msgstr "Noen databaseinstallasjoner kan kun kobles til gjennom en SSH bastion-vert.\n"
+"Dette alternativet gir også et ekstra lag med sikkerhet når VPN ikke er tilgjengelig.\n"
+"Det er vanligvis treigere enn en direkte tilkobling."
 
 #: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "Questo è un database grande, quindi lasciami scegliere quando Metabase deve sincronizzare e scansionare"
+msgstr "Dette er en stor database, så la meg velge når Metabase synkroniserer og skanner."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "Come impostazione predefinita, Metabase esegue una sincronizzazione oraria leggera e un'analisi giornaliera intensiva dei valori dei campi.\n"
-"Se si dispone di un database di grandi dimensioni, si consiglia di attivarlo e rivedere quando e con quale frequenza si verificano le scansioni dei valori di campo."
+msgstr "Som standard kjører Metabase en lettvekts-synkronisering hver time og en intensiv daglig skann av feltverdier.\n"
+"Hvis du har en stor database anbefaler vi at du slår på dette og følger med på når og hvor ofte feltverdi-skanningen skjer."
 
 #: frontend/src/metabase/entities/databases/forms.js:113
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "{0} per generare un ID client e un client segreto per il progetto."
+msgstr "{0} for å generere en Klient ID og en Klient Hemmelighet for ditt prosjekt."
 
 #: frontend/src/metabase/entities/databases/forms.js:115
 #: frontend/src/metabase/entities/databases/forms.js:130
 #: frontend/src/metabase/entities/databases/forms.js:166
 msgid "Click here"
-msgstr "Clicca qui"
+msgstr "Klikk her"
 
 #: frontend/src/metabase/entities/databases/forms.js:118
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "Scegli \"Altro\" come tipo di applicazione. Chiamalo come preferisci."
+msgstr "Velg \"Annet\" som applikasjonstype. Gi den det navnet du vil."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:357
 msgid "{0} to get an auth code"
-msgstr "{0} per prendere un codice di autenticazione"
+msgstr "{0} for å få en autentiseringskode"
 
 #: frontend/src/metabase/entities/databases/forms.js:142
 msgid "with Google Drive permissions"
-msgstr "con i permessi di Google Drive"
+msgstr "Med Google Drive tillatelse"
 
 #: frontend/src/metabase/entities/databases/forms.js:164
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "Per usare Metabase con questi dati, devi abilitare l'accesso API nella console degli sviluppatori Google (Google Developers Console)."
+msgstr "For å bruke Metabase med disse dataene må du aktivere API tilgang i Google Developers Console. "
 
 #: frontend/src/metabase/entities/databases/forms.js:165
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "{0} per andare alla console se non lo hai già fatto"
+msgstr "{0} for å gå til konsollen hvis du ikke allerede har gjort det."
 
 #: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
-msgstr "Come vorresti fare riferimento a questo database?"
+msgstr "Hvordan vil du referere til denne databasen?"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:187
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2403,148 +2405,149 @@ msgstr "Come vorresti fare riferimento a questo database?"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:126
 #: frontend/src/metabase/setup/components/UserStep.jsx:93
 msgid "Next"
-msgstr "Successivo"
+msgstr "Neste"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "Cancella questo {0}"
+msgstr "Slett denne {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "Blocca questo elemento"
+msgstr "Fest dette elementet"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "Sposta questo elemento"
+msgstr "Flytt dette elementet"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:21
 msgid "Edit this question"
-msgstr "Modifica questa domanda (question)"
+msgstr "Rediger dette spørsmålet"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "Tipo di azione"
+msgstr "Handlingstype"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:26
 msgid "View revision history"
-msgstr "Vedi storia di revisione"
+msgstr "Vis revisjonshistorikk"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "Sposta l'azione"
+msgstr "Flytt handling"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "Archivia azione"
+msgstr "Arkiver handling"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:31
 msgid "Add to dashboard"
-msgstr "Aggiungi alla 'dashboard'"
+msgstr "Legg til infotavle"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "Scarica i risultati"
+msgstr "Last ned resultater"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/dashboard/containers/DashboardEmbedWidget.jsx:53
 msgid "Sharing and embedding"
-msgstr "Condividi e incorpora"
+msgstr "Deling og innebygging"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "Un altro tipo di azione"
+msgstr "Andre handlingstyper"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "Ricevi avvisi su questo"
+msgstr "Få varsler om dette"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "Mostra SQL"
+msgstr "Vis SQL'en"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "Segmenti per questo"
+msgstr "Segmenter for dette"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "Mostra dettagli di errore"
+msgstr "Vis feil detaljer"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "Qui c'è un messaggio completo di errore"
+msgstr "Her er hele feilmeldingen"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "Ciao, sono Metabot"
+msgstr "Hei, MetaBot her."
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "Basato sullo schema"
+msgstr "Basert på skjemaet"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
+#, fuzzy
 msgid "A look at your"
-msgstr "Uno sguardo alla tua"
+msgstr "En kikk på din"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
-msgstr "Cerca la lista"
+msgstr "Søk i listen"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
-msgstr "Cercato da {0}"
+msgstr "Søk med {0}"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
-msgstr " o inserisci un ID"
+msgstr " eller skriv inn en ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
-msgstr "Inserisci un ID"
+msgstr "Skriv inn en ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
-msgstr "Inserisci un numero"
+msgstr "Skriv inn et tall"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
-msgstr "Inserisci del testo"
+msgstr "Skriv inn tekst"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
-msgstr "Nessun {0} corrispondente trovato"
+msgstr "Ingen funn på {0}."
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "Includendo tutte le opzioni nel tuo filtro probabilmente non farai molto..."
+msgstr "Inkluderer hver mulighet i filteret ditt vil mest sannsynlig ikke gjøre mye."
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:26
 msgid "Something's gone wrong"
-msgstr "Qualcosa è andato storto"
+msgstr "Noe gikk galt"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:27
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "Ci siamo imbattuti in un errore. Puoi provare ad aggiornare la pagina, o semplicemente tornare indietro."
+msgstr "Vi har støtt på en feil. Du kan prøve å oppdatere siden, eller bare gå tilbake."
 
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
@@ -2554,32 +2557,32 @@ msgstr "Ci siamo imbattuti in un errore. Puoi provare ad aggiornare la pagina, o
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:238
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:213
 msgid "No description yet"
-msgstr "Ancora nessuna descrizione"
+msgstr "Ingen beskrivelse enda"
 
 #: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
-msgstr "Nuovo {0}"
+msgstr "Ny {0}"
 
 #: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
-msgstr "Chiesto da {0}"
+msgstr "Spurt av {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "Oggi, "
+msgstr "Idag, "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "Ieri, "
+msgstr "Igår, "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "Prima revisione."
+msgstr "Første revisjon"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "Ripristinato a una revisione precedente e {0}"
+msgstr "Reversert til en tidligere revisjon og {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
@@ -2587,242 +2590,242 @@ msgstr "Ripristinato a una revisione precedente e {0}"
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
-msgstr "Storia di revisione"
+msgstr "Revisjonshistorikk"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "Quando"
+msgstr "Når"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "Chi"
+msgstr "Hvem"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "Cosa"
+msgstr "Hva"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "Ripristina"
+msgstr "Tilbakestilt"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "Ripristino..."
+msgstr "Reverserer..."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "Ripristino fallito"
+msgstr "Reversering feilet"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "Ripristinato"
+msgstr "Reversert"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "Ogni cosa"
+msgstr "Alt"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "Dashboard"
+msgstr "Infotavler"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "Domande"
+msgstr "Spørsmål"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
-msgstr "Pulse"
+msgstr "Pulser"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "Indietro"
+msgstr "Tilbake"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "Trova..."
+msgstr "Finn..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "Si è verificato un errore"
+msgstr "En feil oppstod"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "Caricamento..."
+msgstr "Laster inn..."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Newsletter di Metabase"
+msgstr "Metabase nyhetsbrev"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "Ricevi e-mail non frequenti su nuove versioni e aggiornamenti delle funzionalità."
+msgstr "Motta epost om nye utgaver og oppdaterte funksjoner."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "Iscriviti"
+msgstr "Abonnere"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "Sei iscritto. Grazie per aver usato Metabase"
+msgstr "Du har abonnert. Takk for at du bruker Metabase!"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:46
 msgid "We're a little lost..."
-msgstr "Siamo un po' persi..."
+msgstr "Vi er litt fortapt..."
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "Password temporanea"
+msgstr "Midlertidig passord"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:207
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:455
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:470
 msgid "Hide"
-msgstr "Nascondi"
+msgstr "Skjul"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:456
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:471
 msgid "Show"
-msgstr "Mostra"
+msgstr "Vis"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "Salvato! Aggiungo alla 'dashboard'?"
+msgstr "Lagret! Vil du legge den til en infotavle?"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "Si grazie!"
+msgstr "Ja takk!"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "Non ora"
+msgstr "Ikke nå"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "Errore:"
+msgstr "Feil:"
 
 #: frontend/src/metabase/admin/settings/selectors.js:241
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
-msgstr "Domenica"
+msgstr "Søndag"
 
 #: frontend/src/metabase/admin/settings/selectors.js:242
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
-msgstr "Lunedì"
+msgstr "Mandag"
 
 #: frontend/src/metabase/admin/settings/selectors.js:243
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
-msgstr "Martedì"
+msgstr "Tirsdag"
 
 #: frontend/src/metabase/admin/settings/selectors.js:244
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
-msgstr "Mercoledì"
+msgstr "Onsdag"
 
 #: frontend/src/metabase/admin/settings/selectors.js:245
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
-msgstr "Giovedì"
+msgstr "Torsdag"
 
 #: frontend/src/metabase/admin/settings/selectors.js:246
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
-msgstr "Venerdì"
+msgstr "Fredag"
 
 #: frontend/src/metabase/admin/settings/selectors.js:247
 #: frontend/src/metabase/components/SchedulePicker.jsx:30
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
-msgstr "Sabato"
+msgstr "Lørdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
-msgstr "Primo"
+msgstr "Først"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
-msgstr "Ultimo"
+msgstr "Sist"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:36
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
-msgstr "15mo (Medio)"
+msgstr "Femtende (midten)"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
-msgstr "Giorno di calendario"
+msgstr "Kalenderdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
-msgstr "il tuo timezone di Metabase"
+msgstr "din Metabase tidssone"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "Filtra questa lista..."
+msgstr "Filtrer denne listen..."
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "Blu"
+msgstr "Blå"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "Verde"
+msgstr "Grønn"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "Rosso"
+msgstr "Rød"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "Giallo"
+msgstr "Gul"
 
 #: frontend/src/metabase/components/Select.info.js:7
 msgid "A component used to make a selection"
-msgstr "Un componente utilizzato per fare una selezione"
+msgstr "En komponent bruker dette valget"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "Selezionato"
+msgstr "Valgt"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "Niente da selezionare"
+msgstr "Ingenting å velge"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:56
 msgid "Sorry, you don’t have permission to see that."
-msgstr "Mi spiace, non hai i permessi per vederlo."
+msgstr "Beklager, du har ikke tilgang til å se dette."
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "C'è stato un errore sconosciuto"
+msgstr "Ukjent feil oppstod"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:18
 #: frontend/src/metabase/nav/containers/Navbar.jsx:373
 msgid "Create"
-msgstr "Crea"
+msgstr "Lag"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "Crea una dashboard"
+msgstr "Lag infotavle"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
-msgstr "Tabella"
+msgstr "Tabell"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
@@ -2830,70 +2833,70 @@ msgstr "Database"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "Creatore"
+msgstr "Skaper"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "Nessun risultto trovato"
+msgstr "Ingen resultater funnet"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "Prova ad aggiustare il tuo filtro per trovare ciò che stai cercando."
+msgstr "Prøv å justere dine filter for å finne hva du leter etter."
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "Visto da"
+msgstr "Vis med"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:121
 msgid "of"
-msgstr "di"
+msgstr "av"
 
 #: frontend/src/metabase/containers/Overworld.jsx:91
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "Non dirlo a nessuno, ma tu sei il mio preferito."
+msgstr "Ikke si det til noen, men du er min favoritt."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "Una volta che hai collegato i tuoi dati, posso mostrarti alcune esplorazioni automatiche chiamate raggi X. Ecco alcuni esempi con dati di esempio."
+msgstr "Når du kobler til dine data, kan jeg gjøre en automatisk utforsking kalt X-ray. Her er noen eksempler med test-data."
 
 #: frontend/src/metabase/containers/Overworld.jsx:180
 #: frontend/src/metabase/containers/Overworld.jsx:384
 msgid "Start here"
-msgstr "Inizia qui"
+msgstr "Start her"
 
 #: frontend/src/metabase/containers/Overworld.jsx:379
 #: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
-msgstr "La nostra analisi"
+msgstr "Vår analyse"
 
 #: frontend/src/metabase/containers/Overworld.jsx:248
 msgid "Browse all items"
-msgstr "Sfoglia tutti gli elementi"
+msgstr "Bla gjennom alle elementer"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:117
 msgid "Replace or save as new?"
-msgstr "Sostituisci o salva come nuovo?"
+msgstr "Erstatt eller lagre som ny?"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace original question, \"{0}\""
-msgstr "Sostituisci la richiesta (`question`) originaria, {0}"
+msgstr "Erstatt det opprinnelige spørsmålet, \"{0}\""
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:171
 msgid "Save as new question"
-msgstr "Salva come nuova richiesta (`question`)"
+msgstr "Lagre som nytt spørsmål"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:92
 msgid "First, save your question"
-msgstr "Prima, salva la tua richiesta (`question`)"
+msgstr "Først, lagre spørsmålet ditt"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:93
 msgid "Save question"
-msgstr "Salva la richiesta (`question`)"
+msgstr "Lagre spørsmålet"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:132
 msgid "What is the name of your card?"
-msgstr "Quale è il nome della tua card?"
+msgstr "Hva er navnet på kortet ditt?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2911,7 +2914,7 @@ msgstr "Quale è il nome della tua card?"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:211
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:26
 msgid "Description"
-msgstr "Descrizione"
+msgstr "Beskrivelse"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
@@ -2921,472 +2924,473 @@ msgstr "Descrizione"
 #: frontend/src/metabase/entities/snippet-collections.js:82
 #: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
-msgstr "E' opzionale ma oh, così utile"
+msgstr "Det er valgfritt, men veldig hjelpsomt"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
 #: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
-msgstr "In quale raccolta dovrebbe andare?"
+msgstr "Hvilken samling skal denne være i?"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "modificato"
+msgstr "modifiert"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "elemento"
+msgstr "element"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "Annulla"
+msgstr "Angre"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:266
 msgid "Applying Question"
-msgstr "Inoltrando Richiesta (`Question`)"
+msgstr "Bruk spørsmål"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "That question isn't compatible"
-msgstr "Questa richiesta non è compatibile"
+msgstr "Det spørsmålet er ikke kompatibelt"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:309
 msgid "Search for a question"
-msgstr "Cercando la richiesta"
+msgstr "Søk etter et spørsmål"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:343
 msgid "We're not sure if this question is compatible"
-msgstr "Non siamo sicuri che questa richiesta sia compatibile"
+msgstr "Vi er ikke sikker på om dette spørsmålet kompatibelt"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "Archivia la 'dashboard'"
+msgstr "Arkiver infotavle"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "Assicurati di fare una selezione per ogni serie, altrimenti il filtro non funzionerà su questa card."
+msgstr "Forsikre deg om at noe i hver serie er valgt, ellers vil ikke filteret virke på dette kortet."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
-msgstr "Questa dashboard sembra vuota"
+msgstr "Denne infotavlen ser ut til å være tom."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
-msgstr "Aggiungi una richiesta(Question) per iniziare a renderla utile!"
+msgstr "Legg til ett spørsmål for og gjøre det nyttig!"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "Modalità giorno"
+msgstr "Dagmodus"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "Modalità notte"
+msgstr "Nattmodus"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "Esci dallo schermo intero"
+msgstr "Lukk fullskjerm"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "Porta a tutto schermo"
+msgstr "Åpne fullskjerm"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "Salvataggio...."
+msgstr "Lagrer..."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:220
 msgid "Add a question"
-msgstr "Aggiungi una richiesta (question)"
+msgstr "Legg til spørsmål"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:223
 msgid "Add a question to this dashboard"
-msgstr "Aggiungi una richiesta (question) alla dashboard"
+msgstr "Legg et spørsmål til denne infotavlen"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
-msgstr "Aggiungi un filtro"
+msgstr "Legg til filter"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "Parametri"
+msgstr "Parametere"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
-msgstr "Aggiungi un campo di testo"
+msgstr "Legg til en tekst boks"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:314
 msgid "Move dashboard"
-msgstr "Sposta la Dashboard"
+msgstr "Flytt infotavlen"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
-msgstr "Modifica la dashboard"
+msgstr "Rediger infotavle"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:307
 msgid "Edit Dashboard Layout"
-msgstr "Modifica il layout della dashboard"
+msgstr "Rediger visning av infotavle"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:365
 msgid "You are editing a dashboard"
-msgstr "Stai modificando una dashboard"
+msgstr "Du redigerer en infotavle"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:370
 msgid "Select the field that should be filtered for each card"
-msgstr "Seleziona il campo che vorresti fosse filtrato per ogni card"
+msgstr "Velg feltet som skal være filtrert for hvert kort"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "Sposta la dasboard in..."
+msgstr "Flytt infotavle til..."
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "Dashboard spostata in {0}"
+msgstr "Infotavlen ble flyttet til {0}"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
-msgstr "Cosa vuoi filtrare?"
+msgstr "Hva vil du filtrere?"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
-msgstr "Che tipo di filtro?"
+msgstr "Hva slags filter?"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:242
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:250
 msgid "Off"
-msgstr "Spegni"
+msgstr "Av"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1 minuto"
+msgstr "1 minutt"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5 minuti"
+msgstr "5 minutter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10 minuti"
+msgstr "10 minutter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15 minuti"
+msgstr "15 minutter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30 minuti"
+msgstr "30 minutter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60 minuti"
+msgstr "60 minutter"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:51
 msgid "Auto-refresh"
-msgstr "Auto-aggiorna"
+msgstr "Auto-forny"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:57
 msgid "Refreshing in"
-msgstr "Aggiornando in"
+msgstr "Fornyes om"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:30
 msgid "Remove this question?"
-msgstr "Eliminare la richiesta (Question)?"
+msgstr "Fjern dette spørsmålet?"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "La tua dashboard è stata salvata"
+msgstr "Infotavlen ble lagret"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:740
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "Guardalo"
+msgstr "Se det"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "Salvalo"
+msgstr "Lagre dette"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "Mostra di più su questo"
+msgstr "Vis mer om dette"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "Questa scheda non ha campi o parametri che possono essere associati a questo tipo di parametro."
+msgstr "Dette kortet har ingen felter eller parametere som kan tilordnes denne parametertypen."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "I valori in questo campo non si sovrappongono ai valori di altri campi che hai scelto."
+msgstr "Verdiene i dette feltet overlapper ikke med verdiene i noen andre felt du har valgt."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
-msgstr "Nessun campo valido."
+msgstr "Ingen gyldige felt"
 
 #: frontend/src/metabase/entities/collections.js:98
 #: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
-msgstr "Il nome deve avere 100 caratteri o meno"
+msgstr "Navn må være 100 tegn eller mindre"
 
 #: frontend/src/metabase/entities/collections.js:112
 #: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
-msgstr "Colore richiesto"
+msgstr "Farge er påkrevd"
 
 #: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
-msgstr "Quale è il nome della tua dashboard?"
+msgstr "Hva er navnet på infotavlen din?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:95
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "ha fatto delle cose fantastiche che è difficile da descrivere"
+msgstr "gjorde noen superstilige ting som er vanskelig å beskrive"
 
 #: frontend/src/metabase/home/components/Activity.jsx:104
 #: frontend/src/metabase/home/components/Activity.jsx:119
 msgid "created an alert about - "
-msgstr "creata una alert su - "
+msgstr "laget en varsel om - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:129
 #: frontend/src/metabase/home/components/Activity.jsx:144
 msgid "deleted an alert about - "
-msgstr "cancellata una alert su - "
+msgstr "slettet en varsel om - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:155
 msgid "saved a question about "
-msgstr "salvata una richiesta (Question) su "
+msgstr "lagret et spørsmål om "
 
 #: frontend/src/metabase/home/components/Activity.jsx:168
 msgid "saved a question"
-msgstr "salvata una richiesta"
+msgstr "lagret et spørsmål"
 
 #: frontend/src/metabase/home/components/Activity.jsx:172
 msgid "deleted a question"
-msgstr "cancellata una richiesta"
+msgstr "slettet et spørsmål"
 
 #: frontend/src/metabase/home/components/Activity.jsx:175
 msgid "created a dashboard"
-msgstr "creata una dashboard"
+msgstr "laget en infotavle"
 
 #: frontend/src/metabase/home/components/Activity.jsx:178
 msgid "deleted a dashboard"
-msgstr "cancellata una dashboard"
+msgstr "slettet en infotavle"
 
 #: frontend/src/metabase/home/components/Activity.jsx:184
 #: frontend/src/metabase/home/components/Activity.jsx:199
 msgid "added a question to the dashboard - "
-msgstr "aggiunta una richiesta (Question) alla dashboard"
+msgstr "la til et spørsmål til infotavlen - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:209
 #: frontend/src/metabase/home/components/Activity.jsx:224
 msgid "removed a question from the dashboard - "
-msgstr "eliminata una richiesta dalla dashboard - "
+msgstr "fjernet et spørsmål fra infotavlen - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:234
 #: frontend/src/metabase/home/components/Activity.jsx:241
 msgid "received the latest data from"
-msgstr "ricevuti gli ultimi dati da"
+msgstr "mottok de siste dataene fra"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
-msgstr "Sconosciuto"
+msgstr "Ukjent"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Hello World!"
-msgstr "Ciao Mondo!"
+msgstr "Hallo verden!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:255
 msgid "Metabase is up and running."
-msgstr "Metabase è su ed è in funzione"
+msgstr "Metabase er oppe og kjører."
 
 #: frontend/src/metabase/home/components/Activity.jsx:261
 #: frontend/src/metabase/home/components/Activity.jsx:291
 msgid "added the metric "
-msgstr "aggiunta la metrica "
+msgstr "la til indikatoren"
 
 #: frontend/src/metabase/home/components/Activity.jsx:275
 #: frontend/src/metabase/home/components/Activity.jsx:365
 msgid " to the "
-msgstr " al "
+msgstr " til "
 
 #: frontend/src/metabase/home/components/Activity.jsx:285
 #: frontend/src/metabase/home/components/Activity.jsx:325
 #: frontend/src/metabase/home/components/Activity.jsx:375
 #: frontend/src/metabase/home/components/Activity.jsx:416
 msgid " table"
-msgstr " tabella"
+msgstr " tabell"
 
 #: frontend/src/metabase/home/components/Activity.jsx:301
 #: frontend/src/metabase/home/components/Activity.jsx:331
 msgid "made changes to the metric "
-msgstr "fatti cambiamenti alla metrica "
+msgstr "gjorde endringer i indikatoren"
 
 #: frontend/src/metabase/home/components/Activity.jsx:315
 #: frontend/src/metabase/home/components/Activity.jsx:406
 msgid " in the "
-msgstr " nel "
+msgstr " i "
 
 #: frontend/src/metabase/home/components/Activity.jsx:338
 msgid "removed the metric "
-msgstr "cancellata la metrica "
+msgstr "fjernet indikatoren"
 
 #: frontend/src/metabase/home/components/Activity.jsx:341
 msgid "created a pulse"
-msgstr "creato un pulse"
+msgstr "laget en puls"
 
 #: frontend/src/metabase/home/components/Activity.jsx:344
 msgid "deleted a pulse"
-msgstr "cancellato un pulse"
+msgstr "slettet en puls"
 
 #: frontend/src/metabase/home/components/Activity.jsx:350
 #: frontend/src/metabase/home/components/Activity.jsx:381
 msgid "added the filter"
-msgstr "aggiunto un filtro"
+msgstr "la til filteret"
 
 #: frontend/src/metabase/home/components/Activity.jsx:391
 #: frontend/src/metabase/home/components/Activity.jsx:422
 msgid "made changes to the filter"
-msgstr "fatti cambiamenti al filtro"
+msgstr "gjorde endringer til filteret"
 
 #: frontend/src/metabase/home/components/Activity.jsx:429
 msgid "removed the filter {0}"
-msgstr "cancellato il filtro {0}"
+msgstr "fjernet filteret {0}"
 
 #: frontend/src/metabase/home/components/Activity.jsx:432
 msgid "joined!"
-msgstr "iscritto!"
+msgstr "ble med!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:532
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "mmm, sembra che non sia ancora successo nulla."
+msgstr "Hmm, det ser ikke ut til at noe har skjedd enda."
 
 #: frontend/src/metabase/home/components/Activity.jsx:535
+#, fuzzy
 msgid "Save a question and get this baby going!"
-msgstr "Salva una richiesta e fai andare questa bambina!"
+msgstr "Lagre ett spørsmål så du får fart på denne skuta!"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "Poni una richiesta e esplora"
+msgstr "Spør ett spørsmål og utforsk"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "Fai clic su grafici o tabelle per esplorare o fare una nuova richiesta utilizzando l'interfaccia facile o il potente editor SQL."
+msgstr "Trykk på diagrammer eller tabeller for å utforske, eller still et spørsmål med det enkle grensesnittet eller det kraftige SQL-redigeringsverktøyet."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "Crea il tuo grafico"
+msgstr "Lag dine egne grafer"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "Crea grafici a linee, grafici a dispersione, mappe e altro."
+msgstr "Lag linjediagrammer, spredningsplott, kart og mer."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "Condividi ciò che trovi"
+msgstr "Del hva du finner"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "Crea dashboard potenti e flessibili e invia aggiornamenti regolari via e-mail o Slack."
+msgstr "Lag kraftige og fleksible infotavler, og send regelmessige oppdateringer via e-post eller Slack."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "Andiamo"
+msgstr "La oss gå videre"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "Suggerimento di installazione"
+msgstr "Tips til oppsett"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "Vedi tutto"
+msgstr "Vis alle"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "Recentemente visualizzato"
+msgstr "Nylig vist"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:77
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "Di recente non hai guardato dashboard o domande"
+msgstr "Du har ikke sett på noen infotavler eller spørsmål nylig"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0} elementi selezionati"
+msgstr "{0} elementer valgt"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 #: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
-msgstr "Non archiviare"
+msgstr "Dearkiver"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:59
 msgid "Activity"
-msgstr "Attività"
+msgstr "Aktivitet"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:31
 msgid "Results for \"{0}\""
-msgstr "Risultati per \"{0}\""
+msgstr "Resultater for \"{0}\""
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
-msgstr "Pulse"
+msgstr "Puls"
 
 #: frontend/src/metabase/lib/core.js:8
 msgid "Entity Key"
-msgstr "Chiave di entità"
+msgstr "Entitetsnøkkel"
 
 #: frontend/src/metabase/lib/core.js:9 frontend/src/metabase/lib/core.js:15
 #: frontend/src/metabase/lib/core.js:21
 msgid "Overall Row"
-msgstr "Riga generale"
+msgstr "Totalrad"
 
 #: frontend/src/metabase/lib/core.js:10
 msgid "The primary key for this table."
-msgstr "La chiave primaria per questa tabella"
+msgstr "Primærnøkkelen for denne tabellen."
 
 #: frontend/src/metabase/lib/core.js:14
 msgid "Entity Name"
-msgstr "Nome Entità"
+msgstr "Entitetsnavn"
 
 #: frontend/src/metabase/lib/core.js:16
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "il \"nome\" di ogni record. Normalmente una colonna chiamata \"nome\", \"titolo\", ecc."
+msgstr "\"Navnet\" for hver oppføring. Vanligvis en kolonne kalt \"navn\", \"tittel\", osv."
 
 #: frontend/src/metabase/lib/core.js:20
 msgid "Foreign Key"
-msgstr "Chiave esterna"
+msgstr "Fremmednøkkel"
 
 #: frontend/src/metabase/lib/core.js:22
 msgid "Points to another table to make a connection."
-msgstr "Punta a un'altra tabella per stabilire una connessione."
+msgstr "Peker på en annen tabell for å lage en kobling."
 
 #: frontend/src/metabase/lib/core.js:257
 msgid "Avatar Image URL"
-msgstr "URL dell'immagine di avatar"
+msgstr "Avatar bilde-URL"
 
 #: frontend/src/metabase/lib/core.js:29 frontend/src/metabase/lib/core.js:34
 #: frontend/src/metabase/lib/core.js:39 frontend/src/metabase/lib/core.js:44
 #: frontend/src/metabase/lib/core.js:49
 msgid "Common"
-msgstr "Comune"
+msgstr "Vanlig"
 
 #: frontend/src/metabase/lib/core.js:28
 #: frontend/src/metabase/meta/Dashboard.js:86
 #: frontend/src/metabase/modes/components/drill/PivotByCategoryDrill.jsx:10
 msgid "Category"
-msgstr "Categoria"
+msgstr "Kategori"
 
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/meta/Dashboard.js:66
 msgid "City"
-msgstr "Città"
+msgstr "By"
 
 #: frontend/src/metabase/lib/core.js:60
 #: frontend/src/metabase/meta/Dashboard.js:78
 msgid "Country"
-msgstr "Paese"
+msgstr "Land"
 
 #: frontend/src/metabase/lib/core.js:240
 msgid "Enum"
@@ -3394,120 +3398,120 @@ msgstr "Enum"
 
 #: frontend/src/metabase/lib/core.js:262
 msgid "Image URL"
-msgstr "URL immagine"
+msgstr "Bilde nettlink"
 
 #: frontend/src/metabase/lib/core.js:274
 msgid "Field containing JSON"
-msgstr "Campo contenente il JSON"
+msgstr "Felt inneholder JSON"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Latitude"
-msgstr "Latitudine"
+msgstr "Breddegrad"
 
 #: frontend/src/metabase/lib/core.js:70
 msgid "Longitude"
-msgstr "Longitudine"
+msgstr "Lengdegrad"
 
 #: frontend/src/metabase/lib/core.js:43
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:144
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:45
 msgid "Number"
-msgstr "Numero"
+msgstr "Nummer"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:75
 #: frontend/src/metabase/meta/Dashboard.js:70
 msgid "State"
-msgstr "Stato"
+msgstr "Stat"
 
 #: frontend/src/metabase/lib/core.js:233
 msgid "UNIX Timestamp (Seconds)"
-msgstr "UNIX timestamp (secondi)"
+msgstr "UNIX tidsstempel (sekunder)"
 
 #: frontend/src/metabase/lib/core.js:228
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "UNIX timestamp (millisecondi)"
+msgstr "UNIX tidsstempel (millisekunder)"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Zip Code"
-msgstr "Codice Postale"
+msgstr "Postnummer"
 
 #: frontend/src/metabase/lib/core.js:119
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
-msgstr "Quantità"
+msgstr "Kvantum"
 
 #: frontend/src/metabase/lib/core.js:107
 msgid "Income"
-msgstr "Ingresso"
+msgstr "Inntekt"
 
 #: frontend/src/metabase/lib/core.js:97
 msgid "Discount"
-msgstr "Sconto"
+msgstr "Avslag"
 
 #: frontend/src/metabase/lib/core.js:193
 msgid "Creation timestamp"
-msgstr "Data e ora della creazione"
+msgstr "Tidsstempel for opprettelse"
 
 #: frontend/src/metabase/lib/core.js:188
 msgid "Creation time"
-msgstr "ora di creazione "
+msgstr "Tid for opprettelse"
 
 #: frontend/src/metabase/lib/core.js:183
 msgid "Creation date"
-msgstr "Data creazione "
+msgstr "Dato for opprettelse"
 
 #: frontend/src/metabase/lib/core.js:245
 msgid "Product"
-msgstr "Prodotto"
+msgstr "Produkt"
 
 #: frontend/src/metabase/lib/core.js:161
 msgid "User"
-msgstr "Utente"
+msgstr "Bruker"
 
 #: frontend/src/metabase/lib/core.js:250
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
-msgstr "Sorgente"
+msgstr "Kilde"
 
 #: frontend/src/metabase/lib/core.js:112
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
-msgstr "Prezzo"
+msgstr "Pris"
 
 #: frontend/src/metabase/lib/core.js:223
 msgid "Join timestamp"
-msgstr "Timestamp di iscrizione"
+msgstr "Tidsstempel når ble med"
 
 #: frontend/src/metabase/lib/core.js:218
 msgid "Join time"
-msgstr "Orario di iscrizione"
+msgstr "Registreringstid"
 
 #: frontend/src/metabase/lib/core.js:213
 msgid "Join date"
-msgstr "Data di iscrizione"
+msgstr "Registreringsdato"
 
 #: frontend/src/metabase/lib/core.js:129
 msgid "Share"
-msgstr "Condividi"
+msgstr "Del"
 
 #: frontend/src/metabase/lib/core.js:151
 msgid "Owner"
-msgstr "Proprietario"
+msgstr "Eier"
 
 #: frontend/src/metabase/lib/core.js:141
 msgid "Company"
-msgstr "Società"
+msgstr "Firma"
 
 #: frontend/src/metabase/lib/core.js:156
 msgid "Subscription"
-msgstr "Sottoscrizione"
+msgstr "Abonnement"
 
 #: frontend/src/metabase/lib/core.js:124
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
-msgstr "Punteggio"
+msgstr "Poengsum"
 
 #: frontend/src/metabase/lib/core.js:48
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
@@ -3515,7 +3519,7 @@ msgstr "Punteggio"
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
-msgstr "Titolo"
+msgstr "Tittel"
 
 #: frontend/src/metabase/lib/core.js:33
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
@@ -3523,55 +3527,55 @@ msgstr "Titolo"
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
-msgstr "Commento"
+msgstr "Kommentar"
 
 #: frontend/src/metabase/lib/core.js:87
 msgid "Cost"
-msgstr "Costo"
+msgstr "Kostnad"
 
 #: frontend/src/metabase/lib/core.js:102
 msgid "Gross margin"
-msgstr "Margine lordo"
+msgstr "Bruttomargin"
 
 #: frontend/src/metabase/lib/core.js:136
 msgid "Birthday"
-msgstr "Compleanno"
+msgstr "Bursdag"
 
 #: frontend/src/metabase/lib/core.js:285
 msgid "Search box"
-msgstr "Casella di ricerca"
+msgstr "Søkeboks"
 
 #: frontend/src/metabase/lib/core.js:286
 msgid "A list of all values"
-msgstr "Una lista di tutti i valori"
+msgstr "En liste med alle verdier"
 
 #: frontend/src/metabase/lib/core.js:287
 msgid "Plain input box"
-msgstr "Casella di input normale"
+msgstr "Enkel informasjonsboks"
 
 #: frontend/src/metabase/lib/core.js:293
 msgid "Everywhere"
-msgstr "Ovunque"
+msgstr "Overalt"
 
 #: frontend/src/metabase/lib/core.js:294
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "L'impostazione predefinita Questo campo verrà visualizzato normalmente in tabelle e grafici."
+msgstr "Standardinnstillingen. Dette feltet vil normalt vises. i tabeller og diagrammer"
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "Solo nelle viste di dettaglio"
+msgstr "Bare i standard visning"
 
 #: frontend/src/metabase/lib/core.js:299
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "Questo campo verrà visualizzato solo quando si visualizzano i dettagli di un singolo record. Usalo per informazioni lunghe o inutili in una tabella o in un grafico."
+msgstr "Dette feltet vil bare vises når du ser på detaljene for en enkeltoppføring. Bruk denne for informasjon som er lang eller som ikke er nyttig i en tabell eller et diagram."
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "Non include"
+msgstr "Ikke inkluder"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabase non recupererà mai questo campo. Utilizzare questo per informazioni sensibili o irrilevanti."
+msgstr "Metabase vil aldri hente dette feltet. Bruk dette for sensitiv eller irrelevant informasjon."
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
@@ -3584,34 +3588,34 @@ msgstr "Metabase non recupererà mai questo campo. Utilizzare questo per informa
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
-msgstr "Conteggio"
+msgstr "Antall"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "Conteggio cumulativo"
+msgstr "KumulativTelling"
 
 #: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
-msgstr "Somma"
+msgstr "Sum"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "Somma cumulativa"
+msgstr "KumulativSum"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Distinct"
-msgstr "Distinto"
+msgstr "Distrikt"
 
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "DeviazioneStandard"
+msgstr "StandardAvvik"
 
 #: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
-msgstr "Media"
+msgstr "Gjennomsnitt"
 
 #: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
@@ -3625,56 +3629,56 @@ msgstr "Min"
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
 msgid "Max"
-msgstr "Max"
+msgstr "Maks"
 
 #: frontend/src/metabase/lib/expressions/parser.js:373
 msgid "sad sad panda, lexing errors detected"
-msgstr "rilevati errori di lessico"
+msgstr "trist trist panda, leksikalske feil ble funnet"
 
 #: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
-msgstr[0] "{0} secondo"
-msgstr[1] "{0} secondi"
+msgstr[0] "{0} sekund"
+msgstr[1] "{0} sekunder"
 
 #: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0} minuto"
-msgstr[1] "{0} minuti"
+msgstr[0] "{0} minutt"
+msgstr[1] "{0} minutter"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "Ehilà"
+msgstr "Hei du"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "Come va"
+msgstr "Hvordan går det"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "Salve"
+msgstr "Halla"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "Saluti"
+msgstr "Velkommen"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "E' bello rivederti"
+msgstr "Godt å se deg"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "Cosa vuoi sapere?"
+msgstr "Hva vil du vite?"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "Cosa hai in mente?"
+msgstr "Hva tenker du på?"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "Cosa vuoi scoprire?"
+msgstr "Hva lurer du på?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
@@ -3682,91 +3686,91 @@ msgstr "Cosa vuoi scoprire?"
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
-msgstr "Dati grezzi"
+msgstr "Rådata"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
 #: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
-msgstr "Conto cumulativo"
+msgstr "Kumulativ telling"
 
 #: frontend/src/metabase/lib/query/description.js:82
 #: frontend/src/metabase/lib/query/description.js:266
 msgid "Average of "
-msgstr "Media di "
+msgstr "Gjennomsnittet av "
 
 #: frontend/src/metabase/lib/query/description.js:87
 #: frontend/src/metabase/lib/query/description.js:268
 msgid "Distinct values of "
-msgstr "Valori distinti di "
+msgstr "Unike verdier av "
 
 #: frontend/src/metabase/lib/query/description.js:92
 #: frontend/src/metabase/lib/query/description.js:270
 msgid "Standard deviation of "
-msgstr "Deviazione standard di "
+msgstr "Standardavviket av "
 
 #: frontend/src/metabase/lib/query/description.js:97
 #: frontend/src/metabase/lib/query/description.js:272
 msgid "Sum of "
-msgstr "Somma di "
+msgstr "Summen av "
 
 #: frontend/src/metabase/lib/query/description.js:102
 #: frontend/src/metabase/lib/query/description.js:274
 msgid "Cumulative sum of "
-msgstr "Somma cumulativa di "
+msgstr "Kumulativ sum av "
 
 #: frontend/src/metabase/lib/query/description.js:107
 #: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
-msgstr "Massimo di "
+msgstr "Største av "
 
 #: frontend/src/metabase/lib/query/description.js:112
 #: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
-msgstr "Minimo di "
+msgstr "Minste av "
 
 #: frontend/src/metabase/lib/query/description.js:126
 #: frontend/src/metabase/lib/query/description.js:286
 msgid "Grouped by "
-msgstr "Raggruppato per "
+msgstr "Gruppert etter "
 
 #: frontend/src/metabase/lib/query/description.js:140
 #: frontend/src/metabase/lib/query/description.js:295
 msgid "Filtered by "
-msgstr "Filtrato per "
+msgstr "Filtrert på "
 
 #: frontend/src/metabase/lib/query/description.js:169
 #: frontend/src/metabase/lib/query/description.js:320
 msgid "Sorted by "
-msgstr "Ordinato per "
+msgstr "Sortert etter "
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "True"
-msgstr "Vero"
+msgstr "Sant"
 
 #: frontend/src/metabase/lib/schema_metadata.js:237
 msgid "False"
-msgstr "Falso"
+msgstr "Usant"
 
 #: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
-msgstr "Seleziona il campo longitudine"
+msgstr "Velg felt for lengdegrad"
 
 #: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
-msgstr "Inserisci la latituine superiore"
+msgstr "Skriv inn øvre breddegrad"
 
 #: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
-msgstr "inserisci la longitudine a sinistra"
+msgstr "Skriv inn venstre lengdegrad"
 
 #: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
-msgstr "Inserisci la latitudine inferiore"
+msgstr "Skriv inn nedre breddegrad"
 
 #: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
-msgstr "Inserisci la longitudine a destra"
+msgstr "Skriv inn høyre lengdegrad"
 
 #: frontend/src/metabase/lib/schema_metadata.js:368
 #: frontend/src/metabase/lib/schema_metadata.js:388
@@ -3776,7 +3780,7 @@ msgstr "Inserisci la longitudine a destra"
 #: frontend/src/metabase/lib/schema_metadata.js:422
 #: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
-msgstr "E'"
+msgstr "Er"
 
 #: frontend/src/metabase/lib/schema_metadata.js:369
 #: frontend/src/metabase/lib/schema_metadata.js:389
@@ -3784,7 +3788,7 @@ msgstr "E'"
 #: frontend/src/metabase/lib/schema_metadata.js:417
 #: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
-msgstr "Non è"
+msgstr "Er ikke"
 
 #: frontend/src/metabase/lib/schema_metadata.js:370
 #: frontend/src/metabase/lib/schema_metadata.js:384
@@ -3794,7 +3798,7 @@ msgstr "Non è"
 #: frontend/src/metabase/lib/schema_metadata.js:418
 #: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
-msgstr "E' vuoto"
+msgstr "Er tom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:385
@@ -3804,197 +3808,197 @@ msgstr "E' vuoto"
 #: frontend/src/metabase/lib/schema_metadata.js:419
 #: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
-msgstr "Non vuoto"
+msgstr "Ikke tom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
-msgstr "Uguale a"
+msgstr "Er lik"
 
 #: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
-msgstr "Non uguale a "
+msgstr "Ikke lik"
 
 #: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
-msgstr "Più grande di"
+msgstr "Større enn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
-msgstr "Meno di"
+msgstr "Mindre enn"
 
 #: frontend/src/metabase/lib/schema_metadata.js:381
 #: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "Tra"
+msgstr "Mellom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
-msgstr "Più grande o uguale a"
+msgstr "Større eller lik"
 
 #: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
-msgstr "Meno di o uguale a"
+msgstr "Mindre eller lik"
 
 #: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
-msgstr "Contiene"
+msgstr "Inneholder"
 
 #: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
-msgstr "Non contiene"
+msgstr "Inneholder ikke"
 
 #: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
-msgstr "Inizia con"
+msgstr "Starter med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
-msgstr "Finisce con"
+msgstr "Slutter med"
 
 #: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "Prima"
+msgstr "Før"
 
 #: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "Dopo"
+msgstr "Etter"
 
 #: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
-msgstr "Dentro"
+msgstr "Inni"
 
 #: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "Solo una tabella con le righe nella risposta, nessuna operazione aggiuntiva."
+msgstr "Bare en tabell med rader i svaret, ingen flere operasjoner."
 
 #: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
-msgstr "Conteggio di righe"
+msgstr "Antall rader"
 
 #: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
-msgstr "Numero totale di righe nella risposta"
+msgstr "Totalt antall rader i svaret"
 
 #: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
-msgstr "Somma di ..."
+msgstr "Summen av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
-msgstr "Somma di tutti i valori di una colonna"
+msgstr "Summen av alle verdiene i en kolonne."
 
 #: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
-msgstr "Media di ..."
+msgstr "Gjennomsnittet av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
-msgstr "Media di tutti i valori di una colonna"
+msgstr "Gjennomsnittet av alle verdiene i en kolonne"
 
 #: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
-msgstr "Numeri di valori distinti di ..."
+msgstr "Antall unike verdier av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "Numero di valori univoci di una colonna tra tutte le righe nella risposta."
+msgstr "Antall unike verdier i en kolonne blant alle radene i svaret."
 
 #: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
-msgstr "Somma cumulativa di ..."
+msgstr "Kumulativ sum av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "Somma additiva di tutti i valori di una colonna. \\\\ ne.x. entrate totali nel tempo."
+msgstr "Additiv sum av alle verdiene i en kolonne.\\\\nf.eks. total omsetning over tid."
 
 #: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
-msgstr "Conteggio cumulativo di righe"
+msgstr "Kumulativ telling av rader"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "Conteggio additivo del numero di righe. \\\\ ne.x. numero totale di vendite nel tempo."
+msgstr "Additiv telling av antall rader.\\\\nf.eks. antall salg over tid."
 
 #: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
-msgstr "Deviazione standard di ..."
+msgstr "Standardavvik for ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "Numero che esprime quanto i valori di una colonna variano tra tutte le righe nella risposta."
+msgstr "Tall som uttrykker hvor mye verdiene i en kolonne varierer blant alle radene i svaret."
 
 #: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
-msgstr "Minimo di ..."
+msgstr "Minste av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
-msgstr "Minimo valore di una colonna"
+msgstr "Minste verdi i kolonnen"
 
 #: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
-msgstr "Massimo di ..."
+msgstr "Største av ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
-msgstr "Massimo valore di una colonna"
+msgstr "Største verdi i kolonnen"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "Scoppia per dimensione"
+msgstr "Bryt ut etter dimensjon"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "lettera minuscola"
+msgstr "liten bokstav"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "lettera maiuscola"
+msgstr "stor bokstav"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "numero"
+msgstr "tall"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "carattere speciale"
+msgstr "spesialtegn"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "deve essere"
+msgstr "må være"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "carattere lungo"
+msgstr "tegn lang"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "Deve essere"
+msgstr "Må være"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "e include"
+msgstr "og inkludere"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
-msgstr "zero"
+msgstr "null"
 
 #: frontend/src/metabase/lib/utils.js:86
 msgid "one"
-msgstr "uno"
+msgstr "en"
 
 #: frontend/src/metabase/lib/utils.js:87
 msgid "two"
-msgstr "due"
+msgstr "to"
 
 #: frontend/src/metabase/lib/utils.js:88
 msgid "three"
@@ -4002,83 +4006,83 @@ msgstr "tre"
 
 #: frontend/src/metabase/lib/utils.js:89
 msgid "four"
-msgstr "quattro"
+msgstr "fire"
 
 #: frontend/src/metabase/lib/utils.js:90
 msgid "five"
-msgstr "cinque"
+msgstr "fem"
 
 #: frontend/src/metabase/lib/utils.js:91
 msgid "six"
-msgstr "sei"
+msgstr "seks"
 
 #: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
-msgstr "sette"
+msgstr "syv"
 
 #: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
-msgstr "otto"
+msgstr "åtte"
 
 #: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
-msgstr "nove"
+msgstr "ni"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Month and Year"
-msgstr "Mese e Anno"
+msgstr "Måned og Dag"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like January, 2016"
-msgstr "Come Gennaio, 2016"
+msgstr "Som Januar, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Quarter and Year"
-msgstr "Trimestre e Anno"
+msgstr "Kvartal og År"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like Q1, 2016"
-msgstr "Come T1, 2016"
+msgstr "Som Q1, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Single Date"
-msgstr "Data Singola"
+msgstr "Enkelt Dato"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like January 31, 2016"
-msgstr "Come Gennaio 31, 2016"
+msgstr "Som 31 Januar, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Date Range"
-msgstr "Intervallo di date"
+msgstr "Datointervall"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "Come Dicembre 25, 2015 - Febbraio 14, 2016"
+msgstr "Som 25 Desember, 2015 - 14 Februar, 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Relative Date"
-msgstr "Date relative"
+msgstr "Relativ Dato"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "Come \"gli ultimi 7 giorni\" o \"questo mese\""
+msgstr "Som \"de siste 7 dagene\" eller \"denne måneden\""
 
 #: frontend/src/metabase/meta/Dashboard.js:60
 msgid "Date Filter"
-msgstr "Filtro per data"
+msgstr "Datofilter"
 
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "All Options"
-msgstr "Tutte le Opzioni"
+msgstr "Alle alternativer"
 
 #: frontend/src/metabase/meta/Dashboard.js:62
 msgid "Contains all of the above"
-msgstr "Contiene tutto quanto sopra"
+msgstr "Inneholder alt ovenfor"
 
 #: frontend/src/metabase/meta/Dashboard.js:74
 msgid "ZIP or Postal Code"
-msgstr "CAP o Codice Postale"
+msgstr "Postnummer"
 
 #: frontend/src/metabase/meta/Dashboard.js:82
 #: frontend/src/metabase/meta/Dashboard.js:112
@@ -4088,11 +4092,11 @@ msgstr "ID"
 #: frontend/src/metabase/meta/Dashboard.js:100
 #: frontend/src/metabase/modes/components/drill/PivotByTimeDrill.jsx:9
 msgid "Time"
-msgstr "Tempo"
+msgstr "Tid"
 
 #: frontend/src/metabase/meta/Dashboard.js:101
 msgid "Date range, relative date, time of day, etc."
-msgstr "Intervallo di date, data relativa, Ora del giorno, ecc,"
+msgstr "Datointervall, relativ dato, tid på dagen, osv."
 
 #: frontend/src/metabase/lib/core.js:56 frontend/src/metabase/lib/core.js:61
 #: frontend/src/metabase/lib/core.js:66 frontend/src/metabase/lib/core.js:71
@@ -4100,143 +4104,143 @@ msgstr "Intervallo di date, data relativa, Ora del giorno, ecc,"
 #: frontend/src/metabase/meta/Dashboard.js:106
 #: frontend/src/metabase/modes/components/drill/PivotByLocationDrill.jsx:9
 msgid "Location"
-msgstr "Posizione"
+msgstr "Sted"
 
 #: frontend/src/metabase/meta/Dashboard.js:107
 msgid "City, State, Country, ZIP code."
-msgstr "Citta, Stato, Paese, CAP."
+msgstr "By, Stat, Land, Postnummer."
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "User ID, product ID, event ID, etc."
-msgstr "ID utente, ID prodotto, ID evento, ecc"
+msgstr "Bruker ID, produkt ID, hendelses ID, osv."
 
 #: frontend/src/metabase/meta/Dashboard.js:118
 msgid "Other Categories"
-msgstr "Altre categorie"
+msgstr "Andre kategorier"
 
 #: frontend/src/metabase/meta/Dashboard.js:119
 msgid "Category, Type, Model, Rating, etc."
-msgstr "Categoria, Tipo, Valutazione, ecc."
+msgstr "Kategori, Type, Modell, Vurdering, osv."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:43
 #: frontend/src/metabase/user/components/UserSettings.jsx:56
 msgid "Account settings"
-msgstr "Impostazioni di account"
+msgstr "Kontoinnstillinger"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:50
 msgid "Exit admin"
-msgstr "Esci da amministratore"
+msgstr "Lukk admin"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:35
 msgid "Logs"
-msgstr "I log"
+msgstr "Logger"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:104
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:22
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:65
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:100
 msgid "Help"
-msgstr "Aiuto"
+msgstr "Hjelp"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:72
 msgid "About Metabase"
-msgstr "Su Metabase"
+msgstr "Om Metabase"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:78
 msgid "Sign out"
-msgstr "Esci"
+msgstr "Logg ut"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Thanks for using"
-msgstr "Grazie per l'uso"
+msgstr "Takk for at du bruker"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:116
 msgid "You're on version"
-msgstr "Tu stai usando la versione"
+msgstr "Du bruker versjon"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:119
 msgid "Built on"
-msgstr "Costruita su"
+msgstr "Bygget den"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:139
 msgid "is a Trademark of"
-msgstr "E un Marchio di"
+msgstr "er et varemerke for"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:141
 msgid "and is built with care in San Francisco, CA"
-msgstr "ed è costruito con cura a San Francisco, in California"
+msgstr "og er bygget med omhu i San Francisco, California"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:224
 msgid "Metabase Admin"
-msgstr "Amministratore Metabase"
+msgstr "Metabase Admin"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:354
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:35
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:36
 msgid "Ask a question"
-msgstr "Poni una domanda"
+msgstr "Still et spørsmål"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:379
 msgid "New dashboard"
-msgstr "Nuova Dashboard"
+msgstr "Ny infotavle"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:385
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "Nuovo Pulse"
+msgstr "Ny puls"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "Referente"
+msgstr "Referanse"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "Quale metrica?"
+msgstr "Hvilken indikator?"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "Definire metriche comuni per il tuo team rende ancora più facile fare domande"
+msgstr "Å definere vanlige indikatorer for ditt lag gjør det enklere å spørre spørsmål"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "Come creare metriche"
+msgstr "Hvordan lage indikatorer"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "Visualizza i dati nel tempo, come una mappa o ruotati per aiutarti a capire tendenze o cambiamenti."
+msgstr "Se data over tid, som et kart, eller pivotert for å gjøre det enklere å forstå trender eller endringer."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
-msgstr "Personalizzato"
+msgstr "Egendefinert"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:157
 msgid "New question"
-msgstr "Nuove domande"
+msgstr "Nytt spørsmål"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "Utilizza il semplice generatore di domande per visualizzare tendenze, elenchi di cose o per creare le tue metriche."
+msgstr "Bruke den enkle spørsmåls-byggeren for å se trender, liser over ting, eller for å lage dine egne indikatorer."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:110
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "Query native"
+msgstr "Lokal spørring"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:111
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "Per domande più complicate, puoi scrivere la tua query SQL o nativa."
+msgstr "For mer kompliserte spørsmål, kan du skrive din egen SQL eller lokal spørring."
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
-msgstr "Seleziona un valore predefinito ..."
+msgstr "Velg en standardverdi..."
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "Filtro di aggiornamento"
+msgstr "Oppdater filter"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4244,22 +4248,22 @@ msgstr "Filtro di aggiornamento"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "Oggi"
+msgstr "I dag"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "Ieri"
+msgstr "I går"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "Ultimi 7 giorni"
+msgstr "Siste 7 dager"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "Ultimi 30 giorni"
+msgstr "Siste 30 dager"
 
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
@@ -4267,8 +4271,8 @@ msgstr "Ultimi 30 giorni"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "Settimana"
-msgstr[1] "Settimane"
+msgstr[0] "Uke"
+msgstr[1] "Uker"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4276,8 +4280,8 @@ msgstr[1] "Settimane"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "Mese"
-msgstr[1] "Mesi"
+msgstr[0] "Måned"
+msgstr[1] "Måneder"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4285,363 +4289,363 @@ msgstr[1] "Mesi"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "Anno"
-msgstr[1] "Anni"
+msgstr[0] "År"
+msgstr[1] "År"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "Ultimi 7 Giorni"
+msgstr "Siste 7 Dager"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "Ultimi 30 Giorni"
+msgstr "Siste 30 Dager"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "Ultima Settimana"
+msgstr "Siste Uke"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "Ultimo Mese"
+msgstr "Siste Måned"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "Ultimo Anno"
+msgstr "Siste År"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "Questa settimana"
+msgstr "Denne Uken"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "Questo mese"
+msgstr "Denne Måneden"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
-msgstr "Quest'anno"
+msgstr "Dette Året"
 
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "Inserisci un valore"
+msgstr "Skriv en verdi..."
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "Inserisci un valore predefinito..."
+msgstr "Skriv en standardverdi..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
 #: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "C'è stato un errore"
+msgstr "En feil oppstod"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "Non trovato"
+msgstr "Ikke funnet"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "Hai apportato modifiche che devono essere pubblicate prima che si riflettano nell'applicazione incorporata."
+msgstr "Du har gjort endringer som må publiseres før de vil bli reflektert i din applikasjonsinnbygging."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "Dovrai pubblicare questo {0} prima di poterlo incorporare in un'altra applicazione."
+msgstr "Du må publisere denne {0} før du kan bygge den inn i en annen applikasjon."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "Scartare le modifiche"
+msgstr "Forkast Endringer."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "Aggiornamento..."
+msgstr "Oppdaterer..."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "Aggiornato"
+msgstr "Oppdatert"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "Fallito!"
+msgstr "Feilet!"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "Pubblicato"
+msgstr "Publiser"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 #: frontend/src/metabase/visualizations/lib/settings/column.js:345
 msgid "Code"
-msgstr "Codice"
+msgstr "Kode"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:296
 msgid "Style"
-msgstr "Stile"
+msgstr "Stil"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "Quali parametri possono utilizzare gli utenti di questo embed?"
+msgstr "Hvilke parametere kan brukere av denne innbyggingen bruke?"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "Questo {0} non ha ancora parametri da configurare."
+msgstr "Denne {0} har ikke noen parametere å konfigurere enda."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "Modificabile"
+msgstr "Redigerbar"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "Bloccato"
+msgstr "Låst"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "Anteprima dei parametri bloccati"
+msgstr "Forhåndsvis Låste Parametere"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "Prova a passare alcuni valori ai tuoi parametri bloccati qui. Il tuo server dovrà fornire i valori reali nel token firmato quando lo utilizzi per davvero."
+msgstr "Prøv å sende noen verdier til dine låste parametere her. Tjeneren din må tilby de faktiske verdiene i den signerte tokenen når du bruker dette på ordentlig."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "Zona pericolosa"
+msgstr "Faresone"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "Questo disabiliterà l'incorporamento per questo {0}."
+msgstr "Dette vil deaktivere innbygging av denne {0}."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "Spubblicato"
+msgstr "Avpubliser"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "Chiaro"
+msgstr "Lys"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "Scuro"
+msgstr "Mørk"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "Bordo"
+msgstr "Ramme"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "per incorporare questo {0} nella tua applicazione:"
+msgstr "For å bygge inn denne {0} i din applikasjon:"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "Inserisci questo snippet di codice nel codice del server per generare l'URL di incorporamento firmato "
+msgstr "Sett inn denne kodesnutten i koden på tjeneren din for å generere den signerte innbyggings-URLen "
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "Quindi inserisci questo snippet di codice nel modello HTML o nell'app singola pagina."
+msgstr "Deretter, sett inn denne kodesnutten i din HTML-mal eller en enkeltsidig applikasjon."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "Incorpora lo snippet di codice per la tua applicazione HTML o Frontend"
+msgstr "Kodesnutt for innbygging for din HTML eller frontend-applikasjon"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "Più {0}"
+msgstr "Mer {0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "esempi su GitHub"
+msgstr "eksempler på GitHub"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "Abilita condivisione"
+msgstr "Aktiver deling"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "Disabilitare link pubblico?"
+msgstr "Deaktiver denne offentlige lenken?"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "Ciò causerà l'interruzione del funzionamento del collegamento esistente. Puoi riattivarlo, ma quando lo fai sarà un link diverso."
+msgstr "Dette vil gjøre sånn at den gjeldende lenken slutter å fungere. Du kan re-aktivere den, men du vil da få en annen lenke."
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "Link pubblico"
+msgstr "Offentlig lenke"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Condividi questo {0} con persone che non hanno un account Metabase utilizzando l'URL di seguito:"
+msgstr "Del denne {0} med folk som ikke har en Metabase-konto ved å bruke nettadressen under:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "Inserimento pubblico"
+msgstr "Offentlig innbygging"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "Incorpora questo {0} nei post del blog o nelle pagine Web copiando e incollando questo snippet:"
+msgstr "Bygg inn denne {0} i blogginnlegg eller nettside ved å kopiere og lime inn denne snutten:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "Incorpora questo {0} in un'applicazione"
+msgstr "Bygg inn denne {0} i en applikasjon"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "Integrando con il codice del server delle applicazioni, è possibile fornire statistiche sicure {0} limitate a uno specifico utente, cliente, organizzazione, ecc."
+msgstr "Ved å integrere med koden til din applikasjonstjener, så kan du tilby sikker statistikk {0} begrenset til en spesifikk bruker, kunde, organisasjon, osv."
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "Rimuovi allegato"
+msgstr "Fjern vedlegg"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "Allega file con risultati"
+msgstr "Legg ved fil med resultatene"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "Questa domanda verrà aggiunta come allegato al file"
+msgstr "Dette spørsmålet vil bli lagt til som vedlegg"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "Questa domanda non sarà inclusa nel tuo Pulse"
+msgstr "Dette spørsmålet vil ikke bli inkludert i din Puls"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Questo impulso non verrà più inviato via email a {0} {1}"
+msgstr "Denne pulsen vil ikke lenger bli sendt til {0} {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0} Indirizzo"
-msgstr[1] "{0} indirizzi"
+msgstr[0] "{0} adresse"
+msgstr[1] "{0} adresser"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "Il canale Slack {0} non riceverà più questo impulso {1}"
+msgstr "Slack-kanalen {0} vil ikke lenger motta denne pulsen {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "Il canale {0} non riceverà più questo impulso {1}"
+msgstr "Kanalen {0} vil ikke lenger motta denne pulsen {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "Modifica pulse"
+msgstr "Rediger puls"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "Cosa è un Pulse?"
+msgstr "Hva er en Puls?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "Fatto"
+msgstr "Skjønner"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "Dove dovrebbero andare questi dati?"
+msgstr "Hvor skal disse dataene sendes?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "Sto togliendo dall'archivio..."
+msgstr "Pakker ut..."
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "Eliminazione dall'archivio fallita"
+msgstr "Utpakking feilet"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "Non archiviato"
+msgstr "Pakket ut"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "Cra un pulse"
+msgstr "Laget puls"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:91
 msgid "Attachment"
-msgstr "Allegato"
+msgstr "Vedlegg"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "Dritta"
+msgstr "Varsko"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:106
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "Mostreremo le prime 10 colonne e 20 righe di questa tabella nel tuo Pulse. Se invii un'email a questo, aggiungeremo un allegato con tutte le colonne e fino a 2.000 righe."
+msgstr "Vi vil vise deg de første 10 kolonnene og 20 radene fra denne tabellen i din Puls. Hvis du sender dette som e-post, så legger vi ved et vedlegg med alle kolonner og opptil 2.000 rader."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:113
 msgid "Raw data questions can only be included as email attachments"
-msgstr "Le domande relative ai dati non elaborati possono essere incluse solo come allegati di posta elettronica"
+msgstr "Rådata-spørsmål kan bare inkluderes som e-postvedlegg"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "Looks like this pulse is getting big"
-msgstr "Sembra che questo pulse stia diventando grande"
+msgstr "Det ser ut til at denne pulsen begynner å bli stor."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:121
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "Raccomandiamo di mantenere gli impulsi piccoli e concentrati per mantenerli digeribili e utili a tutta la squadra."
+msgstr "Vi anbefaler å holde pulsene små og fokuserte for å gjøre de enklere å fordøye og mer anvendelige for hele laget."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:161
 #: frontend/src/metabase/query_builder/components/view/View.jsx:133
 msgid "Pick your data"
-msgstr "Scegli i tuoi dati"
+msgstr "Velg dataene dine"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:163
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "Dai un nome al tuo polso per aiutare gli altri a capire di cosa si tratta"
+msgstr "Velg spørsmål du vil sende med denne pulsen"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
-msgstr "Email"
+msgstr "E-poster"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
-msgstr "Messaggi Slack"
+msgstr "Slack-meldinger"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
-msgstr "Spedito"
+msgstr "Sendt"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
-msgstr "{0} saranno spediti a"
+msgstr "{0} vil bli sendt"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
-msgstr "Messaggi"
+msgstr "Meldinger"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "Spedisci email ora"
+msgstr "Send e-post nå"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "Spedisci {0} ora"
+msgstr "Send til {0} nå"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "Invio..."
+msgstr "Sender..."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "Invio fallito"
+msgstr "Sending feilet"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "Non spedire in quanto pulse non ha risultati"
+msgstr "Sendte ikke, fordi pulsen ikke har noen resultater."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "Pulse ha inviato"
+msgstr "Puls sendt"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0} deve essere impostato da un amministratore."
+msgstr "{0} må settes opp av en administrator"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:299
 msgid "Slack"
@@ -4649,448 +4653,448 @@ msgstr "Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "In quale collezione dovrebbe vivere questa pulsazione?"
+msgstr "Hvilken samling skal denne pulsen bo i?"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "Nome del tuo Pulse"
+msgstr "Gi et navn til pulsen din"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "Dai un nome al tuo polso per aiutare gli altri a capire di cosa si tratta"
+msgstr "Gi et navn til pulsen for å gjøre det enklere for andre å forstå hva den handler om"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "Metriche importanti"
+msgstr "Viktige indikatorer"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "Salta se non ci sono risultati"
+msgstr "Hopp over hvis det ikke er noen resultater"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "Salta l'invio del Pulse se nessuna question ha risultati"
+msgstr "Hopp over en planlagt Puls hvis ingen av spørsmålene har noen resultater"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "Inserisci l'indirizzo email a cui vuoi che vengano inviati questi dati"
+msgstr "Skriv e-postadresser du vil sende disse dataene til"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "Aiuta il tuo team a restare aggiornato con i vostri dati"
+msgstr "Hjelp alle på ditt lag med å holde seg i synk med dine data."
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:31
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "I Pulse ti fanno inviare informazioni da Metabase per email o a Slack in maniera schedulata"
+msgstr "Pulser lar deg sende data fra Metabase som e-post eller Slack-meldinger enten regelmessig eller etter behov."
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
-msgstr "Dopo {0}"
+msgstr "Etter {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
-msgstr "Prima {0}"
+msgstr "Før {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "è vuoto"
+msgstr "Er tom"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "Non vuoto"
+msgstr "Ikke tom"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "Sempre"
+msgstr "Hele tiden"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
-msgstr "Applica"
+msgstr "Bruk"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "Vedi {0}"
+msgstr "Vis {0}"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "Confrontalo con tutte le righe nella tabella"
+msgstr "Sammenlign dette med alle rader i tabellen"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "Analizza i risultati di questa Query"
+msgstr "Analyser resultatene av denne Spørringen"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "Conteggio delle righe per tempo"
+msgstr "Antall rader over tid"
 
 #: frontend/src/metabase/modes/components/drill/PivotByDrill.jsx:52
 msgid "Break out by {0}"
-msgstr "Spezza per {0}"
+msgstr "Bryt ut ved {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:36
 msgid "Summarize this segment"
-msgstr "Totalizza questo segmento"
+msgstr "Oppsummer dette segmentet"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "Vedi come tabella"
+msgstr "Vis dette som en tabell"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "Mostra i sottostanti {0} record"
+msgstr "Vis de underliggende {0} oppføringene"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "Applica i Raggi-X alla question"
+msgstr "Utfør X-ray på dette spørsmålet"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "Raggi-X {0} {1}"
+msgstr "X-ray {0} {1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "questi"
+msgstr "disse"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "questo"
+msgstr "denne"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "Confronta {0} {1} al resto"
+msgstr "Sammenlign {0} {1} med resten"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
-msgstr "Distribuzione"
+msgstr "Distribusjon"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "Vedi dettagli"
+msgstr "Vis detaljer"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "Mostra {1} di questo {0}"
+msgstr "Vis denne {0}s {1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "Ascendente"
+msgstr "Stigende"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "Discendente"
+msgstr "Synkende"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:43
 msgid "over time"
-msgstr "Fuori tempo"
+msgstr "over tid"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:22
 msgid "Avg"
-msgstr "Media"
+msgstr "Gjennomsnitt"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:34
 msgid "Distincts"
-msgstr "Distinti"
+msgstr "Unike"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:55
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "Mostra questo {0}"
-msgstr[1] "Mostra questi {0}"
+msgstr[0] "Vis denne {0}"
+msgstr[1] "Vis disse {0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "Avvicina"
+msgstr "Forstørr"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
-msgstr "Espressione custom"
+msgstr "Egendefinert uttrykk"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
-msgstr "Metriche standard"
+msgstr "Vanlige indikatorer"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
-msgstr "Metabasi"
+msgstr "Metabasics"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "Nome (opzionale)"
+msgstr "Navn (valgfritt)"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "Scegli una aggregazione"
+msgstr "Velg en aggregering"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "Imposta il tuo alert"
+msgstr "Sett opp ditt eget varsel"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "Disiscrivendo..."
+msgstr "Stopper abonnement..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "Errore nel cancellarsi"
+msgstr "Klarte ikke å stoppe abonnement"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "Cancellati"
+msgstr "Stopp abonnement"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "Nessun canale"
+msgstr "Ingen kanal"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "Ok, sei stato cancellato"
+msgstr "Okei, du har meldt deg av"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "Stai ricevendo {0} alert"
+msgstr "Du mottar {0}s varsler"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0} imposta un alert"
+msgstr "{0} satte opp en varsel"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "alert"
+msgstr "varsler"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "Impostiamo i tuoi alert"
+msgstr "La oss sette opp varselet ditt"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "Il vasto mondo degli alert"
+msgstr "En verden av varsler"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "Puoi ottenere diversi tipi di alert"
+msgstr "Det er noen forskjellige typer varsler du kan få"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "Quando è una domanda di dati piatti {0}"
+msgstr "Når et rådata-spørsmål {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "restituisci ogni risultato"
+msgstr "returnerer alle resultater"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "Quando è una linea o una barra {0}"
+msgstr "Når en linje eller stolpe {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "supera una linea gol"
+msgstr "krysser en mållinje"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "Quando è una barra di progresso {0}"
+msgstr "Når en fremdriftsindikator {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "raggiunge il suo gol"
+msgstr "når sitt mål"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "Imposta un alert"
+msgstr "Sett opp et varsel"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "Modifica il tuo alert"
+msgstr "Rediger varselet ditt"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "Modifica alert"
+msgstr "Rediger varsel"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "Questo alert non sarà più inviato a {0}."
+msgstr "Dette varselet vil ikke lenger bli sendt til {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "Il canale Sllack {0} non riceverà più questo alert."
+msgstr "Slack-kanalen {0} vil ikke lenger motta dette varselet."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "Il canale {0} non riceverà più questo alert."
+msgstr "Kanalen {0} vil ikke lenger motta dette varselet."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "Cancella questo alert"
+msgstr "Slett dette varselet."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "Ferma l'invio e cancella l'alert. Non si torna indietro, quindi sii attento."
+msgstr "Stopp levering og slett dette varselet. Det er ingen måte å angre dette, så vær forsiktig."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "Eliminare l'alert?"
+msgstr "Slett dette varselet?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "Avvisami quando la linea..."
+msgstr "Varsle meg når linjen..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "Avvisami quando la barra..."
+msgstr "Varsle meg når fremdriftsindikatoren..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "Supera la linea gol"
+msgstr "Går over mållinjen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "Raggiunge il gol"
+msgstr "Når målet"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Va sotto la linea gol"
+msgstr "Går under mållinjen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "Va sotto il gol"
+msgstr "Går under målet"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "La prima volta che lo supera, oppure ogni volta?"
+msgstr "Første gangen den krysser, eller hver gang?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "La prima volta che raggiunge l'obiettivo, oppure sempre?"
+msgstr "Første gangen den når målet, eller hver gang?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "La prima volta"
+msgstr "Første gangen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "Ogni volta"
+msgstr "Hver gang"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "Dove vuoi inviare questi alert?"
+msgstr "Hvor vil du ha disse varslene sendt?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "Invia una email con gli alert a:"
+msgstr "Send e-postvarsel til:"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} Gli alert basati sugli obiettivi non sono al momento supportati per più di una linea, per cui questo alert sarà inviato ogni qualvolta il grafico abbia {1}."
+msgstr "{0} Måldrevne varseler støttes ikke enda for diagrammer med mer enn én linje, så dette varselet vil bli sendt når enn diagrammet har {1}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 #: src/metabase/pulse.clj
 msgid "results"
-msgstr "risultati"
+msgstr "resultater"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0} Questo tipo di alert è più utile quando la tua domanda salvata "
+msgstr "{0} Denne typen varsel er mest nyttig når dine lagrede spørsmål ikke {1} returnerer noen resultater, men du vil vite når de gjør det."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "Consiglio"
+msgstr "Tips"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
-msgstr "solitamente"
+msgstr "vanligvis"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:61
 msgid "Pick a segment or table"
-msgstr "Seleziona un segmento o una tabella"
+msgstr "Velg et segment eller en tabell"
 
 #: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
-msgstr "Seleziona un database"
+msgstr "Velg en database"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:85
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:31
 msgid "Select..."
-msgstr "Seleziona..."
+msgstr "Velg..."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:79
 msgid "Select a table"
-msgstr "Seleziona una tabella"
+msgstr "Velg en tabell"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:926
 msgid "No tables found in this database."
-msgstr "In questo database non è stata trovata nessuna tabella."
+msgstr "Ingen tabeller funnet for denne databasen"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:901
 msgid "Is a question missing?"
-msgstr "Manca una domanda?"
+msgstr "Mangler det et spørsmål?"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:909
 msgid "Learn more about nested queries"
-msgstr "Scopri di più sulle query annidate"
+msgstr "Lær mer om nøstede spørringer"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:951
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:40
 msgid "Fields"
-msgstr "Campi"
+msgstr "Felter"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:977
 msgid "No segments were found."
-msgstr "Non è stato trovato alcun segmento"
+msgstr "Ingen segmenter ble funnet."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:1000
 msgid "Find a segment"
-msgstr "Trova un segmento"
+msgstr "Finn et segment"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "Mostra meno"
+msgstr "Vis mindre"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "Mostra di più"
+msgstr "Vis mer"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "Seleziona il campo in base al quale ordinare"
+msgstr "Velg et felt det skal sorteres etter"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "Ordina"
+msgstr "Sorter"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "Limite di righe"
+msgstr "Radgrense"
 
 #: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
-msgstr "Campo sconosciuto"
+msgstr "Ukjent felt"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:75
 msgid "field"
-msgstr "campo"
+msgstr "felt"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
-msgstr "Combinazioni"
+msgstr "Matcher"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:135
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:143
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "Aggiungi filtri per restringere la tua risposta"
+msgstr "Legg til filter for å snevre inn svaret ditt"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:282
 msgid "Add a grouping"
-msgstr "Aggiungi un raggruppamento"
+msgstr "Legg til en gruppering"
 
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:37
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:313
@@ -5109,108 +5113,108 @@ msgstr "Aggiungi un raggruppamento"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
-msgstr "Dati"
+msgstr "Data"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:340
 msgid "Filtered by"
-msgstr "Filtrati per"
+msgstr "Filtrert etter"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:357
 msgid "View"
-msgstr "Vista"
+msgstr "Vis"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:374
 msgid "Grouped By"
-msgstr "Raggruppati per"
+msgstr "Gruppert Etter"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "Nessuno"
+msgstr "Ingen"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
-msgstr "Questa domanda è scritta in {0}"
+msgstr "Dette spørsmålet er skrevet i {0}."
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "Nascondi Editor"
+msgstr "Skjul Redigeringsverktøy"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "Nascondi Query"
+msgstr "Skjul Spørring"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
-msgstr "Apri Editor"
+msgstr "Åpne Redigeringsverktøy"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:482
 msgid "Show Query"
-msgstr "Mostra Query"
+msgstr "Vis Spørring"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "Questa metrica è stata ritirata. Non può più essere utilizzata."
+msgstr "Denne indikatoren har blitt forkastet. Den er ikke lenger tilgjengelig for bruk."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "Scarica i risultati completi"
+msgstr "Last ned fullt resultat"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "Scarica questi dati"
+msgstr "Last ned disse dataene"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
-msgstr "Attenzione"
+msgstr "Advarsel"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "La tua risposta ha molte righe, per cui il download potrebbe metterci un po'."
+msgstr "Ditt svar har veldig mange rader, så det kan ta en stund å laste ned."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "La massima dimensione scaricabile è 1 milione di righe."
+msgstr "Maks antall rader ved nedlasting er 1 million."
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:11
 msgid "Edit question"
-msgstr "Modifica la domanda"
+msgstr "Rediger spørsmål"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "SALVA LE MODIFICHE"
+msgstr "LAGRE ENDRINGER"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "ANNULLA"
+msgstr "AVBRYT"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "Sposta la domanda"
+msgstr "Flytt spørsmål"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:155
 msgid "Which collection should this be in?"
-msgstr "In quale collezione va inserito?"
+msgstr "Hvilken samling skal denne være i?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:85
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "Variabili"
+msgstr "Variabler"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "Scopri di più sui tuoi dati"
+msgstr "Lær mer om dataene dine"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "Gli allarmi sono attivi"
+msgstr "Advarsler er på"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "iniziato da"
+msgstr "startet fra"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5218,169 +5222,169 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "query nativa"
+msgstr "lokal spørring"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "Non supportato"
+msgstr "Ikke støttet"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "Mostra il {0}"
+msgstr "Se på {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "Cambia a {0}"
+msgstr "Bytt til {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "Passa al Costruttore"
+msgstr "Bytt til bygger"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "{0} per questa domanda"
+msgstr "{0} for dette spørsmålet"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "Trasforma questa domanda in {0}"
+msgstr "Konverter dette spørsmålet til {0}"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:16
 msgid "This question will take approximately {0} to refresh"
-msgstr "Questa domanda impiegherà circa {0} per aggiornarsi"
+msgstr "Dette spørsmålet vil ta cirka {0} å fornye"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "Aggiornato {0}"
+msgstr "Oppdatert {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
 msgid_plural "rows"
-msgstr[0] "riga"
-msgstr[1] "righe"
+msgstr[0] "rad"
+msgstr[1] "rader"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "Mostra i primi {0} {1}"
+msgstr "Viser først {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "Mostra {0} {1}"
+msgstr "Viser {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "Calcolando"
+msgstr "Vitenskap utføres"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "Se mi dai dei dati, posso mostrarti qualcosa di interessante. Lancia una Query!"
+msgstr "Hvis du gir meg noe data, så kan jeg vise deg noe kult. Kjør en spørring!"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "Come uso questa cosa?"
+msgstr "Hvordan bruker jeg denne?"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Answer"
-msgstr "Ottieni la risposta"
+msgstr "Få svar"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "Puoi fare delle prove con le domande salvate"
+msgstr "Det er ok å leke med lagrede spørsmål"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "Non effettuerai alcuna modifica permanente a una domanda salvata a meno che non clicchi sull'icona di modifica in alto a destra."
+msgstr "Endringer blir ikke lagret til lagrede spørsmål, hvis du ikke klikker endre ikonet oppe i høyre hjørnet."
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "Cerca"
+msgstr "Søk etter"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "Avanzate..."
+msgstr "Avansert..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "Mi dispiace. Qualcosa è andato storto."
+msgstr "Beklager. Noe gikk galt."
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "Aggrega il tempo per"
+msgstr "Grupper tid ved"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "La tua domanda ci ha messo troppo tempo"
+msgstr "Spørsmålet ditt tok for lang tid å svare på"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "Non abbiamo ricevuto una risposta in tempo dal tuo database, per cui ci siamo fermati. Puoi riprovare tra un minuto e, se il problema rimane, inviare una mail a un amministratore per informarlo."
+msgstr "Vi fikk ikke ett svar fra din database i tid, så vi måtte stoppe. Du kan prøve igjen om ett minutt, hvis problemet fortsetter, kan du sende en e-post til administrator for å rapportere."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "Stiamo avendo problemi con il database"
+msgstr "Vi har for øyeblikket tjenerproblemer"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "Prova a rinfrescare la pagina tra un paio di minuti. Se il problema rimane, ti consigliamo di contattare un amministratore."
+msgstr "Prøv oppdatere siden etter å ha ventet ett minutt eller to. Hvis problemet fortsetter, ta kontakt med administrator."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "C'è stato un problema con la tua domanda"
+msgstr "Det var et problem med spørsmålet ditt"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "La maggior parte delle volte questo è causato da una selezione invalida o dall'inserimento di un valore anomalo. Ricontrolla l'inserimento e rilancia la query."
+msgstr "For det meste skyldes dette et ugyldig valg eller feil inntastet verdi. Sjekk input en gang til og prøv spørringen din igjen."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "Questa potrebbe essere la risposta che stai cercando. In caso contrario, prova a togliere o modificare i filtri in modo che siano meno specifici."
+msgstr "Dette kan være svaret du leter etter. Hvis ikke, prøv å fjern eller endre filterne for å gjøre det mindre spesifisert."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "Puoi anche {0} quando ci sono dei risultati"
+msgstr "Du kan også {0} når det er noen resultater."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "ricevi un alert"
+msgstr "få en varsel"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "Torna all'ultima esecuzione"
+msgstr "Tilbake til siste kjøring"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:194
 msgid "Visualization"
-msgstr "Visualizzazione"
+msgstr "Visualisering"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
-msgstr "Nessuna descrizione impostata."
+msgstr "Ingen beskrivelse satt."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "Usa per la domanda corrente"
+msgstr "Bruk til dette spørsmålet"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:14
 msgid "Potentially useful questions"
-msgstr "Domande potenzialmente utili"
+msgstr "Potensielt nyttige spørsmål"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "Raggruppa per {0}"
+msgstr "Grupper med {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "Somma di tutti i valori di {0}"
+msgstr "Sum av alle verdier med {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "Tutti i valori che assume {0}"
+msgstr "Alle distinkte verdier av {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "Numero di {0} raggruppato per {1}"
+msgstr "Nummer av {0} gruppert med {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:89
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5392,70 +5396,70 @@ msgstr "Numero di {0} raggruppato per {1}"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "Riferimento dati"
+msgstr "Datareferanse"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "Scopri di più sulla struttura dei dati per fare domande più utili"
+msgstr "Lær mer om din datastruktur for å spørre nyttigere spørsmål"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "Non posso trovare i metadati della tabella prima di creare una nuova domanda"
+msgstr "Kunne ikke å finne tabellmetadata i før opprettelsen av nytt spørsmål"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "Vedi {0}"
+msgstr "Se {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
-msgstr "Definizione della metrica"
+msgstr "Indikatordefinisjon"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "Filtra per {0}"
+msgstr "Filtrer med {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:38
 msgid "Number of {0}"
-msgstr "Numero di {0}"
+msgstr "Tall av {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:48
 msgid "See all {0}"
-msgstr "Mostra tutti {0}"
+msgstr "Se alle {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
-msgstr "Definizione del segmento"
+msgstr "Segmentdefinisjoner"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
-msgstr "Si è verificato un errore durante il caricamento della tabella"
+msgstr "En feil oppstod ved innlasting av tabell"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "Mostra i dati grezzi per {0}"
+msgstr "Se rådata for {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
-msgstr "Altro"
+msgstr "Mer"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:216
 msgid "Invalid expression"
-msgstr "Espressione non valida"
+msgstr "Ugyldig uttrykk"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:282
 msgid "unknown error"
-msgstr "errore sconosciuto"
+msgstr "ukjent feil"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:53
 msgid "Field formula"
-msgstr "Campo formula"
+msgstr "Felt formel"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:64
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "Pensa che è come scrivere una formula in un foglio di calcolo: puoi usare numeri, campi in questa tabella, simboli matematici come + e alcune funzioni. Quindi puoi digitare qualcosa come Subtotal - Cost."
+msgstr "Tenk på dette litt som å skrive en formel i et regneark: Du kan bruke tall, felter i denne tabellen, matematiske symboler som +, og noen funksjoner. Så du kan skrive noe sånt som Subtotal - Kostnad."
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
@@ -5463,267 +5467,266 @@ msgstr "Pensa che è come scrivere una formula in un foglio di calcolo: puoi usa
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
 msgid "Learn more"
-msgstr "Scopri di più"
+msgstr "Lær mer"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:77
 msgid "Give it a name"
-msgstr "Assegna un nome"
+msgstr "Gi den ett navn"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
 msgid "Something nice and descriptive"
-msgstr "Qualcosa di chiaro e descrittivo"
+msgstr "Noe fint og informativt"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "Aggiungi un campo personalizzato"
+msgstr "Legg til tilpasset felt"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "Includi {0}"
+msgstr "Inkluder {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "Tiene conto del maiuscolo e del minuscolo"
+msgstr "Shiftsensitiv"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "oggi"
+msgstr "idag"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "settimana corrente"
+msgstr "denne uken"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "mese corrente"
+msgstr "denne måneden"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
-msgstr "anno corrente"
+msgstr "dette året"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "questo minuto"
+msgstr "dette minuttet"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "quest'ora"
+msgstr "denne timen"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "non implementato {0}"
+msgstr "ikke implementert {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "vero"
+msgstr "riktig"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "falso"
+msgstr "feil"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "Aggiungi un filtro"
+msgstr "Legg til filter"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
-msgstr "Elemento"
+msgstr "Element"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "Precedente"
+msgstr "Tidligere"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "Corrente"
+msgstr "Nåværende"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:257
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "On"
+msgstr "På"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "Inserisci il numero desiderato"
+msgstr "Skriv inn ønsket tall"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:161
 msgid "Empty"
-msgstr "Vuoto"
+msgstr "Tom"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:119
 msgid "Find a value"
-msgstr "Trova un valore"
+msgstr "Finn en verdi"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "Nascondi il calendario"
+msgstr "Skjul kalender"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "Mostra il calendario"
+msgstr "Vis kalender"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "Puoi inserire più valori separati da virgola"
+msgstr "Du kan skrive inn flere verdier separert med komma"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "Inserisci il testo desiderato"
+msgstr "Skriv inn ønsket tekst"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:210
 msgid "Try it"
-msgstr "Prova"
+msgstr "Prøv den"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:243
 msgid "What's this for?"
-msgstr "A cosa serve?"
+msgstr "Hva er dette til?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:245
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "Le variabili nelle query native ti permettono di sostituire dinamicamente i valori nelle tue query utilizzando i filtri widget o attraverso l'URL."
+msgstr "Variabler i lokale spørringer lar deg dynamisk erstatte verdier i spørringen ved bruk av filter eller gjennom nettlinken."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0} crea una variabile in questo modello SQL chiamato \"nome_variabile\". Le variabili possono essere tipi dati nel pannello laterale, che cambia il loro comportamento. Tutti i tipi di variabile diversi da \"Field Filter\" causeranno automaticamente il posizionamento di un filtro su questa domanda; con i filtri di campo, questo è opzionale. Quando questo widget di filtro viene utilizzato, tale valore sostituisce la variabile nel modello SQL."
+msgstr "{0} oppretter en variabel i denne SQL-malen kalt \"variable_name\". Variabler kan gies typer i sidepanelet, som endrer deres oppførsel. Alle variabeltyper annet enn \"feltfilter\" vil automatisk gjøre at en filter-widget blir plassert på dette spørsmålet; med feltfiltere, så er dette valgfritt. Når denne filterwidgeten er fylt inn, så vil dens verdi erstatte variabelen i SQL-malen."
 
-#. Per essere più intuitivi utilizzerei il termine colonna così che gli utenti sanno che questi sono i filtri che poi si basano sui dati presenti nella colonna che andranno a scegliere
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:259
 msgid "Field Filters"
-msgstr "Filtri per colonna"
+msgstr "Felt filtere"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Fornendo una variabile il tipo \"Campo Filtro\" consente di collegare le schede SQL ai widget filtro dashboard o utilizzare più tipi di widget filtro sulla richiesta SQL. Una variabile Field Filter inserisce SQL simile a quello generato dal generatore di query della GUI quando si aggiungono filtri su colonne esistenti."
+msgstr "Ved å gi en variabel \"Felt Filter\"-typen så kan du lenke SQL-spørsmålskort til filter-widgetsene på infotavler, eller bruke flere typer filter-widgets på ditt SQL-spørsmål. En \"Felt Filter\"-variabel setter inn SQL tilsvarende det som den grafiske spørsmålsbyggeren gjør når det legges til filtere på eksisterende kolonner."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:264
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "Quando aggiungi una variabile Field Filter, dovrai mapparla a un campo specifico. Puoi quindi scegliere di visualizzare un widget filtro nella tua domanda, ma anche se non lo fai, puoi ora mappare la variabile Filtro campo a un filtro dashboard quando aggiungi questa domanda a una dashboard. I filtri di campo dovrebbero essere utilizzati all'interno di una clausola \"WHERE\"."
+msgstr "Når du legger til en \"Felt Filter\"-variabel, så må du tilordne den til et spesifikt felt. Du kan deretter velge å vise en filter-widget på spørsmålet ditt, men selv om du ikke gjør det, så kan du nå tilordne \"Felt Filter\"-variabelen din til et infotavle-filter når du legger dette spørsmålet til en infotavle. Felt Filtere bør brukes inni en \"WHERE\"-klausul."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:271
 msgid "Optional Clauses"
-msgstr "Clausole opzionali"
+msgstr "Valgfrie klausuler"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "parentesi attorno a {0} creano una clausola facoltativa nel modello. Se è impostata \"variabile\", l'intera clausola viene inserita nel modello. In caso contrario, l'intera clausola viene ignorata."
+msgstr "firkant-parenteser rundt en {0} lager en valgfri klausul i malen. Hvis \"variabel\" er satt, da blir hele klausulen satt inn i malen. Ellers så blir hele klausulen ignorert."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:283
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "Per utilizzare più clausole facoltative, è possibile includere almeno una clausola WHERE non facoltativa seguita da clausole facoltative che iniziano con \"AND\"."
+msgstr "For å bruke flere valgfrie klausuler kan du inkludere minst én ikke-valgfri WHERE-klausul etterfulgt av valgfrie klausuler som starter med \"AND\"."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:301
 msgid "Read the full documentation"
-msgstr "Leggi la documentazione completa"
+msgstr "Les hele dokumentasjonen"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:133
 msgid "Filter label"
-msgstr "Etichetta di filtro"
+msgstr "Filter etikett"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:134
 msgid "Variable type"
-msgstr "Tipo di variabile"
+msgstr "Variabel type"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:143
 msgid "Text"
-msgstr "Testo"
+msgstr "Tekst"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
 msgid "Date"
-msgstr "Data"
+msgstr "Dato"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:146
 msgid "Field Filter"
-msgstr "Filtro per colonna"
+msgstr "Felt filter"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Field to map to"
-msgstr "Campo a cui mappare"
+msgstr "Felt å koble til"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:180
 msgid "Filter widget type"
-msgstr "Filtro tipo di widget"
+msgstr "Filter type"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
-msgstr "Richiesto?"
+msgstr "Påkrevd?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
-msgstr "Valore di default del widget"
+msgstr "Standard filter verdi"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "Archivia questa domanda?"
+msgstr "Arkiver spørsmålet?"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "Questa domanda sarà rimossa da ogni dashboard o pulse che la contiene"
+msgstr "Dette spørsmålet vil bli slettet fra alle infotavler eller pulser den er i."
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
-msgstr "Domanda"
+msgstr "Spørsmål"
 
 #: frontend/src/metabase/dashboard/components/AddToDashSelectQuestionModal.jsx:31
 msgid "Pick a question to add"
-msgstr "Scegli una domanda da aggiungere"
+msgstr "Plukk ett spørsmål å legge til"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "Stai modificando questa pagina"
+msgstr "Du kan redigere denne siden"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:78
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:45
 msgid "See this {0}"
-msgstr "Guarda questo {0}"
+msgstr "Se dette {0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "Un sottoinsieme di"
+msgstr "En underdel av"
 
 #: frontend/src/metabase/reference/components/Field.jsx:48
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:31
 msgid "Select a field type"
-msgstr "Scegli un tipo di campo"
+msgstr "Velg en felt type"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:85
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:36
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:54
 msgid "No field type"
-msgstr "Nessun tipo di campo"
+msgstr "Ingen felt type"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.jsx:26
 msgid "by"
-msgstr "per"
+msgstr "av"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:156
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:157
 msgid "Field type"
-msgstr "Tipo di campo"
+msgstr "Felt type"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "Degli una chiave esterna"
+msgstr "Velg en ukjent nøkkel"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
-msgstr "Vedi la formula {0}"
+msgstr "Vis {0} formelen"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "Perché questo {0} è importante"
+msgstr "Hvorfor {0} er viktig"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "Perché questo {0} è interessante"
+msgstr "Hvorfor {0} er interessant"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "Nulla di importante per ora"
+msgstr "Ingenting viktig enda"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:172
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:237
@@ -5732,11 +5735,11 @@ msgstr "Nulla di importante per ora"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:248
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:233
 msgid "Nothing interesting yet"
-msgstr "Nulla di interessante per ora"
+msgstr "Ingenting interessant enda"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "Cose da sapere su questo {0}"
+msgstr "Ting å være klar over om denne {0}"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:182
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:247
@@ -5745,77 +5748,77 @@ msgstr "Cose da sapere su questo {0}"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:258
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:243
 msgid "Nothing to be aware of yet"
-msgstr "Niente di cui essere ancora a conoscenza"
+msgstr "Ingenting å være klar over enda"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "Esplore questa metrica"
+msgstr "Utforsk denne indikatoren"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "Vedi questa metrica"
+msgstr "Vis denne indikatoren"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "Per {0}"
+msgstr "Med {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "Rimuovi l'elemento"
+msgstr "Slett element"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "Perché questa dashboard è la più importante?"
+msgstr "Hvorfor er denne infotavlen den viktigste?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "Cosa c'è di utile o interessante su questo {0}?"
+msgstr "Hva er nyttig eller interessant for denne {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "Scrivi qualcosa di utile"
+msgstr "Skriv noe hjelpsomt her"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "C'è qualcosa di cui gli utenti di questa dashboard debbano essere a conoscenza?"
+msgstr "Er det noe brukere av denne infotavlen bør vite om?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "Qualcosa di cui gli utenti debbano essere a conoscenza di questo {0}?"
+msgstr "Er det noe brukerne skal være klar over angående disse {0}"
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "Secondo quali 2 o 3 campi raggruppi solitamente questa metrica?"
+msgstr "Hvilke 2-3 felter grupperer du vanligvis denne indikatoren etter?"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:25
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "Questo è il punto di partenza perfetto se sei nuovo ai dati della tua azienda o se vuoi semplicemente controllare cosa sta succedendo."
+msgstr "Dette er et perfekt sted å starte hvis bedriftens data er nye for deg, eller du ønsker å se hva som foregår"
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:52
 msgid "Most useful fields to group this metric by"
-msgstr "Campi più utili secondo cui raggruppare questa metrica"
+msgstr "Nyttigste feltene å gruppere denne indikatoren etter"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "Motivo delle modifiche"
+msgstr "Grunn til endring"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "Lascia una nota per spiegare quali modifiche hai effettuato e perché erano necessarie"
+msgstr "Legg igjen et notat for å forklare endringene du gjorde og hvorfor de var nødvendige"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:170
 msgid "Why this database is interesting"
-msgstr "Perchè questo database è interessante"
+msgstr "Hvorfor denne databasen er interessant"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:180
 msgid "Things to be aware of about this database"
-msgstr "Punti di attenzione su questo database"
+msgstr "Ting å være klar over om denne databasen"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "Database e tabelle"
+msgstr "Databaser og tabeller"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:28
@@ -5829,374 +5832,374 @@ msgstr "Database e tabelle"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:31
 msgid "Details"
-msgstr "Dettagli"
+msgstr "Detaljer"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
 #: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
-msgstr "Tabelle in {0}"
+msgstr "Tabeller i {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:226
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:204
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:222
 msgid "Actual name in database"
-msgstr "Nome reale nel database"
+msgstr "Reelt navn i database"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:235
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:231
 msgid "Why this field is interesting"
-msgstr "Perché questo campo è interessante"
+msgstr "Hvorfor er dette feltet interessant"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:245
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:241
 msgid "Things to be aware of about this field"
-msgstr "Punti di attenzione su questo campo"
+msgstr "Ting å være klar over om dette feltet"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:257
 #: frontend/src/metabase/reference/databases/FieldList.jsx:159
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:253
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:160
 msgid "Data type"
-msgstr "Tipo dati"
+msgstr "Datatype"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "I campi in questa tabella appariranno qui man mano verranno aggiunti"
+msgstr "Felter i denne tabellen vil vises her når de blir lagt til"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "Campi in {0}"
+msgstr "Felter i {0}"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:153
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:154
 msgid "Field name"
-msgstr "Nome del campo"
+msgstr "Feltnavn"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:46
 msgid "X-ray this field"
-msgstr "Fai un x-ray al campo"
+msgstr "X-ray dette feltet"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabase non è divertente senza dati"
+msgstr "Metabase er ikke morsomt uten data"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "I tuoi database appariranno qui quando li collegherai"
+msgstr "Dine databaser vil vises her når du har koblet til"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "I database appariranno qui quando i tuoi amministratori li avranno aggiunti"
+msgstr "Databasene vil vises her når en av administratorene har lagt til"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "Connetti un database"
+msgstr "Koble til en database"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "Conteggio di {0}"
+msgstr "Telling av {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "Visualizza i dati piatti di {0}"
+msgstr "Se rådata for {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:213
 msgid "Why this table is interesting"
-msgstr "Perchè questa tabella è interessante"
+msgstr "Hvorfor er denne tabellen interessant"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:223
 msgid "Things to be aware of about this table"
-msgstr "Cose di cui essere a conoscenza riguardanti questa tabella"
+msgstr "Ting å være klar over om denne tabellen"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:29
 msgid "Tables in this database will appear here as they're added"
-msgstr "Le tabelle in questo database appariranno qui man mano verranno aggiunte"
+msgstr "Tabellen i denne databasen vises her etter hvert som de blir lagt til"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:33
 msgid "Questions about this table will appear here as they're added"
-msgstr "Le domande su questa tabella appariranno qui man mano verranno aggiunte"
+msgstr "Spørsmål om denne tabellen vises her etter hvert som de blir lagt til"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:73
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:77
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:76
 msgid "Questions about {0}"
-msgstr "Domande riguardanti {0}"
+msgstr "Spørsmål om {0}"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
 msgid "Created {0} by {1}"
-msgstr "Creato {0} per {1}"
+msgstr "Laget {0} av {1}"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "Campi in questa tabella"
+msgstr "Felter i denne tabellen"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:46
 msgid "Questions about this table"
-msgstr "Domande relative a questa tabella"
+msgstr "Spørsmål om denne tabellen"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "Aiuta il tuo team ad iniziare a lavorare con i vostri dati."
+msgstr "Hjelp ditt lag i gang med dataene dine."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "Mostra al tuo team la cosa più importante scegliendo la dashboard, le metriche e i segmenti più importanti."
+msgstr "Vis ditt lag hva som er viktigst ved å velge din viktigste infotavle, indikatorer og segmenter."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "Inizia"
+msgstr "Gå igang"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "La nostra dashboard più importante"
+msgstr "Vår viktigste infotavle"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "Numeri importanti per noi"
+msgstr "Tall vi følger med på"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "Le metriche sono numeri importanti che la tua azienda ritiene essenziali. Rappresentano spesso un indicatore chiave di come si sta svolgendo l'attività."
+msgstr "Indikatorer er viktige tall som din bedrift bryr seg om. De er ofte et mål på hvordan det går med bedriften."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "Mostra tutte le metriche"
+msgstr "Se alle indikatorer"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "Segmenti e tabelle"
+msgstr "Segmenter og tabeller"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:82
 msgid "Tables"
-msgstr "Tabelle"
+msgstr "Tabeller"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "Segmenti e tabelle sono gli elementi costitutivi dei dati della tua azienda. Le tabelle sono raccolte delle informazioni non elaborate mentre i segmenti sono sezioni specifiche con significati specifici, come {0}"
+msgstr "Segmenter og tabeller er byggeklossene i din organisasjons data. Tabeller er samlinger av rå informasjon mens segmenter er spesifikke stykker med spesiell betydning, som for eksempel {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "Le tabelle sono i mattoncini che compongono l'insieme dei dati della vostra azienda."
+msgstr "Tabeller er byggeblokkene i bedriftens data."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "Mostra tutti i segmenti"
+msgstr "Se alle segmenter"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "Mostra tutte le tabelle"
+msgstr "Se alle tabeller"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "Altre cose da sapere sui nostri dati"
+msgstr "Andre ting å vite om dataene dine"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "Scopri di più"
+msgstr "Finn ut mer"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "Un buon modo per conoscere i tuoi dati è trascorrere un po 'di tempo esplorando le diverse tabelle e altre informazioni disponibili. Potrebbe volerci un po ', ma inizierai a riconoscere nomi e significati nel tempo."
+msgstr "En fin måte å bli kjent med dataene fine er å bruke litt tid på å utforske de forskjellige tabellene og annen informasjon som er tilgjengelig. Det kan ta litt tid, men etter hvert vil du begynne å kjenne igjen navn og hva ting betyr."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "Esplora i nostri dati"
+msgstr "Utforsk dataene våre"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "Ci sono domande?"
+msgstr "Har du spørsmål?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "Contatta {0}"
+msgstr "Kontakt {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "Aiuta i nuovi utenti di Metabase a sentirsi a casa."
+msgstr "Hjelp nye Metabase brukere finne veien igjennom."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "La Guida introduttiva evidenzia la dashboard, le metriche, i segmenti e le tabelle che contano di più e informa gli utenti delle cose importanti che dovrebbero sapere prima di scavare nei dati."
+msgstr "\"Kom igang\"-veilederen fremhever infotavlen, beregninger, segmenter, og de mest viktige tabellene, og informerer brukerne dine om ting de bør vite før de begynner å grave i dataene."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "C'è una dashboard importante per il tuo team?"
+msgstr "Er det en viktig infotavle for ditt lag?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "Crea ora una dashboard"
+msgstr "Lag en infotavle nå"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "Qual è la tua dashboard più importante?"
+msgstr "Hva er din viktigste infotavle?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "Hai delle metriche a cui fai riferimento di frequente?"
+msgstr "Har du noen ofte brukte indikatorer?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "Impara come definire una metrica"
+msgstr "Lær hvordan man definerer en indikator"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "Quali solo le 3-5 metriche più richiamate?"
+msgstr "Hva er de 3-5 mest brukte indikatorene?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "Aggiungi un'altra metrica"
+msgstr "Legg til enda en indikator"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "Hai dei segmenti o delle tabelle che sono richiamati frequentemente?"
+msgstr "Har du noen segmenter eller tabeller som det ofte refereres til?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "Impara come creare un segmento"
+msgstr "Lær hvordan man lager ett segment"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "Quali sono 3-5 segmenti o tabelle comunemente citati che sarebbero utili per questo pubblico?"
+msgstr "Hva er 3-5 segmenter eller tabeller som det ofte henvises til og som vil være nyttige for dette publikumet?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "Aggiungi un'altro segmento o tabella"
+msgstr "Legg til nytt segment eller tabell"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "C'è qualcosa che i tuoi utenti dovrebbero capire o sapere prima di iniziare ad accedere ai dati?"
+msgstr "Er det noe brukerne dine burde forstå eller vite om før de begynner å se på dataene?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "Cosa deve sapere un utente di questi dati prima di iniziare ad accedervi?"
+msgstr "Hva burde en bruker vite før de begynner å se på datene? "
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "p.e., aspettative sulla privacy e sull'uso dei dati, insidie o incomprensioni comuni, informazioni sulle prestazioni del data warehouse, note legali, ecc."
+msgstr "F.eks., forventninger rundt personvern og bruk av data, vanlige fallgruver eller misforståelser, informasjon om ytelsen til datavarehuset, juridiske merknader, osv."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "C'è qualcuno che i tuoi utenti potrebbero contattare per chiedere aiuto se sono confusi su questa guida?"
+msgstr "Er det noen som brukere kan kontakte for å få hjelp dersom de har noen spørsmål angående denne veilederen?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "Chi dovrebbe contattare gli utenti per chiedere assistenza se sono confusi su questi dati?"
+msgstr "Hvem skal brukere kontakte for å få hjelp dersom de har noen spørsmål om disse dataene?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:76
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:97
 msgid "Please enter a revision message"
-msgstr "Per favore scrivi un messaggio per la revisione"
+msgstr "Vennligst oppgi en revisjonsmelding"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "Perché questa metrica è interessante"
+msgstr "Hvorfor denne indikatoren er interessant"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "Cose di che dovresti sapere riguardo questa metrica"
+msgstr "Ting å være klar over med denne indikatoren"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "Come viene calcolata questa metrica"
+msgstr "Hvordan denne indikatoren er beregnet"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:240
 msgid "Nothing on how it's calculated yet"
-msgstr "Per ora nulla rispetto a come è calcolato"
+msgstr "Ingenting om hvordan det er beregnet enda"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:297
 msgid "Other fields you can group this metric by"
-msgstr "Altri campi puoi raggruppare questa metrica per"
+msgstr "Andre felter du kan gruppere denne indikatoren etter"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:298
 msgid "Fields you can group this metric by"
-msgstr "Campi con cui puoi raggruppare questa metrica"
+msgstr "Felter du kan gruppere denne indikatoren etter"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:24
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "Le metriche sono i numeri ufficiali di cui il tuo team si prende cura"
+msgstr "Indikatorer er de offisielle tallene som ditt lag bryr seg om"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Metrics will appear here once your admins have created some"
-msgstr "Le metriche appariranno qui una volta che i tuoi amministratori ne avranno creati alcuni"
+msgstr "Indikatorer vil dukke opp her når administratorene har laget noen"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:28
 msgid "Learn how to create metrics"
-msgstr "Scopri come si creano metriche"
+msgstr "Lær mer om hvordan man lager indikatorer"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:34
 msgid "Questions about this metric will appear here as they're added"
-msgstr "Le 'question' su questa metrica verranno visualizzate qui man mano che vengono aggiunte"
+msgstr "Spørsmål om denne indikatoren vil dukke opp her ettersom de blir lagt til"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "Non ci sono revisioni per questa metrica"
+msgstr "Det er ingen revisjoner for denne indikatoren"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:90
 msgid "Revision history for {0}"
-msgstr "Storia delle revisioni per {0}"
+msgstr "Revisjonshistorikk for {0}"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:44
+#, fuzzy
 msgid "X-ray this metric"
-msgstr "Esegui raggi-X su questa metrica"
+msgstr "Gjør en X-ray på denne indikatoren"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:246
 msgid "Why this Segment is interesting"
-msgstr "Perché questo segmento è interessante"
+msgstr "Hvorfor dette Segmentet er interessant"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:256
 msgid "Things to be aware of about this Segment"
-msgstr "Cose da sapere su questo segmento"
+msgstr "Ting å være klar over når det gjelder dette Segmentet"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:23
 msgid "Segments are interesting subsets of tables"
-msgstr "I segmenti sono sottoinsiemi interessanti di tabelle"
+msgstr "Segmenter er interessante subsett av tabeller"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "Definire segmenti comuni per il tuo team rende ancora più facile fare domande"
+msgstr "Å definere vanlige segmenter for ditt lag gjør det enda enklere å stille spørsmål"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Segments will appear here once your admins have created some"
-msgstr "I segmenti appariranno qui non appena i tuoi admin ne avranno creati"
+msgstr "Segmenter vil vises her når en administrator har laget noen"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:27
 msgid "Learn how to create segments"
-msgstr "Impara come creare dei segmenti"
+msgstr "Lær hvordan man lager segmenter"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:34
 msgid "Questions about this segment will appear here as they're added"
-msgstr "Le domande su questo segmento appariranno qui non appena saranno aggiunte"
+msgstr "Spørsmål om dette segmentet vil vises her når de blir lagt til"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:28
 msgid "There are no revisions for this segment"
-msgstr "Non ci sono revisioni per questo segmento"
+msgstr "Det er ingen revisjoner for dette segmentet"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:37
 msgid "Fields in this segment"
-msgstr "Campi in questo segmento"
+msgstr "Felter i dette segmentet"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:43
 msgid "Questions about this segment"
-msgstr "Domande su questo segmento"
+msgstr "Spørsmål om dette segmentet"
 
-#. Purtroppo in italiano non possiamo essere così snelli come in inglese...
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:50
 msgid "X-ray this segment"
-msgstr "Analizza il segmento ai Raggi-X"
+msgstr "Gjør en X-ray av dette segmentet"
 
 #: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
-msgstr "Accedi"
+msgstr "Logg inn"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:390
@@ -6204,595 +6207,594 @@ msgstr "Accedi"
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
 #: frontend/src/metabase/routes.jsx:197
 msgid "Search"
-msgstr "Cerca"
+msgstr "Søk"
 
-#. Usare cruscotto lo trovo agghiacciante
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
 #: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
-msgstr "Dashboard"
+msgstr "Infotavle"
 
 #: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
-msgstr "Nuova domanda"
+msgstr "Nytt spørsmål"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:127
 msgid "Select the type of Database you use"
-msgstr "Seleziona il tipo di Database che utilizzi"
+msgstr "Velg hvilken database type du bruker"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:103
 msgid "Add your data"
-msgstr "Aggiungi i tuoi dati"
+msgstr "Legg til dataene din"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:107
 msgid "I'll add my own data later"
-msgstr "Aggiungerò i miei dati più tardi"
+msgstr "Jeg vil legge til data senere"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:108
 msgid "Connecting to {0}"
-msgstr "Mi sto connettendo a {0}"
+msgstr "Kobler til {0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:130
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "Avrai bisogno di alcune informazioni sul tuo database, come il nome utente e la password. Se non lo hai in questo momento, Metabase viene fornito con un set di dati di esempio con cui puoi iniziare."
+msgstr "Du trenger noe informasjon om databasen din, som for eksempel brukernavn og passord. Hvis du ikke har det akkurat nå, så kommer Metabase med et eksempel-datasett som du kan begynne med."
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my data later"
-msgstr "Aggiungerò i miei dati più tardi"
+msgstr "Jeg vil legge til data senere"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:42
 msgid "Control automatic scans"
-msgstr "Controlla le scansioni automatiche"
+msgstr "Kontroller automatisk skanninger"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:59
 msgid "Usage data preferences"
-msgstr "Preferenze di utilizzo dei dati "
+msgstr "Innstillinger for bruk av data"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:62
 msgid "Thanks for helping us improve"
-msgstr "Grazie per averci aiutato a migliorare"
+msgstr "Takk for hjelpen"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:63
 msgid "We won't collect any usage events"
-msgstr "Non raccoglieremo eventi di utilizzo"
+msgstr "Vi vil ikke samle inn noen brukshendelser"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:88
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Per aiutarci a migliorare Metabase, desideriamo raccogliere determinati dati sull'utilizzo tramite Google Analytics."
+msgstr "For å kunne hjelpe oss med å forbedre Metabase, så vil vi gjerne samle inn enkelte data for bruk gjennom Google Analytics"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Here's a full list of everything we track and why."
-msgstr "Qui trovi la lista completa di cosa tracciamo e perché"
+msgstr "Her er en liste over det vi sporer og hvorfor."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Consenti a Metabase di raccogliere dati anonimi sugli eventi"
+msgstr "Tillat Metabase å samle inn bruksdata anonymt"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0} reccoglie nulla riguardo i tuoi dati e risultati."
+msgstr "Metabase {0} samler alt om dine data eller resultat på spørsmål."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:117
 msgid "never"
-msgstr "mai"
+msgstr "aldri"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:119
 msgid "All collection is completely anonymous."
-msgstr "Tutte le raccolte dati sono completamente anonime."
+msgstr "All innsamling av data er anonymt."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:120
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "La raccolta dati può essere disabilitata in qualsiasi momento dalle impostazioni di amministrazione."
+msgstr "Samling kan skrus av når som helst i admin-innstillingene"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
-msgstr "Se ti senti bloccato"
+msgstr "Hvis du føler at du sitter fast"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
-msgstr "la nostra guida rapida"
+msgstr "vår oppstartsguide"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
-msgstr "ti manca solo un click."
+msgstr "er bare ett klikk unna"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
-msgstr "Benvenuto in Metabase"
+msgstr "Velkommen til Metabase"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "Sembra che tutto funzioni. Ora ti conosciamo, ti colleghiamo ai tuoi dati e inizi a trovarti delle risposte!"
+msgstr "Ser ut som alt virker. La oss bli kjent, koble til dataene din og start med å finne noen svar!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
-msgstr "Iniziamo"
+msgstr "Lå oss starte"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
-msgstr "Abbiamo impostato tutto!"
+msgstr "Alt er klart og satt opp!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
-msgstr "Portami su Metabase"
+msgstr "Ta meg med til Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:49
 msgid "What should we call you?"
-msgstr "Come dovremmo chiamarti?"
+msgstr "Hva skal vi kalle deg?"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "Ciao {0}. Piacere di conoscerti!"
+msgstr "Hei, {0}. Hyggelig å møte deg!"
 
 #: frontend/src/metabase/entities/users/forms.js:48
 msgid "Create a password"
-msgstr "Crea una password"
+msgstr "Lag ett nytt passord"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:44
 #: frontend/src/metabase/entities/users/forms.js:50
 #: frontend/src/metabase/entities/users/forms.js:97
 msgid "Shhh..."
-msgstr "Shhh..."
+msgstr "Hyyysj..."
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:265
 msgid "Confirm password"
-msgstr "Conferma la password"
+msgstr "Gjenta passord"
 
 #: frontend/src/metabase/entities/users/forms.js:57
 msgid "Shhh... but one more time so we get it right"
-msgstr "Shhh... un'ultima volta così non sbagliamo"
+msgstr "Hyyysj... Men en gang til å vi kan få det riktig"
 
 #: frontend/src/metabase/entities/users/forms.js:85
 msgid "Your company or team name"
-msgstr "Il nome della tua Società o del tuo team"
+msgstr "Navn på din bedrift eller ditt lag"
 
-#. Propongo lieve cambio
 #: frontend/src/metabase/setup/components/UserStep.jsx:291
 msgid "Department of awesome"
-msgstr "Team che spacca"
+msgstr "Avdeling råkul"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "Metabot sta ammirando i tuoi interi..."
+msgstr "MetaBot beundrer dine heltall..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "Metabot sta effettuando miliardi di equazioni differenziali..."
+msgstr "MetaBot går igjennom flere milliarder av forskjellige ligninger..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "Metabot sta facendo scienza..."
+msgstr "MetaBot gjør noen vitenskaplige kalkulasjoner..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "Metabot sta ammirando le tue metriche..."
+msgstr "Metabot sjekker indikatoren din..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "Metabot sta cercando tendenze e anomalie..."
+msgstr "MwtaBot ser etter trender og uthevelser..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
+#, fuzzy
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "Metabot sta consultando l'abaco quantistico..."
+msgstr "MetaBot konsulterer med moder jord..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "Metabot ha un ottimo presentimento riguardo tutto ciò..."
+msgstr "MetaBot føler seg bra med dette..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr "Tra pochi minuti ti mostreremo alcune indagini molto interessanti sui tuoi dati."
+msgstr "Vi vil vise deg noen interessante måter å se på dine data om noen øyeblikk."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "Sembra che ci voglia un po'. Nel frattempo, puoi dare un'occhiata a una di queste esplorazioni di esempio per vedere cosa Metabase può fare per te."
+msgstr "Dette ser ut til å ta en stund. I mellomtiden kan du se på en av disse eksemplene for å se hva Metabase kan gjøre for deg."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "Ho dato un'occhiata ai dati che hai appena collegato, e ho alcune esplorazioni di cose interessanti che ho trovato. Spero che ti piacciano!"
+msgstr "Jeg har akkurat kikke litt på dataene du koblet på, og har noen interessante ting jeg fant. Håper du liker det!"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "Per ora ho finito di esplorare"
+msgstr "Jeg er ferdig med å utforske nå"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "Benvenuto nel costruttore di query!"
+msgstr "Velkommen til spørringsbyggeren!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "Query Builder ti consente di riunire domande (o \"query\") per chiedere informazioni sui tuoi dati."
+msgstr "Spørringsbyggeren lar deg sette sammen spørsmål (eller \"spørringer\") for å se på din data."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "Dimmi di più"
+msgstr "Fortell meg mer"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "Inizia scegliendo la tabella con i dati di cui hai una domanda."
+msgstr "Start med å velge den tabellen med data du har spørsmål om."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "Vai avanti e seleziona la tabella \"Ordini\" dal menu a discesa."
+msgstr "Velg \"Orders\"-tabellen fra nedtrekksmenyen."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "Filtra i dati per vedere ciò che vuoi."
+msgstr "Filtrer dataene fine for å få akkurat det du vil ha."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "Clicca il pulsante più  e seleziona il campo \"Creato alle\""
+msgstr "Trykk på pluss-knappen og velg \"Created At\"-feltet."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "Qui possiamo selezionare per quanti giorni vogliamo vedere i dati, prova 10"
+msgstr "Her kan vi velge hvor mange dager vi ønsker å se data for. Prøv 10."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "Qui puoi scegliere di aggiungere o calcolare i tuoi dati, contare il numero di righe nella tabella o semplicemente visualizzare i dati non elaborati."
+msgstr "Her kan du velge å summere eller ta et gjennomsnitt av dine data, telle antall rader i tabellen, eller bare å vise rådataene."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "Provalo: fai clic su <strong> Dati grezzi (Raw data) </ strong> per cambiarlo in <strong> Numero di righe </ strong> in modo che possiamo contare quanti ordini ci sono in questa tabella."
+msgstr "Prøv i vei: trykk på <strong>Rådata</strong> for å endre det til <strong>Antall rader</strong> sånn at vi kan telle hvor mange ordre det er i denne tabellen."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "Aggiungi un raggruppamento per suddividere i risultati per categoria, giorno, mese e altro."
+msgstr "Legg til en gruppering for å bryte resultatene dine opp i kategori, dag, måned, og mere."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "Facciamolo: fai clic su <strong> Aggiungi un gruppo </ strong> e scegli <strong> Creato a: per settimana </ strong>."
+msgstr "La oss gjøre det: trykk på <strong>Legg til en gruppering</strong>, og velg <strong>Created At: etter Uke</strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "Clicca su \"per giorno\" per cambiarlo in \"Settimana\"."
+msgstr "Trykk på \"etter dag\" og bytt til \"Uke.\""
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "Esegui la tua query."
+msgstr "Kjør spørringen din."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "Stai andando così bene! Fai clic su <strong> Esegui query </ strong> per ottenere i risultati!"
+msgstr "Du gjør det bra! Trykk <strong>Kjør spørring</strong> for å få resultatet ditt"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "Puoi visualizzare i risultati come grafico invece di un a tabella."
+msgstr "Du kan se resultatene som en graf i stedet for en tabell"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "A tutti piacciono i grafici! Clicca <strong>Visualizzazione</strong> e seleziona <strong>Linea</strong>."
+msgstr "Alle liker diagrammer! Trykk på <strong>Visualisering</strong>-nedtrekksmenyen og velg <strong>Linje</strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "Ben fatto!"
+msgstr "Bra gjort!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "E' tutto! Se hai altre domande, chiedi pure"
+msgstr "Det var alt! Hvis du fortsatt har noen spørsmål, sjekk ut vår"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "Manuale Utente"
+msgstr "Brukerveiledning"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "Divertiti ad esplorare i tuoi dati"
+msgstr "Kos deg med å utforske dataene dine!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "Grazie"
+msgstr "Takk"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "Salva le tue domande"
+msgstr "Lagre dine spørsmål"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "In ogni caso, puoi salvare le tue domande (question) così puoi recuperarle dopo. Le Domande (question) salvate possono anche essere messe all'interno di Dashboard o Pulse"
+msgstr "Forresten, du kan lagre spørsmålene dine sånn at du kan referere til dem senere. Lagrede spørsmål kan også legges på infotavler eller pulser."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "Suona bene"
+msgstr "Høres bra ut"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "Ooops!"
+msgstr "Oops!"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "Ci spiace, sembra qualcosa sia andato storto. Prova a ricominciare il tutorial tra un minuto."
+msgstr "Beklager, det ser ut til at noe gikk galt. Vær så snill og start opplæringsveilederen om et øyeblikk."
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "Password aggiornata correttamente!"
+msgstr "Passord vellykket oppdatert!"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "Account aggiornato correttamente!"
+msgstr "Konto vellykket oppdatert!"
 
 #: frontend/src/metabase/entities/users/forms.js:96
 msgid "Current password"
-msgstr "Password attuale"
+msgstr "Nåværende passord"
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Accedi con Google"
+msgstr "Logg inn med Google E-postadresse"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "Dettagli utente"
+msgstr "Brukerdetaljer"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:344
 msgid "Reset to defaults"
-msgstr "Ripristina i valori di default"
+msgstr "Tilbakestill til standard"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:167
 msgid "unknown map"
-msgstr "mappa sconosciuta"
+msgstr "ukjent kart"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "La mappa a griglia richiede longitudine / latitudine separate."
+msgstr "Rutekartet krever grupperte lengdegrader/breddegrader."
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:117
 msgid "more"
-msgstr "di più"
+msgstr "mer"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "Quali campi vuoi usare per le coordinate X e Y?"
+msgstr "Hvilke felter vil du bruke for X- og Y-aksene?"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "Scegli i campi"
+msgstr "Velg felt"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:234
 msgid "Save as default view"
-msgstr "Salva come vista di default"
+msgstr "Lagre som standardvisning"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Draw box to filter"
-msgstr "Disegna un box per filtrare"
+msgstr "Tegn en boks for å filtrere"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:256
 msgid "Cancel filter"
-msgstr "Annulla filtro"
+msgstr "Avbryt filter"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "Mappa a punti"
+msgstr "Kartnål-kart"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
-msgstr "Non impostato"
+msgstr "Ikke satt"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
-msgstr "Righe {0}-{1} di {2}"
+msgstr "Rader {0}-{1} av {2}"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
-msgstr "Dati troncati a {0} righe"
+msgstr "Data redusert til {0} rader."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
-msgstr "Impossibile trovare visualizzazione"
+msgstr "Kunne ikke finne visualisering"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
-msgstr "Impossibile visualizzare questo grafico con questi dati"
+msgstr "Kunne ikke vise grafen med denne dataen."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
-msgstr "Nessun risultato!"
+msgstr "Ingen resultater!"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
-msgstr "Sto ancora aspettando..."
+msgstr "Venter fortsatt..."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
-msgstr "Solitamente impiega una media di {0}"
+msgstr "Dette tar vanligvis gjennomsnittlig {0}."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
-msgstr "(Questo è un po' lungo per una dashboard)"
+msgstr "(dette er litt for langt for en infotavle)"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "Di solito è abbastanza veloce, ma sembra che ci stia prendendo un po' troppo"
+msgstr "Dette er vanligvis ganske kjapt men det ser ut som det tar lang tid nå."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "Select a field"
-msgstr "Seleziona un campo"
+msgstr "Velg ett felt"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "errore"
+msgstr "feil"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:117
 msgid "Click and drag to change their order"
-msgstr "Clicca e trascina per cambiarne l'ordine"
+msgstr "Klikk og dra for å endre rekkefølgen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:130
 msgid "Add fields from the list below"
-msgstr "Aggiungi i campi dalla lista sotto"
+msgstr "Legg til felter fra listen under"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "minore di"
+msgstr "mindre enn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "maggiore di"
+msgstr "mer enn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "minore o uguale a"
+msgstr "mindre enn eller lik som"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "maggiore o uguale a"
+msgstr "større enn eller lik som"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "uguale a"
+msgstr "lik som"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "diverso da"
+msgstr "ikke lik som"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "Formattazione condizionale"
+msgstr "Betinget formatering"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "Puoi aggiungere regole per fare in modo che le celle di questa tabella cambino colore se soddisfano determinate condizioni."
+msgstr "Du kan legge til regler for å lage celler i denne tabellen bytte farger avhengig av verdiene."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "Aggiungi un regola"
+msgstr "Legg til regel"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "Le regole saranno applicate in quest'ordine"
+msgstr "Regler vil bli lagt til i denne sorteringen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "Clicca e trascina per riordinare"
+msgstr "Klikk og dra for å endre rekkefølge."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "Nessuna colonna selezionata"
+msgstr "Ingen kolonner valgt"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "Le celle in questa colonna saranno colorate in base ai loro valori."
+msgstr "Celler i denne kolonnen vil bli toner basert på deres verdier."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "Quando una cella in queste colonne è {0}, verrà colorato di questo colore."
+msgstr "Når en celle i disse kolonnene er {0}, vil det bli toner i denne fargen."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "Quali colonne dovrebbero essere influenzate?"
+msgstr "Hvilke kolonner skal påvirkes?"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "Stile di formattazione"
+msgstr "Formatteringstil"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "Singolo colore"
+msgstr "Enkel farge"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "Intervallo di colori"
+msgstr "Fargeskala"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "Quando una cella in questa colonna è..."
+msgstr "Når en celle i denne kolonnen er..."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "...cambia il suo sfondo con questo colore:"
+msgstr "...endre bakgrunnsfargen til denne fargen:"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "Evidenzia l'intera riga"
+msgstr "Framhev hele raden"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
-msgstr "Colori"
+msgstr "Farger"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "Inizia la serie a"
+msgstr "Start omfanget med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "Il più piccolo valore in questa colonna"
+msgstr "Minste verdi i denne kolonnen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "Il più piccolo valore in ogni colonna"
+msgstr "Minste verdi i hver kolonne"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "Il più piccolo valore in tutte queste colonne"
+msgstr "Minste verdi i alle disse kolonnene"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "Valore personalizzato"
+msgstr "Egen verdi"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "Fine della serie a"
+msgstr "Avslutt området ved"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "Il più grande valore in questa colonna"
+msgstr "Største verdi i denne kolonnen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "Il più grande valore in ogni colonna"
+msgstr "Største verdi i hver kolonne"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "Il valore maggiore di tutte queste colonne"
+msgstr "Største verdi i alle disse kolonnene"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "Aggiungi regola"
+msgstr "Legg til regel"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "Aggiorna regola"
+msgstr "Oppdater regel"
 
 #: frontend/src/metabase/visualizations/index.js:36
 msgid "Visualization is null"
-msgstr "La visualizzazione è nulla"
+msgstr "Visualisering er null"
 
 #: frontend/src/metabase/visualizations/index.js:41
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "La visualizzazione deve definire una variabile statica 'identificatore':"
+msgstr "Visualiseringen må definere en 'identifier' statisk variabel: "
 
 #: frontend/src/metabase/visualizations/index.js:47
 msgid "Visualization with that identifier is already registered: "
-msgstr "La visualizzazione con quell'identificatore è già registrata"
+msgstr "Visualiseringen med den indentifikatoren er allerede registrert: "
 
 #: frontend/src/metabase/visualizations/index.js:75
 msgid "No visualization for {0}"
-msgstr "Nessuna visualizzazione per {0}"
+msgstr "Ingen visualisering for {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "\"{0}\" è un campo non aggregato: se ha più di un valore nello stesso punto dell'asse X, i valori saranno sommati"
+msgstr "\"{0}\" er et ikke-aggregert felt: Hvis det har mer enn én verdi for et punkt på x-aksen, så vil verdiene bli summert."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:93
 msgid "This chart type requires at least 2 columns."
-msgstr "Questo tipo di grafico richiede almeno 2 colonne"
+msgstr "Denne grafetypen krever minst 2 kolonner."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:98
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "Questo tipo di grafico non supporta più di {0} serie di dati"
+msgstr "Denne grafetypen støtter ikke mer enn {0} serier med data."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "Obbiettivo"
+msgstr "Mål"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "Mannaggia! I dati della tua query non ci stanno nella modalità di visualizzazione scelta. La visualizzazione richiede almeno {0} {1} di dati,"
+msgstr "Å nei! Dataene fra spørringen din passer ikke med den valgte visningen. Denne visualiseringen trenger minst {0} {1} med data."
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
@@ -6840,319 +6842,320 @@ msgstr "Mannaggia! I dati della tua query non ci stanno nella modalità di visua
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
-msgstr "colonna"
+msgstr "kolonne"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "Niente da fare. Abbiamo {0} dati {1} da mostrare e non è abbastanza per questa visualizzazione."
+msgstr "Sjanseløst. Vi har {0} data {1} å vise og det er ikke nok for denne visualiseringen."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
 msgid_plural "points"
-msgstr[0] "punto"
-msgstr[1] "punti"
+msgstr[0] "poeng"
+msgstr[1] "poenger"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "Non possiamo fare una mappa a punti con questi dati perchè servono le colonne con latitudine e longitudine"
+msgstr "Kjipern. Vi kan ikke lage et kart med kartnåler av disse dataene fordi vi trenger kolonner både for lengdegrad og breddegrad."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "Per favore configura questo grafico nelle impostazioni"
+msgstr "Vennligst konfigurer denne grafen i grafinstillingene"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "Modifica Impostazioni"
+msgstr "Rediger innstillinger"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:39
 msgid "xValues missing!"
-msgstr "Manca il valore X!"
+msgstr "xVerdier mangler!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
-msgstr "Asse-X"
+msgstr "X-akse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Aggiungi una serie di interruzioni..."
+msgstr "Bryt ut serien..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
-msgstr "Asse-Y"
+msgstr "Y-akse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "Aggiungi un'altra serie..."
+msgstr "Legg til en ny serie..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "Dimensione del fumetto"
+msgstr "Bobblestørrelse"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
-msgstr "Linea"
+msgstr "Linje"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "Curva"
+msgstr "Kurve"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "Passaggio"
+msgstr "Steg"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "Mostra marcatori di punti sulle linee"
+msgstr "Vis punktmarkeringer på linjer"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "impilabile"
+msgstr "Stabling"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "Non impilare"
+msgstr "Ikke stable"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "Pila"
+msgstr "Stable"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "Pila - 100%"
+msgstr "Stable - 100%"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "Mostra obiettivo"
+msgstr "Vis mål"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "Valore da raggiungere"
+msgstr "Målverdi"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "Sostituisci i valori mancanti con"
+msgstr "Erstatt manglende verdier med"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
-msgstr "Zero"
+msgstr "Null"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "Niente"
+msgstr "Ingenting"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "Interpolato lineare"
+msgstr "Linjært Interpolert"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:403
 msgid "X-axis scale"
-msgstr "Scala dell'asse-X"
+msgstr "Skalering av X-akse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Timeseries"
-msgstr "Serie temporali"
+msgstr "Tidsserie"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:425
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:443
 msgid "Linear"
-msgstr "Lineare"
+msgstr "Lineær"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:444
 msgid "Power"
-msgstr "Esponente"
+msgstr "Kraft"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:428
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:445
 msgid "Log"
-msgstr "Log"
+msgstr "Logg"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:430
 msgid "Histogram"
-msgstr "Istogramma"
+msgstr "Histogram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:432
 msgid "Ordinal"
-msgstr "Ordinale"
+msgstr "Ordens"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:438
 msgid "Y-axis scale"
-msgstr "scala asse Y"
+msgstr "Y-akse skala"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:451
 msgid "Show x-axis line and marks"
-msgstr "Mostra linea e punti sull'asse X"
+msgstr "Vis linje og merker for x-akse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:349
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:457
 msgid "Compact"
-msgstr "Compatta"
+msgstr "Kompakt"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:458
 msgid "Rotate 45°"
-msgstr "Ruota di 45°"
+msgstr "Roter 45°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:459
 msgid "Rotate 90°"
-msgstr "Ruota di 90°"
+msgstr "Roter 90°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:466
 msgid "Show y-axis line and marks"
-msgstr "Mostra linea e punti sull'asse X"
+msgstr "Vis linje og merker for y-akse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Auto y-axis range"
-msgstr "Auto range l'asse Y"
+msgstr "Automatisk område for y-aksen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:522
 msgid "Use a split y-axis when necessary"
-msgstr "Dividi l'asse Y quando necessario"
+msgstr "Bruk en delt y-akse hvis det er nødvendig"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:529
 msgid "Show label on x-axis"
-msgstr "Mostra etichetta sul asse X"
+msgstr "Vis etikett på x-akse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:535
 msgid "X-axis label"
-msgstr "Etichetta asse X"
+msgstr "X-akse etikett"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:544
 msgid "Show label on y-axis"
-msgstr "Mostra etichetta sul asse Y"
+msgstr "Vis etikett på y-akse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:550
 msgid "Y-axis label"
-msgstr "Etichetta asse Y"
+msgstr "Y-akse etikett"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Standard Deviation"
-msgstr "Deviazione Standard"
+msgstr "Standardavvik"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
-msgstr "Area"
+msgstr "Område"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
-msgstr "grafico ad area"
+msgstr "områdediagram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
-msgstr "barre"
+msgstr "Søyle"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
-msgstr "grafico a barre"
+msgstr "søylediagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "Quali campi vuoi usare?"
+msgstr "Hvilke felter ønsker du å bruke?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "Imbuto"
+msgstr "Trakt"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
-msgstr "Misura"
+msgstr "Måle"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "Tipo di imbuto"
+msgstr "Trakttype"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "grafico a barre"
+msgstr "Søylediagram"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
-msgstr "grafico lineare"
+msgstr "linjediagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "Si prega di selezionare le colonne di longitudine e latitudine nelle impostazioni del grafico."
+msgstr "Vennligst velg kolonner for lengdegrad og breddegrad i diagraminnstillingene."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
-msgstr "Si prega di selezionare una mappa della regione."
+msgstr "Vennligst velg ett regionalkart."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
+#, fuzzy
 msgid "Please select region and metric columns in the chart settings."
-msgstr "Seleziona le colonne della regione e delle metriche nelle impostazioni del grafico."
+msgstr "Vennligst velg region- og indikator-kolonner i diagraminnstillingene."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
-msgstr "Mappa"
+msgstr "Kart"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
-msgstr "Tipo di mappa"
+msgstr "Kart type"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
-msgstr "Mappa della regione"
+msgstr "Regionalkart"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
-msgstr "Mappa puntine"
+msgstr "Kartnål-kart"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
-msgstr "Tipo di puntine"
+msgstr "Type kartnål"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
-msgstr "Riquadri"
+msgstr "Fliser"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
-msgstr "Marcatori"
+msgstr "Markører"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
-msgstr "Campo latitudine"
+msgstr "Felt for breddegrad"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
-msgstr "Campo longitudine"
+msgstr "Felt for lengdegrad"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
-msgstr "Campo per Metrica"
+msgstr "Indikatorfelt"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
-msgstr "Campo Regione"
+msgstr "Felt for region"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
-msgstr "Raggio"
+msgstr "Radius"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
-msgstr "Offusca"
+msgstr "Uskarphet"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
-msgstr "Opacità minima"
+msgstr "Min gjennomsiktighet"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
-msgstr "Max Zoom"
+msgstr "Maks zoom"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:234
 msgid "No relationships found."
-msgstr "Nessuna relazione trovata"
+msgstr "Ingen forhold funnet"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:272
 msgid "via {0}"
@@ -7160,395 +7163,400 @@ msgstr "via {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
-msgstr "Questo {0} è connesso a:"
+msgstr "{0} er koblet til:"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "Object Detail"
-msgstr "Dettagli oggetto"
+msgstr "Objekt detaljer"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:93
 msgid "object"
-msgstr "oggetto"
+msgstr "objekt"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
-msgstr "Totale"
+msgstr "Total"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
-msgstr "Quali colonne vuoi usare?"
+msgstr "Hvilke kolonner vil du bruke?"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
-msgstr "Torta"
+msgstr "Pai"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
-msgstr "Dimensione"
+msgstr "Dimensjon"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
+#, fuzzy
 msgid "Show legend"
-msgstr "Mostra legenda"
+msgstr "Vis forklaring"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
+#, fuzzy
 msgid "Show percentages in legend"
-msgstr "Mostra percentuali nella legenda"
+msgstr "Vis prosenter i forklaring"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
-msgstr "Percentuale della fetta minore"
+msgstr "Minste oppstykkings-prosent"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "Obiettivo raggiunto"
+msgstr "Mål møtt"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "Obiettivo superato"
+msgstr "Mål overskredet"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "Obiettivo {0}"
+msgstr "Mål {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "La visualizzazione del progresso richiede un numero."
+msgstr "Fremdriftsvisualisering krever et tall."
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "Avanzamento"
+msgstr "Fremdrift"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/entities/snippet-collections.js:87
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "Colore"
+msgstr "Farge"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "Grafico a righe"
+msgstr "Raddiagram"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
-msgstr "grafico a righe"
+msgstr "raddiagram"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:381
 msgid "Separator style"
-msgstr "stile del separatore"
+msgstr "Separatorstil"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "Numero di posizioni decimali"
+msgstr "Nummer med desimal punkter"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:405
 msgid "Add a prefix"
-msgstr "Aggiungi un prefisso"
+msgstr "Legg til prefiks"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:409
 msgid "Add a suffix"
-msgstr "Aggiungi un suffisso"
+msgstr "Legg til suffiks"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:398
 msgid "Multiply by a number"
-msgstr "Moltiplica per un numero"
+msgstr "Multipliser med ett tall"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
-msgstr "Dispersione"
+msgstr "Spredning"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
-msgstr "Trama sparsa"
+msgstr "spredningsdiagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
-msgstr "Tabella Pivot"
+msgstr "Pivoter tabellen"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "Campi visibili"
+msgstr "Synlige felter"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
+#, fuzzy
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Scrivi qui, e usa `Markdown` se vuoi"
+msgstr "Skriv her, og bruk gjerne Markdown hvis du vil"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "Allineamento verticale"
+msgstr "Loddrett justering"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "Alto"
+msgstr "Topp"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "Medio"
+msgstr "Midten"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "Basso"
+msgstr "Bunn"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "Allineamento Orizzontale"
+msgstr "Vannrett justering"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "Sinistra"
+msgstr "Venstre"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "Centro"
+msgstr "Senter"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "Destra"
+msgstr "Høyre"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "Mostra sfondo"
+msgstr "Vis bakgrunn"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0} bidone"
-msgstr[1] "{0} bidoni"
+msgstr[0] "{0} samling"
+msgstr[1] "{0} samlinger"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
-msgstr "intervallo automatico"
+msgstr "Auto samling"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "DELETE /api/alert/:id è deprecato. Modifica il valore `archiviato` tramite PUT /api/alert/:id."
+msgstr "DELETE /api/alert/:id er foreldet. Bruk heller dens`archived`-verdi via PUT /api/alert/:id."
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "Mostra valore non valido"
+msgstr "ukjent vis verdi"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "valore invalido per il prefisso"
+msgstr "ukjent verdi for prefiks"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "valore invalido per il nome della regola"
+msgstr "ukjent verdi for regelnavn"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "Il valore non può essere convertito in un JSON a codifica base64"
+msgstr "verdi kunne ikke leses som base64 kodet JSON"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "tipo di entità invalido"
+msgstr "Ukjent enhetstype"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "Comparazione non valida tra tipi di entità. Può essere solo uno di \"tabella\", \"segmento\" or \"adhoc\""
+msgstr "Ugyldig entitetstype for sammenligning. Kan kun være en av \"tabell\", \"segment\", eller \"adhoc\""
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "Errore durante lo svolgimento della query atto a determinare la Carta metadato risultato:"
+msgstr "Feil ved kjøring av spørring for å bestemme metadata for kort-resultat:"
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/alert/:id è deprecato. Modifica il valore `archiviato` tramite PUT /api/alert/:id."
+msgstr "DELETE /api/card/:id er utgående. Arkiver istedenfor ved bruk av `archived` verdi via PUT /api/card/:id."
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "Campo non valido: {0}"
+msgstr "Ukjent felt: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "Valore non valido \"{0}\" per \"{1}\": {2}"
+msgstr "Ukjent verdi \"{0}\" for \"{1}\": {2}"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "dev'essere uno di: {0}"
+msgstr "Må være en av: {0}"
 
 #: src/metabase/api/common.clj
+#, fuzzy
 msgid "Invalid Request."
-msgstr "Richiesta invalida"
+msgstr "Ukjent forespørsel."
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "Non trovato."
+msgstr "Ikke funnet."
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "Non hai i permessi per farlo."
+msgstr "Du har ikke tilganger til å gjøre dette."
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "Errore interno del server."
+msgstr "Intern tjenerfeil."
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "Avviso: l'endpoint {0}/{1} non ha una docstring."
+msgstr "Advarsel: endepunktet {0}/{1} har ikke en docstring."
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "avviare la richiesta di streaming"
+msgstr "starter strømningsforespørsel"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "connessione chiusa, richiesta di cancellazione"
+msgstr "Kobling lukket, avbryter forespørsel"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "Risposta non pronta, scrittura di un byte e sospensione ..."
+msgstr "Respons ikke tilgjengelig, skriver en byte & sover..."
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "La condivisione pubblica non è abilitata."
+msgstr "Offentlig deling er ikke aktivert."
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "L'incorporamento non è abilitato."
+msgstr "Innebygging er ikke aktivert."
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "L'oggetto è stato archiviato."
+msgstr "Objektet har blitt arkivert."
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "Tentato di tornare un boolean come una risposta API. Non è permesso."
+msgstr "Forsøkte å returnere en boolsk verdi som et API-svar. Dette er ikke tillatt!"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "La query sorgente per questa query è Carta {0}"
+msgstr "Kilde-spørring for denne spørringen er kort {0}"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "Formato di esportazione non valido: {0}"
+msgstr "Ukjent eksport format: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "JSON URL o risorsa non valida: {0}"
+msgstr "Ukjent JSON nettlink eller resurs: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "JSON contenente le informazioni riguardo i file GeoJSON da usare nelle visualizzazioni su mappa al posto di quelli US o mondiali presenti di default"
+msgstr "JSON som inneholder informasjon om egendefinert GeoJSON-filer for bruk i kart-visualiseringer istedenfor det innebygde kartet over stater i USA eller verdenskartet."
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "Chiave GeoJSON personalizzata non valida: {0}"
+msgstr "Ukjent tilpasset GeoJSON nøkkel: {0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "Parametro invalido: {0} "
+msgstr "Ukjent parameter: {0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
-msgstr " DELETE /api/pulse/:id è deprecato. Cambia il suo valore `archiviato` tramite PUT /api/pulse/:id."
+msgstr "DELETE /api/pulse/:id er avleggs. Istedenfor bruk arkiverings API via PUT /api/pulsen/:id."
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "Endpoint della API non esiste"
+msgstr "API punkt fins ikke."
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "La password non corrisponde a quella salvata"
+msgstr "Passord er ikke likt lagret passord."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "non corrisponde alla password salvata"
+msgstr "er ikke likt lagret passord"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "Problemi di connessione a un server LDAP, ricadrà su autenticazione locale"
+msgstr "Problem tilkobling til LDAP-tjener, vil falle tilbake til lokal autorisering {0}"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "Token di reset invalido"
+msgstr "Ugyldig tilbakestillingsnøkkel"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "Client ID per Google Auth SSO. Se impostato, Google Auth è considerato abilitato"
+msgstr "Klient-ID for Google Auth SSO. Hvis denne er satt, så er Google Auth ansett for å være aktivert."
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "Quando è impostato, consente agli utenti di registrarsi autonomamente se l'indirizzo email riferito al proprio Google account appartiene a questo dominio."
+msgstr "Når denne er satt, så kan brukere registrere seg med sin egen Google-konto dersom e-postadressen er fra dette domenet."
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr " Google Auth token invalido."
+msgstr "Ugyldig Google Auth nøkkel."
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "Email non verificata"
+msgstr "E-postadresse ikke verifisert."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Avrai bisogno di un amministratore per creare un account su Metabase prima che tu possa usare Google per accedere."
+msgstr "En administrator må lage en Metabase-konto før du kan bruke Google til å logge inn."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "Autenticato con successo Google Auth token per: {0} {1}"
+msgstr "Autentisering med Google Auth token var vellykket for: {0} {1}"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "Aggiungi database"
+msgstr "Legg til database"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "Resta connesso"
+msgstr "Koble til"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "Connetti i tuoi dati così tutto il tuo team puoi iniziare ad esplorare."
+msgstr "Koble til dine data sånn at hele laget ditt kan starte å utforske."
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "Imposta una email"
+msgstr "Sett opp e-post"
 
 #: src/metabase/api/setup.clj
+#, fuzzy
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "Aggiungi le credenziali email così puoi invitare i membri del team e avere aggiornamenti tramite Pulse."
+msgstr "Legg til legitimasjon for e-post sånn at du enklere kan invitere lagmedlemmer og motta oppdateringer via pulser."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Imposta credenziali slack"
+msgstr "Sett Slack innlogging"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "Il tuo team usa Slack? Se cos', puoi inviare aggiornamenti automatici tramite pulse e chiedere domande con MetaBot"
+msgstr "Bruker laget ditt Slack? I så fall kan du sende automatiske oppdateringer via pulser og stille spørsmål med MetaBot."
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "Invita i membri del tuo team"
+msgstr "Inviter lagmedlemmer"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "Condividi risposte e dati con il resto del tuo team."
+msgstr "Del svar og data med resten av ditt lag."
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "Nascondi tabelle non rilevanti"
+msgstr "Skjul irrelevante tabeller"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "Cura i tuoi dati"
+msgstr "Organiser dataene dine"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "Se i tuoi dati contengono informazioni tecniche o irrilevanti puoi nasconderle."
+msgstr "Hvis dataene inneholder teknisk eller irrelevant informasjon så kan du skjule det."
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "Organizza le Question"
+msgstr "Organiser spørsmål"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "Hai molte Question salvate in {0}? Crea collezioni per aiutare a gestirle e aggiungi il contesto."
+msgstr "Har du mange lagrede spørsmål i {0}? Lag samlinger for å håndtere dem og sette dem i kontekst."
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7565,1271 +7573,1273 @@ msgstr "Metabase"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "Crea metriche"
+msgstr "Lag indikator"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "Stabilisce metriche canoniche per rendere più facile ottenere le giuste risposte agli altri membri del tuo gruppo"
+msgstr "Definer standardindikatorer for å gjøre det enklere for resten av ditt lag å finne de riktige svarene."
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "Crea segmenti"
+msgstr "Lag segmenter"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "Mantieni ognuno sulla stessa pagina creando insiemi canonici di filtri che ognuno può utilizzare quando interroga"
+msgstr "Hjelp alle med å forstå hverandre ved å lage standard-sett med filtere som alle kan bruke når de stiller spørsmål."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "La tabella \"{0}\" è ora visibile. Risincronizza."
+msgstr "Tabell \"{0}\" er synlig. Synkroniserer på nytt."
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "intervallo automatico"
+msgstr "Auto samle"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "nessun intervallo"
+msgstr "Ikke samle"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "Giorno"
-msgstr[1] "Giorni"
+msgstr[0] "Dag"
+msgstr[1] "Dager"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "Minuto"
-msgstr[1] "Minuti"
+msgstr[0] "Minutt"
+msgstr[1] "Minutter"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "Ora"
-msgstr[1] "Ore"
+msgstr[0] "Time"
+msgstr[1] "Timer"
 
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "Trimestre"
-msgstr[1] "Trimestri"
+msgstr[0] "Kvartal"
+msgstr[1] "Kvartaler"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "Minute dell'ora"
+msgstr "Minutt i time"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "Ore del giorno"
+msgstr "Time på dagen"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "Giorno della settimana"
+msgstr "Dag i uke"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "Giorno del mese"
+msgstr "Dag i måned"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "Giorno dell'anno"
+msgstr "Dag i år"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "Settimana dell'anno"
+msgstr "Uke i år"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "Mese dell'anno"
+msgstr "Måned i år"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "Trimestre dell'anno"
+msgstr "Kvartal i år"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10 bidoni"
+msgstr "10 samlinger"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50 bidoni"
+msgstr "50 samlinger"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100 bidoni"
+msgstr "100 samlinger"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "intervalla ogni 0.1 gradi"
+msgstr "Samle hver 0,1 grader"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "intervalla ogni 1 grado"
+msgstr "Samle hver grad"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "intervalla ogni 10 gradi"
+msgstr "Samle hver 10ende grad"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "intervalla ogni 20 gradi"
+msgstr "Samle hver 20ende grad"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "Nessun Image Writer appropriato trovato!"
+msgstr "Ingen passende bildeforfatter funnet!"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "Indirizzo email già utilizzato"
+msgstr "E-postadresse allerede brukt."
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "Indirizzo email già associato ad un altro utente."
+msgstr "E-postadresse allerede assosiert med annen bruker."
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "Non è possibile riattivare un utente attivo"
+msgstr "Kan ikke aktivere en aktiv bruker"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "Password non valida"
+msgstr "Ugyldig passord"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "Tutto {0}"
+msgstr "Alle {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}, tutto {1}"
+msgstr "{0}, alle {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "Confronto di {0} e {1}"
+msgstr "Sammenligning av {0} og {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "Dashboard di confronto generato automaticamente che confronta {0} e {1}"
+msgstr "Automatisk generert sammenligningsinfotavle som sammenligner {0} og {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "somma"
+msgstr "sum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "media"
+msgstr "gjennomsnitt"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "minimo"
+msgstr "minimum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "massimo"
+msgstr "maksimum"
 
 #: src/metabase/automagic_dashboards/core.clj
+#, fuzzy
 msgid "distinct count"
-msgstr "conta distinti"
+msgstr "distinkt telling"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "deviazione standard"
+msgstr "standardavvik"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "conta comulato"
+msgstr "kumulativt antall"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "somma cumulata"
+msgstr "kumulativ sum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0} e {1}"
+msgstr "{0} og {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{0} di {1}"
+msgstr "{0} av {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{0} per {1}"
+msgstr "{0} med {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{0} nel segmento di {1}"
+msgstr "{0} i {1} segmentet"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "{0} segmento"
+msgstr "{0} segment"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "{0} metrica"
-msgstr[1] "{0} metriche"
+msgstr[0] "{0} indikator"
+msgstr[1] "{0} indikatorer"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "{0} campo"
+msgstr "{0} felt"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "\"{0}\" question"
+msgstr "\"{0}\" spørsmål"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "Confronta con {0}"
+msgstr "Sammenlign med {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "Confronta con l'intero dataset"
+msgstr "Sammenlign med hele datasettet"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "Applicando l'euristico %s a %s."
+msgstr "Bruk heuristikk %s til %s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "Dimensioni delle associazioni: n%s"
+msgstr "Dimensjoner bindinger:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "Utilizzando le definizioni::nMetrics:n%snFilters:n%s"
+msgstr "Bruker definisjoner:nBeregninger:n%snFiltere:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "Non posso creare la dashboard per {0}"
+msgstr "Kan ikke lage infotavle for {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "{0}primo"
+msgstr "{0}ste"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "{0}secondo"
+msgstr "{0}dre"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "{0}terzo"
+msgstr "{0}dje"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0}mo"
+msgstr "{0}de"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "a {0}"
+msgstr "på {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "su {0}"
+msgstr "på {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "in {0} settimane - {1}"
+msgstr "om {0} uke - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "in {0}"
+msgstr "om {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "in Q{0} - {1}"
+msgstr "i K{0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "Q{0}"
+msgstr "K{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0} è {1}"
+msgstr "{0} er {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "0} è tra {1} e {2}"
+msgstr "{0} er mellom {1} og {2}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "0} è tra {1} e {2}; e {3} è tra {4} e {5}"
+msgstr "{0} er mellom {1} og {2}, og {3} er mellom {4} og {5}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "dove {0}"
+msgstr "hvor {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "Uno sguardo più da vicino a {0}"
+msgstr "En grundigere titt på {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "Uno sguardo più da vicino al {0}"
+msgstr "En grundigere titt på {0}"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "Aggiungendo %s cards alla dashboard %s:n%s"
+msgstr "Legger til %s kort til infotavlen %s:n%s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
-msgstr "0 <= punteggio <= {0}"
+msgstr "0 <= poengsum <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= larghezza <= {0}"
+msgstr "1 <= bredde <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "Riferimenti di metrica validi"
+msgstr "Gyldige indikatorreferanser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "Riferimenti validi per i filtri"
+msgstr "Gyldig filter referanse"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "Riferimenti validi per il raggruppamento"
+msgstr "Gyldig gruppe referanser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "Riferimenti validi per order_by"
+msgstr "Gyldig order_by referanser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "Riferimenti validi per i filtri della dashboard"
+msgstr "Gyldige referanser for infotavlefilter"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "Riferimenti validi per la dimensione"
+msgstr "Gyldig dimensjonelle referanser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "Riferimenti validi per la dimensione "
+msgstr "Gyldig kort dimensjon referanser"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "Errore nel parsing %s:n%s"
+msgstr "Feil under tolking av %s:n%s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "Nessun utente trovato con l'indirizzo email \"{0}\""
+msgstr "Fant ingen bruker med epostadressen \"{0}\""
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "Per favore verifica lo spelling e prova ancora."
+msgstr "Kontroller skrivemåten og prøv igjen"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "Sto resettando la password per {0}"
+msgstr "Tilbakestiller passord for {0}..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
-msgstr "OK [[[{0}]]]"
+msgstr "Ok [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "FALLITO [[[{0}]]]"
+msgstr "FEIL [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Per favore usare il seguente URL per settare l'installazione di Metabase:"
+msgstr "Vennligst bruk følgende URL for å sette opp Metabase-installasjonen din:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Metabase si sta spegnendo"
+msgstr "Metabase avslutter..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabase si è spento completamente"
+msgstr "Avslutning av Metabase FERDIG"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Metabase versione {0} in avvio ..."
+msgstr "Starter Metabase versjon {0} ..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "La timezone di sistema è \"{0}\" ..."
+msgstr "System tidssone er \"{0}\" ..."
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Prepariamo e migriamo il database di Metabase"
+msgstr "Setter opp og migrerer Metabase DB. Vennligst vent litt, dette kan ta noen øyeblikk..."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "Sembra che questa sia una nuova installazione... prepariamo il wizard di setup"
+msgstr "Det ser ut som at dette er en ny installasjon ... forbereder installasjonsveilederen"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Inizializzazione Metabase COMPLETA"
+msgstr "Metabase oppstart ferdig"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "Lanciando il Webserver Jetty Embedded"
+msgstr "Starter Embedded Jetty Webserver med konfigurasjon:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "Shutting down il Webserver Jetty Embedded"
+msgstr "Stopper Embedded Jetty Webserver"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "Start di Metabase in STANDALONE mode"
+msgstr "Starter Metabase i STANDALONE-modus"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "Inizializzazione di Metabase FALLITA"
+msgstr "Metabase oppstart feilet"
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "Il database ha un lock di migrazione; non è possibile lanciare migrazioni"
+msgstr "Database har migreringer, kan ikke kjøre migreringer."
 
 #: src/metabase/db/liquibase.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "Puoi forzare il rilascio di questi vincoli tramite `java -jar metabase.jar migrate release-locks`."
+msgstr "Du kan løse opp låsningene ved å kjøre `java -jar metabase.jar migrate release-locks`."
 
 #: src/metabase/db/liquibase.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "Verifica se il Database ha migrazioni non eseguite"
+msgstr "Sjekker om databasen har ukjørte migreringer..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "Il Database ha migrazioni non eseguite. Attendere che il blocco migrazione sia cancellato..."
+msgstr "Database her ukjørte migreringer. Vent mens migreringslåsen blir løst..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "Il blocco della migrazione è cancellato. Esecuzione migrazioni ..."
+msgstr "Migreringslås er løst. Kjører migreringer..."
 
 #: src/metabase/db/liquibase.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "vincoli di migrazione ripuliti, ma non c'è nulla da fare qui! Le migrazioni sono state terminate da un'altra istanza."
+msgstr "Migreringslås er løst, men ingenting å gjøre her! Migreringer ble ferdige i en annen instanse."
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Settando Liquibase"
+msgstr "Setter opp Liquibase..."
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibase è pronto"
+msgstr "Liquibase er ferdig."
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "Verifica {0} Database Connection ..."
+msgstr "Verifiserer {0} sin database tilkobling..."
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "Verifica delle Connessioni al database..."
+msgstr "Verifiserer database tilkobling... "
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Migrazione Database in corso"
+msgstr "Kjører Database migreringer..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "Migrazione Database corrente ..."
+msgstr "Database nåværende migrering... "
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "Mmm, non abbiamo potuto connetterci al database"
+msgstr "Hmm, vi klarte ikke koble til databasen."
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "Verifica che host e porte siano settate correttamente"
+msgstr "Sjekk at vert og port innstillingene er riktige"
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "Non abbiamo potuto connetterci al host del tunnel ssh"
+msgstr "Vi klarte ikke koble til SSH tunnelverten."
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "Verifica username e password."
+msgstr "Sjekk brukernavn og passord."
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "Controlla l'hostname e la porta"
+msgstr "Sjekk vertsnavn og port."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "Sembra che il nome del database non sia corretto"
+msgstr "Ser ut som databasenavnet er feil."
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "Sembra che il tuo host non sia valido."
+msgstr "Det ser ut som vertsnavnet er feil."
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "Per favore fare una doppia verifica e provare ancora"
+msgstr "Vennligst dobbeltsjekk og prøv igjen."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "Sembra che la tua password sia errata."
+msgstr "Ser ut som passordet er feil."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "Sembra che hai dimenticato di inserire la tua password"
+msgstr "Ser ut som du har glemt å legge inn passordet ditt."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "Sembra che il tuo username non sia corretto"
+msgstr "Ser ut som brukernavn er feil."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "Sembra che username e password siano incorretti"
+msgstr "Ser ut som brukernavn eller passord er feil."
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "Timezone da usare quando si eseguino le query. Il default è la timezone di sistema"
+msgstr "Tilkoblingstidssone som skal brukes ved kjøring av spørringer. Standard er systemets tidssone"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "Driver registrati {0} {1}"
+msgstr "Registrert driver {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "Nessuna funzione -init-driver trovata per \"{0}\""
+msgstr "Ingen -init-driver funksjon funnet for \"{0}\""
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "Impossibile adattare la stringa data \"{0}\" per il sistema base di dati \"{1}\""
+msgstr "Klarer ikke å tolke dato-teksten \"{0}\" for databasemotoren \"{1}\""
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "Non si riesce a mappare la classe \"{0}\" ad un Campo base_type, ritorno a :type/*."
+msgstr "Vet ikke hvordan klassen \"{0}\" skal tilordnes en Field base_type, faller tilbake på :type/*."
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "Connessione fallita al database {0}"
+msgstr "Feilet ved tilkobling til database: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "Idendificatore BigQuery non valido: \"{0}\""
+msgstr "Ugyldig BigQuery-identifikator: \"{0}\""
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "L'istruzione BigQuery non può essere parametrizzata!"
+msgstr "BigQuery-uttrykk kan ikke parametriseres!"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "Impostazione timezone fallita:"
+msgstr "Feilet ved oppsett av tidssone:"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Devi abilitare le Google Analytics API. Usa questo link per accedere alla Google Developers Console: {0}"
+msgstr "Du må aktivere Google Analytics APIet. Bruk denne lenken for å gå til Google Developers Console: {0}"
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "è vietato utilizzare query SQL per database H2 mediante l'utente database di default (admin)"
+msgstr "Å kjøre SQL-spørringer mot H2-databaser med standard (admin) database-bruker er forbudt."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "Errore: metabase.driver.FixedHiveDriver è registrato, ma sembra che JDBC non lo stia usando."
+msgstr "Feil: metabase.driver.FixedHiveDriver er registrert, men JDBC ser ikke ut til å bruke den."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "Trovato metabase.driver.FixedHiveDriver."
+msgstr "Fant metabase.driver.FixedHiveDriver."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "Registrato con successo il metabase.driver.FixedHiveDriver con JDBC."
+msgstr "Registrering av metabase.driver.FixedHiveDriver til JDBC vellykket."
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "L'indirizzo email che vuoi usare come mittente di Metabase"
+msgstr "E-postadresse du vil skal være av sender fra Metabase."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "L'indirizzo del server SMTP che invia le tue email."
+msgstr "E-postadresse for SMTP-tjeneren som håndterer dine e-poster."
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "Username SMTP"
+msgstr "SMTP brukernavn:"
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "Password SMTP"
+msgstr "SMTP passord."
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "La porta che il server SMTP usa per le email outgoing"
+msgstr "Porten SMTP-tjeneren bruker for utgående e-poster."
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "Protocollo SMTP sicuro (tls, ssl, starttls, o nessuno)"
+msgstr "SMTP sikker koblingsprotokoll. (TLS, SSL, STARTTLS eller ingen)"
 
 #: src/metabase/email.clj
 msgid "none"
-msgstr "nessuno"
+msgstr "ingen"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "L'host SMTP non è settato"
+msgstr "SMTP vert er ikke satt."
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "L'invio email è fallito"
+msgstr "Feilet ved sending av e-post."
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "Errore nel test della connessione SMTP"
+msgstr "Feil ved testing av SMTP kobling"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "Abilitare autenticazione LDAP"
+msgstr "Aktiver LDAP autorisering."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "Hostname server"
+msgstr "Vertsnavn til tjener."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "Porta server, normalmente 389 o 636, se si usa SSL"
+msgstr "Port til tjener, vanligvis 389 eller 636 hvis SSL er i bruk."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "Usa SSL, TLS o testo in chiaro"
+msgstr "Bruk SSL, TLS eller ren tekst."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "Il Nome Unificativo da associare (se presente), questo utente verrà utilizzato per gestire le informazioni sugli altri utenti."
+msgstr "Det Fremtredende Navnet å binde som (om noe), denne brukeren vil bli brukt til å hente informasjon om andre brukere."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "La password da associare per il gestore."
+msgstr "Passordet til å binde med for å søke etter bruker."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "Ricerca base per utenti (verrà fatta ricorsivamente)"
+msgstr "Søk base for brukere. (Vil gjøre gjentagende søk)"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "filtri di ricerca utente, il segnaposto '{login}' verrà rimpiazzato dall'utente autenticato"
+msgstr "Oppslagsfilter for bruker, plassholderteksten '{login}' vil bli erstattet med den brukerdefinerte innloggingen."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "Attributo per usare l'email dell'utente. (solitamente \"mail\", \"email\" o \"userPrincipalName\")"
+msgstr "Attributt som brukes for brukerens e-post. (vanligvis \"mail\", \"email\", eller \"userPrincipalName\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "Attributo da utilizzare per il nome dell'utente (generalmente \"givenName\")"
+msgstr "Attributt å bruke for brukerens fornavn (vanligvis \"givenName\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "Attributo da utilizzare per il cognome dell'utente (generalmente \"sn\")"
+msgstr "Attributt å bruke for brukerens etternavn (vanligvis \"sn\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "Abilita la sincronizzazione dei gruppi di utenze con LDAP"
+msgstr "Aktiver synkronisering av gruppemedlemsskap med LDAP."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "Ricerca base per gruppi, non è richiesta se la tua cartella LDAP fornisce uno strato \"memberOf\". (ricercherà ricorsivamente)"
+msgstr "Base for søk i grupper, ikke påkrevd hvis din LDAP-katalog tilbyr et \"memberOf\" overlegg. (Vil bli søkt rekursivt)"
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "JSON contiene le mappature di LDAP ai gruppi Metabase."
+msgstr "JSON som knytter sammen LDAP- og Metabase-grupper."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "token di trasporto delle API Slack ottenuto da https://api.slack.com/web#authentication"
+msgstr "Slack API bearer token som fåes fra https://api.slack.com/web#authentication"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "Abilita MetaBot, per effettuare le tue ricerche e vedere le domande salvate direttamente tramite Slack"
+msgstr "Aktiver MetaBot, som lar deg søke etter og vise spørsmålene dine direkte via Slack."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "L'ultima controllo MetaBot è stato {0} fa."
+msgstr "Sist MetaBot sjekket inn var {0} siden."
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "Questa istanza ora gestirà i compiti di MetaBot."
+msgstr "Denne instansen vil nå ta hånd om MetaBase forespørsler."
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "Ecco cosa posso {0}:"
+msgstr "Her er hva jeg kan {0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "Non so come {0} `{1}` .n{2}"
+msgstr "Jeg vet ikke hvordan man {0} `{1}`.n{2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr "Uh oh! :piangi:n> {0}"
+msgstr "Oi sann! :cry:n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "Ecco le tua {0} più recenti cards:n{1}"
+msgstr "Her er dine {0} siste kort:n{1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "Potresti essere un po' più preciso? Ho trovato queste cards con nomi corrispondenti:n{0}"
+msgstr "Kan du være litt mer spesifikk? Jeg fant disse kortene med navn som stemmer overens:n{0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "Non so cos'è la Card `{0}`. Dammi un Card ID o il nome"
+msgstr "Jeg vet ikke hvilket kort `{0}` er. Gi meg et kort-ID eller navn."
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "Quale carta visualizzare? Dammi una parte di nome o ID e te la mostro. Se non sai quale carta vuoi visualizzare prova la `lista di metabot`"
+msgstr "Vise hvilket kort? Gi meg en del av navnet på kortet eller dets ID så kan jeg vise deg det. Hvis du ikke vet hvilket kort du vil ha, prøv `metabot list`."
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "Ok, solo un secondo ..."
+msgstr "Ok, vent ett lite sekund..."
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "Non trovato"
+msgstr "Ikke funnet"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "Carica le citazioni di Kanye"
+msgstr "Laster Kanye sitater..."
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "Valutazione comando Metabot:"
+msgstr "Evaluerer MetaBot kommando:"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "Vai a casa websocket, sei ubriaco."
+msgstr "Gå hjem nettplugg, du er full."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "Errore lanciando il metabot:"
+msgstr "Feil innlasting av MetaBot:"
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "Il MetaBot WebSocket è chiuso. Riconnessione ora."
+msgstr "MetaBot WebSocket er lukket. Kobler opp på nytt nå."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "Errore connettendo il websocket:"
+msgstr "Feil ved kobling til websocket:"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "Questa istanza sta eseguendo i compiti di MetaBot."
+msgstr "Denne instansen utfører MetaBot-plikter."
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "Un'altra istanza stra gestendo i compiti di MetaBot."
+msgstr "En annen instans utfører allerede MetaBot-plikter."
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "Avvio dei thread di MetaBot..."
+msgstr "Starter MetaBase tråder..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "Arresto di MetaBot..."
+msgstr "Stopper MetaBot... 🤖"
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBot è già avviato. Ferma prima il precedente WebSocket listener."
+msgstr "MetaBot kjører allerede. Avslutter den forrige websocket kjøringen først."
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "Chiave pubblica a codifica Base-64 per il certificato SSL di questo sito"
+msgstr "Base-64 kodet offentlig nøkkel for denne siden sin SSL sertifikat."
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "Specificalo per abilitare il Pinning della chiave pubblica HTTP"
+msgstr "Spesifiser dette for å aktivere HTTP Public Key Pinning."
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "Vedi {0} per ulteriori informazioni."
+msgstr "Se {0} for mer informasjon."
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "Non puoi salvare la Domanda: la query ha riferimenti circolari"
+msgstr "Kan ikke lagre spørsmål: hovedspørring har sirkulære referanser."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "La Carta {0} non esiste."
+msgstr "Kort {0} fins ikke."
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "Non possiedi i permessi per eseguire query native sul database {0}."
+msgstr "Du har ikke tilganger til å kjøre lokal spørring i nåtid mot database {0}."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "Colore non valido"
+msgstr "Ugyldig farge"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "deve essere un colore con codice hex di 6 caratteri"
+msgstr "må være en gyldig 6-tegn hex fargekode"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "Il nome della collezione non può essere vuoto!"
+msgstr "Navn på samling kan ikke være tomt!"
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "non può essere vuoto"
+msgstr "kan ikke være blank"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "locazione della Collezione non valida: percorso non valido"
+msgstr "Ugyldig samlingsplassering: sti er ugyldig."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "Non puoi muovere una Collezione Personale"
+msgstr "Du kan ikke flytte en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "locazione della Collezione non valida: alcuni degli ancestori non esistono"
+msgstr "Ugyldig plassering av samling: noen eller alle toppsamlinger finnes ikke."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "Non puoi archiviare la Collezione Root"
+msgstr "Du kan ikke arkivere hovedsamlingen."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "Non puoi archiviare la Collezione Personale"
+msgstr "Du kan ikke arkivere en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "Non puoi spostare la Collezione Root"
+msgstr "Du kan ikke flytte hovedsamlingen."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "Non puoi spostare una Collezione dentro se stessa o in una discendente da se stessa."
+msgstr "Du kan ikke flytte en samling til seg selv eller til en av undersamlingene."
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "Sto spostando la Collezione {0} e le proprie discendenti da {1} a {2}"
+msgstr "Flytter samlingen {0} og dens etterkommere fra {1} til {2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "Non sei autorizzato a cambiare il proprietario di una Collezione Personale."
+msgstr "Du har ikke lov til å endre eieren av en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "Non sei autorizzatio a spostare una Collezione Personale."
+msgstr "Du har ikke lov til å flytte en personlig samling."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "Non puoi spostare una collezione e archiviarla allo stesso tempo."
+msgstr "Du kan ikke flytte en samling og arkivere den samtidig."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "Non puoi cancellare una Collezione Personale!"
+msgstr "Du kan ikke slette en Personling samling"
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "{0} {1} è una Collezione Personale"
+msgstr "{0} {1}s personlige samling"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "Non puoi aggiornare una Revisione di una Collezione!"
+msgstr "Du kan ikke oppdatere en CollectionRevision!"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "Il campo {0} è stato impostato prima automaticamente per visualizzare una lista di widget ma adesso ha {1} valori."
+msgstr "Feltet {0} var tidligere automatisk satt til å vise en liste-widget, men har nå {1} verdier."
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "Cambia il campo per usare lo strumento di ricerca"
+msgstr "Endrer feltet til å vise en søke-widget istedenfor."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "Memorizzo i valori aggornati per il Campo {0}..."
+msgstr "Lagrer oppdaterte feltverdier for feltet {0}..."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "In registrazione il valore per il campo {0}..."
+msgstr "Lagrer feltverdier for feltet {0}..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabase può tentare di trasformare i nomi della tua tabella e dei campi in una versione più umana, esempio \"somehorriblename\" diventa \"Some Horrible Name\""
+msgstr "Metabase kan forsøke å transformere tabellen og feltnavnene til mer fornuftige, menneske-lesbare versjoner, f.eks. \"somehorriblename\" blir til \"Some Horrible Name\"."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "In ogni caso, non è garantito che funzioni bene se i nomi non sono in inglese."
+msgstr "Men, dette virker ikke så bra for feltnavn som ikke er på engelsk."
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "Vuoi che indoviniamo?"
+msgstr "Vil du at vi skal gjette?"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "Non puoi creare o revocare permessi per il gruppo `Admin`"
+msgstr "Du kan ikke gi eller frata rettigheter for 'Admin'-gruppen."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "permessi non validi per il percorso: \"{0}\""
+msgstr "Ugyldig sti for rettighetsobjekt: \"{0}\"."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "Non puoi modificare un campo di permessi!"
+msgstr "Du kan ikke oppdatere en tilgangsoppføring!"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "Cancellalo e creane uno nuovo."
+msgstr "Slett den og lag en ny en."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "Non puoi modificare i permessi per una Collezione Personale o sue discendenti."
+msgstr "Du kan ikke redigere tilganger for en personlig samling eller dens undersamlinger."
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "Sembra che qualcun altro abbia modificato i permessi ed i tuoi dati siano scaduti."
+msgstr "Det ser ut som om noen andre endret rettighetene og dine data er utdatert."
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "Per favore controlla i nuovi dati e riprova."
+msgstr "Vennligst last inn ny data og prøv igjen."
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "Creato il magico gruppo di permessi \"{0}\" (ID = {1})"
+msgstr "Opprettet magisk tilgangsgruppe \"{0}\" (ID = {1})"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "Un gruppo con questo nome è già presente."
+msgstr "En gruppe med det navnet eksisterer allerede."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "Non puoi modificare o eliminare i permessi del gruppo \"{0}\" "
+msgstr "Du kan ikke redigere eller slette \"{0}\" tilgangsgruppen!"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "Non puoi aggiungere né rimuovere utenti dal gruppo `MetaBot`."
+msgstr "Du kan ikke legge til eller slette brukere til/fra 'MetaBot' gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "Non puoi aggiungere né rimuovere utenti dal gruppo `Tutti gli Utenti`."
+msgstr "Du kan ikke legge til eller slette brukere til/fra 'alle brukere' gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "Non puoi rimuovere l'ultimo utente del gruppo `Amministratori`."
+msgstr "Du kan ikke slette siste medlem av 'Administrator' gruppen!"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "Non puoi aggiornare una Revisione di Permessi."
+msgstr "Du kan ikke oppdatere en tilgangsrevisjon!"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "Allarme non valido: non ha una Carta associata."
+msgstr "Ugyldig varsel: Varselet er ikke tilknyttet et kort"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "Il valore deve essere una mappa con le chiavi  `{0}`, `{1}` e `{2}`."
+msgstr "verdien må være et oppslagsverk med nøklene `{0}`, `{1}` og `{2}`."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "Il valore deve essere una mappa con le seguenti chiavi  `{0}`"
+msgstr "verdien må være et oppslagsverk med disse nøklene `({0})`"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "Errore nell'elaborazione dei permessi per la query: {0}"
+msgstr "En feil oppstod ved utregning av tillatelser for spørringen: {0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "Tipo di query non valido: {0}"
+msgstr "Ugyldig spørringstype: {0}"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "Non puoi aggiornare una Esecuzione di Query!"
+msgstr "Du kan ikke oppdatere en QueryExecution!"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "Non puoi aggiornare una Revisione!"
+msgstr "Du kan ikke oppdatere en Revision!"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "Impostazione {0} non esiste. nTrovato: {1}"
+msgstr "Innstillingen {0} finnes ikke.nFant: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "Aggiornamento del valore dei settings-last-updated nel DB..."
+msgstr "Oppdaterer verdien for settings-last-updated i DB..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "Controlla se le impostazioni in cache sono scadute (con chiamata al DB)"
+msgstr "Sjekker om mellomlageret for innstillinger er utdatert (krever kall til DB)..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "Le impostazioni sono stata modificate su un'altra istanza, e saranno ricaricate qui."
+msgstr "Innstillingene har endret seg på en annen instans, og vil bli lastet inn på nytt her."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "Ricaricamento delle impostazioni di cache..."
+msgstr "Oppdaterer mellomlageret for innstillinger..."
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "Stringa non valida: deve essere o \"true\" o \"false\" (case-insensitive)."
+msgstr "Ugyldig verdi for tekststreng: må være enten \"true\" eller \"false\" (store/små bokstaver har ingen betydning)."
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "Non puoi aggiornare  `settings-last-updated` direttamente! Verrà fatto automaticamente."
+msgstr "Du kan ikke oppdatere `settings-last-updated` selv! Dette gjøres automatisk."
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "Errore nell'inserire una nuova Impostazione:"
+msgstr "En feil oppstod ved innsetting av en ny innstilling:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "Presupposto che Setting esiste già nel DB e aggiornando il valore esistente."
+msgstr "Antar at innstillingen allerede finnes i DB og oppdaterer eksisterende verdi."
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "il valore deve essere una mappa per ogni valore che sia una stringa che un numero."
+msgstr "verdi må være et oppslagsverk hvor hver verdi er enten en tekststreng eller et tall."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "Caricamento dei plugins nella cartella {0}..."
+msgstr "Laster programtillegget fra mappen {0}..."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "Caricamento plugin {0}..."
+msgstr "Laster inn plugin {0}... "
 
 #: src/metabase/plugins.clj
+#, fuzzy
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Sembra che non hai alcune dipendenze esterne nella cartella di plugin di Metabase."
+msgstr "Det ser ut som du har eksterne avhengigheter i din Metabase plugins-mappe."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Con Java 9 o superiore, Metabase non può aggiungerli automaticamente nel tuo classpath."
+msgstr "Med Java 9 eller høyere, Metabase kan ikke automatisk legge de til i klassemappen"
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "Invece, dovresti includerli all'avvio con l'opzione -op. Per esempio:"
+msgstr "Dermed må du inkludere disse ved oppstart med -cp konfigureringen. For eksempel:"
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "Per maggiori dettagli, visita https://metabase.com/docs/latest/operations-guide/start.html#java-versions."
+msgstr "Se https://metabase.com/docs/latest/operations-guide/start.html#java-versions for mer deltaljer."
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "(Se stai già eseguendo Metabase in questa maniera, puoi ignorare questo messaggio.)"
+msgstr "(Hvis du allerede kjører Metabase med denne måten, kan du ignorere denne meldingen)"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Identifica quando le nuove versioni di Metabase sono disponibili."
+msgstr "Identifiser når det kommer nye Metabase versjoner."
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Informazioni sulle versioni disponibili di Metabase."
+msgstr "Informasjon om tilgjengelige versjoner av Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "Nome utilizzato per questa istanza di Metabase"
+msgstr "Navnet brukt for instansen av Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "URL base di questa istanza di Metabase. es.  \"http://metabase.my-company.com\"."
+msgstr "Base nettadresse for Metabase instansen, f.eks \"http://metabase.my-company.com\"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "La lingua principale per questa istanza di Metabase."
+msgstr "Standard språk for denne Metabase instansen."
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "Questo sarà applicato solo alle email, Picchi, etc. Il browser specificherà la lingua utilizzata nell'interfaccia utente."
+msgstr "Dette gjelder kun for e-poster, pulser, osv. Brukeres nettlesere def"
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "L'indirizzo email di riferimento in caso di incontro di un problema."
+msgstr "E-postadressen brukere skal referere til hvis det oppstår ett problem."
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Consenti di raccogliere anonimamente l'utilizzo dei dati per aiutarci a migliorare Metabase."
+msgstr "Aktiver logging av anonym brukerdata for å hjelpe Metabase med å bli bedre."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "Il template URL del map tile server usato nelle visualizzazioni della mappa, per esempio da OpenStreetMaps o MapBox."
+msgstr "URL-malen for kartflis-tjeneren som brukes i kart-visualiseringer, for eksempel fra OpenStreetMaps eller MapBox."
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "Abilita gli amministratori per creare link di visualizzazione pubblica (ed iframes integrabili) per Domande e Dashboard?"
+msgstr "Gjør det mulig for administratorer å lage offentlig tilgjengelige lenker (og innbyggbare iframes) for spørsmål og infotavler?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "Consentire agli amministratori di integrare in sicurezza domande e dashboard all'interno di altre applicazioni?"
+msgstr "Gjør det mulig for administratorer å bygge inn spørsmål og infotavler på en sikker måte inni andre applikasjoner?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "Consentire di utilizzare le domande salvate come sorgente per altre query?"
+msgstr "Godkjenn bruk av lagrede spørsmål som grunnen til andre spørringer."
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "Abilitare la cache consentirà di salvare i risultati delle query che richiedono un lungo tempo di esecuzione"
+msgstr "Aktivering av mellomlagring vil lagre resultater av spørringer som tar lang til å kjøre."
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "La dimensione massima della cache, per domanda salvata, in kilobytes:"
+msgstr "Maks-størrelsen til mellomlageret, per lagrede spørsmål, i kilobytes:"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "Il tempo massimo assoluto (secondi) per gestire i risultati delle query in cache"
+msgstr "Den absolutt lengste tiden som mellomlagrede spørringsresultater skal beholdes, i sekunder."
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabase registrerà tutte le domande salvate con un tempo medio di esecuzione delle query superiore in secondi di:"
+msgstr "Metabase vil mellomlagre alle lagrede spørsmål med en gjennomsnittlig utførelse tid som er lenger enn dette i sekunder:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "Per determinare quanto tempo i risultati delle query devono restare in cache, prendiamo il tempo di esecuzione medio e lo moltiplichiamo per questo valore."
+msgstr "For å avgjøre hvor lenge hvert lagrede spørsmåls mellomlagrede resultat skal bli værende, så tar vi spørringens gjennomsnittlige kjøretid og ganger det med hva enn du skriver inn her."
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "Così se una query impiega mediamente 2 minuti, impostando un moltiplicatore di 10, il suo risultato rimarrà in cache per 20 minuti."
+msgstr "Så hvis en spørring tar gjennomsnittlig 2 minutter å kjøre, og du skriver inn 10 for din multipliserer, så vil mellomlagringen være tilgjengelig i 20 minutter."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "Quando si utilizza la strategia degli intervalli predefinita e non viene fornito un numero di intervalli, questo numero verrà utilizzato come predefinito."
+msgstr "Når den vanlige inndelings-strategien brukes og et antall inndelinger ikke er gitt, vil dette antallet bli brukt som standard."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "Quando si utilizza la strategia degli intervalli predefinita per un campo di tipo Coordinate (come Latitudine e Longitudine), questo numero verrà utilizzato come larghezza predefinita dell'intervallo (in gradi)."
+msgstr "Når den vanlige inndelings-strategien brukes for et koordinat-felt (sånn som lengdegrad og breddegrad), så vil dette tallet bli brukt som standardstørrelse på inndelingen (i grader)."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "Impossibile validare il token."
+msgstr "Klarte ikke å validere token."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Errore nel recuperare lo stato del token:"
+msgstr "En feil oppstod ved henting av status for token:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "Si è verificato un errore durante il controllo della validità di questo token."
+msgstr "Det oppstod en feil ved validering av tokenen."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "Convalida del token scaduta."
+msgstr "Tidsavbrudd for token-validering."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "Token non valido: il token non è nel formato giusto."
+msgstr "Invalid token: token er ikke på riktig format."
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "Controllo con il MetaStore per vedere se {0} è valido..."
+msgstr "Sjekker med MetaStore for å se om {0} er valid..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "Token per l'incorporamento premium. Vai al MetaStore per ottenere il tuo!"
+msgstr "Token for premium-innebygging. Gå til MetaStore for å få din egen!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "Il token è valido."
+msgstr "Nøkkel er gyldig."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "Errore nell'installazione dell'incorporamento premium"
+msgstr "En feil oppstod ved setting av premium innebyggingstoken."
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "Impossibile confrontare il risultato con l'obiettivo per l'avviso."
+msgstr "Klarte ikke å sammenligne resultatene med målet for varselet."
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "L'ID della domanda è ''{0}'' con le impostazioni di visualizzazione ''{1}''"
+msgstr "Spørsmål-ID er \"{0}\" med visualiseringsinnstilingene \"{1}\""
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "Avviso non riconosciuto con condizione \"{0}\""
+msgstr "Ikke gjenkjent varsel med betingelsen \"{0}\""
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "Tipo di canale {0} non riconosciuto"
+msgstr "Ikke gjenkjent kanal-type {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "Errore nell'inviare la notifica!"
+msgstr "Feil ved sending av varsel!"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "Impossibile trovare il selettore di colori JS a ''{0}''"
+msgstr "Kan ikke finne JS farge velger her \"{0}\""
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "La carta ha errori: {0}"
+msgstr "Kort har feil: {0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "Errore di rendering della carta a impulsi"
+msgstr "Feil ved visning av pulskort"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "Ritaglio del commento finale dalla carta con ID {0}"
+msgstr "Beskjærer etterfølgende kommentar fra kortet med id {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "Non si trova il campo con ID: {0}"
+msgstr "Kan ikke finne felt med ID: {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "\"{0}\" è un campo richiesto."
+msgstr "\"{0}\" er ett påkrevd parameter."
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "Trovato \"{0}\" senza terminazione \"{1}\" nella query \"{2}\""
+msgstr "Fant \"{0}\" uten avsluttende \"{1}\" i spørringen \"{2}\""
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "Impossibile di sostituire \"{0}\": parametro non specificato.nTrovato: {1}"
+msgstr "Klarte ikke å erstatte \"{0}\": param ikke spesifisert.nFant: {1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "Non possiedi i permessi per visualizzare Card {0}."
+msgstr "Du har ikke tilgang til å vise Kort {0}."
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "Non hai i permessi per eseguire questa query."
+msgstr "Du har ikke tilgang til å kjøre denne spørringen."
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "Aggiornamento Impronta eseguita {0}, aggiornata {1}, nessun dato trovato {2}, fallito {3}."
+msgstr "Fingeravtrykk-oppdateringer prøvde {0}, oppdaterte {1}, ingen data funnet {2}, feilet {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "Numero totale di campi classificati {0}, {1} falliti"
+msgstr "Totalt antall felt klassifisert {0}, {1} feilet"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "Numero totale di tabelle classificate {0}, modificate {1}"
+msgstr "Total antall tabeller klassifisert {0}, {1} oppdatert"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "Errore nel generare l'impronta per {0}"
+msgstr "Feil ved generering av fingeravtrykk for {0}"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "Aggiornati {0} campi set di valore, creati {1}, rimossi {2} con {3} errori."
+msgstr "Oppdatert {0} felt verdisett, opprettet {1}, slettet {2} med {3} feil"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "Numero totale di campi: sincronizzati {0}, aggiornati {1}"
+msgstr "Total antall felt synkronisert {0}, antall felt oppdatert {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "Numero totale di tabelle: sincronizzate {0}, aggiornate {1}"
+msgstr "Total antall tabeller synkronisert {0}, antall tabeller oppdatert {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "Trovato timezone id {0}"
+msgstr "Fant tidssone id {0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "Numero totale di chiavi esterne sincronizzate {0}, aggiornate {1}, {2} tabelle fallite durante l'aggiornamento."
+msgstr "Total antall fremmednøkler synkronisert {0}, {1} oppdatert og {2} tabeller mislyktes å oppdatere"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
@@ -8837,394 +8847,399 @@ msgstr "{0} Database {1} \"{2}\""
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "Tabella {0} \"{1}\""
+msgstr "Tabell {0} \"{1}\""
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "Campo {0} \"{1}\""
+msgstr "Felt {0} \"{1}\""
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "Campo {0}"
+msgstr "Felt \"{0}\""
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "passo \"{0}\" per {1}"
+msgstr "steg \"{0}\" for {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "Completati {0} su {1}"
+msgstr "Ferdigstilt {0} på {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "Inizio: {0}"
+msgstr "Start: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "Fine: {0}"
+msgstr "Slutt: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "Durata: {0}"
+msgstr "Tid brukt: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "Step completato \"{0}\""
+msgstr "Ferdigstilt steg \"{0}\""
 
 #: src/metabase/task.clj
+#, fuzzy
 msgid "Loading tasks namespace:"
-msgstr "Caricando lo spazio dei nomi delle attività:"
+msgstr "Laster inn navnerom for oppgaver:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Schedulatore Quartz in avvio"
+msgstr "Starter Quartz Scheduler"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Schedulatore Quartz in fase di arresto"
+msgstr "Stopper Quartz Scheduler"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "Il lavoro esiste già:"
+msgstr "Jobben eksisterer allerede:"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Caricamento in corso di Metabase..."
+msgstr "Laster inn Metabase..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "Possibile conflitto di fuso orario trovato nel database {0}."
+msgstr "Mulig tidssone konflikt funnet i database {0}"
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "Il fuso orario della JVM è {0} e il fuso orario rilevato del database è {1}."
+msgstr "JVM tidssone er {0}, oppdaget database tidssone er {1}"
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configura un rapporto del fuso orario per garantire conversioni corrette di data e ora."
+msgstr "Konfigurer en rapport tidssone for å sikre dato- og tidskonvertering"
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "Chiave segreta utilizzata per firmare Token Web JSON per le richieste agli endpoint `/ api / embed`."
+msgstr "Hemmelig nøkkel for å signere JSON Web Tokens for tilkobling til `/api/embed`."
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEY deve essere di almeno 16 caratteri."
+msgstr "MB_ENCRYPTION_SECRET_KEY må være minst 16 tegn."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "La crittografia delle credenziali salvate è ABILITATA per questa istanza di Metabase."
+msgstr "Lagret legitimasjonskryptering er ENABLED for denne Metabase-instansen."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "La crittografia delle credenziali salvate è DISABILITATA per questa istanza di Metabase."
+msgstr "Lagret legitimasjonskryptering er DISABLED for denne Metabase-instansen."
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "nPer ulteriori informazioni, vedere"
+msgstr "For mer informasjon, se"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "il valore deve essere un numero intero."
+msgstr "verdi må være ett heltall."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "il valore deve essere una stringa."
+msgstr "verdi må være en streng."
 
 #: src/metabase/util/schema.clj
+#, fuzzy
 msgid "value must be a boolean."
-msgstr "il valore deve essere un booleano."
+msgstr "verdien må være boolsk."
 
 #: src/metabase/util/schema.clj
+#, fuzzy
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "il valore deve essere una stringa che corrisponde all'espressione regolare '{0}'."
+msgstr "verdi må være en streng som tilfredsstiller kravene til regex `{0}`."
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "il valore deve soddisfare uno dei seguenti requisiti: "
+msgstr "verdi må tilfredsstille en av følgende krav: "
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "il valore potrebbe essere 0, o se non 0, {0}"
+msgstr "verdi må være null, eller hvis ikke null, {0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "il valore deve essere uno di: {0}."
+msgstr "verdi må være en av disse: {0}."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "il valore deve essere un array."
+msgstr "verdi må være en matrise."
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "Ogni {0}"
+msgstr "Hver {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "L'array non può essere vuoto"
+msgstr "Matrisen kan ikke være tom."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "il valore non deve essere una stringa vuota."
+msgstr "verdi kan ikke være blank streng."
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "Numero intero maggiore di zero"
+msgstr "Heltall mer enn 0"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "Il valore deve essere un numero intero maggiore di zero."
+msgstr "verdi må være ett heltall over 0."
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "Numero maggiore di zero"
+msgstr "Tall over 0"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "il valore deve essere un numero maggiore di zero."
+msgstr "verdi må være ett tall over null"
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "Parola chiave o stringa"
+msgstr "Søkeord eller streng"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "Tipo di campo valido"
+msgstr "Gyldig felt type"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "il valore deve essere un tipo di campo valido"
+msgstr "verdi må være en gyldig felt type."
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "Tipo di campo valido (parola chiave o stringa)"
+msgstr "Gyldig felt type (søkeord eller streng)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "il valore deve essere un tipo di campo valido (parola chiave o stringa)"
+msgstr "verdi må være en gyldig felt type (søkeord eller streng)"
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "Tipo di entità valido (parola chiave o stringa)"
+msgstr "Gyldig enhetstype (søkeord eller streng)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "il valore deve essere un tipo di entità valido (parola chiave o stringa)."
+msgstr "verdi må være en gyldig enhetstype (søkeord eller streng)"
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "Mappa valida"
+msgstr "Gyldig kart"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "il valore deve essere una mappa."
+msgstr "verdi må være ett kart."
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "Indirizzo email valido"
+msgstr "Gyldig e-postadresse"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "il valore deve essere un indirizzo email valido."
+msgstr "verdi må være en gyldig e-postadresse"
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "Password non abbastanza robusta"
+msgstr "Ugyldig passord styrke"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "il valore deve essere un numero intero valido."
+msgstr "verdi må være ett gyldig heltall"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "il valore deve essere un numero intero valido maggiore di zero."
+msgstr "verdi må være ett gyldig heltall større enn null."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "il valore deve essere una stringa booleana valida (\"true\" or \"false\")"
+msgstr "verdi må være en gyldig boolsk streng (\"true\" eller \"false\")"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "il valore deve essere una stringa JSON valida."
+msgstr "verdi må være en gyldig JSON streng."
 
 #: src/metabase/util/schema.clj
+#, fuzzy
 msgid "value must be a valid embedding params map."
-msgstr "Il valore deve essere presente nei parametri della mappa"
+msgstr "verdi må være en gyldig embedding params kart."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "Permesso dati"
+msgstr "Tilgang til data"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "Permessi della raccolta"
+msgstr "Tilgang til samlinger"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
-msgstr "Vedi tutti i permessi della raccolta"
+msgstr "Se alle tilganger til samlinger"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
-msgstr "Cambia anche sotto-raccolte"
+msgstr "Endre også undersamlinger"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "Puoi modificare questa raccolta e i suoi contenuti"
+msgstr "Kan endre denne samlingen og inneholdet"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "Può visualizzare gli elementi in questa raccolta"
+msgstr "Kan se elementer i denne samlingen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
-msgstr "Accesso alla raccolta"
+msgstr "Tilgang til samlinger"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "Questo gruppo ha il permesso di vedere almeno una sottoraccolta di questa raccolta."
+msgstr "Denne gruppen har tilgang til å vise minst en undersamling av denne samlingen."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "Questo gruppo ha il permesso di modificare almeno una sottoraccolta di questa raccolta."
+msgstr "Denne gruppen har tilganger til å endre minst en av undersamlingene til denne samlingen."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
-msgstr "Visualizza sotto-raccolte"
+msgstr "Vis undersamlingen"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:245
 msgid "Remember Me"
-msgstr "Ricordami"
+msgstr "Husk meg"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:73
 msgid "X-ray this schema"
-msgstr "Raggi X di questo schema"
+msgstr "Kjør X-ray på dette skjema"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "Modifica i permessi per questa raccolta"
+msgstr "Endre tilgangenene for denne samlingen"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "Aggiungi questa domanda alla dashboard"
+msgstr "Legg dette spørsmålet til en infotavle"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "Creare una nuova dashboard"
+msgstr "Legg til ny infotavle"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:47
 msgid "The page you asked for couldn't be found."
-msgstr "La pagina che hai rihiesto non può essere trovata."
+msgstr "Siden du spurte etter fins ikke."
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "Seleziona un {0}"
+msgstr "Velg en {0}"
 
 #: frontend/src/metabase/containers/Overworld.jsx:234
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "Salva dashboard, domande e collezioni in \"{0}\""
+msgstr "Lagre infotavle, spørsmål og samlinger i \"{0}\""
 
 #: frontend/src/metabase/containers/Overworld.jsx:235
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "Accedi a dashboard, domande e collezioni in \"{0}\" "
+msgstr "Adgang til infotavler, spørsmål og samlinger i \"{0}\""
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "Confronto"
+msgstr "Sammenlign"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "Rimpicciolire"
+msgstr "Zoom ut"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "Relazionato"
+msgstr "Relatert"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "Altri raggi X"
+msgstr "Flere X-ray spørringer"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "Nessun risultato"
+msgstr "Ingen resultater"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:42
 msgid "Metabase couldn't find any results for your search."
-msgstr "Metabase non può trovare nessun risultato per la tua ricerca."
+msgstr "Metabase kan ikke finne noen resultater for ditt søk."
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "Nessuna metrica presente"
+msgstr "Ingen indikatorer"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:41
+#, fuzzy
 msgid "Aggregations"
-msgstr "aggregazioni"
+msgstr "Aggregeringer"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:42
 msgid "Operators"
-msgstr "operatori"
+msgstr "Operatører"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:35
 msgid "Custom fields"
-msgstr "campi personalizzati"
+msgstr "Egendefinerte felter"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "Dashboard migrati"
+msgstr "Migrerte infotavler"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "Pulse migrati"
+msgstr "Migrerte pulser"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "Domande migrate"
+msgstr "Migrerte spørsmål"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "Spostamento di istanze di {0} che non sono in una collezione nella collezione {1} {2}"
+msgstr "Flytter instanser av {0} som ikke er i en samling til {1} samling {2}"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "Impossibile concedere le autorizzazioni: {0}"
+msgstr "Klarte ikke å gi tillatelser: {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "Impossibile decodificare la stringa crittografata. Hai cambiato o ti sei dimenticato di impostare MB_ENCRYPTION_SECRET_KEY?"
+msgstr "Kan ikke dekryptere kryptert tekststreng. Har du endret eller glemt å sette MB_ENCRYPTION_SECRET_KEY?"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "tutte le collezioni personali"
+msgstr "Alle personlige samlinger"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "Host"
+msgstr "Vert"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "Porta"
+msgstr "Port"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "Username del database"
+msgstr "Database brukernavn"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "Quale username usi per accedere al database?"
+msgstr "Hvilket brukernavn vil du bruke ved tilkobling til databasen?"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "Password del database"
+msgstr "Database passord"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "Nome del database"
+msgstr "Database navn"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
@@ -9232,15 +9247,15 @@ msgstr "birds_of_the_world"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "Usi una connesione sicura (SSL)?"
+msgstr "Bruk sikker kobling (SSL)?"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "Opzioni stringhe di connessione JDBC aggiuntive"
+msgstr "Ekstra JDBC koblingsstreng alternativer"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
-msgstr "ID del progetto"
+msgstr "Prosjekt ID"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
@@ -9248,7 +9263,7 @@ msgstr "praxis-beacon-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
-msgstr "ID del Dataset"
+msgstr "Datasett ID"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
@@ -9256,35 +9271,37 @@ msgstr "toucanSightings"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "ID client"
+msgstr "Klient ID"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "Client segreto"
+msgstr "Klient hemmelighet"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "codice di autorizzazione"
+msgstr "Autoriseringskode"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "Hosts"
+msgstr "Verter"
 
 #: src/metabase/driver/druid.clj
+#, fuzzy
 msgid "Broker node port"
-msgstr "Porta del nodo intermediario"
+msgstr "Knuteport for megler"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "Id dell'account di Google Analytics"
+msgstr "Google Analytics konto ID"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "stringa di connessione"
+msgstr "Koblingsstring"
 
 #: src/metabase/driver/h2.clj
+#, fuzzy
 msgid "Users/camsaul/bird_sightings/toucans"
-msgstr "Utenti/camsaul/bird_sightings/toucans"
+msgstr "Brukere/camsaul/bird_sightings/toucans"
 
 #: src/metabase/driver/mongo.clj
 msgid "carrierPigeonDeliveries"
@@ -9292,107 +9309,106 @@ msgstr "carrierPigeonDeliveries"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "Database di autenticazione"
+msgstr "Autorisering Database"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "database optionale da usare in autenticazione"
+msgstr "Alternative database å bruke ved autorisering"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "opzioni aggiuntive di stringa di connessione Mongo"
+msgstr "Ekstra Mongo koblingsstreng alternativer"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "ID di Sistema di Oracle (SID)"
+msgstr "Oracle system ID (SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "Normalmente qualcosa come ORCL o XE"
+msgstr "Bruker vanligvis være lignende ORCL eller XE"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "opzionale se usi il nome del servizio"
+msgstr "Alternativt hvis bruk av servicenavn"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Nome del servizio Oracle"
+msgstr "Oracle service navn"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "alias opzionale TNS"
+msgstr "Valgfritt TNS alias"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
-msgstr "alveare"
+msgstr "kube"
 
 #: src/metabase/driver/redshift.clj
 msgid "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
-msgstr "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
+msgstr "mitt-kluster-navn.abcd1234.no-1.redshift.amazonaws.com"
 
-#. not sure for the context
 #: src/metabase/driver/redshift.clj
 msgid "toucan_sightings"
 msgstr "toucan_sightings"
 
 #: src/metabase/models/collection.clj
 msgid "default"
-msgstr "predefinito"
+msgstr "standard"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "Nomefile"
+msgstr "Filnavn"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr "/home/camsaul/toucan_sightings.sqlite"
+msgstr "/home/camsaul/toucan_sightings.sqlite 😋"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
-msgstr "BirdsOfTheWorld"
+msgstr "FugleneIVerden"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "Nome dell'istanza del Database"
+msgstr "Database instanse navn"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "N/A"
+msgstr "I/T"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "dominio Windows"
+msgstr "Windows domene"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:528
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:534
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:543
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
-msgstr "Etichette"
+msgstr "Etiketter"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
-msgstr "Aggiungi membri"
+msgstr "Legg til medlemmer"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "Collezione in cui è salvato"
+msgstr "Samling den er lagret i"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "Tutti gli utenti"
+msgstr "Alle brukere"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Amministratori"
+msgstr "Administratorer"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
-msgstr "Metabot"
+msgstr "MetaBot"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "Condividi"
+msgstr "Deling"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
@@ -9416,7 +9432,7 @@ msgstr "Condividi"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "Display"
+msgstr "Visning"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:402
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:437
@@ -9427,127 +9443,127 @@ msgstr "Display"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:521
 msgid "Axes"
-msgstr "Assi"
+msgstr "Akser"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:219
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:62
 msgid "Formatting"
-msgstr "Formattazione"
+msgstr "Formatering"
 
 #: frontend/src/metabase/containers/Overworld.jsx:121
 msgid "Try these x-rays based on your data."
-msgstr "Prova questi raggi-x basati sui tuoi dati"
+msgstr "Prøv disse X-ray spørsmålene basert på din data."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:38
 msgid "There was a problem displaying this chart."
-msgstr "Si é verificato un errore nel visualizzare questo grafico."
+msgstr "Det er ett problem med visning av denne grafen."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:39
 msgid "Sorry, you don't have permission to see this card."
-msgstr "Spiacenti, non hai i permessi per vedere questa card."
+msgstr "Beklager, du har ikke tilgang til å se dette kortet."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "Solo un avviso:"
+msgstr "Bare en liten ting:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "{0} senza il 'Sample Dataset', il tutorial del 'Query Builder' non funzionerà. Puoi sempre ripristinare il set di dati campione, ma tutte le domande che hai salvato utilizzando questi dati andranno perse."
+msgstr "{0} uten eksempel-datasettet, så vil ikke spørrings-veilederen virke. Du kan alltids gjenopprette eksempel-datasettet, men spørsmål du har lagret med disse dataene vil gå tapt."
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "Raggi-X"
+msgstr "X-ray"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "Confronta con il resto"
+msgstr "Sammenlignet med resten"
 
 #: frontend/src/metabase/entities/databases/forms.js:18
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "Usa la timezone di Java Virtual Machine (JVM)"
+msgstr "Bruk JVM-tidssone"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "Ti suggeriamo di lasciar perdere, a meno che tu non stia eseguendo manualmente il fuso orario in molte o la maggior parte delle tue query con questi dati."
+msgstr "Vi anbefaler å la denne være slått av, med mindre du endrer tidssone manuelt i mange eller alle dine spørringer mote disse dataene."
 
 #: frontend/src/metabase/containers/Overworld.jsx:395
 msgid "Your team's most important dashboards go here"
-msgstr "le dashboard più importanti del tuo team vanno qui"
+msgstr "Ditt lags viktigste infoskjermer finnes her"
 
 #: frontend/src/metabase/containers/Overworld.jsx:396
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "Inserisci le dashboard in {0} per visualizzarli in questo spazio per tutti"
+msgstr "Fest infotavler til {0} for at de skal vises på denne plassen for alle sammen"
 
 #: src/metabase/db/liquibase.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "Impossibile rilasciare il blocco Liquibase dopo una migrazione fallita"
+msgstr "Ikke mulig å åpne Liquibase-låsen etter en migreringsfeil"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "Usa Il Time Zone di JVM"
+msgstr "Bruk JVM-tidssone"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "Stiamo analizzando le tabelle e i campi per aiutarti a esplorare i tuoi dati."
+msgstr "Vi analyserer nå tabellene og feltene for å hjelpe deg med å utforske dataene dine."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
-msgstr "Suggerimento: "
+msgstr "Tips: "
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:240
 msgid "Select a currency type"
-msgstr "Seleziona un tipo di valuta"
+msgstr "Velg valutatype"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
-msgstr "Tipo Campo"
+msgstr "Felt type"
 
 #: frontend/src/metabase/admin/routes.jsx:118
 #: frontend/src/metabase/nav/containers/Navbar.jsx:267
 msgid "Troubleshooting"
-msgstr "Risoluzione Problemi"
+msgstr "Feilsøking"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Enable X-ray features"
-msgstr "Abilita funzioni raggi X"
+msgstr "Aktiver X-ray-funksjonalitet"
 
 #: frontend/src/metabase/admin/settings/selectors.js:220
 msgid "Formatting Options"
-msgstr "Opzioni formattazione"
+msgstr "Formateringsinnstillinger"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "Dettagli processo"
+msgstr "Oppgavedetaljer"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "Log di Troubleshooting"
+msgstr "Feilsøkingslogger"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "Stai cercando di arrivare al fondo di qualcosa? Questa sezione mostra i log delle attività in background di Metabase, che possono aiutare a far luce su cosa sta succedendo."
+msgstr "Prøver du å komme til bunns i noe? Denne delen viser logger fra Metabases bakgrunnsoppgaver, som kan si litt mer om hva som skjer."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "Attività"
+msgstr "Oppgave"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
-msgstr "DB ID"
+msgstr "Database id"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "Iniziato alle"
+msgstr "Startet"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "Finito alle"
+msgstr "Avsluttet"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "Durata (ms)"
+msgstr "Varighet (ms)"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:34
 #: frontend/src/metabase/lib/core.js:92
@@ -9557,99 +9573,99 @@ msgstr "Valuta"
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
-msgstr "Scegli un utente o un canale..."
+msgstr "Velg en bruker eller kanal..."
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
 msgid "No formatting settings"
-msgstr "Nessuna impostazione di formattazione"
+msgstr "Ingen formateringsinnstillinger"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "Etichetta per questo intervallo (facoltativo)"
+msgstr "Etikett for dette området (valgfritt)"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "Aggiungi un intervallo"
+msgstr "Legg til et område"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "è minore di"
+msgstr "er mindre enn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "è maggiore di"
+msgstr "er større enn"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "è uguale o minore di"
+msgstr "er mindre eller lik"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "è uguale o maggiore di"
+msgstr "er større eller lik"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "è uguale a"
+msgstr "er lik"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "è diverso da"
+msgstr "er ikke lik"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "è nullo"
+msgstr "er null"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "non è nullo"
+msgstr "er ikke null"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "contiene"
+msgstr "inneholder"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "non contiene"
+msgstr "inneholder ikke"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "inizia con"
+msgstr "starter med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "finisce con"
+msgstr "slutter med"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "Quando una cella in queste colonne {0} sarà colorata in questo colore."
+msgstr "Når en celle i disse kolonnene {0} så vil den bli farget med denne fargen."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "Quando una cella in questa colonna..."
+msgstr "Når en celle i denne kolonnen..."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "La visualizzazione richiede che raggruppi per un campo."
+msgstr "Denne visualiseringen krever at du grupperer på et felt."
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:184
 msgid "Date style"
-msgstr "Stile Data"
+msgstr "Datostil"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:207
 msgid "Date separators"
-msgstr "Separatori della data"
+msgstr "Datoskilletegn"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:226
 msgid "Abbreviate names of days and months"
-msgstr "Abbrevia i nomi dei giorni e dei mesi"
+msgstr "Forkort navn på dag og måneder"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:236
 msgid "Show the time"
-msgstr "Mostra l'ora"
+msgstr "Vis tiden"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM"
@@ -9665,43 +9681,43 @@ msgstr "HH:MM:SS.MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:265
 msgid "Time style"
-msgstr "Stile ora"
+msgstr "Tidsstil"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:314
 msgid "Unit of currency"
-msgstr "Unità per valuta"
+msgstr "Valutaenhet"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:334
 msgid "Currency label style"
-msgstr "Stile etichetta valuta"
+msgstr "Valutaetikettstil"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:361
 msgid "Where to display the unit of currency"
-msgstr "Dove mostrare l'unità della valuta"
+msgstr "Hvor valutaenheten skal vises"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:394
 msgid "Minimum number of decimal places"
-msgstr "Numero minimo di posizioni decimali"
+msgstr "Minste antall desimaler"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "Tipo di grafico in pila"
+msgstr "Stablet diagramtype"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "etichetta obbiettivo"
+msgstr "Måletikett"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "Mostra la linea del trend"
+msgstr "Vis trendlinje"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "Stile della linea"
+msgstr "Linjestil"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "Mostra i punti sulla linea"
+msgstr "Vis prikker på linjer"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:348
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
@@ -9711,226 +9727,226 @@ msgstr "Auto"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "Quale asse?"
+msgstr "Hvilken akse?"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "Linea + Barra"
+msgstr "Linje + Stolpe"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
-msgstr "Grafico a barre e linea"
+msgstr "linje- og stolpediagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "La visualizzazione Gauge richiede un numero."
+msgstr "Målervisualisering trenger et nummer."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
 msgid "Gauge"
-msgstr "Gauge"
+msgstr "Måler"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
-msgstr "Intervallo Gauge"
+msgstr "Målerområde"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:107
 msgid "Field to show"
-msgstr "Campo da mostrare"
+msgstr "Felt å vise"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
-msgstr "l'ultimo {0}"
+msgstr "siste {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
-msgstr "{0} era {1} {2}"
+msgstr "{0} var {1} {2}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
-msgstr "Raggruppa per un campo \"time\" per vedere come è cambiato nel tempo"
+msgstr "Grupper etter et tidsfelt for å se hvordan dette har endret seg over tid"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:51
 msgid "Switch positive / negative colors?"
-msgstr "Cambia colori positivi / negativi"
+msgstr "Bytt positive / negative farger?"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
-msgstr "Colonna Pivot"
+msgstr "Pivoter kolonnen"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
-msgstr "Colonna della cella"
+msgstr "Cellekolonne"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
-msgstr "Colonne visibili"
+msgstr "Synlige kolonner"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
-msgstr "Formattazione condizionale"
+msgstr "Betinget Formatering"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
-msgstr "Titolo della colonna"
+msgstr "Kolonnetittel"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:243
 msgid "Show a mini bar chart"
-msgstr "Mostra un grafico a barre mini"
+msgstr "Vis et ministolpediagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:254
 msgid "Link"
-msgstr "Link"
+msgstr "Lenke"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:258
 msgid "Email link"
-msgstr "Link dell'email"
+msgstr "E-post-lenke"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:262
 msgid "Image"
-msgstr "Immagine"
+msgstr "Bilde"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:266
 msgid "Automatic"
-msgstr "Automatico"
+msgstr "Automatisk"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:271
 msgid "View as link or image"
-msgstr "Visualizza come link o immagine"
+msgstr "Vis som lenke eller bilde"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:281
 msgid "Link text"
-msgstr "Testo del link"
+msgstr "Lenketekst"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "Non è un intero valido: \"{0}\""
+msgstr "Ikke et gyldig heltall: \"{0}\""
 
 #: src/metabase/api/embed.clj
 msgid "Embedding is not enabled for this object."
-msgstr "L'incorporamento non è abilitato per questo oggetto."
+msgstr "Innebygging er ikke aktivert for dette objektet."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "Il problema di connessione al server LDAP fallirà con l'autenticazione locale: {0}"
+msgstr "Problem med tilkobling til LDAP-tjener; faller tilbake til lokal autorisering: {0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "Quando si include un offset, deve essere incluso anche un limite."
+msgstr "Når det brukes en forskyvning, så må det også brukes en grense."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "Quando si include un limite, deve essere incluso anche un offset."
+msgstr "Når det brukes en grense, så må det også brukes en forskyvning."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr "Applicando l'euristico {0} a {1}."
+msgstr "Anvender heuristikk {0} for {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr "Vincoli di dimensione:n{0}"
+msgstr "Dimensjoner bindinger:n{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr "Utilizzo delle definizioni:nMetrica:n{0}Filtri:n{1}"
+msgstr "Bruker definisjoner:nIndikatorer:n{0}nFiltere:n{1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
-msgstr "minuto"
+msgstr "minutt"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "ora"
+msgstr "time"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "giorno della settimana"
+msgstr "ukedag"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "giorno del mese"
+msgstr "dag i måned"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "giorno dell'anno"
+msgstr "dag i året"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "settimana"
+msgstr "uke"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
-msgstr "mese"
+msgstr "måned"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "trimestre"
+msgstr "kvartal"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "Aggiunta di {0} carte alla dashboard {1}: n {2}"
+msgstr "Legger {0} kortene til infotavlen {1}:n{2}"
 
 #: src/metabase/util/yaml.clj
 msgid "Error parsing {0}:n{1}"
-msgstr "Analisi degli errori {0}:n{1}"
+msgstr "Feil ved tolking av {0}:n{1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "ATTENZIONE: il filtraggio funziona solo sulle dimensioni! '' {0} '' è una metrica. Filtro ignorato."
+msgstr "ADVARSEL: Filtrering virker bare på dimensjoner! \"{0}\" er en indikator. Ignorerer filter."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "ATTENZIONE: una data non può appartenere a più intervalli discreti, quindi usarli insieme con AND non ha senso."
+msgstr "ADVARSEL: En dato kan ikke tilhøre flere diskrete intervaller, så å OGe dem sammen gir ikke mening."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "Questi intervalli sono ignorati: {0}"
+msgstr "Ignorerer disse intervallene: {0}"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "ATTENZIONE: non so come negare: {0}"
+msgstr "ADVARSEL: Vet ikke hvordan man omvender: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "L'ordinamento con Druid è consentito solo nelle query che hanno una o più colonne di breakout. Ignorando: clausola order-by."
+msgstr "Sortering med Druid er kun tillatt i spørringer som har en eller flere utbrytingskolonner. Ignorerer :order-by-klausul."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "ATTENZIONE: ha senso solo specificare: campi per una query senza aggregazione. Ignorando la clausola."
+msgstr "ADVARSEL: Det gir kun mening å spesifisere :fields for en spørring uten aggregering. Ignorerer klausulen."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "AVVISO: Druid non permette limitSpec nelle query timeseries. La clausola LIMIT verrà ignorata."
+msgstr "ADVARSEL: Druid tillater ikke limitSpec i tidsseriespørringer. Ignorerer LIMIT-klausulen."
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "Form per HoneySQL:"
+msgstr "HoneySQL Skjema:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "Impossibile analizzare la data \"{0}\""
+msgstr "Kan ikke tolke dato \"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "Connessione del client chiusa, annullamento della query"
+msgstr "Klienten lukket tilkoblingen, avbryter spørring"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "Impostazione del fusorario con istruzione: {0}"
+msgstr "Setter tidssone med uttrykket: {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "Non sono supportati più filtri di data"
+msgstr "Flere datofiltere er ikke tillatt"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":not non è ancora stato implementato"
+msgstr ":not er ikke implementert enda"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "È consentito un solo segmento di Google Analytics alla volta."
+msgstr "Kun ett Google Analytics-segment er tillatt om gangen."
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
@@ -9938,100 +9954,100 @@ msgstr "MONGO AGGREGATION PIPELINE:"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "Errore: colonne non corrispondenti nei risultati! Previsto: {0} Got: {1}"
+msgstr "Feil: kolonnene passer ikke i resultater! Forventet: {0} Fikk: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "Impossibile creare il file temp in `{0}` per gli allegati di posta elettronica"
+msgstr "Kan ikke lage midlertidig fil i `{0}` for e-postvedlegg "
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "Errore nella richiesta di pre-elaborazione:"
+msgstr "Feil ved preprosessering av spørring:"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "Clausola del filtro non valida: {0}"
+msgstr "Ulovlig filterklausul: {0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "Clausola non valida:"
+msgstr "Ugyldig klausul:"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Errore: la query di origine della query non è stata risolta. Probabilmente hai prima bisogno di 'pre-elaborare' la query."
+msgstr "Feil: spørringens kildespørring har ikke blitt løst. Du trenger sannsynligvis å `preprosessere` spørringen først."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "Nessuna espressione chiamata \"{0}\""
+msgstr "Ingen uttrykk heter \"{0}\""
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "Nessuna aggregazione all'indice: {0}"
+msgstr "Ingen samling på indeksen: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "La lunghezza totale dei valori del campo è {0} (max {1})."
+msgstr "Feltverdienes totale lengde er {0} (maks {1})."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "Valori ammessi per questo Campo."
+msgstr "FeltVerdier er ikke tillatt for dette Feltet."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "Valori non ammessi per questo Campo."
+msgstr "FeltVerdier er IKKE tillatt for dette Feltet."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr "Il campo {0} ''{1}'' dovrebbe avere FieldValues ​​e appartiene a un database con l'aggiornamento FieldValues ​​On-Demand."
+msgstr "Feltet {0} \"{1}\" bør ha FeltVerdier og tilhører en Database med På-Forespørsel FeltVerdier-oppdatering."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "Non puoi creare o revocare i permessi per il gruppo \"Admin\"."
+msgstr "Du kan ikke lage eller tilbakekalle tillatelser for \"Admin\"-gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "Non puoi aggiungere o rimuovere utenti al/dal gruppo \"MetaBot\"."
+msgstr "Du kan ikke legge til eller fjerne brukere i \"MetaBot\"-gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "Non puoi aggiungere o rimuovere utenti al/dal gruppo \"All Users\"."
+msgstr "Du kan ikke legge til eller fjerne brukere i \"Alle Brukere\"-gruppen."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "Non puoi rimuovere l'ultimo membro del gruppo \"Admin\"!"
+msgstr "Du kan ikke fjerne det siste medlemmet av \"Admin\"-gruppen!"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "Errore nell'inserimento di una nuova Impostazione: {0}"
+msgstr "Feil ved tillegg av ny innstilling: {0}"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr "le descrizioni defsetting devono essere ':internal?' o internazionalizzate, trovate: '{0}'"
+msgstr "Beskrivelse for defsetting-tekststrenger må være `:internal?` eller internasjonalisert, fant: `{0}`"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "Caricamento plugin {0}...{1}"
+msgstr "Laster plugin {0}... {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr "Oggetto digitato per tipo, contenente le impostazioni di formattazione"
+msgstr "Objekt kodet etter type, inneholder formateringsinnstillinger"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "Permettere agli utenti di esplorare i dati usando i raggi X"
+msgstr "Tillat brukere å utforske data ved hjelp av X-rays"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "Usando questo URL per controllare il token: {0}"
+msgstr "Bruker følgende URL for å sjekke token: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "Impossibile validare il token: 404 non trovato."
+msgstr "Validering av token feilet: 404 ikke funnet."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "Si è verificato un errore durante il controllo della validità di questo token:"
+msgstr "Det oppstod en feil ved sjekk av hvorvidt denne tokenen var valid:"
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -10039,270 +10055,270 @@ msgstr "Si è verificato un errore durante il controllo della validità di quest
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "Token per funzionalità premium. Vai al MetaStore per ottenere il tuo!"
+msgstr "Token for premium-egenskaper. Gå til MetaStore for å få din egen!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "Il formato del token non è valido. Il token dovrebbe essere 64 caratteri esadecimali."
+msgstr "Token-format er ugyldig. Token skal være 64 heksadesimale siffer."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium features token"
-msgstr "Errore durante l'impostazione delle funzioni premium del token"
+msgstr "Feil ved setting av token for premium-egenskaper"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "Errore durante la convalida del token:"
+msgstr "Feil ved validering av token:"
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "Errore durante la pre-elaborazione della query"
+msgstr "Feil ved preprosesseringsspørring"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "Nessun form nativo è stato restituito"
+msgstr "Ingen lokale skjema returnert."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "Risposta non valida dal driver del database. Nessuno stato fornito."
+msgstr "Ugyldig svar fra databasedriveren. Ingen status oppgitt."
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "Errore generale"
+msgstr "Generell feil"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "Hash della query mancante!"
+msgstr "Mangler spørringshash!"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "La tabella ''{0}'' non ha campi associati."
+msgstr "Tabellen \"{0}\" har ingen felter assosiert med seg."
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "È stato raggiunto il limite massimo di query simultanee"
+msgstr "Grense for maksimalt antall parallelle spørringer nådd"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "Non so come ottenere informazioni sul Campo:"
+msgstr "Jeg vet ikke hvordan jeg kan hente informasjon om feltet:"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr "metabase.query-processor.interface/*driver* non associato."
+msgstr "metabase.query-processor.interface/*driver* er løs."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "Errore nel processo di query: numero non corrispondente di colonne nella query e nei risultati."
+msgstr "Feil i spørringsprosessor: ulikt antall kolonner i spørringen og resultatene."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "{0} campi previsti, {1} ottenuti"
+msgstr "Forventet {0} felter, fant {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "Previsti: {0}"
+msgstr "Forventet: {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "Effettivo: {0}"
+msgstr "Faktisk: {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "Impossbile binnare il Campo senza un valore min/max"
+msgstr "Felt kan ikke grupperes uten en min/maks-verdi"
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "{0} non supportato da questo driver."
+msgstr "{0} er ikke støttet av denne driveren."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "Segmento {0} non esistente o non valido."
+msgstr "Segmentet {0} eksisterer ikke, eller er invalid."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "Metrica {0} non esistente o non valido."
+msgstr "Indikatoren {0} eksisterer ikke eller er ikke valid."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "Query sorgente mancante nella Scheda {0}"
+msgstr "Mangler kildespørring i Kort {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "Query sorgente recuperata dalla Scheda {0}:"
+msgstr "Hentet kildespørring fra Kort {0}"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "Errore durante la conversione della query MBQL in nativa:"
+msgstr "Feil ved transformasjon av MBQL-spørring til lokal spørring:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "Non riesco a eseguire la query: non posso trovare la tabella sorgente {0}."
+msgstr "Kan ikke utføre spørring: finner ikke kildetabellen {0}."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr "Errore durante la registrazione dei metadati dei risultati della query:"
+msgstr "Feil ved lagring av spørringsmetadataene."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr "Errore: Query Processor Store non inizializzato."
+msgstr "Feil: Spørringsprosessoren er ikke initialisert."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "Errore: la tabella {0} non è presente nel Query Processor Store."
+msgstr "Feil: Tabellen {0} er ikke tilgjengelig i spørringsprosessorsettet."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "Errore: il Campo {0} non è presente nel Query Processor Store."
+msgstr "Feil. Felt {0} er ikke tilgjengelig i spørringsprosessorsettet."
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "Elenco attività pulito con successo, eliminate {0} righe."
+msgstr "Opprydding av oppgavehistorikk vellykket - {0} rader fjernet"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "no"
+msgstr "ikke"
 
 #: src/metabase/db.clj src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "Per maggiori informazioni, guardare"
+msgstr "For mer informasjon, se"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "Numero intero maggiore o uguale a zero"
+msgstr "Heltall større enn eller lik null"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "il valore deve essere un numero intero maggiore o uguale a zero."
+msgstr "verdi må være et heltall større enn eller lik null."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "il valore deve essere 0 o un numero intero maggiore."
+msgstr "verdi må være et heltall større enn eller lik null."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "il valore deve essere un numero intero valido, maggiore o uguale a zero."
+msgstr "verdi må være et heltall større enn eller lik null."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "Nuovi utenti per stato negli ultimi 30 giorni"
+msgstr "Nye brukere per status i løpet av de siste 30 dagene "
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "Creato il, per giorno della settimana"
+msgstr "Opprettet Dato etter ukedag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "Creato il, per trimestre di anno"
+msgstr "Opprettet Dato etter kvartal i året"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "[[this.short-name]] per paese"
+msgstr "[[this.short-name]] per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "Utenti per sorgente"
+msgstr "Brukere per kilde"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "Le principali pagine esterne che hanno portato gli utenti al tuo sito"
+msgstr "De eksterne sidene som brakte flest brukere til din side"
 
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 msgid "How [[this]] is distributed and more."
-msgstr "Come [[this]] è distribuito e altro."
+msgstr "Hvordan [[this]] er distribuert og mer."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "Il [[this]] nel tempo"
+msgstr "[[this]] over tid"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "Crescita dell'utente"
+msgstr "Brukervekst"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "Indipendentemente dal fatto che ci siano o no dei modelli in cui accadono."
+msgstr "Hvorvidt det er noen mønstere for når det skjer."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "Utenti per stato"
+msgstr "Brukere per status"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "Sessioni"
+msgstr "Sesjoner"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr "Come alcuni dei numeri in [[this]] si mettono in relazione l'uno con l'altro"
+msgstr "Hvor noen av tallene i [[this]] relaterer seg til hverandre"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "Vendite per paese"
+msgstr "Omsetning per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "Unire la data per mese dell'anno"
+msgstr "Innmeldingsdato etter måned i året"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "[[Timestamp]] per ora del giorno"
+msgstr "[[Timestamp]] etter time i døgnet"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "Uno sguardo a [[this]]"
+msgstr "Et blikk på [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "Le ultime 5 per catogoria"
+msgstr "Siste 4 i hver kategori"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "Numero di ordini"
+msgstr "Antall ordre"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "Crescita degli eventi"
+msgstr "Hendelsesvekst"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
-msgstr "Totale [[GenericTable]]"
+msgstr "Totalt [[GenericTable]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "Crescita degli incassi"
+msgstr "Inntekstvekst"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "10 migliori paesi per vendite negli ultimi 30 giorni"
+msgstr "Topp 10 land etter omsetning i løpet av de siste 30 dagene"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "[[this]] per mese dell'anno"
+msgstr "[[this]] etter måned i året"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "Transazioni per giorno della settimana"
+msgstr "Transaksjoner per ukedag"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "Sessioni per tipo di dispositivo"
+msgstr "Sesjoner etter type enhet"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "Transazioni per paese"
+msgstr "Transaksjoner per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "Unisci la data per trimestre"
+msgstr "Innmeldingsdato etter kvartal i året"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "Eventi per ora del giorno"
+msgstr "Hendelser per time i døgnet"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
@@ -10311,16 +10327,16 @@ msgstr "[[Singleton]]"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
-msgstr "Top 5 [[this]]"
+msgstr "Topp 5 [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "Ultimi 5 [[this]]"
+msgstr "Siste 5 [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "[[Timestamp]] per giorno del mese"
+msgstr "[[Timestamp]] etter dag i måneden"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
@@ -10332,15 +10348,15 @@ msgstr "Per [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
-msgstr "Valori nulli"
+msgstr "Nullverdi"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "Eventi totali"
+msgstr "Totalt antall hendelser"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr "Uno sguardo a [[GenericTable]] attraverso il tuo [[this]], e come cambia nel tempo."
+msgstr "Et blikk på [[GenericTable]] på tvers av dine [[this]], og hvordan det endrer seg over tid."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
@@ -10348,24 +10364,24 @@ msgstr "[[this]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "Come [[this]] cambia nel tempo"
+msgstr "Hvordan [[this]] endrer seg over tid"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "Come si confrontano per stagionalità"
+msgstr "Sesongvariasjoner"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "Reddito medio per transazione"
+msgstr "Gjennomsnittlig inntekt per transaksjon"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
-msgstr "[[this]] per paese"
+msgstr "[[this]] per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "Reddito per stato"
+msgstr "Inntekt per stat"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
@@ -10373,294 +10389,294 @@ msgstr "Per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "Un'occhiata da vicino al tuo [[this]]"
+msgstr "En nærmere kikk på din [[this]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How [[GenericNumber]] is distributed"
-msgstr "Come è distribuito [[GenericNumber]]"
+msgstr "Hvordan [[GenericNumber]] er fordelt"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "[[Timestamp]] per trimestre"
+msgstr "[[Timestamp]] etter kvartal i året"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "Eventi per paese"
+msgstr "Hendelser per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "Giorni della settimana in cui [[this.short-name]] sono stati aggiunti"
+msgstr "Ukedager når [[this.short-name]] ble lagt til"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] were added"
-msgstr "Mesi in cui [[this.short-name]] sono stati aggiunti"
+msgstr "Måneder når [[this.short-name]] ble lagt til"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "Come si confrontano tra categorie diverse"
+msgstr "Hvordan de varierer på tvers av forskjellige kategorier"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "Nuovi utenti per sorgente negli ultimi 30"
+msgstr "Nye brukere per kilde i løpet av de siste 30"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "Eventi per trimestre"
+msgstr "Hendelser per kvartal i året"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "Ecco una rapida occhiata al tuo [[this]]"
+msgstr "Her er en rask titt på din [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[this]] per [[GenericCategoryLarge]], primi 5"
+msgstr "[[this]] per [[GenericCategoryLarge]], topp 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days when [[this.short-name]] were added"
-msgstr "Giorni in cui [[this.short-name]] sono stati aggiunti"
+msgstr "Dager når [[this.short-name]] ble lagt til"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "Totale ordini per sorgente"
+msgstr "Totalt antall ordre per kilde"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "[[this]] per trimestre"
+msgstr "[[this]] etter kvartal i året"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "Eventi per [[GenericCategoryMedium]]"
+msgstr "Hendelser per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per state"
-msgstr "Eventi per stato"
+msgstr "Hendelser per status"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top landing pages"
-msgstr "Top landing pages"
+msgstr "Hovedsider"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "Ecco uno sguardo più vicino al tuo [[this]] nel tempo"
+msgstr "Her er en nærmere kikk på din [[this]] over tid"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "Somma di [[this]] per [[Country]]"
+msgstr "Summen av [[this]] for [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "Stati che stanno ottenendo i migliori risultati"
+msgstr "Stater som yter best"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "Creato per mese dell'anno"
+msgstr "Opprettet Dato etter måned i året"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "Somma di [[this]] per [[State]]"
+msgstr "Sum av [[this]] for [[State]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "Somma di [[GenericNumber]] per [[this]]"
+msgstr "Sum av [[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "Eventi per coordinate"
+msgstr "Hendelser etter koordinater"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "Migliori pagine di riferimento"
+msgstr "Topp sidehenvisninger"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr "Un'esplorazione ai tuoi utenti per cominciare."
+msgstr "En utforskning av dine brukere for å få deg i gang."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr "Una panoramica del tuo [[this]] e di come è distribuito nel tempo, luogo e categorie."
+msgstr "En oversikt av din [[this]] og hvordan det fordeler seg over tid, sted og kategorier."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "Entrate medie per stato"
+msgstr "Gjennomsnittlig inntekt per stat"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[this]] per [[GenericCategoryMedium]]"
+msgstr "[[this]] etter [[FenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "Transazioni totali"
+msgstr "Totalt antall transaksjoner"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] che si sono uniti nel tempo"
+msgstr "[[this.short-name]] som har blitt innmeldt over tid"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "Il [[this]] per luogo"
+msgstr "[[this]] etter plassering"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "Eventi per mese dell'anno"
+msgstr "Hendelser per måned i året"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[this]] per [[GenericNumber]]"
+msgstr "[[this]] etter [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "Trimestri quando [[this.short-name]] sono stati aggiunti"
+msgstr "Kvartal når [[this.short-name]] ble lagt til"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "Come questi [[this.short-name]] sono distribuiti"
+msgstr "Hvordan disse [[this.short-name]] er fordelt"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[this.short-name]] per [[GenericNumber]]"
+msgstr "[[this.short-name]] for [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "Da dove stanno arrivando gli utenti"
+msgstr "Hvor brukerne dine kommer fra"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "[[this]] confronti e correlazioni"
+msgstr "[[this]] sammenligninger og korrelasjoner"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "Entrate totali"
+msgstr "Total inntekt"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "Entrate totali per mese"
+msgstr "Total inntekt per måned"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "Numero di utenti per sorgente"
+msgstr "Antall brukere per kilde"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "Transazioni per stato"
+msgstr "Transaksjoner per status"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[this]] per [[Timestamp]]"
+msgstr "[[this]] for [[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "Nuovi utenti per sorgente negli ultimi 30 giorni"
+msgstr "Nye brukere per kilde i løpet av de siste 30 dagene"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "Unisci la data per giorno del mese"
+msgstr "Innmeldingsdato etter dato i måneden"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "Sconto medio %"
+msgstr "Gjennomsnittlig rabatt i %"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "Metrica generata automaticamente su [[GenericTable]]"
+msgstr "Automatisk genererte indikatorer for [[GenericTable]]."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "[[this]] per giorno del mese"
+msgstr "[[this]] etter dag i måneden"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "Sessioni totali in ogni paese"
+msgstr "Totalt antall sesjoner i hvert land"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "Transazioni per mese dell'anno"
+msgstr "Transaksjoner per måned i året"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "Vendite per prodotto"
+msgstr "Omsetning per produkt"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "Utenti in ogni paese"
+msgstr "Brukere i hvert land"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "[[this]] per ora del giorno"
+msgstr "[[this]] etter time i døgnet"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "Eventi negli ultimi 30 giorni"
+msgstr "Hendelser i løpet av de siste 30 dager"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "Transazioni per sorgente"
+msgstr "Transaksjoner per kilde"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "Dove hai acquisito i tuoi utenti"
+msgstr "Hvor du har skaffet brukerne dine fra"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "Come si confrontano attraverso la posizione"
+msgstr "Hvordan de fordeler seg over plasseringer"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "[[this]] per prodotto"
+msgstr "[[this]] etter produkt"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr "[[this]] per mese dell'anno"
+msgstr "[[this]] for hver måned i året"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "Per paese"
+msgstr "Etter land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr "Uno sguardo profondo a come i paesi operino in modo differente per te."
+msgstr "Et dypdykk i hvordan forskjellige land yter for deg."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "Vendite per stato"
+msgstr "Omsetning per stat"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
-msgstr "Eventi per [[GenericNumber]]"
+msgstr "Hendelser etter [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "Vendite per prodotto [[ProductCategoryMedium]]"
+msgstr "Omsetning per produkt [[ProductCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "Acquisizione degli utenti per paesi"
+msgstr "Brukertilegnelse etter land"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "[[this]] per source"
-msgstr "[[this]] per sorgente"
+msgstr "[[this]] etter kilde"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by day of the week"
-msgstr "[[this]] per giorno della settimana"
+msgstr "[[this]] etter ukedag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "Giorni del mese in cui [[this.short-name]] si sono uniti"
+msgstr "Dager i måneden når [[this.short-name]] ble innmeldt"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "Ecco una panoramica delle persone nel tuo [[this]]"
+msgstr "Her er en oversikt over folk i din [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr "Come [[GenericTable]] sono distribuiti in questo campo temporale e se ha schemi stagionali."
+msgstr "Hvordan [[GenericTable]] er fordelt over dette tidsfeltet, og om det er noen sesongvariasjoner."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10671,47 +10687,47 @@ msgstr "Come [[GenericTable]] sono distribuiti in questo campo temporale e se ha
 #: resources/automagic_dashboards/table/UserTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
-msgstr "Panoramica"
+msgstr "Overblikk"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "In che modo questa metrica è distribuita tra diverse categorie"
+msgstr "Hvordan denne indikatoren er fordelt på tvers av forskjellige kategorier"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr "[[this.short-name]] per stato"
+msgstr "[[this.short-name]] etter status"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "Giorni ferial quando [[this.short-name]] si è unito."
+msgstr "Ukedager når [[this.short-name]] ble innmeldt"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] joined"
-msgstr "Ore quando [[this.short-name]] si è unito"
+msgstr "Timer når [[this.short-name]] ble innmeldt"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "Entrate totali per mese"
+msgstr "Total inntekt per måned"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "Una ripartizione del tuo [[this]] nel tempo, il suo minimo, massimo, medio e altro."
+msgstr "En oversikt over dine [[this]] over tid, og dets minsteverdi, maksverdi, gjennomsnittsverdi og mer."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "Quantità media per stato"
+msgstr "Gjennomsnittlig antall per status"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr "Come confrontare attraverso numeri diversi"
+msgstr "Hvordan de varierer på tvers av forskjellige tall"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "Nuovi utenti per paese negli ultimi 30 giorni"
+msgstr "Nye brukere per land i løpet av de siste 30 dagene"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr "Transazioni nel tempo"
+msgstr "Transaksjoner over tid"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
@@ -10719,89 +10735,89 @@ msgstr "[[this]] per [[GenericCategorySmall]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "Qualche ripartizione"
+msgstr "Noen oversikt"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[State]]"
-msgstr "Media di [[this]] per [[State]]"
+msgstr "Gjennomsnittet av [[this]] for [[State]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "Transazioni per trimestre"
+msgstr "Transaksjoner per kvartal i året"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "Per coordinate"
+msgstr "Etter koordinater"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "Un'occhiata da vicino al tuo [[this]] per prodotti"
+msgstr "Her er en nærmere kikk på dine [[this]] etter produkter"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per quarter of the year"
-msgstr "[[this]] per trimestre"
+msgstr "[[this]] per kvartal i året"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Una panoramica del tuo dato [[this]] da Google Analytics"
+msgstr "Her er en oversikt over dine [[this]]-data fra Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "Trimestri quando [[this.short-name]] si è unito"
+msgstr "Kvartaler når [[this.short-name]] ble innmeldt"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "Nuovo [[this.short-name]] negli ultimi 30 giorni"
+msgstr "Nye [[this.short-name]] i løpet av de siste 30 dager"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "Sessioni totali per desktop, mobile o tablet"
+msgstr "Totalt antall sesjoner etter skrivebord, mobil, eller nettbrett"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "Esempio approfondito"
+msgstr "Detaljert eksempel"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "Entrata media per sorgente"
+msgstr "Gjennomsnittlig inntekt per kilde"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "[[Timestamp]] per giorno della settimana"
+msgstr "[[Timestamp]] etter ukedag"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "Un'occhiata da vicino al tuo [[this]]"
+msgstr "Her er en nærmere kikk på dine [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "Ecco uno sguardo più vicino al tuo [[this]] campo"
+msgstr "Her er en nærmere kikk på dine [[this]]-felt"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
-msgstr "Riepilogo"
+msgstr "Oppsummering"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "Come [[this]] è distribuito geograficamente"
+msgstr "Hvordan [[this]] er fordelt geografisk"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "Le pagine con le visite maggiori"
+msgstr "Sidene med flest sidevisninger"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "Come [[Number1]] è correlato con [[Number2]]"
+msgstr "Hvordan [[Number1]] er korrelert med [[Number2]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "Migliori 10 stati per vendite negli ultimi 30 giorni"
+msgstr "Topp 10 stater etter omsetning i løpet av de siste 30 dager"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "Top 10 stati per vendite"
+msgstr "Topp 10 stater etter omsetning"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
@@ -10809,62 +10825,62 @@ msgstr "[[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "Dove queste transazioni sono avvenute"
+msgstr "Hvor disse transaksjonene skjedde"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "Migliori 10 paesi per vendite"
+msgstr "Topp 10 land etter omsetning"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "Vendite per stato"
+msgstr "Omsetning etter stat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "Da dove proviene la maggior parte delle sessioni"
+msgstr "Hvor de fleste av dine sesjoner kom fra"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "Migliori canali di acquisizione"
+msgstr "De viktigste tilegnelseskanaler"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These [[this.short-name]] across time"
-msgstr "Questi [[this.short-name]] nel tempo"
+msgstr "Disse [[this.short-name]] over tid"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "Quantità media"
+msgstr "Gjennomsnittlig antall"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "Vendite per sorgente"
+msgstr "Omsetning per kilde"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "Reddito medio per paese"
+msgstr "Gjennomsnittlig inntekt per land"
 
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 msgid "How [[this]] is distributed"
-msgstr "Come [[this]] è distribuito"
+msgstr "Hvordan [[this]] er distribuert"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr "Distinti [[FK]]"
+msgstr "Unike [[FK]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "Come sono distribuite queste transazioni"
+msgstr "Hvordan disse transaksjonene er fordelt"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "Per stato"
+msgstr "Per stat"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr "Conteggio di [[GenericCategoryMedium]] per [[this]]"
+msgstr "Antall [[GenericCategoryMedium]] for [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10879,68 +10895,68 @@ msgstr "Conteggio di [[GenericCategoryMedium]] per [[this]]"
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
-msgstr "Uno sguardo al tuo [[this]]"
+msgstr "Et blikk på dine [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[GenericNumber]] by [[this]]"
-msgstr "[[GenericNumber]] per [[this]]"
+msgstr "[[GenericNumber]] etter [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "Somma di [[GenericNumber]] per [[this]]"
+msgstr "Summen av [[GenericNumber]] etter [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your [[this]] table"
-msgstr "Uno sguardo alla tua tabella [[this]]"
+msgstr "Et blikk på din [[this]]-tabell"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr "Quante [[GenericTable]] ci sono per stato, e quanto è rappresentato ogni stato per altre categorie"
+msgstr "Hvor mange [[GenericTable]] det er per status, og hvordan hver status er representert på tvers av kategorier."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "Pagine più visitate"
+msgstr "Mest viste sider"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "Esplorazione di esempio"
+msgstr "Eksempelutforskning"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales vs. rating"
-msgstr "Vendite vs Rating"
+msgstr "Omsetning vs. Vurdering"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per hour of the day"
-msgstr "[[this]] per ora del giorno"
+msgstr "[[this]] per time i døgnet"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Where your [[this.short-name]] are"
-msgstr "Dove sono i tuoi [[this.short-name]]"
+msgstr "Hvor dine [[this.short-name]] er"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These are the same for all your [[this.short-name]]"
-msgstr "Queste sono le stesse per tutti i tuoi [[this.short-name]]"
+msgstr "Disse er det samme for alle dine [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "Eventi per categorie diverse"
+msgstr "Hendelser for forskjellige kategorier"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Where these [[this.short-name]] are"
-msgstr "Dove sono questi [[this.short-name]]"
+msgstr "Hvor disse [[this.short-name]] er"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr "Fuori tempo"
+msgstr "Over tid"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr "Un riepilogo degli eventi nella tua tabella [[this]]"
+msgstr "En oppsummering av hendelsene i din [[this]]-tabell"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "Transazioni per sorgente nel tempo"
+msgstr "Transaksjoner per kilde over tid"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10948,103 +10964,103 @@ msgstr "Transazioni per sorgente nel tempo"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
-msgstr "Come è stato distribuito il [[this]]"
+msgstr "Hvordan [[this]] er fordelt"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "Reddito totale per sorgente"
+msgstr "Total inntekt per kilde"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "Totale [[this.short-time]]"
+msgstr "Total [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Some metrics we found about your transactions."
-msgstr "Alcune metriche che abbiamo trovato sulle tue transazioni."
+msgstr "Noen indikatorer vi fant som gjelder dine transaksjoner."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr "Come stanno andando i tuoi diversi prodotti."
+msgstr "Hvordan dine forskjellige produkter yter."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "Dove questi eventi stanno accadendo"
+msgstr "Hvor disse hendelsene skjer"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "Quali stati USA ti stanno portando più affari."
+msgstr "Hvilken stat i USA fører til mest virksomhet."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare across time"
-msgstr "Come si paragonano nel tempo"
+msgstr "Hvordan de varierer over tid."
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average transaction income per month"
-msgstr "Entrate medie delle transazioni al mese"
+msgstr "Gjennomsnittlig inntekt for transaksjoner per måned"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "Quantità media al mese"
+msgstr "Gjennomsnittlig antall per måned"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "Modelli stagionali in [[this]]"
+msgstr "Sesongvariasjoner i [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr "Eventi nel tempo"
+msgstr "Hendelser over tid"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "Ordini e reddito per sorgente"
+msgstr "Bestillinger og inntekt per kilde"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "Transazioni per ora del giorno"
+msgstr "Transaksjoner per time i døgnet"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "Da dove proviene la maggior parte del tuo traffico."
+msgstr "Hvor den meste av trafikken kommer fra."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr "Ecco uno sguardo veloce a [[this]]"
+msgstr "Her er en rask kikk på [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr "Sembra che il tuo [[this]] abbia transazioni, quindi ecco uno sguardo ad esse"
+msgstr "Det ser ut som at [[this]] inneholder transaksjoner, så her er en rask titt på dem"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "Sconto medio al mese"
+msgstr "Gjennomsnittlig rabatt per måned"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "[[Timestamp]] per mese dell'anno"
+msgstr "[[Timestamp]] for måned i året"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr "[[this]] per [[GenericCategorySmall]] nel tempo"
+msgstr "[[this]] per [[GenericCategorySmall]] over tid"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "Distribuzione per coordinate"
+msgstr "Fordeling over koordinater"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "Vendite per sorgente"
+msgstr "Omsetning etter kilde"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "Vendite per ogni categoria di prodotto"
+msgstr "Omsetning for hver produktkategori"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "Un'occhiata da vicino alle metriche ed alle dimensioni utilizzate nella question salvata."
+msgstr "En nærmere titt på indikatorene og dimensjonene som er brukt i dette lagrede spørsmålet."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
@@ -11052,11 +11068,11 @@ msgstr "[[this.short-name]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "Vendite per prodotto [[ProductCategoryLarge]]"
+msgstr "Omsetning per produkt [[ProductCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "Quantità media per paese"
+msgstr "Gjennomsnittlig antall per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
@@ -11064,105 +11080,105 @@ msgstr "[[this.short-name]] per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "Ecco uno sguardo al tuo [[this]] per sorgente"
+msgstr "Her er en nærmere kikk på dine [[this]] per kilde"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "Eventi per giorno del mese"
+msgstr "Hendelser per dag i måneden"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "Se sei in correlazioni, questi sono i raggi-X per te."
+msgstr "Hvis du liker korrelasjoner, så er dette X-rayen for deg."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
-msgstr "Sessioni per paese"
+msgstr "Sesjoner etter Land"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr "Qualche metrica interessante sulle tue statistiche GA per iniziare."
+msgstr "Noen interessante indikatorer om din GA-statistikk for å la deg komme i gang."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
-msgstr "[[this]] per stato"
+msgstr "[[this]] per stat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "[[Timestamp]] per trimestre"
+msgstr "[[Timestamp]] etter kvartal i året"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "Com'è distribuito attraverso il tempo e altre categorie."
+msgstr "Hvordan det er fordelt over tid og over andre kategorier"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr "Uno sguardo ai tuoi eventi nel tempo e per varie categorie."
+msgstr "En titt på dine hendelser over tid og over andre kategorier"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[GenericTable]] per [[this]]"
-msgstr "[[GenericTable]] per [[this]]"
+msgstr "[[GenericTable]] per [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "Quantità media per sorgente"
+msgstr "Gjennomsnittlig antall per kilde"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "Top 5 per categoria"
+msgstr "Topp 5 per kategori"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "Eventi per giorno della settimana"
+msgstr "Hendelser per ukedag"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] per month"
-msgstr "Nuovo [[this.short-name]] per mese"
+msgstr "Nye [[this.short-name]] per måned"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "I migliori esecutori"
+msgstr "Toppytere"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "Transazioni negli ultimi 30 giorni"
+msgstr "Transaksjoner i løpet av de siste 30 dagene"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr "[[GenericTable]] per [[this]]"
+msgstr "[[GenericTable]] for [[this]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Panoramica dei tuoi [[this]] dati da Google Analytics"
+msgstr "Oversikt over dine [[this]]-data fra Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "Creato Il per ora del giorno"
+msgstr "Opprettet Dato etter time på døgnet"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "Vendite mensili"
+msgstr "Omsetning per måned"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
-msgstr "Come il [[this]] è distribuito per categorie"
+msgstr "Hvordan [[this]] er fordelt på tvers av kategorier"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "[[Timestamp]] per mese dell'anno"
+msgstr "[[Timestamp]] etter måned i året"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "Quante sessioni totali rispetto a quanti singoli utenti hai avuto ogni giorno."
+msgstr "Hvor mange sesjoner totalt vs. hvor mange individuelle brukere du hadde hver dag."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "Come questa metrica è distribuira attraverso numeri differenti"
+msgstr "Hvordan denne indikatoren er fordelt på tvers av forskjellige nummer"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "Sessioni per pagina in cui è iniziata la sessione"
+msgstr "Sesjoner etter side hvor sesjonen startet"
 
 #: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
@@ -11171,20 +11187,20 @@ msgstr "Sessioni per pagina in cui è iniziata la sessione"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
-msgstr "Valori distinti"
+msgstr "Unike verdier"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] were added"
-msgstr "Ore quando [[this.short-name]] è stato aggiunto"
+msgstr "Timer når [[this.short-name]] ble lagt til"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "[[Timestamp]] per giorno della settimana"
+msgstr "[[Timestamp]] etter ukedag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] attraverso il tempo"
+msgstr "[[GenericNumber]] over tid"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11193,43 +11209,43 @@ msgstr "[[GenericNumber]] attraverso il tempo"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Heres an overview of your [[this]]"
-msgstr "Ecco una panoramica del tuo [[this]]"
+msgstr "Her er en oversikt over dine [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by coordinates"
-msgstr "[[this.short-name]] per coordinate"
+msgstr "[[this.short-name]] etter koordinater"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "Ecco uno sguardo più vicino al tuo [[this]] per stato"
+msgstr "Her er en nærmere titt på dine [[this]] per stat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "\"Creato il\" per giorno del mese"
+msgstr "Opprettet Dato etter dag i måneden"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "Vendite per coordinate"
+msgstr "Omsetning etter koordinater"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "Nuovo [[this.short-name]] nel tempo"
+msgstr "Nye [[this.short-name]] over tid"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
-msgstr "Unire la data per ora del giorno"
+msgstr "Innmeldingsdato etter time i døgnet"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by hour of day"
-msgstr "[[Timestamp]] per ora del giorno"
+msgstr "[[Timestamp]] etter time i døgnet"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "Sessioni e utenti unici per giorno"
+msgstr "Sesjoner og unike brukere per dag"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr "Eventi per [[GenericCategoryLarge]]"
+msgstr "Hendelser per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -11238,27 +11254,27 @@ msgstr "Eventi per [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr "Come confrontano per distribuzione"
+msgstr "Hvordan de varierer etter distribusjon"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "Entrata per paese"
+msgstr "Inntekt per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "Eccoti alcuni dettagli in merito al tuo [[this]] per regione"
+msgstr "Her er en nærmere titt på dine [[this]] per land"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by product [[ProductCategory]]"
-msgstr "Vendite per prodotto [[ProductCategory]]"
+msgstr "Salg etter produkt [[ProductCategory]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr "[[this]] per [[GenericCategoryLarge]], ultimi 5"
+msgstr "[[this]] per [[GenericCategoryLarge]], siste 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "[[this.short-name]] aggiunti negli ultimi 30 giorni"
+msgstr "[[this.short-name]] lagt til i løpet av de siste 30 dagene"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
@@ -11266,386 +11282,386 @@ msgstr "Per [[Source]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "Quantità media articolo per mese"
+msgstr "Gjennomsnittlig antall ting per måned"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr "Il numero di [[GenericTable]] per paese, e come ogni paese è rappresentato in categorie diverse."
+msgstr "Antall [[GenericTable]] per land, og hvordan hvert land er representert i forskjellige kategorier."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the week"
-msgstr "[[this]] per giorno della settimana"
+msgstr "[[this]] per ukedag"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "Quantità media per sorgente"
+msgstr "Gjennomsnittlig antall per kilde"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr "[[this.short-name]] by [[Timestamp]]"
+msgstr "[[this.short-name]] for [[Timestamp]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "Riepilogo statistiche"
+msgstr "Sammenfattet statistikk"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "Vendite per mese"
+msgstr "Omsetning per måned"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
-msgstr "[[GenericNumber]] per data di unione"
+msgstr "[[GenericNumber]] etter innmeldingsdato"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[Country]]"
-msgstr "Media di [[this]] per [[Country]]"
+msgstr "Gjennomsnittet av [[this]] for [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] attraverso il tempo"
+msgstr "[[this]] over tid"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "Unire la data per giorno della settimana"
+msgstr "Innmeldingsdato etter ukedag"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "We crunched the numbers for your [[this]]"
-msgstr "Abbiamo ridotto i numeri per il tuo [[this]]"
+msgstr "Vi knuste tall for din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] joined"
-msgstr "Mesi quando [[this.short-name]] si è unito"
+msgstr "Måneder når [[this.short-name]] ble innmeldt"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "Impossibile analizzare la risorsa `{0}` come JSON"
+msgstr "Ressursen `{0}` kan ikke tolkes som JSON"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "Impossibile trovare JSON tramite il percorso relativo `{0}`"
+msgstr "Finner ikke JSON via den relative stien `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "Connessione all'host scaduta per URL `{0}`"
+msgstr "Tidsavbrudd for tilkobling til vert på URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "Impossibile collegare URL `{0}` ad un host sconosciuto "
+msgstr "Klarte ikke å koble til ukjent vert på URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "Impossibile collegare URL `{0}` ad un host"
+msgstr "Klarte ikke å koble til vert på URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "Connessione a URL `{0}` rifiutata dall'host"
+msgstr "Tilkobling nektet av vert for URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "Impossibile trovare la risorsa su URL `{0}`"
+msgstr "Klarte ikke å motta ressurs på URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "Impossibile formattare la risorsa su URL `{0}` come JSON"
+msgstr "Klarte ikke å tolke ressursen på URL `{0}` som JSON"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "Problemi durante la connessione al server LDAP, procedere con l'autenticazione in locale: {0}"
+msgstr "Problem med tilkobling til LDAP-server, faller tilbake på lokal autentisering: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "Gli stati delle BigQuery non possono essere parametrizzate."
+msgstr "BigQuery-uttrykk kan ikke parametriseres!"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "ATTENZIONE: Druid non consente limitSpec nelle query di serie temporali. Ignorare la condizione LIMIT"
+msgstr "ADVARSEL: Druid tillater ikke limitSpec i tidsseriespørringer. Ignorerer LIMIT-klausulen."
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "Dettagli di connessione Snowflake non validi: Manca il nome del DB"
+msgstr "Ugyldig Snowflake-tilkoblingsdetaljer: manglende DB-navn."
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "Apprezzeremo il tuo feedback"
+msgstr "Vi vil sette pris på din tilbakemelding."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Sembra che Metabase non sia rientrato nelle tue aspettative"
+msgstr "Det ser ut som Metabase ikke fungerte tilfredsstillende for deg."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "Ti andrebbe di rispondere a 5 domandine veloci per aiutare il nostro team a comprendere perchè e migliorare le cose in futuro?"
+msgstr "Har du lyst til å svare på 5 raske spørsmål for å hjelpe Metabase-teamet med å forstå hvorfor, og gjøre ting bedre i fremtiden?"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Ci auguriamo che ti sia trovato bene con Metabase."
+msgstr "Vi håper du likte Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "Ti andrebbe di dirci come sta andando, rispondendo a 6 domandine veloci?"
+msgstr "Kunne du tenke deg å svare på en kort undersøkelse med 6 spørsmål for å fortelle oss hvordan det går?"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} ha creato un account Metabase."
+msgstr "{0} opprettet en konto til Metabase"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} ha accettato l'invito a Metabase."
+msgstr "{0} aksepterte sin invitasjon til Metabase"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "[Metabase] Richiesta di recupero Password"
+msgstr "[Metabase] Forespørsel om tilbakestilling av passord"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metabase] Notifica"
+msgstr "[Metabase] Varsel"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metabase] Aiuta a migiorare Metabase"
+msgstr "[Metabase] Hjelp Metabase å bli bedre."
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Metabase] Raccontaci come vanno le cose."
+msgstr "[Metabase] Fortell oss hvordan ting går."
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Errore: la query di origine della query non è stata risolta. Probabilmente hai prima bisogno di 'pre-elaborare' la query."
+msgstr "Feil: spørringens kildespørring har ikke blitt løst. Du trenger sannsynligvis å `preprosessere` spørringen først."
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "Non so che farci"
+msgstr "Jeg vet ikke hva jeg skal gjøre med:"
 
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "Non so come impacchettare:"
+msgstr "Jeg vet ikke hvordan man kan pakke inn:"
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "Impostazione di `query-caching-max-kb` a {0} fallita."
+msgstr "Klarte ikke å sette `query-caching-max-kb` til {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "Valori maggiori a {1} non sono consentiti."
+msgstr "Verdier større enn {1} er ikke tillatt."
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "Il database {0} non esiste"
+msgstr "Databasen {0} finnes ikke."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "Errore: Il database non risulta presente nel Query Processor Store"
+msgstr "Feil: Databasen finnes ikke i Query Processor Store."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr "Chiave segreta per l'inclusione non valida! Deve essere una chiave esadecimale a codifica 256-bit (ad esempio una stringa di 64 caratteri)."
+msgstr "Ugyldig embedding-secret-key! Den hemmelige nøkkelen må være en heksadesimalkodet 256-bit-nøkkel (dvs. en streng på 64 tegn)."
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "JWT manca `alg`."
+msgstr "JWT mangler `alg`."
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "JWT `alg` non può essere `none`"
+msgstr "JWT `alg` kan ikke være `none`."
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "La chiave segreta per l'inclusione non è stata configurata"
+msgstr "Den hemmelige innebyggingsnøkkelen har ikke blitt satt."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "Token mancante nel keypath"
+msgstr "Token mangler verdi for keypath"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr "esempio in profondità"
+msgstr "Detaljert eksempel"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "Chiave"
+msgstr "Nøkkel"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "Classe"
+msgstr "Klasse"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "Trigger"
+msgstr "Triggere"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr "Vedi trigger"
+msgstr "Vis triggere"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "Informazioni sullo scheduler"
+msgstr "Planleggingsinfo"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "Priorità"
+msgstr "Prioritet"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr "Ultima Esecuzione"
+msgstr "Sist kjørt"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "Prossima Esecuzione"
+msgstr "Neste kjøringstid"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "Data inizio"
+msgstr "Start tid"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "Data fine"
+msgstr "Slutt tid"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "Tempo di innesco finale"
+msgstr "Siste kjøringstid"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr "Può Lanciare ancora?"
+msgstr "Kan kjøres igjen?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "Innesco per {0}"
+msgstr "Triggere for {0}"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:26
 msgid "Tasks"
-msgstr "Tasks"
+msgstr "Oppgaver"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:31
 msgid "Jobs"
-msgstr "Jobs"
+msgstr "Jobber"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:735
 msgid "Duplicated {0}"
-msgstr "Duplicato {0}"
+msgstr "Duplisert {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "Duplica questo elemento"
+msgstr "Dupliser denne"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "Archivia questo elemento"
+msgstr "Arkiver denne"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:325
 msgid "Duplicate dashboard"
-msgstr "Duplica dashboard"
+msgstr "Dupliser tavle"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "Duplica \"{0}\""
+msgstr "Dupliser \"{0}\""
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "Duplica"
+msgstr "Dupliser"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "Domani"
+msgstr "Imorgen"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "Questo {0}"
+msgstr "Dette {0}"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "Prossimo {0}"
+msgstr "Neste {0}"
 
 #: frontend/src/metabase/lib/query_time.js:135
 #: src/metabase/pulse/render/datetime.clj
 msgid "Previous {0}"
-msgstr "Precedente {0}"
+msgstr "Sist {0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "Precedente {0} {1}"
+msgstr "Sist {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "Prossimo {0} {1}"
+msgstr "Neste {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "Ora"
+msgstr "Nå"
 
 #: frontend/src/metabase/lib/query_time.js:174
 msgid "{0} {1} ago"
-msgstr "{0} {1} fa"
+msgstr "{0} {1} siden"
 
 #: frontend/src/metabase/lib/query_time.js:175
 msgid "{0} {1} from now"
-msgstr "{0} {1} da ora"
+msgstr "{0} {1} fra nå"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] "Intervallo di default"
-msgstr[1] "Intervalli di default"
+msgstr[0] "Standard periode"
+msgstr[1] "Standard perioder"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] "Minuto dell'ora"
-msgstr[1] "Minuti dell'ora"
+msgstr[0] "Minutt i time"
+msgstr[1] "Minutter av time"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] "Ora del giorno"
-msgstr[1] "Ore del giorno"
+msgstr[0] "Time på dagen"
+msgstr[1] "Timer i dagen"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] "Giorno della settimana"
-msgstr[1] "Giorni della settimana"
+msgstr[0] "Dag i uke"
+msgstr[1] "Dager i uke"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] "Giorno del mese"
-msgstr[1] "Giorni del mese"
+msgstr[0] "Dag i måned"
+msgstr[1] "Dager i måned"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] "Giorno dell'anno"
-msgstr[1] "Giorni dell'anno"
+msgstr[0] "Dag i år"
+msgstr[1] "Dager i år"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] "Settimana dell'anno"
-msgstr[1] "Settimane dell'anno"
+msgstr[0] "Uke i år"
+msgstr[1] "Uker i år"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] "Mese dell'anno"
-msgstr[1] "Mesi dell'anno"
+msgstr[0] "Måned i år"
+msgstr[1] "Måneder i år"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] "Trimestre dell'anno"
-msgstr[1] "Trimestri dell'anno"
+msgstr[0] "Kvartal i år"
+msgstr[1] "Kvartaler i år"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
 #: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] "{0} selezione"
-msgstr[1] "{0} selezioni"
+msgstr[0] "{0} valgt"
+msgstr[1] "{0} valgte"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
 msgid "[Q]Q"
@@ -11653,221 +11669,220 @@ msgstr "[Q]Q"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr "Questo"
+msgstr "Dette"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:136
 msgid "Invalid"
-msgstr "Invalido"
+msgstr "Ukorrekt"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "Aggiungi tempo"
+msgstr "Legg til tid"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
-msgstr "Niente da confrontare con il precedente {0}"
+msgstr "Ingenting å sammenligne siden {0}."
 
 #: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
-msgstr "di {0}"
+msgstr "etter {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "il valore deve essere un tipo di database valido"
+msgstr "verdi må være en gyldig database motor."
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "Connessione rifiutata dall'host per URL `{0}`"
+msgstr "Tilkobling nektet av vert for nettlink `{0}`"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "Attenzione: rilevata stringa di connessione Postgres con `ssl=true`"
+msgstr "Advarsel: Postgres koblingsstreng med `ssl=true` funnet."
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "Potresti aver bisogno di aggiungere `?sslmode=require` alla stringa di connessione al tuo DB."
+msgstr "Det kan hende du må legge inn `?sslmode=require` i koblingsstreng til databasen."
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Se Metabase fallisce l'avvio, per favore aggiungilo e riprova."
+msgstr "Hvis Metabase feiler ved oppstart, vennligst legg det inn og prøv igjen."
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "Vedi https://github.com/metabase/metabase/issues/8908 per ulteriori dettagli."
+msgstr "Se http://github.com/metabase/metabase/issues/8908 for detaljer."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "ATTENZIONE: Utilizzare Metabase con H2 come database interno non è raccomandato per ambienti di produzione."
+msgstr "ADVARSEL: Bruk av H2 applikasjonsdatabase med Metabase er ikke anbefalt for produksjon."
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "Per installazioni di produzione si raccomanda caldamente di usare invece Postgres, MySQL o MariaDB."
+msgstr "For produksjon, anbefaler vi bruk av Postgres, MySQL eller MariaDB istedenfor."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "Se decidi di utilizzare ancora H2, si prega di eseguire regolarmente il backup del file di database."
+msgstr "Hvis du avgjør å bruke H2 for produksjon, vennligst bekreft at backup databasefilen jevnlig."
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "Vedi https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres per ulteriori informazioni"
+msgstr "Se https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for mer informasjon"
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "Impossibile collegarsi al DB Metabase {0}"
+msgstr "Kan ikke koble til Metabase {0} DB."
 
-#. I have more than one doubt about this. How can we translate Question in general in this software?
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr "Errore nell'aggiunta della direttiva SQL sulla Domanda (`Question`) salvata di BigQuery"
+msgstr "Feil ved tillegg av utdatert SQL direktiv til BigQuery lagret spørsmål."
 
 #: src/metabase/driver.clj
 msgid "Failed to notify {0} Database {1} updated"
-msgstr "Fallimento della notifica {0} Database {1} aggiornato"
+msgstr "Feilet ved varsling av {0} database {1} oppdatert"
 
 #: src/metabase/driver/impl.clj
 msgid "Loading driver {0} {1}"
-msgstr "Caricamento driver {0} {1}"
+msgstr "Laster inn driver {0} {1}"
 
 #: src/metabase/driver/impl.clj
 msgid "Load driver {0}"
-msgstr "Carica driver {0}"
+msgstr "Last inn driver {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Driver non registrato dopo il caricamento: {0}"
+msgstr "Driver ikke registrert etter innlasting: {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr "Errore: tentativo di modificare {0} proprietà `:abstract?` da {1} a {2}."
+msgstr "Feil: prøver å endre {0} egenskapen `:abstract?`fra {1} til {2}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered abstract driver {0}"
-msgstr "Registrato driver astratto {0}"
+msgstr "Registrerte abstrakt driver {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered driver {0}"
-msgstr "Driver registrato {0}"
+msgstr "Registrerer driver {0}"
 
 #: src/metabase/driver/impl.clj
 msgid "(parents: {0})"
-msgstr "(genitori: {0})"
+msgstr "(foreldre: {0})"
 
 #: src/metabase/driver/impl.clj
 msgid "Initializing driver {0}..."
-msgstr "Inizializzazione del driver {0}..."
+msgstr "Laster driver {0}..."
 
 #: src/metabase/driver/impl.clj
 msgid "Reason:"
-msgstr "Ragione:"
+msgstr "Årsak:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
-msgstr "Caratteristiche del driver non valido: {0}"
+msgstr "Ugyldig driver funksjon: {0}"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "Modulo HoneySQL non valido:"
+msgstr "Ugyldig HoneySQL form:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr "Chiusura del pool di connessioni per il database {0} ..."
+msgstr "Avslutter tilkoblingspool for database {0} ..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "Errore di caricamento del namespace"
+msgstr "Lastingsfeil av navnerom "
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "Avvio listener di eventi:"
+msgstr "Starter hendelseslytter"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "Errore inaspettato ascoltando eventi"
+msgstr "Ukjent feil ved lytting etter hendelser"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "Errore di sincronizzazione Database {0}"
+msgstr "Feil ved synkronisering av database {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr "Impossibile eseguire la sincronizzazione del database."
+msgstr "Kunne ikke kjøre sync-database"
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr "Livello della query nidificata errato: la query non ha una query sorgente"
+msgstr "Feil med flernivå spørring: spørring har ingen kildespørring"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
-msgstr "Non so come fare {0}"
+msgstr "Jeg vet ikke hvordan jeg skal gjøre dette `{0}`"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr "Qui c'è cosa posso fare: "
+msgstr "Her er det jeg kan gjøre: "
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "Errore nel comando Metabot"
+msgstr "Feil i Metabot kommando"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "Websocket associato a questo evento Slack è diverso dal websocket che si sta attualmente utilizzando."
+msgstr "Websocket assosiert med denne Slack saken er forskjellig fra websocketen vi kjører nå"
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr "Il ValoreDelCampo per il Campo {0} rimane invariato. Saltando..."
+msgstr "Feltverdier for Felt {0} forblir uendret. Hopper over..."
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "Impossibile normalizzare: "
+msgstr "Ikke mulig å normalisere"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
-msgstr "Impossibile trovare l'ID campo corrispondente per la destinazione:"
+msgstr "Kunne ikke finne matchet felt ID for mål"
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabase non ha le autorizzazioni per scrivere nella directory dei plugin {0}"
+msgstr "Metabase har ikke tilgang til å skrive til mappen med plugins {0}"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabase non può utilizzare la directory dei plugin {0}"
+msgstr "Metabase kan ikke bruke mappen med plugins {0}"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "Controlla che la directory esista e che Metabase abbia i permessi per scriverci."
+msgstr "Kontroller at mappen eksisterer og at Metabase har tilgang til å skrive"
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "Puoi cambiare la directory che Metabase utilizza per i moduli impostando la variabile d'ambiente MB_PLUGINS_DIR."
+msgstr "Du kan endre mappen Metabase bruker for moduler ved å sette miljøvariabelen MB_PLUGINS_DIR."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "Tornando a una directory temporanea per ora."
+msgstr "Faller tilbake til en midlertidig mappe"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabase non può scrivere sulla cartella temporanea. Imposta MB_PLUGINS_DIR su una directory scrivibile e riavvia Metabase."
+msgstr "Metbase kan ikke skrive til den midlertidige mappen. Sett MB-PLUGINS_DIR til en mappe det kan skrives til og start Metabase på nytt"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar non è più richiesto da Metabase 1.0+. Puoi cancellarlo dalla directory dei plugin."
+msgstr "spark-deps.jar er ikke lenger påkrevd av Metabase 1.0+. Du kan slette den fra plugin-mappen."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "Inizializzazione plugin fallita {0}"
+msgstr "Kunne ikke initialisere plugin {0}"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "Caricamento plugin in {0}..."
+msgstr "Laster inn plugins fra {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Utilizzo del caricatore di base Clojure come classloader di contesto condiviso: {0}"
+msgstr "Bruker Clojure base laster som delt kontekst klasselaster: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr "Impostando il classloader del contesto thread corrente a classloader condiviso {0} ..."
+msgstr "Setter gjeldende trådkontekst klasselaster til delt klasselaster {0}..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11875,318 +11890,323 @@ msgstr "Impostando il classloader del contesto thread corrente a classloader con
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr "Impostando il classloader del contesto thread a classloader APPENA CREATO {0} ..."
+msgstr "Stiller inn gjeldende trådkontekst klasselaster til NYTT SKAPET klasselaster {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "Aggiunto l'URL {0} al classpath"
+msgstr "Legg inn nettlink {0} til klassebane"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "Il plugin {0} dichiara una dipendenza che Metabase non comprende: {1}"
+msgstr "Plugin {0} deklarert som en påkrevd plugin kjenner ikke Metabase til: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "Fare riferimento al riferimento manifest del plugin per un elenco completo delle dipendenze del plugin valide:"
+msgstr "Vennligst se referansemanifestet for plugin for en liste av gyldige plugin-avhengigheter:"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "Metabase non può inizializzare il plugin {0} per via di dipendenze richieste."
+msgstr "Metabase kan ikke starte plugin {0} på grunn av påkrevde pakker."
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr "Classe non trovata: {0}"
+msgstr "Klasse ikke funnet: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "Il plugin ''{0}'' dipende dal plugin ''{1}''"
+msgstr "Plugin \"{0}\" har krav i plugin \"{1}\""
 
 #: src/metabase/plugins/dependencies.clj
+#, fuzzy
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} dipendenza {1} soddisfatta? {2}"
+msgstr "{0} avhengighet {1} tilfredsstilt? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "Plugins con dipendenze insoddisfatte: {0}"
+msgstr "Plugins med utilfredsstilte avhengigheter: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr "Estrai file {0} -> {1}"
+msgstr "Pakk ut filen {0} -> {1}"
 
 #: src/metabase/util/files.clj
 msgid "Resource does not exist."
-msgstr "La risorsa è inesistente"
+msgstr "Ressursen eksisterer ikke."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "Caricamento plugin namespace {0} ..."
+msgstr "Laster inn plugin navnerom {0}..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "Dipendenze soddisfatte; questi plugin verranno caricati adesso: {0}"
+msgstr "Avhengigheter godkjent; disse plugin vil bli lastet inn: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "Registrazione del driver proxy JDBC per {0} ..."
+msgstr "Registrerer JDBC proxy driver for {0}..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "Annullamento della registrazione del driver JDBC originale {0} ..."
+msgstr "Avregistrerer original JDBC driver {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
-msgstr "Proprietà di connessione predefinita {0} non esiste."
+msgstr "Standard tilkoblingsverdi {0} eksisterer ikke."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "proprietà di connessione non valida {0}: non una stringa o una mappa."
+msgstr "Ugyldig tilkoblingsberdi {0}: Ikke en tekststreng eller et oppslagsverk."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr "Carica driver di caricamento in modo `lazy` {0}"
+msgstr "Last inn lazy loading driver {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "Impossibile inizializzare il plugin: manca la proprieta' richiesta 'nome-driver'"
+msgstr "Kan ikke initialisere plugin: mangler nødvendig egenskap `driver-name`"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "Attenzione: Il plugin manifest per {0} non contiene proprieta' di connessione"
+msgstr "Advarsel: Pluginmanifestet for {0} inneholder ikke verdier for tilkobling"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr "Registrazione del driver di caricamento in modo `lazy` {0}..."
+msgstr "Registrerer lazy loading driver {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "Errore nell'esecuzione della query per la Scheda {0}"
+msgstr "Feil ved kjøring av spørring for Kort {0}"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "Ultima settimana"
+msgstr "Forrige uke"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "Questa settimana"
+msgstr "Denne uken"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "Ultimo mese"
+msgstr "Forrige måned"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "Questo mese"
+msgstr "Denne måneden"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr "Ultimo trimestre"
+msgstr "Forrige kvartal"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "Questo trimestre"
+msgstr "Dette kvartaler"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "Ultimo anno"
+msgstr "I fjor"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr "Quest'anno"
+msgstr "Dette året"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr "*driver* senza restrizioni."
+msgstr "*driver* er ikke tilknyttet"
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr "Errore di sincronizzazione dei campi per Tabella \"{0}\""
+msgstr "Feil ved synkronisering av Felt for Tabell \"{0}\""
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr "L'hash di {0} corrispende all'hash registrato, salto la sincronizzazione dei campi"
+msgstr "Avtrykk av {0} stemmer med lagret avtrykk, hopper over synk av Felt"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "Campo"
+msgstr "Felt"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr "Si è verificato un errore verificando se il camp {0} ha bisogno di essere creato o riattivato"
+msgstr "Feil ved sjekking om Felt {0} må opprettes eller reaktiveres"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "Sto marcando il campo \"{0}\" come inattivo."
+msgstr "Markerer Feltet \"{0}\" som inaktivt."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr "Errore di ritiro {0}"
+msgstr "Feil ved arkivering av {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Il tipo Database di {0} è stato modificato da \"{1}\" a \"{2}\"."
+msgstr "Databasen av type {0} har blitt endret fra ''{1}'' til ''{2}''."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+#, fuzzy
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Il tipo base di {0} è stato modificato da \"{1}\" a \"{2}\"."
+msgstr "Grunntype for {0} har blitt endret fra \"{1}\" til \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+#, fuzzy
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Il tipo Speciale di {0} è stato modificato da \"{1}\" a \"{2}\"."
+msgstr "Spesialtype for {0} har blitt endret fra \"{1}\" til \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "Il commento è stato aggiunto per {0}."
+msgstr "Kommentar ble lagt til for {0}"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Schedulatore Quartz in fase di arresto {0}"
+msgstr "Stopper Quartz Scheduler {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Schedulatore Quartz in fase di avvio {0}"
+msgstr "Starter Quartz Scheduler {0}"
 
 #: src/metabase/task.clj
+#, fuzzy
 msgid "Error loading tasks namespace {0}"
-msgstr "Errore nel caricamento dello spazio dei nomi delle attività {0}"
+msgstr "Feil ved lasting av navnerom for oppgaver {0}"
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "Inizializzazione task {0}"
+msgstr "Initialiserer oppgave {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "Errore nell'inizializzazione task {0}"
+msgstr "Feil ved initialisering av oppgave {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "Problema nell'invio dell'email di abbandono"
+msgstr "Feil ved sending av oppsigelses-epost"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "Invio statistiche anonime in corso"
+msgstr "Sender anonym brukerstatistikk"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "Errore di invio statistiche d'uso anonime"
+msgstr "Feil med å sende anonymt bruker statistikk"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "Errore nell'invio di Pulse {0}"
+msgstr "Feil ved sending av Pulse {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "Invio pulse pianificati..."
+msgstr "Sender planlagte pulser..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "Task SendPulses fallito"
+msgstr "Oppgaven SendPulses feilet"
 
 #: src/metabase/task/sync_databases.clj
+#, fuzzy
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "Impossibile eseguire le attività di pianificazione per il database {0}"
+msgstr "Kunne ikke planlegge oppgaver for Database {0}"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "Cancella l'history dei task"
+msgstr "Rydder opp i oppgavehistorikk"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "Task history eliminata correttamente, le righe sono state cancellate"
+msgstr "Opprydding i oppgavehistorikk fullført, rader ble slettet"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "Task history eliminata correttamente, nessuna riga è stata cancellata"
+msgstr "Opprydding i oppgavehistorikk fullført, ingen rader ble slettet"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "Controllo le informazioni della nuova versione di Metabase"
+msgstr "Ser etter ny Metase versjonsinformasjon"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "Errore nel recupero delle informazioni di versione"
+msgstr "Feil ved henting av versjonsinformasjon"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "Massima memoria disponibile per la JVM: {0}"
+msgstr "Maksimalt minne tilgjengelig for JVM: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr "Non qualcosa con un ID: {0}"
+msgstr "Ikke noe med en ID: {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
-msgstr "[[CreateDate]] per mese dell'anno"
+msgstr "[[CreateDate]] etter måned i året"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr "Ecco un rapido sguardo al tuo [[this]]"
+msgstr "Her er en rask titt på din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "[[CreateTimestamp]] con l'ora del giorno"
+msgstr "[[CreateTimestamp]] etter time på dagen"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "Dove hai acquisito i tuoi utenti"
+msgstr "Der du har fått brukerne fra"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr "Com'è distribuito attraverso il tempo e altre categorie"
+msgstr "Hvordan det er distribuert over tid og andre kategorier."
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per sorgente"
+msgstr "Her er en nærmere titt på [[this]] per ressurs"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr "Ecco un rapido sguardo al [[this]] "
+msgstr "Her er en kjapp titt på [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "[[CreateTimestamp]] con il giorno del mese"
+msgstr "[[CreateTimestamp]] etter dag i måneden"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Here's an overview of the people in your [[this]]"
-msgstr "Ecco una panoramica delle persone nel tuo [[this]]"
+msgstr "Her er en oversikt over personene i din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "[[CreateTimestamp]] con il trimestre dell'anno"
+msgstr "[[CreateTimestamp]] etter kvartal i året"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare across location"
-msgstr "Come confrontano tramite il luogo"
+msgstr "Hvordan de kan sammenlignes på tvers av plassering"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per prodotto"
+msgstr "Her er en nærmere titt på dine [[this]] etter produkt"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "[[CreateTimestamp]] con il mese dell'anno"
+msgstr "[[CreateTimestamp]] etter måned i året"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "Una panoramica del tuo [[this]] e com'è distribuito attraverso il tempo, il luogo e le categorie"
+msgstr "Oversikt over dine [[this]] og hvordan de er distribuert over tid, sted og kategorier."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]]"
+msgstr "Her er en nærmere titt på din [[this]] "
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "[[CreateTimestamp]] con il giorno della settimana"
+msgstr " [[CreateTimestamp]] etter dag i uken"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Ecco una panoramica dei dati del tuo [[this]] da Google Analytics"
+msgstr "Her er en oversikt over dine [[this]]-data fra Google Analytics"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -12195,1536 +12215,1547 @@ msgstr "Ecco una panoramica dei dati del tuo [[this]] da Google Analytics"
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 msgid "Here's an overview of your [[this]]"
-msgstr "Ecco una panoramica del tuo [[this]]"
+msgstr "Her er en oversikt over dine [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Here's a closer look at your [[this]] field"
-msgstr "Ecco uno sguardo più da vicino al campo del tuo [[this]]"
+msgstr "Her er en nærmere titt på ditt felt [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per nazione"
+msgstr "Her er en nærmere titt på dine [[this]] per land"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "Se ti interessano le correlazioni, questa è la `x-ray` per te."
+msgstr "Hvis du liker sammenhenger, er dette x-rayen for deg."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
-msgstr "[[CreateDate]] con il giorno della settimana"
+msgstr "[[CreateDate]] etter dag i uken"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr "Sembra che il tuo [[this]] abbia delle transazioni, quindi eccone uno sguardo"
+msgstr "Det ser ut som dine [[this]] har transaksjoner, så her er en titt på dem"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] per stato"
+msgstr "Her er en nærmere titt på dine [[this]] per stat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the month"
-msgstr "[[CreateTime]] per giorno del mese"
+msgstr "[[CreateDate]] etter dag i måneden"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTime]] by hour of the day"
-msgstr "[[CreateTime]] per ora del giorno"
+msgstr "[[CreateTime] etter time på dagen"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "Ecco uno sguardo più da vicino al tuo [[this]] nel tempo"
+msgstr "Her er en nærmere titt på dine [[this]] over tid"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "[[CreateDate]] per trimestre dell'anno"
+msgstr "[[CreateDate]] etter kvartal i året"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:202
 msgid "Edit user"
-msgstr "Modifica utente"
+msgstr "Rediger bruker"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "Nuovo utente"
+msgstr "Ny bruker"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:206
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "Reset password"
+msgstr "Nullstill passord"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:210
 msgid "Deactivate user"
-msgstr "Disattiva utente"
+msgstr "Deaktiver bruker"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "Riattivare {0}?"
+msgstr "Aktiver {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "Non è stato possibile inviare loro un invito via email, quindi assicurati di dire loro di accedere al log utilizzando {0} e questa password che abbiamo generato per loro:"
+msgstr "Vi kunne ikke sende dem en invitasjon på e-post, så bi beskjed om at de må logge inn med {0} og dette passordet som vi har generert:"
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "collezione"
+msgstr "kolleksjon"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "collezioni"
+msgstr "kolleksjoner"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
-msgstr "dashboard"
+msgstr "tavle"
 
 #: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
-msgstr "dashboards"
+msgstr "tavler"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "Il nome è richiesto"
+msgstr "Fornavn er påkrevd"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "Deve essere 100 caratteri o meno"
+msgstr "Må være mindre enn 100 tegn"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "Il cognome è richiesto"
+msgstr "Etternavn er påkrevd"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "L'email è obbligatoria"
+msgstr "Epost er påkrevd"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "Gli oggetti che archivierai appariranno qui."
+msgstr "Ting du arkiverer vil være her"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "Nessuna descrizione"
+msgstr "Ingen beskrivelse"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "Somma di tutti i valori"
+msgstr "Sum av alle verdier"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "Vedi tutti i valori DISTINCT"
+msgstr "See alle distinkte verdier"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "Sfoglia i contenuti dei tuoi database, tabelle e colonne. Scegli un database per iniziare"
+msgstr "Bla gjennom innholdet i dine databaser, tabeller og kolonner. Velg en database for å komme i gang."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr "I metadati dei risultati delle carte passati alle API sono VALIDI. Grazie!"
+msgstr "Metadata fra Kort-resultat sendt inn til API er GYLDIG. Takk!"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr "i metadati dei risultati delle card passati alle API sono NON VALIDI. Esecuzione della query per recuperare i metadati corretti."
+msgstr "Metadata fra Kort-resultat sendt inn til API er UGYLDIG. Kjører spørring for å hente korrekt metadata."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr "I metadati dei risultati delle carte trasmessi all'API sono MANCANTI. Esecuzione della query per recuperare i metadati corretti."
+msgstr "Metadata fra Kort-resultat sendt inn til API MANGLER. Kjører spørring for å hente korrekt metadata."
 
 #: src/metabase/api/email.clj
 msgid "{0} was autocorrected to {1}"
-msgstr "{0} è stato corretto automaticamente in {1}"
+msgstr "{0} ble automatisk rettet til {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id è deprecato. Invece, modifica il valore `archiviato` tramite PUT /api/metric/:id."
+msgstr "DELETE /api/metric/:id er utfaset. Endre dens `archived`-verdi via PUT /api/metric/:id."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:id è deprecato. Invece, modifica il valore `archiviato` tramite PUT /api/segment/:id."
+msgstr "DELETE /api/segment/:id er utfaset. Endre dens `archived`-verdi via PUT /api/segment/:id."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "Il valore di is_superuser deve corrispondere alla presenza dell'ID del gruppo di amministratori in group_ids."
+msgstr "Verdien av is_superuser må korrespondere med tilstedeværelsen av Admin group ID i group_ids."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "Errore imprevisto durante la scrittura di caratteri `keepalive`"
+msgstr "Uventet feil ved skriving av keepalive-tegn"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "Output imprevisto nella risposta asincrona delle API"
+msgstr "Uventet utdata i asynkront API svar"
 
 #: src/metabase/async/api_response.clj
+#, fuzzy
 msgid "starting streaming response"
-msgstr "avvio della risposta in streaming"
+msgstr "startet strømmesvar"
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "Uscita chiusa, annullamento della richiesta keepalive."
+msgstr "Utkanal stengt, avbryter keepalive-forespørsel."
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "Finita la risposta asincrona, chiusura dei canali."
+msgstr "Asynkront svar ferdig, lukker kanaler."
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr "Nessuna risposta dopo aver atteso {0}. Annullamento della richiesta."
+msgstr "Ikke svar etter å ha ventet {0}. Avbryter forespørsel."
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "Canale di input chiuso inaspettatamente."
+msgstr "Inndatakanal ble uventet lukket."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr "f finito, il permesso verrà restituito"
+msgstr "f ferdig, tillatelse vil bli returnert"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr "richiesta annullata, il permesso verrà restituito"
+msgstr "forespørsel avbrutt. tillatelse vil bli returnert"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr "Errore imprevisto che tenta di eseguire la funzione dopo aver ottenuto il permesso"
+msgstr "Uventet feil ved forsøk på å kjøre funksjon etter å ha hentet tillatelse"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr "Non è in esecuzione la chiamata di funzione in attesa: canale di output già chiuso."
+msgstr "Kjører ikke ventende funksjonskall: utkanal stengt."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr "Il thread corrente ha già un permesso per {0}, non aspetterà di acquisirne un altro"
+msgstr "Gjeldende tråd har allerede tillatelse for {0}, vil ikke vente på å få en ny"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr "Canale di output chiuso, salterà l'esecuzione di {0}."
+msgstr "Utkanal stengt, kommer ikke til å kjøre {0}."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "Eseguendo {0} su thread separati..."
+msgstr "Kjører {0} i en egen tråd..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr "Errore in esecuzione {0}"
+msgstr "Feil ved kjøring av {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr "Richiesta annullata, annullamento futuro"
+msgstr "Forespørsel avbrutt, avbryter future"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
-msgstr "Chiusura del vecchio pool di connessioni per il database {0} ..."
+msgstr "Stenger gammel tilkoblingspool for database {0} ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:"
-msgstr "Ecco le tue {0} carte più recenti:"
+msgstr "Her er dine {0} siste kort:"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr "Potresti essere un po' più specifico o usare l'ID? Ho trovato queste carte con nomi corrispondenti:"
+msgstr "Kan du være litt mer spesifikk, eller bruke ID? Jeg fant disse kortene med navn som matchet:"
 
 #: src/metabase/driver/common/parameters/values.clj
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "Scheda {0} non trovata."
+msgstr "Kort {0} ble ikke funnet"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "Eccezione nella chiamata API"
+msgstr "Unntak ved API-kall"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "Richiesta annullata prima della fine."
+msgstr "Forespørsel ble avbrutt før den ble ferdig"
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "Metabase supporta solo richieste di tipo JSON."
+msgstr "Metabase støtter bare JSON-forespørsler."
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Assicurati di aver impostato l'header 'Content-Type: application/json'"
+msgstr "Dobbeltsjekk at det er satt opp 'Content-Type: application/json' på spørringshodet."
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "Impostazione dell'URL del sito di Metabase su {0}"
+msgstr "Setter URL for Metabase-nettsted til {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "Errore schedulando l'attività per il DB"
+msgstr "Feil ved planlegging av oppgaver for DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "Errore eliminando la schedulazione dell'attività per il DB"
+msgstr "Feil ved fjerning av planlagte oppgaver for DB."
 
 #: src/metabase/models/database.clj
+#, fuzzy
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr "{0} Database \"{1}\" la schedulazione della sincronizzazione/analisi è stata modificata!"
+msgstr "{0} Database \"{1}\" planlagte synk/analyse-oppgaver har blitt endret!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr "La sincronizzazione dei metadati era: \"{0}\" - ora è: \"{1}\""
+msgstr "Synk metadata var: \"{0}\" er nå: \"{1}\""
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr "La cache dei `FieldValues` era: ''{0}'', ora è: ''{1}''"
+msgstr "Mellomlagret FieldValues var \"{0}\" er nå: \"{1}\""
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "Non puoi aggiornare il \"creator_id\" della Metrica"
+msgstr "Du kan iukke oppdatere creator_id for en Indikator."
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBot può avere soltanto i permessi della Collezione"
+msgstr "MetaBot kan bare ha tillatelser for Samling."
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "Impossibile concedere i permessi"
+msgstr "Kunne ikke gi tillatelser"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "Modifica permessi"
+msgstr "Endrer tillatelser"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr "DA:"
+msgstr "Fra:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr "A:"
+msgstr "Til:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "Non puoi aggiornare il \"creator_id\" di un Segmento"
+msgstr "Du kan ikke oppdatere creator_id på et segment."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr "Tentativo di impostare l'impostazione {0} su valore offuscato. Cambiamento ignorato."
+msgstr "Prøvde å sette Innstilling {0} til tilslørt verdi. Ignorerer endring."
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
-msgstr "Usando il valore della variabile ambiente {0}"
+msgstr "Bruker verdien av miljøvariabel {0}"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "Sto aggiungendo l'utente {0} al gruppo di Tutti gli Utenti"
+msgstr "Legger Bruker {0} til sikkerhetsgruppen Alle Brukere"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "Sto aggiungendo l'utente {0} al gruppo dell'Amministratore"
+msgstr "Legger Bruker {0} til sikkerhetsgruppen Admin"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "Fallimento query"
+msgstr "Feil ved spørring"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "Numero massimo di query contemporanee per il Database a cui si è connessi"
+msgstr "Maksimalt tillatt antall samtidige spørringer per tilkoblet Database."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "Si è verificato un Time out dopo {0} millisecondi."
+msgstr "Tidsavbrudd etter {0} millisekund."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr "Istruzione per mancata accensione"
+msgstr "Vådeskudd-instruksjoner"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
-msgstr "Archiviare?"
+msgstr "Arkivere dette?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
-msgstr "Impara dai nostri dati"
+msgstr "Lær om våre data"
 
 #: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
-msgstr "usa DNS SRV quando ti connetti"
+msgstr "Koble til ved hjelp av DNS SRV"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "L'utilizzo di questa opzione richiede che l'host fornito sia un nome di dominio completo. Se ci si connette a un cluster Atlas, potrebbe essere necessario abilitare questa opzione. Se non sai cosa significa, lascialo disabilitato."
+msgstr "Dette alternativet krever at oppgitt vert er et FQDN. Hvis du kobler til et Atlas-kluster trenger du kanskje å aktivere dette. Hvis du ikke vet hva dette betyr, la det være deaktivert."
 
 #: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "Esegui automaticamente query quando esegui semplici filtri e riepiloghi"
+msgstr "Kjør spørringer automatisk under enkle filtreringer og oppsummeringer"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Quando è attivo, Metabase eseguirà automaticamente le query quando gli utenti eseguono semplici esplorazioni con i pulsanti Riassumi e Filtro durante la visualizzazione di una tabella o di un grafico. È possibile disattivarlo se l'interrogazione di questo database è lenta. Questa impostazione non influisce sui drill-through o sulle query SQL."
+msgstr "Når dette er på, vil Metabase automatisk kjøre spørringer når brukere utfører enkle utforskniger med Summer- og filterknapper når de leser tabeller eller diagrammer. Du kan slå av dette hvis databasespørringer går tregt. Denne innstillingen påvirker ikke drilling eller SQL-spørringer."
 
 #: frontend/src/metabase/containers/Overworld.jsx:329
 msgid "Learn about this database"
-msgstr "Impara da questo database"
+msgstr "Lær om denne databasen"
 
 #: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
-msgstr "Archiviare questa dashboard?"
+msgstr "Arkiver denne infotavlen?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:112
 msgid "All results"
-msgstr "Tutti i risultati"
+msgstr "Alle resultater"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:175
 msgid "Our Analytics"
-msgstr "La nostra analisi"
+msgstr "Våre Analyser"
 
 #: frontend/src/metabase/lib/schema_metadata.js:513
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr "Somma additiva di tutti i valori di una colonna. \\ne.x. entrate totali nel tempo."
+msgstr "Additiv sum av alle verdier i en kolonne.\\nF.eks total inntekt over tid."
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr "Conteggio additivo di tutti i valori di una riga. \\ne.x. numero totale di vendite nel tempo."
+msgstr "Additiv telling av antall rader.\\nF.eks totalt antall salg over tid."
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:98
 msgid "Filter"
-msgstr "Filtro"
+msgstr "Filter"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:50
 msgid "record"
 msgid_plural "records"
-msgstr[0] "record"
-msgstr[1] "record"
+msgstr[0] "post"
+msgstr[1] "poster"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:369
 msgid "Browse Data"
-msgstr "Sfoglia i dati"
+msgstr "Bla gjennom data"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:402
 msgid "Write SQL"
-msgstr "Scrivi SQL"
+msgstr "Skriv SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:86
 msgid "Simple question"
-msgstr "Domanda semplice"
+msgstr "Enkelt spørring"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:87
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "Raccogli qualche dato, guardalo, e filtra, riepilogalo e visualizzalo facilemnte"
+msgstr "Velg noen data, se på dem og enkelt filtrere, summere og visualisere dem."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:98
 msgid "Custom question"
-msgstr "Domanda personalizzata"
+msgstr "Egendefinert spørring"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:99
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "Usa l'editor avanzato per notebook per unire i dati, creare colonne personalizzate, fare matematica e altro."
+msgstr "Bruk den avanserte notatblokk-editoren for å forene data, opprette egendefinerte kolonner, gjøre matematiske operasjoner og mer."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
-msgstr "Metriche di base"
+msgstr "Grunnleggende Indikatorer"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
-msgstr "Personalizzato... "
+msgstr "Egendefinert.."
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "Aggiungi raggruppamento"
+msgstr "Legg til gruppering"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr "Scegli un limite"
+msgstr "Velg en grense"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "Mostra massimo"
+msgstr "Vis maksimum"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:45
 msgid "Get Preview"
-msgstr "Anteprima"
+msgstr "Hent Forhåndsvisning"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "Torna ai risultati precedenti"
+msgstr "Tilbake til forrige resultater"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "Valori di esempio"
+msgstr "Eksempelverdier"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "Naviga il contenuto dei tuoi database, tabelle e colonna. Scegli un database per iniziare. "
+msgstr "Bla gjennom innholdet på dine databaser, tabeller og kolonner. Velg en database for å komme i gang."
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "Visualizza"
+msgstr "Visualiser"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "Dati in join"
+msgstr "Sammenføyningsdata"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "Colonna personalizzata"
+msgstr "Egendefinert kolonne"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:60
 msgid "Summarize"
-msgstr "Riassume"
+msgstr "Oppsummer"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr "Aggregazione"
+msgstr "Aggreger"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Punto di rottura"
+msgstr "Utbrudd"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "Scegli la metrica che vuoi vedere"
+msgstr "Velg indikatorene du vil se"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 msgid "Pick a column to group by"
-msgstr "Scegli la colonna da raggruppare "
+msgstr "Velg kolonnen du vil gruppere etter"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:28
 msgid "Pick your starting data"
-msgstr "Scegli una data d'inizio"
+msgstr "Velg dine startdata"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select None"
-msgstr "Seleziona nula"
+msgstr "Velg ingen"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:47
 msgid "Select All"
-msgstr "Seleziona tutto"
+msgstr "Velg alle"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:152
 msgid "Pick a table..."
-msgstr "Scegli una tabela"
+msgstr "Velg en tabell..."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "Inserisci un limite"
+msgstr "Angi en grense"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:273
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "Le parentesi attorno a {0} creano una clausola facoltativa nel modello.  Se è impostata \"variabile\", l'intera clausola viene inserita nel modello.  In caso contrario, l'intera clausola viene ignorata."
+msgstr "Klammer runt en {0} lager et valgfritt klausul i malen. Hvis \"variabel\" er satt, vil hele klausulet bli satt inn i malen. Hvis ikke, vil hele klausulen bli ignorert."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:290
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "Quando si utilizza un Field Filter, il nome della colonna non deve essere incluso in SQL.  Invece, la variabile dovrebbe essere mappata su un campo nel pannello laterale."
+msgstr "Ved bruk av Felt Filter, bør kolonnenavnet ikke inkluderes i SQL. Variablen bør heller kobles til et felt i sidepanelet."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "Vedi la query originale"
+msgstr "Vis den lokale spørringen"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "Query nativa per questa domanda"
+msgstr "Lokal spørring for dette spørsmålet"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "Converti questa domanda a una query nativa"
+msgstr "Konverter dette spørsmålet til en lokal spørring"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "SQL per questa domanda"
+msgstr "SQL for dette spørsmålet"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "Converti questi domande a SQL"
+msgstr "Konverter dette spørsmålet til SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "Ricevi avvisi"
+msgstr "Hent alarmer"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "{0} punto di rottura"
-msgstr[1] "{0} punti di rottura"
+msgstr[0] "{0} utbrudd"
+msgstr[1] "{0} utbrudd"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Hide filters"
-msgstr "Nascondi i filtri"
+msgstr "Skjul filtre"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Show filters"
-msgstr "Mostra i filtri"
+msgstr "Vis filtre"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:18
 msgid "Started from"
-msgstr "Iniziato da"
+msgstr "Startet fra"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0} riga"
-msgstr[1] "{0} righe"
+msgstr[0] "{0} rad"
+msgstr[1] "{0} rader"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "Mostra tutte le righe"
+msgstr "Vis alle rader"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "Mostra {0}"
+msgstr "Vis {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "Mostra prima {0}"
+msgstr "Viser de første {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "Mostra {0}"
+msgstr "Viser {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "Riassunto"
+msgstr "Oppsummert"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Hide editor"
-msgstr "Nascondi l'editor"
+msgstr "Gjem editor"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx:17
 msgid "Show editor"
-msgstr "Mostra l'editor"
+msgstr "Vis editor"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "Seleziona la metrica che vorresti vedere"
+msgstr "Velg målingene du vil se"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:29
 msgid "{0} options"
-msgstr "{0} opzioni"
+msgstr "{0} alternativer"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "Selezione una visualizzazione"
+msgstr "Velg en visualisering"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "Filtrato da"
+msgstr "Filtrer på"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
-msgstr "Somma per"
+msgstr "Oppsummer på"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
-msgstr "Raggruppato da"
+msgstr "Grupper etter"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
-msgstr "Aggiungi una metrica"
+msgstr "Legg til en indikator"
 
 #: frontend/src/metabase/lib/core.js:137 frontend/src/metabase/lib/core.js:142
 #: frontend/src/metabase/lib/core.js:147 frontend/src/metabase/lib/core.js:152
 #: frontend/src/metabase/lib/core.js:157 frontend/src/metabase/lib/core.js:162
 #: frontend/src/metabase/user/components/UserSettings.jsx:64
 msgid "Profile"
-msgstr "Profilo"
+msgstr "Profil"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "Questo di solito è piuttosto veloce ma sembra richiedere del tempo proprio ora."
+msgstr "Dette går vanligvis ganske fort men ser ut til å bruke litt tid akkurat nå."
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
-msgstr "Combo"
+msgstr "Kombinasjon"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
-msgstr "Riga"
+msgstr "Rad"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "Tendenza "
+msgstr "Trend"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "Booleano"
+msgstr "Boolsk"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:62
 msgid "Unknown Segment"
-msgstr "Segmento sconosciuto"
+msgstr "Ukjent segment"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:73
 msgid "Unknown Filter"
-msgstr "Filtro sconosciuto "
+msgstr "Ukjent filter"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Left outer join"
-msgstr "Left outer join"
+msgstr "Venstre ytre sammenføyning"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:26
 msgid "Right outer join"
-msgstr "Right outer join"
+msgstr "Høyre ytre sammenføyning"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:27
 msgid "Inner join"
-msgstr "Inner join"
+msgstr "Indre sammenføyning"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:28
 msgid "Full outer join"
-msgstr "Full outer join"
+msgstr "Full ytre sammenføyning"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr "I metadati dei risultati delle carte trasmessi all'API sono MANCANTI.  Esecuzione della query per recuperare i metadati corretti."
+msgstr "Metadata for kortresultater sendt inn til API MANGLER. Kjører spørring for å hente korrekt metadata."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "Problema di connessione al server LDAP, si ritorna all'autenticazione locale"
+msgstr "Problem ved tilkobling til LDAP-server, bruker lokal autentisering"
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "Impossibile creare il Database: impossibile trovare il driver {0}."
+msgstr "Kan ikke opprette Database: kan ikke finne driver {0}."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "Query fallita"
+msgstr "Spørring feilet"
 
 #: src/metabase/async/util.clj
 msgid "Warning: {0} returned `nil`"
-msgstr "Attenzione: {0} ha restituito `nil`"
+msgstr "Advarsel: {0} returnerte `nil`"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "Errore imprevisto durante la scrittura del risultato sul canale di output: già chiuso"
+msgstr "Uventet feil ved skriving av resultat til utkanal: stengt"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "Errore imprevisto durante la scrittura dell' eccezione sull' output: già chiuso"
+msgstr "Uventet feil ved skriving av unntak til utkanal: stengt"
 
 #: src/metabase/async/util.clj
+#, fuzzy
 msgid "Request canceled, canceling future."
-msgstr "Richiesta annullata, annullamento futuro."
+msgstr "Forespørsel avbrutt, avbryter future."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "Metabase può trasferire dati solo da database H2 a database Postgres o MySQL/MariaDB."
+msgstr "Metabase kan bare overføre fra H2 til Postgres eller MySQL/MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "ATTENZIONE: L'uso di Metabase con un database di applicazioni H2 non è raccomandato per gli ambienti di produzione."
+msgstr "ADVARSEL: Å bruke Metabase med H2 application database er ikke anbefalt for bruk i produksjon."
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "Impostazione database dell'applicazione"
+msgstr "Databaseinnstillinger for applikasjon"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "Impossibile trovare il driver {0}."
+msgstr "Kunne ikke finne driver {0}."
 
 #: src/metabase/driver/impl.clj
+#, fuzzy
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "I driver astratti non possono derivare da driver genitori concreti"
+msgstr "Abstrakte drivere kan ikke derivere fra konkrete foreldredrivere."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "Potrebbe essere necessario aggiungere \"trustServerCertificate = true\" alle opzioni di connessione aggiuntive per connettersi con SSL."
+msgstr "Du må kanskje legge til 'trustServerCertificate=true' til tilkolingsalternativene for å koble til med SSL."
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr "Non conosco come alias {0}, previsto un identificatore"
+msgstr "Vet ikke hva jeg skal kalle {0}, forventet en Identifikator."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "Il client ha chiuso la connesione. Annullamento query"
+msgstr "Klienten avsluttet tilkoblingen, avbryter spørring"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0} non è un valido DN."
+msgstr "{0} er ikke en gyldig DN"
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "Errore durante la registrazione della richiesta API"
+msgstr "Feil ved logging av API-forespørsel"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "Impostazione del site-url fallita"
+msgstr "Kunne ikke sette url for nettsted"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "Errore nel terminare il thread pool per il DB"
+msgstr "Feil ved ødelegging av trådpool for DB."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Aggiornato il nome mostrato per {0} \"{1}\"_ \"{2}\" -> \"{3}\""
+msgstr "Oppdaterer visningsnavn for {0} \"{1}\": \"{2}\" -> \"{3}\""
 
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr "Strategia di umanizzazione \"{0}\" invalida. Strategie valide: {1}"
+msgstr "Ugylding humaniseringsstrategi \"{0}\". Gyldige strategier er: {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Strategia di umanizzazione {0} invalida. Strategie valide: {1}"
+msgstr "Endrer humaniseringsstrategi for Tabell- & Feltnavn fra \"{0}\" til \"{1}\""
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr "Errore durante il salvataggio della cronologia delle attività"
+msgstr "Feil ved lagring av oppgavehistorikk"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar non è più necessario da Metabase 0.32.0+. Puoi cancellarlo dalla cartella dei plugins."
+msgstr "Metabase 0.32.0+ trenger ikke spark-deps.jar. Du kan slette den fra plugin-mappen."
 
 #: src/metabase/plugins/classloader.clj
+#, fuzzy
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "Usare il classloader APPENA CREATO per contesto condiviso: {0} "
+msgstr "Bruker NEWLY CREATED classloader som delt context classloader: {0}"
 
 #: src/metabase/util/files.clj
 msgid "Failed to copy file"
-msgstr "Impossibile copiare il file"
+msgstr "En feil oppstod ved filkopiering"
 
 #. check that the URL is valid
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "Url non valido: {0}"
+msgstr "Ugyldig URL for nettsted: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "site-url non è valido;  restituendo zero per ora.  Sarà ripristinato alla prossima richiesta."
+msgstr "nettsted-url er ugylding; returnerer nil for nå. Vil bli tilbakestilt ved neste spørring."
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "Altri risultati sono stati inclusi come file allegati"
+msgstr "Fler resultater har blitt lagt til som filvedlegg"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "Questa domanda è stata inclusa come allegato"
+msgstr "Dette spørsmålet har blitt lagt til som filvedlegg"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "Non è stato possibile visualizzare questo Pulse. "
+msgstr "Vi var ute av stand til å vise denne Pulsen."
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "Si prega di visualizzare questa scheda in Metabase."
+msgstr "Vennligst vis dette kortet i Metabase"
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "Si è verificato un errore durante la visualizzazione di questa scheda."
+msgstr "En feil oppstod ved visning av dette kortet"
 
 #: src/metabase/query_processor.clj
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "Si possono solo determinare le colonne richieste per le interrogazioni MBQL"
+msgstr "Kan bare avgjøre forventede kolonner fir MBQL-spørringer."
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "Non ci sono colonne disponibili"
+msgstr "Ingen kolonner returnert."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Attenzione: non è possibile determinare i campi per una \"query-source\" esplicita a meno che non si includano anche \"metadati\" di origine."
+msgstr "Advarsel: kunne ikke bestemme felt for en eksplisitt `kilde-spørring` hvis du ikke inkluderer `kilde-metadata`."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "Impossibile risolvere {0}: il campo non esiste o la sua tabella appartiene a un database diverso."
+msgstr "Kan ikke løse {0}: Felt eksisterer ikke eller Tabellen hører til en annen Database."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr "Impossibile risolvere :field-literal dentro :fk-> senza un join interno con esplicito :alias."
+msgstr "Kan ikke løse :felt-literal inni :fn->hvis ikke indre sammenføyning med eksplisitt :alias."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "Non trovata Tabella ID per {0}"
+msgstr "Kan ikke finne Tabell ID for {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "Nessuna informazione di corrispondenza trovata"
+msgstr "Ingen matchende info funnet."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "Non è stato possibile risolvere {0}"
+msgstr "Kunne ikke løse {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr "Clausola chiave esterna non valida: impossibile aggiungere join corrispondente."
+msgstr "Ugyldig fn->klausul: ingen steder å legge til korresponderende sammenføyning."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "Il driver {0} non supporta le chiavi esterne."
+msgstr "{0} driver støtter ikke fremmednøkler."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
+#, fuzzy
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr "Impossibile dedurre ':source-metadata' per la query con query nativa senza metadati di origine."
+msgstr "Kan ikke antyde `:source-metadata` for kildespørring med naturlig spørring uten metadata fra kilde."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "Errore del processore di query: il numero di colonne ritornate dal driver non corrisponde ai risultati."
+msgstr "Spørringsprosessorfeil: antall kolonner returnert fra driver matcher ikke resultat."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "Previste {0} colonne, ma la prima riga dei risultati ha {1} colonne."
+msgstr "Forventet {0} kolonner, men første rad i resultatene har {1} kolonner."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "Nessuna espressione denominata {0} trovata. Trovata {1}"
+msgstr "Fant ingen uttrykk kalt {0}. Fant: {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "Valori distinti di {0}"
+msgstr "Unike verdier av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "Media di {0}"
+msgstr "Gjennomsnittet av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "Somma di {0}"
+msgstr "Summen av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "Devizione standard di {0}"
+msgstr "SD av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "Minimo di {0}"
+msgstr "Min av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "Massimo di {0}"
+msgstr "Max av {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "Somma di {0} che soddisfano la condizione"
+msgstr "Sum av {0} matchende betingelser"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
-msgstr "Percentuali di righe che soddisfano la condizione"
+msgstr "Andel av rader som matcher betingelsen"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "Numero di righe che soddisfano la condizione"
+msgstr "Antall rader som matcher betingelsen"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "Richiesta già cancellata, non verrà eseguito il codice QP sincrono."
+msgstr "Forespørsel er allerede avbrutt, vil ikke kjøre synkron QP-kode."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "Inaspettata risposta 'nil' dal Processore di Query."
+msgstr "Fikk uventet svar `nil` fra spørringsprosessor."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "Ottenuta una InterruptedException. Query in cancellazione"
+msgstr "Fikk InterruptedException. Avbryter spørring."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr "Eccezione non gestita, aspettata 'catch-exceptions' middleware per gestirla."
+msgstr "Ubehandlet unntak, forventet at `catch-exceptions`-mellomvare skulle behandle den."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after %s"
-msgstr "Time out query dopo %s"
+msgstr "Tidsavbrudd for spørring etter %s."
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "Creazione di un nuovo pool di thread di query per Database {0}"
+msgstr "Lager en ny tråd-pool for spørringer for Database {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "Distruzione del pool di thread per il Database {0}"
+msgstr "Ødelegger tråd-pool for spørringer for Database {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "RIchiesta annullata, annullamento della query in sospeso"
+msgstr "Forespørsel avbrutt, avbryter ventende spørring"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "Impossibile aggiornare il campo cestinato: mancano i metadati sorgente alla query"
+msgstr "Kan ikke oppdatere samlede felt: spørring mangler kilde-metadata"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "Impossibile aggiornare il campo cestinato: impossibile trovare i metadati sorgente corrispondenti per il Campo \"{0}\""
+msgstr "Kan ikke oppdatere samlede felt: kunne ikke finne matchende metadata i kilden for Felt \"{0}\""
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "Usare il backend cache del processore query: {0}"
+msgstr "Bruk av mellomlagringsserverdel for spørringsprosessor: {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "Metrica invalida: {0} motivo {1}"
+msgstr "Ugyldig indikator: {0} grunn: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "Errore sconosciuto"
+msgstr "Ukjent feil"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "Risposta nil inaspettata dal query processor"
+msgstr "Uventet null-svar fra spørringsprosessoren."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "Query annullata"
+msgstr "Spørring avbrutt"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "Impossibile risolvere i driver per la query: ':database' ID non valido o mancante."
+msgstr "Kunne ikke finne driver for spørring: manglende eller ugyldig `:database`-ID."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "Impossibile risolvere il driver per la query:  Database {0} non esiste "
+msgstr "Kunne ikke finne driver for spørring: Database {0} eksisterer ikke."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "Impossibile usare :fields :all in join contro la query sorgente a meno che non abbia :source-metadata"
+msgstr "Kan ikke bruke :felt :alle i sammenføyninger mot kildespørringer hvis den ikke har :kilde-metadata."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "Clausola :joined-field sbagliata: join con alias \"{0}\" non esiste. Trovato: {1}"
+msgstr "Uønsket :forent-felt klausul: sammenføyning med alias \"{0}\" eksisterer ikke. Fant: {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr ":source-table \"{0}\" invalida: deve essere risolta a un ID di una tabella ora."
+msgstr "Ugylding :kilde-tabell \"{0}\": burde vært løst til en Tabell-ID nå."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "Impossibile memorizzare Tabelle o Campi prima che il Database sia memorizzato"
+msgstr "Kan ikke lagre Tabeller eller Felt før Database er lagret."
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "Tentativo di recuperare il secondo database. Le query possono referenziare solo un database."
+msgstr "Prøver å hente Database nummer to. Spørringer kan bare referere til en Database."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "Recupero tabella {0} fallito: la tabella non esiste o appartiene a un database differente."
+msgstr "Kunne ikke hente Tabell {0}: Tabell eksistere ikke, eller hører til en annen Database."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "Recupero campo {0} fallito: il campo non esiste o appartiene a un database differente."
+msgstr "Kunne ikke hente Felt {0}: Felt eksisterer ikke, eller hører til en annen Database."
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "Recupero template \"{0}\" fallito. Ti sei ricordato di costruire il frontend di metabase?"
+msgstr "Kunne ikke laste mal \"{0}\". Husket du å bygge Metabase-frontend?"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "Impossibile trovare il file DB \"{0}\"."
+msgstr "DB-fil for Eksempeldatasett \"{0}\" ble ikke funnet."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "Caricamento database di esempio..."
+msgstr "Laster inn eksempeldata..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "Caricamento del database di esempio fallito"
+msgstr "Feil ved innlasting av eksempeldatasett"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "Trovate nuove tabelle:"
+msgstr "Fant nye tabeller:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "Spunta tabelle come inattive:"
+msgstr "Markerer tabeller som inaktive:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "Aggiornamento descrizioni tabelle:"
+msgstr "Oppdaterer beskrivelse for tabeller:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "Riprogrammando lavoro {0}"
+msgstr "Planlegger jobb {0}"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "Errore riprogrammazione lavoro"
+msgstr "Feil ved endring av planlagte tidspunkt for oppgave"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "Avvio Esecuzione Pulse: {0}"
+msgstr "Starter utføring av Puls: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "Esecuzione Pulse Terminata: {0}"
+msgstr "Puls ferdig utført: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "Scheduling dei task per il Database {0} non riuscita"
+msgstr "Kunne ikke planlegge oppgaver for Database {0}"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "All elements must be distinct."
+msgstr "Alle elementer må være unike."
 
 #:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "Scegli le colonne che desideri includere"
+msgstr "Velg kolonnene du vil inkludere"
 
 #: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Quando questa opzione è attiva, Metabase eseguirà automaticamente query quando l'utente fa semplici esplorazioni con il bottone Riassunto e Filtri mentre osserva una tabella o un grafico. Puoi disattivarla se interrogare il database è lento. Questa impostazione non influisce sui drill-throughs o sulle query SQL."
+msgstr "Når dette er på, vil Metabase automatisk kjøre spørringer når brukere utfører enkle utforskniger med Summer- og filterknapper når de leser tabeller eller diagrammer. Du kan slå av dette hvis databasespørringer går tregt. Denne innstillingen påvirker ikke drilling eller SQL-spørringer."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "Cambia tipo di join"
+msgstr "Endre sammenføyningstype"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr "Non so come alias {0}, atteso un identificatore."
+msgstr "Vet ikke hva jeg skal kalle {0}, forventet en Identifikator."
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "Errore nell' aggiungere l' Utente {0} al Gruppo {1}"
+msgstr "Feil ved å legge Bruker {0} til Gruppe {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Cambiando la strategia di umanizzazione dei nomi tabella e campo da ''{0}'' a ''{1}''"
+msgstr "Endrer humaniseringsstrategi for Tabell- & Feltnavn fra \"{0}\" til \"{1}\""
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "Loop infinito rilevato: query pre-processata ricorsivamente {0} volte "
+msgstr "Uendelig løkke oppdaget: ferdigbeheandlet spørring rekursivt {0} ganger."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Attenzione: impossibile determinare i campi per una 'source-query' esplicita a meno che non si includano 'source-metadata'."
+msgstr "Advarsel: kunne ikke bestemme felt for en eksplisitt `kilde-spørring` hvis du ikke inkluderer `kilde-metadata`."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
+#, fuzzy
 msgid "Error determining expected columns for query"
-msgstr "Errore nel determinare le colonne previste per la query"
+msgstr "Kunne ikke avgjøre forventede kolonner for spørring."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr "Eccezione non gestita, previsto `catch-exception`middleware per gestirla."
+msgstr "Ubehandlet unntak, forventet at `catch-exceptions`-mellomvare skulle behandle den."
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:126
 msgid "Diagnostic Info"
-msgstr "Informazioni Diagnostiche"
+msgstr "Diagnostisk info"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:123
 msgid "Select Metabase process:"
-msgstr "Seleziona i processi di Metabase:"
+msgstr "Velg Metabase prosess:"
 
 #: frontend/src/metabase/admin/tasks/containers/Logs.jsx:133
 msgid "All Metabase processes"
-msgstr "Tutti i processi di Metabase:"
+msgstr "Alle Metabase prosesser"
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:13
 msgid "The window was closed before completing Google Authentication."
-msgstr "La finestra è stata chiusa prima di aver completato l'Autenticazione Google."
+msgstr "Vinduet ble lukket før Google Autentiseringen ble ferdig."
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:51
 msgid "There was an issue signing in with Google. Pleast contact an administrator."
-msgstr "Si è verificato un errore loggandosi tramite Google. Si prega di contattare un amministratore."
+msgstr "Det oppstod en feil ved innlogging med Google. Vennligst kontakt en administrator."
 
 #: frontend/src/metabase/plugins/builtin/auth/password.js:9
 msgid "Sign in with email"
-msgstr "Loggati con email"
+msgstr "Logg inn med e-post"
 
 #: frontend/src/metabase/entities/databases/forms.js:23
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
-msgstr "Usare questa opzione richiede che l'host fornito sia un FQDN. Se ti connetti ad un cluster Atlas, potresti aver bisogno di abilitare questa opzione. Se non sai cosa significa, lasciala disattivata."
+msgstr "Dette alternativet krever at oppgitt vert er et FQDN. Hvis du kobler til et Atlas-kluster trenger du kanskje å aktivere dette. Hvis du ikke vet hva dette betyr, la det være deaktivert."
 
 #: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "Di default, Metabase esegue una sincronizzazione oraria leggera e un'intensa scansione giornaliera dei valori dei campi. Se si dispone di un grande database, si consiglia di attivare questa opzione e rivedere quando e quanto spesso accadono le scansioni del valore del campo."
+msgstr "Som standard utfører Metabase en lettvektssync en gang i timen og en intensiv daglig scan av feltverdier. Hvis du har en stor database anbefaler vi å slå dette på og se hvor ofte feltverdiscanningen utføres."
 
 #: frontend/src/metabase/containers/Overworld.jsx:126
 msgid "Remove these suggestions"
-msgstr "Rimuovi questi suggerimenti"
+msgstr "Fjern disse forslagene"
 
 #: frontend/src/metabase/containers/Overworld.jsx:135
 msgid "Remove these suggestions?"
-msgstr "Rimuovere questi suggerimenti?"
+msgstr "Fjern disse forslagene?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:151
 msgid "These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt icon on one of your tables."
-msgstr "Questi non si presenterà più sulla homepage di ognuno dei vostri utenti, ma si può sempre ottenere i raggi-x facendo clic su Naviga Dati nella navigazione principale, quindi facendo clic sull'icona fulmine su una delle tue tabelle."
+msgstr "Disse vil ikke vises på hjemmesiden for noen av dine brukere lengre, men du kan alltids komme det til dine x-rays ved å klikke på Bla gjennom data i hovedmenyen og så på lyn-ikonet på en av dine tabeller."
 
 #: frontend/src/metabase/containers/Overworld.jsx:274
 msgid "Hide this section"
-msgstr "Nascondi questa sezione"
+msgstr "Skjul denne seksjonen"
 
 #: frontend/src/metabase/containers/Overworld.jsx:282
 msgid "Remove this section?"
-msgstr "Rimuovi questa sezione?"
+msgstr "Fjern denne seksjonen?"
 
 #: frontend/src/metabase/containers/Overworld.jsx:298
 msgid "\"Our Data\" won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation."
-msgstr "\"I nostri dati\" non apparirà più sulla homepage di nessuno dei tuoi utenti, ma puoi sempre navigare attraverso i tuoi database e tabelle facendo clic su Naviga Dati nella navigazione principale."
+msgstr "\"Vår data\" vil ikke vises på hjemmesiden for noen av brukerne lengre, men du kan alltids bla gjennom dine databaser og tabeller ved å klikke Bla gjennom data i hovedmenyen."
 
 #: frontend/src/metabase/entities/collections.js:95
 msgid "My new fantastic collection"
-msgstr "La mia nuova fantastica collezione"
+msgstr "Min nye fantastiske samling"
 
 #: frontend/src/metabase/lib/core.js:178
 msgid "Cancelation timestamp"
-msgstr "Timestamp annullamento"
+msgstr "Tidspunkt for avbrytelse"
 
 #: frontend/src/metabase/lib/core.js:173
 msgid "Cancelation time"
-msgstr "Orario di annullamento"
+msgstr "Tid for avbrytelse"
 
 #: frontend/src/metabase/lib/core.js:168
 msgid "Cancelation date"
-msgstr "Data di annullamento"
+msgstr "Dato for avbrytelse"
 
 #: frontend/src/metabase/lib/core.js:208
 msgid "Deletion timestamp"
-msgstr "Timestamp cancellazione"
+msgstr "Tidspunkt for sletting"
 
 #: frontend/src/metabase/lib/core.js:203
 msgid "Deletion time"
-msgstr "Orario cancellazione"
+msgstr "Tid for sletting"
 
 #: frontend/src/metabase/lib/core.js:198
 msgid "Deletion date"
-msgstr "Data cancellazione"
+msgstr "Dato for sletting"
 
 #: frontend/src/metabase/lib/core.js:298
 msgid "Only in detail views"
-msgstr "Solo nelle visualizzazioni dettagliate"
+msgstr "Bare i detaljvisning"
 
 #: frontend/src/metabase/lib/core.js:303
 msgid "Do not include"
-msgstr "Non includere"
+msgstr "Ikke inkluder"
 
 #: frontend/src/metabase/lib/core.js:304
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
-msgstr "Questo campo non sarà visibile o selezionabile nelle domande create con le interfacce GUI. Sarà comunque accessibile nelle query SQL/native."
+msgstr "Dette feltet vil ikke være synlig eller valgbart i spørsmål laget i brukergrensesnittet. Den vil fremdeles kunne nås i SQL/lokale spørringer."
 
 #: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
-msgstr "Somma cumulativa"
+msgstr "Kumulativ sum"
 
 #: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
-msgstr "Deviazione standard"
+msgstr "Standardavvik"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be at least {0} characters long"
-msgstr "deve essere almeno lunga {0} caratteri"
+msgstr "må være på minst {0} tegn"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be at least {0} characters long"
-msgstr "Deve essere almeno lunga {0} caratteri"
+msgstr "Må være på minst {0} tegn"
 
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:82
 msgid "Name (required)"
-msgstr "Nome (obbligatorio)"
+msgstr "Navn (påkrevd)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
-msgstr "Esegui testo selezionato"
+msgstr "Kjør valgt tekst"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
-msgstr "Esegui query"
+msgstr "Kjør spørring"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
-msgstr "(⌘ + invio)"
+msgstr "(⌘ + enter)"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
-msgstr "(Ctrl + invio)"
+msgstr "(Ctrl + enter)"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "Here's where your results will appear"
-msgstr "Qui è dove appariranno i tuoi risultati"
+msgstr "Her vil dine resultater vises"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:16
 msgid "You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question."
-msgstr "Non farai alcuna modifica permanente ad una domanda salvata a meno che non fai clic su Salva e scegli di sostituire la domanda originale."
+msgstr "Du lager ingen permanente endringer til en lagret spørring hvis du ikke klikker Lagre og velger å erstatte originalspørsmålet."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:200
 msgid "There aren't any filter widgets for this type of field yet."
-msgstr "Non esiste ancora alcun widget filtro per questo tipo di campo."
+msgstr "Det fins ikke noen filter-widget for denne type felt enda."
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:27
 msgid "Look up this field"
-msgstr "Cerca questo campo"
+msgstr "Søk opp dette feltet"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
 msgid "Why this metric is interesting"
-msgstr "Perché questa metrica è interessante"
+msgstr "Hvorfor denne indikatoren er interessant"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
 msgid "Things to be aware of about this metric"
-msgstr "Cose da sapere su questa metrica"
+msgstr "Ting å være oppmerksom på vedrørende denne indikatoren"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "How this metric is calculated"
-msgstr "Come è calcolata questa metrica"
+msgstr "Hvordan denne indikatoren er kalkulert"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:215
 msgid "Table this is based on"
-msgstr "Questa tabella è basata su"
+msgstr "Tabellen dette er basert på"
 
 #: frontend/src/metabase/visualizations/lib/renderer_utils.js:276
 msgid "(empty)"
-msgstr "(vuoto)"
+msgstr "(tom)"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Goal line"
-msgstr "Linea obbiettivo"
+msgstr "Mållinje"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Trend line"
-msgstr "Linea tendenza"
+msgstr "Trendlinje"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:317
 msgid "Show values on data points"
-msgstr "Mostra i valori sui data points"
+msgstr "Vis verdier på datapunkter"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:325
 msgid "Values to show"
-msgstr "Valori da mostrare"
+msgstr "Verdier som skal vises"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:332
 msgid "As many as can fit nicely"
-msgstr "Quanti più si adattano bene"
+msgstr "Så mange som får plass"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:333
 msgid "All"
-msgstr "Tutti"
+msgstr "Alle"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:9
 msgid "Data includes missing dimension values."
-msgstr "I dati includono dei valori dimensionali mancanti."
+msgstr "Data inkluderer verdier som mangler i dimensjonen."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:17
 msgid "We encountered an invalid date: \"{0}\""
-msgstr "Abbiamo riscontrato una data invalida: \"{0}\""
+msgstr "Vi kom over en ugyldig dato: \"{0}\""
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:38
 msgid "The query for this chart was run in {0} rather than {1} due to database or driver constraints."
-msgstr "La query per questo grafico è stata eseguita in {0} invece di {1} a causa del database o dei vincoli del driver."
+msgstr "Spørringen for denne grafen ble kjørt i {0} i stedet for {1} på grunn av database- eller driverbegrensninger."
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:47
 msgid "This chart contains queries run in multiple timezones: {0}"
-msgstr "Questo grafico contiene query eseguite in fusi orari multipli: {0}"
+msgstr "Denne grafen inneholder spørringer som kjøres i flere tidssoner: {0}"
 
 #: src/metabase/api/public.clj
 msgid "An error occurred while running the query."
-msgstr "Si è verificato un errore durante l'esecuzione della query."
+msgstr "En feil oppstod ved kjøring av spørring."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Output H2 database already exists: %s, removing."
-msgstr "Il database di output H2 esiste già: %s, rimozione."
+msgstr "H2-måldatabase eksisterer allerede: %s, fjerner."
 
 #: src/metabase/cmd/dump_to_h2.clj
 msgid "Don't need to migrate, just use the existing H2 file"
-msgstr "Non c'è bisogno di migrare, basta usare il file H2 esistente"
+msgstr "Trenger ikke migrere, bare bruk eksisterende H2-fil"
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Target DB is already populated!"
-msgstr "Target DB è già popolato!"
+msgstr "Mål-DB er allerede fylt inn!"
 
 #: src/metabase/core.clj
 msgid "System info:n {0}"
-msgstr "Info di sistema:n {0}"
+msgstr "Systeminformasjon:n {0}"
 
 #: src/metabase/db.clj
 msgid "Database setup"
-msgstr "Setup database"
+msgstr "Databaseoppsett"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren''t in a Collection to {1} Collection {2}"
-msgstr "Muovendo istanze di {0} che non sono in una Collezione a {1} Collezione {2}"
+msgstr "Flytter instanser av {0} som ikke er i en Samling til {1} Samling {2}"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid '{{...}}' clause: expected a param name"
-msgstr "Clausola '{{..}}' invalida: atteso il nome di un parametro"
+msgstr "Ugyldig '{{...}}' klausul: Forventet et parameternavn"
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'{{...}}' clauses cannot be empty."
-msgstr "'{{...}}' clausole non possono essere vuote."
+msgstr "'{{...}}' klausuler kan ikke være tomme."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "'[[...]]' clauses must contain at least one '{{...}}' clause."
-msgstr "'[[...]]' clausole devono contenere almeno una '{{...}}' clausola."
+msgstr "'[[...]]' klausuler må inneholde minst en '{{...}}' klausul."
 
 #: src/metabase/driver/common/parameters/parse.clj
 msgid "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'"
-msgstr "Query invalida: trovati '[[' o '{{' senza corrispondenza ']]' or '}}'"
+msgstr "Ugyldig spørring: fant  '[[' eller '{{' uten matchende ']]' eller '}}'"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "You''ll need to pick a value for ''{0}'' before this query can run."
-msgstr "Dovrai prendere un valore per \"{0}\" prima che questa query possa essere eseguita."
+msgstr "Du må velge en verdi for \"{0}\" før denne spørringen kan kjøre."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Can''t find field with ID: {0}"
-msgstr "Impossibile trovare campo con ID: {0}"
+msgstr "Kan ikke finne felt med ID: {0}"
 
 #: src/metabase/driver/impl.clj
+#, fuzzy
 msgid "Error loading driver namespace"
-msgstr "Errore durante il caricamento del driver namespace"
+msgstr "Feil ved lasting av navnerom for driver"
 
 #: src/metabase/driver/impl.clj
 msgid "Could not load {0} driver."
-msgstr "Non è possibile caricare il driver {0}."
+msgstr "Kunne ikke laste driver {0}."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run query: missing required parameters: {0}"
-msgstr "Impossibile eseguire la query: mancano dei parametri richiesti: {0}"
+msgstr "Kan ikke kjøre spørring: mangler påkrevde parameter: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1}"
-msgstr "Non so come analizzare {0} {1}"
+msgstr "Vet ikke hvordan man leser {0} {1}"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don''t know how to alias {0}, expected an Identifier."
-msgstr "Non so come fare l'alias {0}, aspettato un Identificativo."
+msgstr "Vet ikke hva jeg skal kalle {0}, forventet en Identifikator."
 
 #. it's better return a slightly broken SQL query with a probably incorrect string representation of the value than
 #. to have the entire QP run fail because of an unknown type.
 #: src/metabase/driver/sql/util/unprepare.clj
 msgid "Don''t know how to unprepare values of class {0}"
-msgstr "Non so come disfare i valori della classe {0}"
+msgstr "Vet ikke hvordan verdier av klasse {0} uforberedes"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Creating new connection pool for {0} database {1} ..."
-msgstr "Creando un nuovo pool di connessione per {0} database {1} ..."
+msgstr "Lager ny tilkoblingspool for {0} database {1} ..."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Invalid timezone ''{0}''"
-msgstr "Fuso orario non valido ''{0}''"
+msgstr "Ugyldig tidssone \"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Cannot set timezone: invalid or missing SQL format string for driver {0}."
-msgstr "Impossibile settare fuso orario: formato SQL per driver {0} mancante o non valida."
+msgstr "Kan ikke sette tidssone: ugyldig eller manglende SQL-formatstreng for driver {0}."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Did you implement set-timezone-sql?"
-msgstr "Hai implementato set-timezone-sql?"
+msgstr "Implementerte du set-timezone-sql?"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}''"
-msgstr "Settaggio fuso orario ''{0}'' fallito"
+msgstr "Kunne ikke angi tidssone \"{0}\""
 
 #: src/metabase/driver/util.clj
 msgid "Database connection error"
-msgstr "Errore nella connessione al database"
+msgstr "Feil ved databasetilkobling"
 
 #: src/metabase/models/interface.clj
 msgid "Error parsing JSON"
-msgstr "Errore nel parsing JSON"
+msgstr "Feil ved analyse av JSON"
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data"
-msgstr "Indica se visualizzare o meno i dati sulla homepage. Gli amministratori potrebbero disattivare questo al fine di indirizzare gli utenti a contenuti migliori di dati grezzi"
+msgstr "Om man skal vise data på hjemmesiden eller ikke. Administratorer kan slå av denne for å bedre omdirigere brukere til innhold i stedet for rådata."
 
 #: src/metabase/public_settings.clj
 msgid "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data"
-msgstr "Indica se visualizzare o meno i suggerimenti a raggi x sulla homepage. Essi saranno anche nascosti se eventuali dashboard sono bloccate. Gli amministratori potrebbero nascondere questo per indirizzare gli utenti a contenuti migliori di dati grezzi"
+msgstr "On du skal vise forslag til x-rays på hjemmesiden eller ikke. De vil være skjult hvis noen infotavler er festet. Admins kan skjule dette for å bedre omdirigere brukere til innhold i stedet for rådata."
 
 #: src/metabase/public_settings.clj
 msgid "Identify the source of HTTP requests by this header's value, instead of its remote address."
-msgstr "Identificare la fonte delle richieste HTTP dal valore di questa intestazione, invece del suo indirizzo remoto."
+msgstr "Identifiser kilden av HTTP-forespørslen med denne header-verdien i stedet for dens eksterne adresse."
 
 #: src/metabase/public_settings.clj
+#, fuzzy
 msgid "Could not resolve Setting {0}/{1}"
-msgstr "Impossibile risolvere Impostazioni {0}/{1}"
+msgstr "Kunne ikke løse Innstilling {0}/{1}"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid Setting: {0}/{1}"
-msgstr "Impostazione invalida: {0}/{1}"
+msgstr "Ugyldig innstilling: {0}/{1}"
 
 #: src/metabase/pulse.clj
 msgid "reached its goal"
-msgstr "ha raggiunto l'obiettivo"
+msgstr "nådde sitt mål"
 
 #: src/metabase/pulse.clj
 msgid "gone below its goal"
-msgstr "non ha raggiunto l'obiettivo"
+msgstr "gått under målet"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via email"
-msgstr "Inviando Pulse ({0}: {1}) via email"
+msgstr "Sender Puls ({0}: {1}) via e-post"
 
 #: src/metabase/pulse.clj
 msgid "Pulse: {0}"
-msgstr "Pulse: {0}"
+msgstr "Puls: {0}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) via Slack"
-msgstr "Inviando Pulse ({0}: {1}) via Slack"
+msgstr "Sender Puls ({0}: {1}) via Slack"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via email"
-msgstr "Inviando avviso ({0}: {1}) via email"
+msgstr "Sender Alarm ({0}: {1}) på e-post"
 
 #: src/metabase/pulse.clj
 msgid "Metabase alert: {0} has {1}"
-msgstr "L'avviso Metabase {0} ha {1}"
+msgstr "Metabase alarm: {0} har {1}"
 
 #: src/metabase/pulse.clj
 msgid "Sending Alert ({0}: {1}) via Slack"
-msgstr "Inviando avviso ({0}: {1}) via Slack"
+msgstr "Sender Alarm ({0}: {1}) til Slack"
 
 #: src/metabase/pulse.clj
 msgid "Alert: {0}"
-msgstr "Avviso: {0}"
+msgstr "Alarm: {0}"
 
 #: src/metabase/pulse/render/color.clj
+#, fuzzy
 msgid "Can''t find JS color selector at ''{0}''"
-msgstr "Impossibile trovare selettore colore JS in \"{0}\""
+msgstr "Kan ikke finne JS-fargevelger på \"{0}\""
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attemping to format them as such?"
-msgstr "SISTEMAMI: Questi non sono letterali temporali validi: {0} {1}. Per quale motivo si sta tentando di utilizzare tale formato?"
+msgstr "FIXMEG: Disse er ikke gyldige kronologiske litteraler: {0} {1}: Så hvorfor prøver vi å formatere de som det?"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found for join against Table {0} ''{1}'' on Field {2} ''{3}'' via FK {4} ''{5}''"
-msgstr "Nessuna informazione corrispondente trovata per join con tabella {0} ''{1}'' nei campi {2} ''{3}'' via FK {4} ''{5}''"
+msgstr "Ingen matchende informasjon for sammenføyning mot Tabell {0} \"{1}\" for Felt {2} \"{3}\" via FN {4} \"{5}\""
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don''t know how to get information about Field: {0}"
-msgstr "Non so come ottenere informazioni riguardo il campo: {0}"
+msgstr "Vet ikke hvordan vi skal få informasjon om Felt: {0}"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after {0}"
-msgstr "Time out query dopo {0}"
+msgstr "Tidsavbrudd for spørring etter {0}"
 
 #: src/metabase/query_processor/middleware/format_rows.clj
 msgid "Formatting rows with results timezone ID {0}"
-msgstr "La formattazione delle righe con i risultati timezone ID {0}"
+msgstr "Formaterer resultatrader med tidssone ID {0}"
 
 #: src/metabase/query_processor/timezone.clj
 msgid "Invalid timezone ID ''{0}''"
-msgstr "ID fuso orario ''{0}'' non valido"
+msgstr "Ugyldig tidssone-ID \"{0}\""
 
 #: src/metabase/sync/analyze/fingerprint.clj
 msgid "Saving fingerprint for {0}"
-msgstr "Salvataggio impronte digitali per {0}"
+msgstr "Lagrer fingeravtrykk for {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandoment email!"
-msgstr "Invio email di abbandono!"
+msgstr "Sender e-post med oppsigelse!"
 
 #: src/metabase/transforms/core.clj
 msgid "Resulting transforms do not conform to expectations.nExpected: {0}"
-msgstr "Le trasformazioni risultanti non sono conformi a expectations.nExpected: {0}"
+msgstr "Resulterende transformering svarer ikke til forventningene. Forventet: {0}"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0}"
-msgstr "Time out dopo {0}"
+msgstr "Tidsavbrudd etter {0}"
 
 #: src/metabase/util/date_2.clj
+#, fuzzy
 msgid "No temporal adjuster named {0}"
-msgstr "Nessun regolatore temporale denominato {0}"
+msgstr "Det er ingen kronologisk justerer som heter {0}"
 
 #: src/metabase/util/date_2.clj
 msgid "Invalid unit: {0}"
-msgstr "Unità non valida: {0}"
+msgstr "Ugyldig enhet: {0}"
 
 #: src/metabase/util/date_2/parse.clj
 msgid "Don''t know how to parse {0} using format {1}"
-msgstr "Non so come analizzare {0} usando il formato {1}"
+msgstr "Vet ikke hvordan jeg leser {0} ved å bruke formatet {1}"
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath {0}"
-msgstr "Il token non ha valore per il keypath {0}"
+msgstr "Nøkkel mangler for sti {0}"
 
 #: src/metabase/util/stats.clj
 msgid "Sending usage stats FAILED"
-msgstr "Invio statistiche di utilizzo FALLITO"
+msgstr "Sending av bruksstatistikk FEILET"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:69
 msgid "There was an error saving"
-msgstr "Si è verificato un errore durante il salvataggio"
+msgstr "Det oppstod en feil under lagring"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:75
 msgid "OK"
@@ -13732,108 +13763,108 @@ msgstr "OK"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}."
-msgstr "Per autorizzare gli utenti a registrarsi con Google hai bisogno di dare a Metabase una Google Developers console di applicazione client ID. Questo prevede pochi passi, e le istruzioni su come creare una chiave possono essere trovate qua {0}."
+msgstr "For å tillate innlogging med Google må du gi Metabase en kliend ID til Googles utviklerkonsoll. Det er bare et par steg og instruksjoner på hvordan du lager en nøkkel finnes {0}."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:134
 msgid "Be sure to include the full client ID, including the apps.googleusercontent.com suffix."
-msgstr "Assicurati di includere tutto il client ID, includendo il suffisso apps.googleusercontent.com"
+msgstr "Pass på å inkludere hele klient-IDen, inkludert suffikset apps.googleusercontent.com."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:30
 msgid "Metabase {0} is available."
-msgstr "Metabase {0} è disponibile."
+msgstr "Metabase {0} er tilgjengelig."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:31
 msgid "You're running {0}"
-msgstr "Stai eseguendo {0}"
+msgstr "Du kjører på {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:57
 msgid "Sorry, we were unable to check for updates at this time."
-msgstr "Siamo spiacenti, non siamo stati in grado di controllare gli aggiornamenti in questo momento."
+msgstr "Beklager, vi kunne ikke sjekke for oppdateringer akkurat nå."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:96
 msgid "patch release"
-msgstr "rilascio patch"
+msgstr "patch-utgivelse"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:10
 msgid "Dates and Times"
-msgstr "Date e Orari"
+msgstr "Datoer og tidspunkt"
 
 #: frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx:25
 msgid "Numbers"
-msgstr "Numeri"
+msgstr "Nummer"
 
 #: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
-msgstr "Nessun gruppo mappabile"
+msgstr "Ingen grupper kan tilordnes"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:108
 msgid "Metabase Documentation"
-msgstr "Documentazione Metabase"
+msgstr "Metabase Dokumentasjon"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:109
 msgid "Includes a troubleshooting guide"
-msgstr "Contiene una guida di risoluzione dei problemi"
+msgstr "Inkluderer en guide for feilsøking"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:113
 msgid "Post on the Metabase support forum"
-msgstr "Posta sul forum di supporto di Metabase"
+msgstr "Lag innlegg på Metabase-forumet"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:114
 msgid "A community forum for all things Metabase"
-msgstr "Un forum comunitario per tutte le cose di Metabase"
+msgstr "Et fellesskap for alt om Metabase"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:118
 msgid "File a bug report"
-msgstr "Invia un file di bug report"
+msgstr "Send inn en feilrapport"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:119
 msgid "Create a GitHub issue (includes the diagnostic info below)"
-msgstr "Crea una issue su GitHub (includendo le informazioni di diagnostica riportate sotto)"
+msgstr "Opprett GitHub-issue (inkluderer diagnostikk-informasjonen under)"
 
 #: frontend/src/metabase/admin/tasks/containers/Help.jsx:127
 msgid "Please include these details in support requests. Thank you!"
-msgstr "Si prega di includere questi dettagli nelle richieste di supporto. Grazie!"
+msgstr "Vennligst inkluder disse detaljene i brukerstøttehenvendelsen. Takk!"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:37
 msgid "youlooknicetoday@email.com"
-msgstr "staibenissimooggi@email.it"
+msgstr "haenfindag@epost.no"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:50
 msgid "Remember me"
-msgstr "Ricordami"
+msgstr "Husk meg"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
-msgstr "Per ragioni di sicurezza, i link per il reset della password scadono dopo poco. Se hai ancora bisogno di resettare la password puoi {0}."
+msgstr "Av sikkerhetsgrunner, løper lenker for tilbakestilling av passord ut etter en liten stund. Hvis du fremdeles trenger å tilbakestille passordet ditt kan du {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
-msgstr "Salva la nuova password"
+msgstr "Lagre nytt passord"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
-msgstr "Nessuna corrispondenza"
+msgstr "Ingen resultater"
 
 #: frontend/src/metabase/components/form/CustomForm.jsx:178
 msgid "Submit"
-msgstr "Invia"
+msgstr "Send inn"
 
 #: frontend/src/metabase/entities/databases/forms.js:15
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host. This option also provides an extra layer of security when a VPN is not available. Enabling this is usually slower than a direct connection."
-msgstr "Alcune installazioni di database sono accessibili solo collegandosi tramite un host SSH bastion. Questa opzione fornisce anche un ulteriore livello di sicurezza quando una VPN non è disponibile. Abilitarla è di solito più lenta di una connessione diretta."
+msgstr "Noen databaseinstallasjoner kan bare nås ved tilkobling gjennom en SSH bastion-vert. Dette alternativet gir et ekstra lag med sikkerhet der VPN ikke er tilgjengelig. Dette er normalt tregere enn en direkte tilkobling."
 
 #: frontend/src/metabase/entities/databases/forms.js:19
 msgid "We suggest you leave this off unless you're doing manual timezone casting in many or most of your queries with this data."
-msgstr "Vi suggeriamo di lasciare disattivata questa opzione a meno che non si sta facendo il fuso orario manuale in molti o nella maggior parte delle vostre domande con questi dati."
+msgstr "Vi foreslår at du lar denne være deaktivert såfremt du ikke bestemmer tidssone manuelt i mange eller de fleste spørringene med disse dataene."
 
 #: frontend/src/metabase/entities/databases/forms.js:128
 msgid "{0} to get an auth code."
-msgstr "{0} per ottenere un auth code"
+msgstr "{0} for å få en autentiseringskode."
 
 #: frontend/src/metabase/entities/databases/forms.js:136
 #: src/metabase/models/collection.clj
 msgid "or"
-msgstr "o"
+msgstr "eller"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
 #: frontend/src/metabase/entities/databases/forms.js:227
@@ -13841,46 +13872,46 @@ msgstr "o"
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
-msgstr "richiesto"
+msgstr "påkrevd"
 
 #: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
-msgstr "Tipo database"
+msgstr "Databasetype"
 
 #: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
-msgstr "Questo è un processo leggero che controlla la presenza di aggiornamenti dello schema di questo database. Nella maggior parte dei casi, sarebbe bene lasciare questo settaggio per sincronizzare ogni ora."
+msgstr "Dette er en lettvektsprosess som sjekker databaseskjema for oppdateringer. I de fleste tilfeller vil det gå bra å sette denne til å synkronisere hver time."
 
 #: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
-msgstr "Metabase può scansire i valori presenti in questo campo di questo database per abilitare i filtri checkbox nelle dashboard e nelle query. Questo può essere un processo ad alta intensità di risorse, in particolare se si dispone di un database molto ampio."
+msgstr "Metabase kan scanne verdiene i hvert felt i denne databasen for å aktivere aktiveringsboksfiltre i infotavler og spørsmål. Dette er forholdsvis ressurskrevende, spesielt hvis du har en veldig stor database."
 
 #: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
-msgstr "Collezione"
+msgstr "Samling"
 
 #: frontend/src/metabase/entities/users/forms.js:55
 msgid "Confirm your password"
-msgstr "Conferma la tua password"
+msgstr "Bekreft ditt passord"
 
 #: frontend/src/metabase/entities/users/forms.js:60
 msgid "passwords do not match"
-msgstr "le password non corrispondono"
+msgstr "passordene stemmer ikke"
 
 #: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
-msgstr "Dipartimento del Fantastico"
+msgstr "Utroligavdelingen"
 
 #: frontend/src/metabase/lib/core.js:88 frontend/src/metabase/lib/core.js:93
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "Finanziario"
+msgstr "Finansiell"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
 msgid "Numeric"
-msgstr "Numerico"
+msgstr "Numerisk"
 
 #: frontend/src/metabase/lib/core.js:169 frontend/src/metabase/lib/core.js:174
 #: frontend/src/metabase/lib/core.js:179 frontend/src/metabase/lib/core.js:184
@@ -13890,44 +13921,44 @@ msgstr "Numerico"
 #: frontend/src/metabase/lib/core.js:219 frontend/src/metabase/lib/core.js:224
 #: frontend/src/metabase/lib/core.js:229 frontend/src/metabase/lib/core.js:234
 msgid "Date and Time"
-msgstr "Data e Ora"
+msgstr "Dato og tid"
 
 #: frontend/src/metabase/lib/core.js:241 frontend/src/metabase/lib/core.js:246
 #: frontend/src/metabase/lib/core.js:251
 msgid "Categorical"
-msgstr "Categorico"
+msgstr "Kategorisk"
 
 #: frontend/src/metabase/lib/core.js:258 frontend/src/metabase/lib/core.js:263
 #: frontend/src/metabase/lib/core.js:268
 msgid "URLs"
-msgstr "URL"
+msgstr "URL-er"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
-msgstr "Ritorna la media dei valori nella colonna."
+msgstr "Returnerer gjennomsnittet av verdiene i kolonnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
 msgid "The column whose values to average."
-msgstr "La colonna i cui valori medi."
+msgstr "Kolonnene som gjennomsnittet skal baseres på."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
-msgstr "inizio"
+msgstr "start"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
-msgstr "fine"
+msgstr "slutt"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:16
 msgid "Checks a date or numeric column's values to see if they're within the specified range."
-msgstr "Controlla il valore di una colonna con date o numeri per controllare se i valori sono dentro un range specifico."
+msgstr "Sjekker en dato eller numerisk kolonne for å se om de er innenfor det spesifiserte området."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:17
 msgid "Rating"
-msgstr "Rating"
+msgstr "Karakter"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
@@ -13938,171 +13969,171 @@ msgstr "Rating"
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
-msgstr "condizione"
+msgstr "villkår"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
-msgstr "output"
+msgstr "utdata"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "Testa una lista di casi e ritorna il valore della prima corrispondenza, con un valore di default opzionale nel caso non si trovino corrispondenze."
+msgstr "Tester en liste over saker og returnerer korresponderende verdi for den første sanne saken, med en valgfri standardverdi hvis ingenting annet tilfredsstiller."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
-msgstr "Peso"
+msgstr "Wekt"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
-msgstr "Grande"
+msgstr "Stor"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
-msgstr "Medio"
+msgstr "Medium"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
-msgstr "Piccolo"
+msgstr "Liten"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
-msgstr "Qualcosa che possa essere espressa come vera o falsa."
+msgstr "Noe som skal evalueres som sant eller usant."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:54
 msgid "The value that will be returned if the preceeding condition is true."
-msgstr "Il valore che verrà restituito se la condizione precedente è vera."
+msgstr "Verdien som skal returneres hvis foregående villkår er sant."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
-msgstr "valore1"
+msgstr "verdi1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
-msgstr "valore2"
+msgstr "verdi2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
-msgstr "Esamina i valori di ogni argomento in ordine e restituisce il primo valore non nullo per ogni riga."
+msgstr "Ser på verdiene i hvert argument i rekkefølge og returnerer den første verdien for hver rad som ikke er null."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
-msgstr "Commenti"
+msgstr "Kommentarer"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
-msgstr "Note"
+msgstr "Notater"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
-msgstr "Nessun commento"
+msgstr "Ingen kommentarer"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:73
 msgid "A column or value."
-msgstr "Una colonna o un valore."
+msgstr "En kolonne eller verdi"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:77
 msgid "If value1 is empty, value2 gets returned if it's not empty, and so on."
-msgstr "Se valore1 è vuoto, valore2 viene restituito e così via."
+msgstr "Hvis verdi1 er tom, vil verdi2 bli returnert hvis den ikke er tom, og så videre."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 msgid "Combines two or more strings of text together."
-msgstr "Combina due o più stringhe di testo assieme."
+msgstr "Kombinerer to eller fler tekststrenger."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
-msgstr "Cognome"
+msgstr "Etternavn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
-msgstr "Nome"
+msgstr "Fornavn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:89
 msgid "value2 will be added on to the end of this."
-msgstr "valore2 verrà aggiunto alla fine di questo."
+msgstr "verdi2 vil bli lagt til slutten av dette."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:93
 msgid "This will be added to the end of value1."
-msgstr "Questo verrà aggiunto alla fine del valore1"
+msgstr "Dette vil bli lagt til i slutten på verdi1."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
-msgstr "stringa1"
+msgstr "streng1"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
-msgstr "stringa2"
+msgstr "streng2"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
-msgstr "Verifica se stringa1 contiene al suo interno stringa2."
+msgstr "Sjekker om streng1 inneholder streng2."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
-msgstr "Stato"
+msgstr "Status"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
-msgstr "Approvare"
+msgstr "Bestått"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
-msgstr "Il contenuto di questa stringa sarà oggetto di verifica."
+msgstr "Innholdet i tekststrengen vil bli sjekket."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
-msgstr "La stringa del testo da cercare."
+msgstr "Tekststrengen som skal søkes etter."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:116
 msgid "Returns the count of rows in the source data."
-msgstr "Ritorna il numero di righe nei dati sorgente."
+msgstr "Returnerer antall rader i kildedata."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
-msgstr "Conta solo le righe dove la condizione è vera."
+msgstr "Tell bare rader som oppfyller villkåret."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
-msgstr "Subtotale"
+msgstr "Subtotal"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
-msgstr "L'additivo totale di righe attraverso un breakout."
+msgstr "Sammenlagt total av rader på tvers av et utbrudd."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
-msgstr "La somma progressiva di una colonna attraverso un breakout."
+msgstr "Rullende sum av en kolonne på tvers av et utbrudd."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "The column to sum."
-msgstr "La colonna da sommare."
+msgstr "Kolonnen som skal summeres."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
-msgstr "Il numero di valori distinti in questa colonna."
+msgstr "Antall unike verdier i denne kolonnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
-msgstr "La colonna di cui contare i valori distinti."
+msgstr "Kolonnen du vil telle unike verdier i."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
@@ -14129,711 +14160,713 @@ msgstr "La colonna di cui contare i valori distinti."
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
-msgstr "testo"
+msgstr "tekst"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
-msgstr "comparazione"
+msgstr "sammenlikning"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
-msgstr "Ritorna vero se la fine del testo corrisponde al testo di comparazione."
+msgstr "Returnerer sann hvis enden av teksten matcher sammenlikningsteksten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
-msgstr "Appetito"
+msgstr "apetitt"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
-msgstr "affamato"
+msgstr "sulten"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 msgid "A column or string of text to check."
-msgstr "Una colonna o stringa di testo da verificare."
+msgstr "En kolonne eller tekststreng å sjekke."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
-msgstr "La stringa di testo con cui dovrebbe terminare il testo originale."
+msgstr "Tekststrengen dem originale teksten skal slutte med."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
-msgstr "regular_expression"
+msgstr "regulært_uttrykk"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
-msgstr "Estrae le sottostringhe corrispondenti secondo un'espressione regolare."
+msgstr "Henter ut matchende delstrenger i henhold til regulært uttrykk."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
-msgstr "Indirizzo"
+msgstr "Adresse"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 msgid "The column or string of text to search though."
-msgstr "La colonna o la stringa di testo da cercare."
+msgstr "Kolonnen eller tekststrengen det skal søkes gjennom."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
-msgstr "L'espressione regolare da corrispondere."
+msgstr "Det regulære uttrykket som skal stemme overens."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the string of text in all lowercase."
-msgstr "Ritorna la stringa di testa in minuscolo."
+msgstr "Returnerer tekststrengen i små bokstaver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to lowercase."
-msgstr "La colonna con i valori da convertire in minuscolo."
+msgstr "Kolonnen med verdier som skal konverteres til små bokstaver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
-msgstr "Rimuove lo spazio bianco iniziale da una stringa di testo."
+msgstr "Fjerner innledende tomrom fra en tekststreng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column with values you want to trim."
-msgstr "La colonna con i valori su cui vuoi effettuare il trim."
+msgstr "Kolonnen med verdier du vil trimme."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
-msgstr "Ritorna il valore maggiore trovato nella colonna."
+msgstr "Returnerer den største verdien i kolonnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
-msgstr "Età"
+msgstr "Alder"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
-msgstr "La colonna numerica di cui vuoi trovare il massimo."
+msgstr "Kolonnen du vil finne den største verdien i."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "Returns the smallest value found in the column."
-msgstr "Ritorna il valore minore trovato nella colonna."
+msgstr "Returnerer den minstre verdien i kolonnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
-msgstr "Salario"
+msgstr "Lønn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
-msgstr "La colonna numerica di cui vuoi trovare il minimo."
+msgstr "Kolonnen du vil finne den minste verdien i."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
-msgstr "posizione"
+msgstr "posisjon"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
-msgstr "lunghezza"
+msgstr "lengde"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:185
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "new_text"
-msgstr "nuovo_testo"
+msgstr "ny_tekst"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
-msgstr "Sostituisce una parte del testo in input con il nuovo testo."
+msgstr "Erstatter en del av inputteksten med en ny tekst."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "ID Ordine"
+msgstr "Rekkefølge ID"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
-msgstr "Parte dell'ID aggiornata"
+msgstr "Oppdatert Del av ID"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:244
 msgid "The text that will be modified."
-msgstr "Il testo che verrà modificato."
+msgstr "Teksten som vil bli endret."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:193
 msgid "The position where the replacing will start."
-msgstr "La posizione in cui inizia la sostituzione"
+msgstr "Posisjonen det erstattingen vil starte."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
 msgid "The number of characters to replace."
-msgstr "Il numero di caratteri da sostituire."
+msgstr "Antall tegn som skal erstattes."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:197
 msgid "The text to use in the replacement."
-msgstr "Il testo da usare in sostituzione"
+msgstr "Tekst som skal erstatte."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
-msgstr "Rimuove lo spazio bianco da una stringa di testo."
+msgstr "Fjerner påfølgende mellomrom i en tekststreng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
-msgstr "Restituisce la percentuale di righe nei dati che corrispondono alla condizione, sottoforma di decimale."
+msgstr "Returnerer prosentandelen av rader som tilfredstiller villkåret, som et desimaltall."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
-msgstr "Restituisce vero se l'inizio del testo corrisponde al testo di confronto."
+msgstr "Returnerer sann hvis begynnelsen av teksten stemmer overens med sammenlikningsteksten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
-msgstr "Nome Corso"
+msgstr "Kursnavn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
-msgstr "Scienze Informatiche"
+msgstr "Informatikk"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
-msgstr "La stringa di testo con cui dovrebbe cominciare il testo originale."
+msgstr "Tekststrengen den opprinnelige teksten burde starte med."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
-msgstr "Calcola la deviazione standard della colonna."
+msgstr "Kalkulerer standardavviket til kolonnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
-msgstr "Popolazione"
+msgstr "Befolkning"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
 msgid "A numeric column."
-msgstr "Una colona numerica."
+msgstr "En numerisk kolonne."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
-msgstr "Ritorna una porzione del testo sottoposto."
+msgstr "Returnerer en del av teksten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:313
 msgid "The text to return a portion of."
-msgstr "Il testo di cui ritornare una porzione."
+msgstr "Teksten du vil returnere en del av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
-msgstr "La posizione da cui iniziare a copiare i caratteri."
+msgstr "Posisionen å starte å kopiere tegn fra."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
-msgstr "Il numero di caratteri da ritornare."
+msgstr "Antall tegn som skal returneres."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
-msgstr "Aggiunge tutti i valori della colonna."
+msgstr "Summerer alle verdiene i kolonnen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
-msgstr "La colonna numerica da sommare"
+msgstr "Den numeriske kolonnen du vil summere."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
-msgstr "Somma i valori in una colonna dove le righe corrispondono alla condizione."
+msgstr "Summerer verdier i kolonner der rader matcher betingelser."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
-msgstr "Stato Ordine"
+msgstr "Ordrestatus"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
-msgstr "Valido"
+msgstr "Gyldig"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
-msgstr "Rimuove spazi bianchi iniziali e finali da una stringa di testo."
+msgstr "Fjerner innledende og påfølgende mellomrom fra en tekststreng."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
 msgid "Returns the string of text in all upper case."
-msgstr "Ritorna la stringa di testo con tutte lettere maiuscole."
+msgstr "Returnerer tekststrengen i store bokstaver"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
-msgstr "La colonna i cui valori sono da convertire in maiuscoli."
+msgstr "Kolonnen med verdier som skal konverteres til store bokstaver."
 
 #: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
-msgstr "deve essere {0} ed includere {1}."
+msgstr "må være {0} og inkludere {1}."
 
 #: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
-msgstr "deve essere {0}."
+msgstr "må være {0}"
 
 #: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
-msgstr "deve includere {0}."
+msgstr "må inkludere  {0}"
 
 #: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
-msgstr[0] "lunghezza minima {0} carattere"
-msgstr[1] "lunghezza minima {0} caratteri"
+msgstr[0] "minst {0} tegn"
+msgstr[1] "minst {0} tegn"
 
 #: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
-msgstr[0] "{0} lettera minuscola"
-msgstr[1] "{0} lettere minuscole"
+msgstr[0] "{0} liten bokstav"
+msgstr[1] "{0} små bokstaver"
 
 #: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
-msgstr[0] "{0} lettera maiuscola"
-msgstr[1] "{0} lettere maiuscole"
+msgstr[0] "{0} stor bokstav"
+msgstr[1] "{0} store bokstaver"
 
 #: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
-msgstr[0] "{0} numero"
-msgstr[1] "{0} numeri"
+msgstr[0] "{0} tall"
+msgstr[1] "{0} tall"
 
 #: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
-msgstr[0] "{0} carattere speciale "
-msgstr[1] "{0} caratteri speciali "
+msgstr[0] "{0} spesialtegn"
+msgstr[1] "{0} spesialtegn"
 
 #: frontend/src/metabase/lib/validate.js:8
 msgid "must be a valid email address"
-msgstr "deve essere un indirizzo di posta valido"
+msgstr "må være en gyldig e-postadresse"
 
 #: frontend/src/metabase/lib/validate.js:10
 msgid "must be {0} characters or less"
-msgstr "deve essere {0} caratteri o meno"
+msgstr "må være mindre enn {0} tegn"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:113
 msgid "Thanks for using Metabase!"
-msgstr "Grazie per utilizzare Metabase!"
+msgstr "Takk for at du valgte Metabase!"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "Powered by {0}"
+msgstr "Leveres av {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
-msgstr "A:"
+msgstr "Til:"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
-msgstr "Questa domanda non può essere utilizzata perché si basa su di un database differente."
+msgstr "Dette spørsmålet kan ikke brukes fordi det er basert på en annen type database."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:43
 msgid "Couldn't find a saved question with that ID number."
-msgstr "Non è stato possibile trovare una domanda salvata con questo numero ID."
+msgstr "Kunne ikke finne et lagret spørsmål med det ID-nummeret."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:54
 msgid "Pick a saved question"
-msgstr "Scegli una domanda salvata"
+msgstr "Valgte et lagret spørsmål"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:56
 msgid "Pick a different question"
-msgstr "Scegli una domanda differente"
+msgstr "Velg et annet spørsmål"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:61
 msgid "Loading…"
-msgstr "Caricamento..."
+msgstr "Laster..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:78
 msgid "Question #…"
-msgstr "Domanda #..."
+msgstr "Spørsmål #..."
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:80
 msgid "Question #{0}"
-msgstr "Domanda #{0}"
+msgstr "Spørsmål #{0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:114
 msgid "Last edited {0}"
-msgstr "Ultima modifica {0}"
+msgstr "Sist redigert {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:250
 msgid "{0} creates a variable in this query template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the query template."
-msgstr "{0} crea una variabile in questo modello di query chiamata \"variable_name\". Alle variabili possono essere date tipi dal pannello laterale, che cambia il loro comportamento. Tutti i tipi di variabile diversi da \"Filtro di campo\" causeranno automaticamente un widget di filtro da posizionare su questa domanda; con i Filtri di Campo è opzionale. Quando questo widget di filtro è compilato, questo valore sostituisce la variabile nel template della query."
+msgstr "{0} lager en variabel i denne spørre-malen kalt \"variabelnavn\". Variabler kan gis en type i sidepanelet, som endrer dens oppførsel. Alle variabler som ike er \"Felt Filter\" vil automatisk føre til at en widget blir plassert på dette spørsmålet; med Felt Filter er dette valgfritt. Når denne filter-widgeten er fylt inn, vil den verdier erstatte variablen i spørre-malen"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:261
+#, fuzzy
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Dare a una variabile del tipo \"Filtro Campo\" consente di collegare le domande a widget filtro dashboard o utilizzare più tipi di widget filtro sulla vostra domanda SQL. Una variabile Filtro Campo inserisce SQL simile a quella generata dal costruttore di query GUI quando si aggiungono filtri su colonne esistenti."
+msgstr "Å gi en variabel typen \"Felt Filter\" lar deg koble sammen spørsmål til infotavlens filter-widgeter eller lar det bruke flere filter-widgeter i ditt SQL-spørsmål. En Felt Filter-variabel setter inn SQL likt det som er generert med brukergrensesnittet for å bygge spørringer når du legger til filter på eksisterende kolonner."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
-msgstr "Nome variabile"
+msgstr "Variabelnavn"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:218
 msgid "Filter widget label"
-msgstr "Etichetta widget filtro"
+msgstr "Etikett for filter-widget"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:64
 msgid "Select a foreign key"
-msgstr "Seleziona una chiave esterna"
+msgstr "Velg en fremmednøkkel"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:50
 msgid "Hi, {0}. Nice to meet you!"
-msgstr "Ciao, {0}. Piacere di fare la tua conoscenza!"
+msgstr "Hei, {0}. Hyggelig å møte deg!"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:270
 msgid "12-hour clock"
-msgstr "12 ore"
+msgstr "12-timersklokke"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:274
 msgid "24-hour clock"
-msgstr "24 ore"
+msgstr "24-timersklokke"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:341
 msgid "Symbol"
-msgstr "Simbolo"
+msgstr "Symbol"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:365
 msgid "In the column heading"
-msgstr "Nell'intestazione colonna"
+msgstr "i kolonneoverskriften"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:366
 msgid "In every table cell"
-msgstr "In ogni cella della tabella"
+msgstr "I hver tabellcelle"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:341
 msgid "Value formatting"
-msgstr "Formattazione del valore"
+msgstr "Verdiformat"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:350
 msgid "Full"
-msgstr "Pieno"
+msgstr "Fullt"
 
-#. nella versione v.0.35 questa traduzione non funziona
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
-msgstr "Non variato rispetto al {0} precedente."
+msgstr "Ingen endring fra sist {0}"
 
 #: src/metabase/api/database.clj
 msgid "Connection to ''{0}:{1}'' successful, but could not connect to DB."
-msgstr "Connessione a ''{0}:{1}'' avvenuta, ma non posso connettermi al database."
+msgstr "Tilkobling til \"{0}:{1}\" var vellykket, men kunne ikke koble til DB."
 
 #: src/metabase/api/database.clj
 msgid "Connection to host ''{0}'' successful, but port {1} is invalid."
-msgstr "Connessione all'host ''{0}'' avvenuta, ma la porta {1} è invalida."
+msgstr "Tilkobling til verten \"{0}\" lyktes, men port {1} er ugyldig."
 
 #: src/metabase/api/database.clj
 msgid "Host ''{0}'' is not reachable"
-msgstr "L'host ''{0}'' non è raggiungibile"
+msgstr "Kunne ikke nå verten \"{0}\""
 
 #: src/metabase/api/database.clj
 msgid "Unable to connect to database."
-msgstr "Impossibile collegarsi al database."
+msgstr "Ikke i stand til å koble til database."
 
 #: src/metabase/api/database.clj
 msgid "Cannot connect to Database"
-msgstr "Non è possibile collegarsi al Database"
+msgstr "Kan ikke koble til Database"
 
 #: src/metabase/api/embed.clj
 msgid "You''re not allowed to specify a value for {0}."
-msgstr "Non è possibile specificare un valore per {0}."
+msgstr "Du har ikke tillatelse til å angi en verdi for {0}."
 
 #: src/metabase/api/embed.clj
 msgid "You can''t specify a value for {0} if it''s already set in the JWT."
-msgstr "Non puoi specificare un valore per {0} se è già settato in JWT."
+msgstr "Du kan ikke sette en verdi for {0} hvis den allerede er satt i JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You must specify a value for {0} in the JWT."
-msgstr "Devi specificare un valore per {0} nel token JWT"
+msgstr "Du må spesifisere en verdi for {0} i JWT."
 
 #: src/metabase/api/embed.clj
 msgid "You can only specify a value for {0} in the JWT."
-msgstr "Puoi specificare un solo valore per {0} nel token JWT"
+msgstr "Du kan bare spesifisere en verdi for {0} i JWT."
 
 #: src/metabase/api/field.clj
 msgid "Error searching field values"
-msgstr "Errore durante la ricerca dei valori del campo"
+msgstr "Feil ved søk i feltverdier"
 
 #: src/metabase/api/field.clj
 msgid "Error searching for remapping"
-msgstr "Errore durante la ricerca per la rimappatura"
+msgstr "Feil ved søk etter verdier for andre felt"
 
 #: src/metabase/api/session.clj
 msgid "Google Auth token appears to be incorrect. "
-msgstr "Il token Google Auth sembra non corretto"
+msgstr "Google Auth token ser ikke ut til å være korrekt. "
 
 #: src/metabase/api/session.clj
 msgid "Double check that it matches in Google and Metabase."
-msgstr "Doppio controllo che corrisponda in Google e metabase."
+msgstr "Dobbeltsjekk at det stemmer overens i Google og Metabase."
 
 #: src/metabase/api/table.clj
 msgid "Everything else"
-msgstr "Tutto il resto"
+msgstr "Alt annet"
 
 #: src/metabase/core.clj
 msgid "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."
-msgstr "ATTENZIONE: Hai abilitato la tracciatura dei namespace, attività che può loggare informazioni sensibili come le password dei database."
+msgstr "ADVARSEL: Du har aktivert navneromsporing, som kan lagre sensitiv informasjon som databasepassord."
 
 #: src/metabase/db.clj
 msgid "Database Upgrade Required"
-msgstr "Aggiornamento del database necessario"
+msgstr "Databaseoppgradering kreves"
 
 #: src/metabase/db.clj
 msgid "NOTICE: Your database requires updates to work with this version of Metabase."
-msgstr "AVVISO: Il tuo database richiede aggiornamenti per poter funzionare con questa versione di Metabase."
+msgstr "MERKNAD: Din database krever oppdateringer for å fungere med denne versjonen av Metabase."
 
 #: src/metabase/db.clj
 msgid "Please execute the following sql commands on your database before proceeding."
-msgstr "Si prega di eseguire i seguenti comandi sql nel proprio database prima di procedere."
+msgstr "Vennligst utfør disse SQL-kommandoene på din database før du fortsetter."
 
 #: src/metabase/db.clj
 msgid "Once your database is updated try running the application again."
-msgstr "Una volta che il tuo database è aggiornato, prova a lanciare nuovamente l'applicazione."
+msgstr "Prøv å kjør applikasjonen på nytt etter at databasen er oppdatert."
 
 #: src/metabase/db.clj
 msgid "Database requires manual upgrade."
-msgstr "Il database necessita di un aggiornamento manuale."
+msgstr "Databasen krever manuell oppgradering"
 
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "Imposta la transaction per il rollback automatico..."
+msgstr "Sett transaksjon til automatisk tilbakerulling..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
 msgid "Disable auto-commit..."
-msgstr "Disabilita l'auto-commit..."
+msgstr "Deaktiver auto-commit..."
 
 #: src/metabase/db.clj
 msgid "Set default db connection with connection pool..."
-msgstr "Imposta la connessione db predefinita con il pool di connessioni..."
+msgstr "Sett standard databasetilkobling med tilkoblingspool..."
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
-msgstr "Verificata con successo {0} {1} la connessione al database."
+msgstr "Verifiserte databasetilkobling {0} {1}."
 
 #. if both of the decoders above fail, then the date string is invalid
 #: src/metabase/driver/common/parameters/dates.clj
 msgid "Don''t know how to parse date param ''{0}'' — invalid format"
-msgstr "Non so come analizzare il parametro data ''{0}'' - formato non valido"
+msgstr "Vet ikke hvordan datoparameter \"{0}\" skal tolkes — ugyldig format"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "The sub-query from referenced question #{0} failed with the following error: {1}"
-msgstr "La sub-query da domanda referenziata #{0} è fallita con il seguente errore: {1}"
+msgstr "Spørsmål #{0} refererte til en underspørring som feilet med følgende feilmelding: {1}"
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
-msgstr "ATTENZIONE: Metabase supporta ufficialmente solo MySQL {0}/MariaDB {1} e superiore."
+msgstr "ADVARSEL: Metabase støtter offisielt bare MySQL {0}/MariaDB {1} og nyere."
 
 #: src/metabase/driver/mysql.clj
 msgid "All Metabase features may not work properly when using an unsupported version."
-msgstr "Tutti i componenti di Metabase potrebbero non funzionare correttamente usando una versione non supportata."
+msgstr "Alle Metabase funksjoner vil kanskje ikke fungere skikkelig med en versjon som ikke er støttet."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Unable to substitute parameters"
-msgstr "Impossibile sostituire i parametri"
+msgstr "Ikke i stand til å bytte ut parameter"
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Cannot run the query: missing required parameters: {0}"
-msgstr "Impossibile lanciare la query: parametri mancanti: {0}"
+msgstr "Kan ikke kjøre spørring: mangler påkrevde parameter: {0}"
 
 #: src/metabase/driver/sql/parameters/substitution.clj
 msgid "Don''t know how to parse {0} {1} as a temporal literal"
-msgstr "Non so come analizzare {0} {1} come letterale temporale"
+msgstr "Vet ikke hvordan jeg tolker {0} {1} som en kronologisk literal"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting {0} database timezone with statement: {1}"
-msgstr "Settando {0} al database fusorario con statement: {1}"
+msgstr "Setter tidssone for database {0} med uttrykk: {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to readwrite"
-msgstr "Errore durante l'impostazione della connessione per la lettura/scrittura"
+msgstr "Kunne ikke sette tilkobling til lesskriv"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone ''{0}'' for {1} database"
-msgstr "Settaggio fuso orario ''{0}'' per {1} database fallito"
+msgstr "Kunne ikke sette tidssonen på database {1} til \"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting transaction isolation level for {0} database to {1}"
-msgstr "Errore nell'impostare il livello di isolamento delle transazioni per il database {0} in {1}"
+msgstr "Kunne ikke sette isolasjonsnivå for transaksjoner fir database {0} til {1}"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting connection to read-only"
-msgstr "Errore durante l'impostazione della connessione solo lettura"
+msgstr "Kunne ikke sette tilkobling til skrivebeskyttet"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting default holdability for connection"
-msgstr "Errore impostando di default il \"set hold\" per la connessione"
+msgstr "Kunne ikke sette standard holdbarhet for tilkobling"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Error setting result set fetch direction to FETCH_FORWARD"
-msgstr "Errore impostando la direzione di recupero del risultato a FETCH_FORWARD"
+msgstr "Kunne ikke sette henteretnin til FETCH_FORWARD"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Query canceled, calling PreparedStatement.cancel()"
-msgstr "Query cancellata, calling PreparedStatement.cancel()"
+msgstr "Spørring avbrutt, kaller PreparedStatement.cancel()"
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database"
-msgstr "Fallita connessione al database"
+msgstr "Feil ved databasetilkobling"
 
 #: src/metabase/driver/util.clj
 msgid "Unable to determine connection properties for driver {0}"
-msgstr "Impossibile determinare le proprietà di connessione per il driver {0}"
+msgstr "Kunne ikke avgjøre tilkoblingsegenskaper for driver {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Error fetching field values"
-msgstr "Errore nel caricamento dei valori dei campi"
+msgstr "Feil ved henting av feltverdier"
 
 #: src/metabase/models/setting.clj
 msgid "You cannot set {0}; it is a read-only setting."
-msgstr "Non puoi settare {0}; è un opzione readonly."
+msgstr "Du kan ikke endre innstillingen {0}; den er skrivebeskyttet"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must have `:visibilty` `:internal`, `:setter` `:none`, or internationalized, found: `{0}`"
-msgstr "la stringa di descrizione defsettind deve avere ':visibility' ':internal', ':setter' ':none', o internazionalizzato, trovato: '{0}'"
+msgstr "Tekststrenger som beskriver defsetting må ha `:visibilty` `:internal`, `:setter` `:none`, eller internasjonalisert, funnet: `{0}`"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} is internal"
-msgstr "L'impostazione {0} è interna"
+msgstr "Innstilling {0} er intern"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "Caricando i plugin locali del manifest a {0}"
+msgstr "Laster lokalt plugin manifest fra {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Codice tracciatura Google Analytics."
+msgstr "Sporingskode for Google Analytics."
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
-msgstr "Inviando Pulse ({0}: {1}) con {2} Card via email"
+msgstr "Sender Puls ({0}: {1}) med {2} Kort via e-post"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
-msgstr "Inviando Pulse ({0}: {1}) con {2} Card via Slack"
+msgstr "Sender Puls ({0}: {1}) med {2} Kort via Slack"
 
 #: src/metabase/pulse/render.clj
 msgid "Rendering pulse card with chart-type {0} and render-type {1}"
-msgstr "Renderizzando pulse card con grafico di tipo {0} e render di tipo {1}"
+msgstr "Gjengivelse av pulskort med graftype {0} og gjengivelsestype {1}"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "SISTEMAMI: Questi non sono letterali temporali validi: {0} {1}. Per quale motivo si sta tentando di utilizzare tale formato?"
+msgstr "FIXMEG: Disse er ikke gyldige kronologiske litteraler: {0} {1}: Så hvorfor prøver vi å formatere de som det?"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
-msgstr "Errore durante la riduzione dei risultati"
+msgstr "Feil ved redusering av resutatrader"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Unexpected nil result"
-msgstr "Risultato vuoto inaspettato"
+msgstr "Uventet nil resultat"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0} ms, raising timeout exception."
-msgstr "Query timeout dopo {0} ms, sollevando timeout exception."
+msgstr "Spørring fikk tidsavbrudd etter {0} ms, reiste tidsavbrudd-unntak."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Timed out after {0}."
-msgstr "Time out dopo {0}."
+msgstr "Tidsavbrudd etter {0}."
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query canceled before finishing."
-msgstr "Query cancellata prima del termine."
+msgstr "Spørring ble avbrutt før den kunne gjøre seg ferdig."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Unknown query type {0}"
-msgstr "Tipo query {0} non riconosciuto"
+msgstr "Ukjent spørringstype {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error purging old cache entires"
-msgstr "Errore durante l'eliminazione della cache precedente"
+msgstr "Feil ved sletting av mellomlagrede oppføringer"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Caching results for next time for query with hash {0}."
-msgstr "Risulatati nella cache per la prossima volta per query con hash {0}"
+msgstr "Mellomlagre resultater for neste spørring med hash {0}."
 
 #: src/metabase/query_processor/middleware/cache.clj
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error saving query results to cache."
-msgstr "Errore durante il salvataggio dei risultati della query nella cache."
+msgstr "Feil ved mellomlagring av spørreresultater."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Successfully cached results for query."
-msgstr "Risultati memorizzati nella cache per la query."
+msgstr "Vellykket mellomlagring av resultat av spørring."
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Query took {0} to run; miminum for cache eligibility is {1}"
-msgstr "La query ci ha messo {0} per essere eseguita; il minimo idoneo per la cache è {1}"
+msgstr "Spørringen ble ferdig på {0}; må være minimum {1} for å kvalifisere til mellomlagring"
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Results are too large to cache."
-msgstr "I risultati sono troppi per entrare in cache"
+msgstr "Resultater er for store til å mellomlagres."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Serialization timed out after {0}."
-msgstr "Serializzazione timeout dopo {0}."
+msgstr "Tidsavbrudd for serialisering etter {0}."
 
 #: src/metabase/query_processor/middleware/cache/impl.clj
 msgid "Error parsing serialized results"
-msgstr "Errore durante l'analisi dei risultati serializzati"
+msgstr "Feil ved lesing av serialiserte resultater"
 
+#. Duplicate?
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error purging old cache entries"
-msgstr "Errore durante la pulizia della cache."
+msgstr "Feil ved sletting av mellomlagrede oppføringer"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Caching results for query with hash {0}."
-msgstr "Risultati nella cache per query con hash {0}."
+msgstr "Mellomlagrer resultat for spørring med hash {0}."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Cannot save QueryExecution, missing :context"
-msgstr "Impossibile salvare QueryExecution, :context mancante"
+msgstr "Kan ikke lagre QueryExecution, mangler :context"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Error saving query execution info"
-msgstr "Errore nel salvare le informazioni di esecuzione della query"
+msgstr "Feil ved lagring av informasjon om utføring av spørring"
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve database for query: missing or invalid `:database` ID."
-msgstr "Impossibile risolvere il database per la query: ID ':database' mancante o non valido."
+msgstr "Kunne ikke finne database for spørring: manglende eller ugyldig `:database` ID."
 
 #: src/metabase/query_processor/middleware/resolve_database_and_driver.clj
 msgid "Unable to resolve driver for query"
-msgstr "Impossibile risolvere i driver per la query"
+msgstr "Kunne ikke finne driver for spørring"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced question #{0} could not be found"
-msgstr "La domanda di riferimento #{0} non può essere trovata"
+msgstr "Kunne ikke finne referert spørsmål #{0}"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "Referenced query is from a different database"
-msgstr "La query referenziata è di un altro database"
+msgstr "Referert spørring er fra en annen database"
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
+#, fuzzy
 msgid "This query has circular referencing sub-queries. "
-msgstr "La query ha un riferimento circolare alla sotto-query"
+msgstr "Denne spøringen har underspørringer som er sirkulærrefererende. "
 
 #: src/metabase/query_processor/middleware/resolve_referenced.clj
 msgid "These questions seem to be part of the problem: \"{0}\" and \"{1}\"."
-msgstr "Queste domande sembrano essere parte del problema: \"{0}\" e \"{1}\"."
+msgstr "Disse spørsmålene ser ut til å være en del av problemet: \"{0}\" og \"{1}\"."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query"
-msgstr "Errore durante la registrazione dei metadata della query"
+msgstr "Feil ved opptak av metatataresultater for spørring"
 
 #: src/metabase/query_processor/streaming/xlsx.clj
 msgid "Query result"
-msgstr "Risultato della query"
+msgstr "Resultat"
 
 #: src/metabase/sync/analyze/query_results.clj
 msgid "Error generating insights for column:"
-msgstr "Errore durante la generazione dell'approfondimento della colonnna:"
+msgstr "Feil ved generering av innsikt for kolonne:"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Sending abandonment email!"
-msgstr "Sto inviando l'email di abbandono!"
+msgstr "Sender oppsigelses-epost"
 
 #: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "È possibile creare metriche salvate per aggiungere un'opzione metrica denominata. Le metriche salvate includono il tipo di aggregazione, il campo aggregato e, opzionalmente, qualsiasi filtro aggiunto. Come esempio, si potrebbe usare questo per creare qualcosa di simile ad un modo ufficiale di calcolare il \"Prezzo medio\" per una tabella degli ordini."
+msgstr "Du kan opprete lagrede indikatorer for å legge til et alternativ som heter navngitt indikator. En navngitt indikator inkluderer aggregeringstypen, -feltet og alle filter du velger å legge til. Du kan f.eks bruke dette for å lage en offisiell måte å kalkulere \"Gjennomsnittlig pris\" for en Ordretabell på."
 
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:105
 msgid "Select and add filters to create your new segment."
-msgstr "Selezione e aggiungi i filtri per creare il tuo nuovo segmento."
+msgstr "Velg og legg til filter for å opprette ditt nye segment."
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
-msgstr "Alfabetico"
+msgstr "Alfabetisk"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
@@ -14841,478 +14874,479 @@ msgstr "Smart"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
-msgstr "Ordine colonna: {0}"
+msgstr "Kolonnesortering: {0}"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
 msgid "Unhide all"
-msgstr "Mostra tutto"
+msgstr "Vis alle"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:204
 msgid "Hide all"
-msgstr "Nascondi tutto"
+msgstr "Skjul alle"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:206
 msgid "Unhide"
-msgstr "Mostra"
+msgstr "Vis"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:22
 msgid "New metric"
-msgstr "Nuova metrica"
+msgstr "Ny indikator"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:45
 msgid "Create metrics to add them to the Summarize dropdown in the query builder"
-msgstr "Crea metriche per aggiungerle al menu a tendina Riassumere del costruttore delle query"
+msgstr "Lag indikatorer og legg dem til Summer-nedtrekksmenyen i spørringsbyggeren"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:22
 msgid "New segment"
-msgstr "Nuovo segmento"
+msgstr "Nytt segment"
 
 #: frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx:71
 msgid "Filter by table"
-msgstr "Filtra per tabella"
+msgstr "Filtrer etter tabell"
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:64
 msgid "Checking HTTPS..."
-msgstr "Controllo HTTPS..."
+msgstr "Sjekker HTTPS..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx:66
 msgid "It looks like HTTPS is not properly configured"
-msgstr "Sembra che l'HTTPS non sia configurato correttamente"
+msgstr "Det ser ut til at HTTPS ikke er konfigurert skikkelig"
 
 #: frontend/src/metabase/admin/settings/selectors.js:57
 msgid "Redirect to HTTPS"
-msgstr "Redirect verso HTTPS"
+msgstr "Omdiriger til HTTPS"
 
 #: frontend/src/metabase/admin/settings/selectors.js:219
 msgid "Localization"
-msgstr "Localizzazione"
+msgstr "Lokalisering"
 
 #: frontend/src/metabase/admin/settings/selectors.js:222
 msgid "Instance language"
-msgstr "Lingua d'istanza"
+msgstr "Språk for instans"
 
 #: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
-msgstr "Opzioni di Localizzazione"
+msgstr "Lokaliseringsalternativ"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:51
 msgid "This database doesn't have any tables."
-msgstr "Questo database non ha tabelle."
+msgstr "Databasen har ingen tabeller"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
 msgid "This field only accepts a single value because it's used in a SQL query."
-msgstr "Questo campo accetta un valor singolo in quanto è utilizzato in una query SQL."
+msgstr "Dette feltet aksepterer en enkel verdi fordi det er brukt i en SQL-spørring."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:17
 msgid "Service Accounts"
-msgstr "Account di servizio"
+msgstr "Servicekontoer"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:26
 msgid "Metabase connects to Big Query via {0}."
-msgstr "Metabase si collega a Big Query con {0}."
+msgstr "Metabase kobler til Big Query via {0}."
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:29
 msgid "Continue using an OAuth application to connect"
-msgstr "Prosegui con un'applicazione OAuth per connetterti"
+msgstr "Fortsett å benytte en OAuth-applikasjon for å koble til"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:43
 msgid "We recommend switching to use {0} instead of an OAuth application to connect to BigQuery"
-msgstr "Raccomandiamo di usare {0} invece di un' applicazione OAuth per collegarsi a BigQuery"
+msgstr "Vi anbefaler å bytte til {0} i stedet for en OAuth-applikasjon for å koble til BigQuery"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:48
 msgid "Connect to a Service Account instead"
-msgstr "Collegati invece a un Account di Servizio"
+msgstr "Koble til en servicekonto i stedet"
 
 #: frontend/src/metabase/entities/databases/forms.js:44
 msgid "invalid JSON"
-msgstr "JSON invalido"
+msgstr "ugyldig JSON"
 
 #: frontend/src/metabase/entities/databases/forms.js:50
 msgid "SSH private key"
-msgstr "Chiave privata SSH"
+msgstr "Privatnøkkel for SSH"
 
 #: frontend/src/metabase/entities/databases/forms.js:51
 msgid "Paste the contents of your ssh private key here"
-msgstr "Incolla qui il contenuto della tua chiave privata SSH"
+msgstr "Lim inn din private ssh-nøkkel her"
 
 #: frontend/src/metabase/entities/databases/forms.js:55
 msgid "Passphrase for the SSH private key"
-msgstr "Passphrase per la chiave privata SSH"
+msgstr "Passfrase for den private SSH-nøkkelen"
 
 #: frontend/src/metabase/entities/databases/forms.js:58
 msgid "SSH Authentication"
-msgstr "autenticazione SSH"
+msgstr "SSH-autentisering"
 
 #: frontend/src/metabase/entities/databases/forms.js:60
 msgid "SSH Key"
-msgstr "chiave SSH"
+msgstr "SSH-nøkkel"
 
 #: frontend/src/metabase/entities/databases/forms.js:65
 msgid "Server SSL certificate chain"
-msgstr "Certificate chain per il server SSL"
+msgstr "SSL-sertifikatkjede for tjener"
 
 #: frontend/src/metabase/entities/databases/forms.js:66
 msgid "Paste the contents of the server's SSL certificate chain here"
-msgstr "Incolla qui il contenuto del certificate chain del server SSL"
+msgstr "Lim in tjenerens SSL-sertifikatkjede her"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:11
 msgid "Paste a connection string"
-msgstr "Incolla la stringa di connessione"
+msgstr "Lim inn en tilkoblingsstreng"
 
 #: frontend/src/metabase/entities/databases/mongo-fields.js:12
 msgid "Fill out individual fields"
-msgstr "Compilare i singoli campi"
+msgstr "Fyll ut individuelle felter"
 
 #: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
-msgstr "Inserisci qui del codice SQL che puoi riutilizzare in seguito"
+msgstr "Skriv inn litt SQL her som du kan gjenbruke senere"
 
 #: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
-msgstr "Dai un nome al tuo snippet"
+msgstr "Gi ditt utvalg et navn"
 
 #: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
-msgstr "Clienti Attuali"
+msgstr "Gjeldende Kunder"
 
 #: frontend/src/metabase/entities/snippet-collections.js:80
 #: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
-msgstr "Aggiungi una descrizione"
+msgstr "Legg til en beskrivelse"
 
 #: frontend/src/metabase/entities/users/forms.js:37
 msgid "Use site default"
-msgstr "Usa i default del sito"
+msgstr "Bruk standardverdi"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
-msgstr "trova"
+msgstr "finn"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
-msgstr "sostituisci"
+msgstr "erstatt"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
-msgstr "Il testo da cercare."
+msgstr "Teksten som skal søkes etter."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
-msgstr "Il testo con cui sostituire."
+msgstr "Teksten som det skal erstattes med."
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
-msgstr "Modificando {0}"
+msgstr "Redigerer {0}"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
-msgstr "Crea il tuo nuovo snippet"
+msgstr "Lag ditt nye utvalg"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
-msgstr "Snippet Archiaviati"
+msgstr "Arkiverte utvalg"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
-msgstr "Gli snippet sono pezzi di SQL riutilizzabili"
+msgstr "Utvalg er gjenbrukbare biter av SQL"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
-msgstr "Crea uno snippet"
+msgstr "Lag et utvalg"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
-msgstr "Snippet"
+msgstr "Utvalg"
 
 #: frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx:15
 msgid "SQL Snippets"
-msgstr "Snippet SQL"
+msgstr "SQL Utvalg"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:38
 msgid "Your language is set to {0}"
-msgstr "La tua lingua è impostata su {0}"
+msgstr "Språket er satt til {0}"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:50
 msgid "What's your preferred language?"
-msgstr "Qual è la tua lingua preferita?"
+msgstr "Hva er ditt foretrukne språk?"
 
 #: frontend/src/metabase/setup/components/LanguageStep.jsx:54
 msgid "This language will be used throughout Metabase and will be the default for new users."
-msgstr "Questa lingua verrà utilizzata in Metabase è sarà il default per i nuovi utenti."
+msgstr "Dette språket vil bli brukt i hele Metabase og vil være standardspråk for nye brukere."
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:159
 msgid "We filtered out {0} row(s) containing null values."
-msgstr "Abbiamo filtrato {0} riga/righe contenenti valori null."
+msgstr "Vi filtrerte {0} rad(er) med nullverdier."
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:133
 msgid "Show values for this series"
-msgstr "Mostra i valori per queste serie"
+msgstr "Vis verdier for denne serie"
 
 #: src/metabase/api/card.clj
 msgid "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
-msgstr "Il tempo medio di esecuzione della query è {0}; usando \"magic\" TTL di {1}"
+msgstr "Spørsmålets gjennomsnittlige utføringstid er {0}; bruker \"magisk\" TTL på {1}"
 
 #: src/metabase/api/native_query_snippet.clj
 msgid "A snippet with that name already exists. Please pick a different name."
-msgstr "Esiste già uno snippet con questo nome. Scegli un nome diverso per piacere."
+msgstr "Et utvalg med samme navn eksisterer fra før. Velg et annet."
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Metric]"
-msgstr "[Metrica Sconosciuta]"
+msgstr "[Ukjent Indukator]"
 
 #: src/metabase/api/query_description.clj
 msgid "[Unknown Segment]"
-msgstr "[Segmento Sconosciuto]"
+msgstr "[Ukjent Segment]"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error writing error to output stream"
-msgstr "Errore di scrittura nel flusso di uscita"
+msgstr "Feil ved skriving av feil ut utdatastrøm"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Caught unexpected Exception in streaming response body"
-msgstr "Errore inaspettato nel corpo della risposta"
+msgstr "Fanget uventet Unntak i responsstrømmen"
 
 #: src/metabase/async/streaming_response.clj
 msgid "bound-fn caught unexpected Exception"
-msgstr "Eccezione inaspettata della funzione bound"
+msgstr "bound-fn fanget et uventet Unntak"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Error determining whether HTTP request was canceled"
-msgstr "Errore nel determinare se la richiesta HTTP è stata annullata"
+msgstr "Kunne ikke avgjøre om HTTP-forespørsel ble avbrutt"
 
 #: src/metabase/async/streaming_response.clj
+#, fuzzy
 msgid "Check cancelation status timed out after {0}"
-msgstr "time out del controllo annullamento dopo {0}"
+msgstr "Sjekk status for tidsavbrudd for avbrytelsen etter {0}"
 
 #: src/metabase/async/streaming_response.clj
 msgid "Unexpected exception in do-f-async"
-msgstr "Eccezione non gestita in do-f-async"
+msgstr "Uventet unntak i do-f-async"
 
 #: src/metabase/async/streaming_response.clj src/metabase/server.clj
 msgid "Unexpected exception writing error response"
-msgstr "Eccezione non gestita nella scrittura della risposta d'errore"
+msgstr "Uventet unntak ved skriving av feilsvar"
 
 #: src/metabase/driver/common.clj
 msgid "Server certificate not trusted - did you specify the correct SSL certificate chain?"
-msgstr "Certificato Server non affidabile - hai utilizzato la certificate chain SSL corretta?"
+msgstr "Serversertifikat kan ikke stoles på - spesifiserte du korrekt SSL-sertifikatkjede?"
 
 #: src/metabase/driver/common.clj
 msgid "Server appears to require SSL - please enable SSL above"
-msgstr "Sembra che il server richieda SSL - per favore abilita SSL sopra"
+msgstr "Tjener ser ut til å kreve SSL - venligst aktiver SSL ovenfor"
 
 #: src/metabase/driver/common.clj
 msgid "Username"
-msgstr "Nome utente"
+msgstr "Brukernavn"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Don''t know how to parse parameter of type {0}"
-msgstr "Impossibile fare il parse del parametro di tipo {0}"
+msgstr "Vet ikke hvordan jeg skal tolke parameter av type {0}"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Invalid :card parameter: missing `:card-id`"
-msgstr ":card parameter: invalido. ':card-id' mancante"
+msgstr "Ugyldig :cart parameter: manglende `:card-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Unable to resolve Snippet: missing `:snippet-id`"
-msgstr "Impossibile risolvere lo Snippet: ':snippet-id' mancante"
+msgstr "Kunne ikke løse Utvalg: mangler `:snippet-id`"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Snippet {0} {1} not found."
-msgstr "Snippet {0} {1} non trovato."
+msgstr "Utvalg {0} {1} ikke funnet."
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error determining value for parameter"
-msgstr "Errore nel determinare il valore del parametro"
+msgstr "Kunne ikke avgjøre verdi for parameter"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "Error building query parameter map"
-msgstr "Errore nella costruzione della mappa dei parametri query"
+msgstr "Feil ved bygging av oppslagsverk for spørreparameter"
 
 #: src/metabase/middleware/log.clj
 msgid "ASYNC"
-msgstr "Asincrono"
+msgstr "ASYNKRON"
 
 #: src/metabase/middleware/log.clj
 msgid "{0} ({1} DB calls)"
-msgstr "{0} ({1} Chiamate DB)"
+msgstr " {0} ({1} DB-kall) "
 
 #: src/metabase/middleware/log.clj
 msgid "App DB connections: {0}/{1}"
-msgstr "Connessioni DB App: {0}/{1}"
+msgstr "App-DB tilkoblinger: {0}/{1}"
 
 #: src/metabase/middleware/log.clj
 msgid "Jetty threads: {0}/{1} ({2} idle, {3} queued)"
-msgstr "Threads Jetty: {0}/{1} ({2} inattivo/i, {3} accodato/i)"
+msgstr "Jetty-tråder: {0}/{1} ({2} inaktiv, {3} i kø)"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} total active threads)"
-msgstr "({0} thread attivi totale/i)"
+msgstr "({0} aktive tråder totalt)"
 
 #: src/metabase/middleware/log.clj
 msgid "Queries in flight: {0}"
-msgstr "Query in partenza: {0}"
+msgstr "Spørringer underveis: {0}"
 
 #: src/metabase/middleware/log.clj
 msgid "({0} queued)"
-msgstr "({0} accodato/i)"
+msgstr "({0} i kø)"
 
 #: src/metabase/models/collection.clj
 msgid "Collection must be in the same namespace as its parent"
-msgstr "La Collection deve stare assieme alle altre Collection parenti"
+msgstr "Samling må være i samme navnerom som sin forelder"
 
 #: src/metabase/models/collection.clj
 msgid "Personal Collections must be in the default namespace"
-msgstr "Le Collection personali devono essere nello spazio di default"
+msgstr "Personlige samlinger må være i standard navnerom"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection to a different namespace once it has been created."
-msgstr "Non puoi spostare una Collection in uno spazio differente una volta che è stata creata."
+msgstr "Du kan ikke flytte en Samling til et annet navnerom etter det har blitt opprettet."
 
 #: src/metabase/models/collection.clj src/metabase/models/permissions.clj
 msgid "Collection does not exist."
-msgstr "La collezione non esiste."
+msgstr "Samling eksisterer ikke."
 
 #: src/metabase/models/collection.clj
 msgid "A {0} can only go in Collections in the {1} namespace."
-msgstr "Un {0} può andare solo in Collezioni {1}"
+msgstr "En {0} kan bare gå til en samling i navnerom {1}."
 
 #: src/metabase/models/database.clj
 msgid "Error sending database deletion notification"
-msgstr "Errore invio notifica cancellazione database"
+msgstr "Kunne ikke sende varsel om sletting av database"
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "You cannot update the creator_id of a NativeQuerySnippet."
-msgstr "Non puoi aggiornare il creator_id di una NativeQuerySnippet"
+msgstr "Du kan ikke oppdatere creator_id på en NaturligSpørringUtvalg."
 
 #: src/metabase/models/setting.clj
 msgid "Error fetching value of Setting"
-msgstr "Errore recupero Impostazione"
+msgstr "Feil ved henting av verdi for Innstilling"
 
 #: src/metabase/public_settings.clj
 msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
-msgstr "Il linguaggio che verrà usato per l'interfaccia utente di Metabase, le e-mail di sistema, i pulses e gli alert."
+msgstr "Standardspråket for alle brukere i Metabase brukergrensesnitt, system, e-post, pulser og alarmer."
 
 #: src/metabase/public_settings.clj
 msgid "This is also the default language for all users, which they can change from their own account settings."
-msgstr "Questa è anche la lingua di default per tutti gli utenti, la quale può essere cambiata dagli utenti nelle loro impostazioni account."
+msgstr "Dette er også standardspråk for alle brukere, som de kan endre fra sine brukerkontoinnstillinger."
 
 #: src/metabase/public_settings.clj
 msgid "Invalid locale {0}"
-msgstr "Località non trovata {0}"
+msgstr "Ugylding lokale {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
-msgstr "Forza tutto il traffico a usare HTTPS con un redirect se il sito utilizza HTTPS"
+msgstr "Tving all trafikk til å bruke HTTPS via omdirigering, hvis URL for nettsted er HTTPS"
 
 #: src/metabase/public_settings.clj
 msgid "Cannot redirect requests to HTTPS unless `site-url` is HTTPS."
-msgstr "Impossibile reindirizzare le richieste ad HTTPS finchè 'site-url' non è HTTPS"
+msgstr "Kan ikke omdirigere forespørsler til HTTP hvis ikke `nettsted-url` er HTTPS."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error registering fonts: Metabase will not be able to send Pulses."
-msgstr "Errore registrazione fonts: Metabase non potrà inviare i Pulse"
+msgstr "Feil ved registrering av skrifttyper: Metabase vil ikke være i stand til å sende Pulser."
 
 #: src/metabase/pulse/render/png.clj
 msgid "This is a known issue with certain JVMs. See {0} and for more details."
-msgstr "Questo è un problema noto con alcune Macchine Virtuali Java (JVM). Vedi {0} per maggiori informazioni."
+msgstr "Dette er et kjent problem med enkelte JVM-er. Se {0} for detaljer."
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error rendering Pulse"
-msgstr "Errore nel rendering del Pulse"
+msgstr "Feil ved gjengivelse av Puls"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Query timed out after {0}, raising timeout exception."
-msgstr "Timeout query dopo {0}, eccezione timeout inviata"
+msgstr "Tidsavbrudd for spørring {0}, reiser unntak for tidsavbrudd."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "No fields found for table {0}."
-msgstr "Non ci sono campi trovati per la tabella {0}."
+msgstr "Ingen felt funnet for tabell {0}."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Case"
-msgstr "Casistica"
+msgstr "Sak"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Variance of {0}"
-msgstr "Variazione di {0}"
+msgstr "Varians av {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Median of {0}"
-msgstr "Media di {0}"
+msgstr "Middelverdi for {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "{0}th percentile of {1}"
-msgstr "{0} percentile di {1}"
+msgstr "{0}ende persentil av {1}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Not caching results: results are larger than {0} KB"
-msgstr "I risultati non saranno messi in cache: la dimensione dei risultati supera {0} KB"
+msgstr "Mellomlagrer ikke resultat: resultater er større enn {0} KB"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Cannot cache results: expected byte array, got {0}"
-msgstr "Impossibile mettere in cache i risultati: atteso un array di bi byte, ottenuto {0}"
+msgstr "Kan ikke mellomlagre resultat: forventet bytematrise, fikk {0}"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Request is closed; no one to return cached results to"
-msgstr "La richiesta è chiusa; Impossibile restituire la richiesta cache a qualcuno"
+msgstr "Forespørsel er lukket; ingen å returnere mellomlagret resultat til"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Error attempting to fetch cached results for query with hash {0}"
-msgstr "Errore nel tentativo di recupero dei dati cache per la query con hash {0}"
+msgstr "Feil ved henting av mellomlagret resultat for spørring med hash {0}"
 
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
 msgid "Error preparing statement to fetch cached query results"
-msgstr "Errore creazione dichiarazione per il recupero dei dati cache della query"
+msgstr "Feil ved forbereding av uttrykk for å hente mellomlagrede resultater"
 
 #: src/metabase/query_processor/middleware/catch_exceptions.clj
 msgid "Error processing query: {0}"
-msgstr "Errore elaborazione query: {0}"
+msgstr "Feil ved behandling av spørring: {0}"
 
 #: src/metabase/server.clj
 msgid "Unexpected exception in endpoint"
-msgstr "Eccezione non gestita nella destinazione"
+msgstr "Uventet unntak hos endepunkt"
 
 #: src/metabase/server.clj
 msgid "Unexpected Exception in API request handler"
-msgstr "Eccezione non gestita nel gestore delle chiamate API"
+msgstr "Uventet unntak i API-forespørselsbehandling"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error reducing {0}"
-msgstr "Errore nel ridurre {0}"
+msgstr "Feil ved redusering {0}"
 
 #: src/metabase/sync/analyze/fingerprint/insights.clj
 msgid "Error generating timeseries insight keyed by: {0}"
-msgstr "Errore nella generazione delle serie temporali con chiave: {0}"
+msgstr "Feil ved generering av innsikt i tidsserie ved nøkkel: {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "La posizione {0} del database è cambiata da \"{1}\" a \"{2}\"."
+msgstr "Databaseposisjon til {0} har endret seg fra \"{1}\" til \"{2}\"."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Unscheduling task for Database {0}: trigger: {1}"
-msgstr "Rimuovere programmazione per Database {0}: evento: {1}"
+msgstr "Fjerner tidsplanen for oppgave i Database {0}: utløser: {1}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a keyword or string."
-msgstr "il valore deve essere una keyword o una stringa."
+msgstr "verdien må være et nøkkelord eller en tekststreng."
 
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
-msgstr "La stringa deve avere un valore valido \"two-letter ISO\" o \"language-country\".\n"
-"Esempio 'it' o 'it_IT'"
+msgstr "Tekststrengen må være en tobokstavs ISO-kode for språk eller språk-land. F.eks 'no' eller 'nb_NO'"
 
 #: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
 msgid "Rows {0}-{1}"
-msgstr "Righe {0}-{1}"
+msgstr "Rad {0}-{1}"
 
+#. To audit, or an audit will generate different meanings in norwegian. Using verb.
 #: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
 #: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
 msgid "Audit"
-msgstr "Revisione"
+msgstr "Revider"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
@@ -15321,11 +15355,11 @@ msgstr "JWT"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
 msgid "User attribute configuration (optional)"
-msgstr "Configurazione degli attributi utente (opzionale)"
+msgstr "Konfigurer brukerattributt (valgfritt)"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
 msgid "Using {0}"
-msgstr "In uso {0}"
+msgstr "Bruker {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
@@ -15334,446 +15368,443 @@ msgstr "SAML"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
 msgid "Set up SAML-based SSO"
-msgstr "Configura SSO basato su SAML"
+msgstr "Sett opp SAML-basert SSO"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
 msgid "SAML Authentication"
-msgstr "Autenticazione SAML"
+msgstr "SAML-autentisering"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
 msgid "Configure your identity provider (IdP)"
-msgstr "Configura il tuo identity provider (IdP)"
+msgstr "Konfigurer din identitetsleverandør (IdP)"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
 msgid "Your identity provider will need the following info about Metabase."
-msgstr "Al tuo identity provider serviranno le seguenti informazioni da Metabase"
+msgstr "Din identitetsleverandør vil trenge følgende informasjon om Metabase."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
 msgid "URL the IdP should redirect back to"
-msgstr "URL a cui l'IdP deve reindirizzare l'IdP"
+msgstr "URL som IdP skal omdirigere tilbake til"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
 msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
 "and the ACS (Consumer) URL in OneLogin."
-msgstr "Questo si chiama Single Sign On URL in Okta, l'Application Callback URL in Auth0,\n"
-"e l'URL ACS (Consumer) in OneLogin."
+msgstr "Dette kalles Single Sign On URL i Okta, Application Callback URL i Auth0, og ACS (Consumer) URL i OneLogin."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
 msgid "SAML attributes"
-msgstr "attributi SAML"
+msgstr "SAML-attributter"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
 msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
 "\"Name\" in the attribute statements section."
-msgstr "Nella maggior parte degli IdP, è necessario inserire ciascuno di questi in una casella di input etichettata\n"
-"\"Nome\" nella sezione delle dichiarazioni degli attributi."
+msgstr "I de fleste IdPer, vil du trenge å sette hver av disse i et inndatafelt merket \"Navn\" i seksjonen for attributt"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
 msgid "User's email attribute"
-msgstr "Attributo e-mail dell'utente"
+msgstr "Brukers e-postattributt"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
 msgid "User's first name attribute"
-msgstr "Attributo del nome dell'utente"
+msgstr "Brukerens fornavnattributt"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
 msgid "User's last name attribute"
-msgstr "Attributo del cognome dell'utente"
+msgstr "Brukerens etternavnattributt"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
 msgid "Tell Metabase about your identity provider"
-msgstr "Comunicate a Metabase il vostro fornitore di identità"
+msgstr "Fortell Metabase om din indentitetsleverandør"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
 msgid "Metabase will need the following info about your provider."
-msgstr "A Metabase servono le seguenti informazioni del tuo provider"
+msgstr "Metabase trenger følgende informasjon om din tilbyder."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
 msgid "SAML Identity Provider URL"
-msgstr "URL del fornitore di identità SAML"
+msgstr "URL for SAML-identitetsleverandør"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
 msgid "SAML Identity Provider Certificate"
-msgstr "Certificato di identità SAML"
+msgstr "Sertifikat for SAML-identitetsleverandør"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
 msgid "SAML Application Name"
-msgstr "Nome dell'applicazione SAML"
+msgstr "SAML-applikasjonsnavn"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
 msgid "Sign SSO requests (optional)"
-msgstr "Firmare le richieste di SSO (opzionale)"
+msgstr "Underskriv SSO-forespørsler (valgfritt)"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
 msgid "SAML Keystore Path"
-msgstr "Percorso SAML Keystore"
+msgstr "Sti for SAML-nøkkellager"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
 msgid "SAML Keystore Password"
-msgstr "Password SAML Keystore"
+msgstr "Passord for SAML-nøkkellager"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
 msgid "Shh..."
-msgstr "Shh..."
+msgstr "Hysj..."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
 msgid "SAML Keystore Alias"
-msgstr "SAML Keystore Alias"
+msgstr "Alias for SAML Nøkkellager"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
 msgid "Synchronize group membership with your SSO"
-msgstr "Sincronizzare l'appartenenza al gruppo con la vostra SSO"
+msgstr "Synkroniser gruppemedlemsskap med din SSO"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
 msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
 "be added to based on the SSO group they're in."
-msgstr "Per abilitare questo, è necessario creare delle mappature per dire a Metabase quale gruppo (o gruppi) i vostri utenti devono\n"
-"essere aggiunti in base al gruppo SSO in cui si trovano."
+msgstr "For å aktivere dettem må du lage tilordninger som forteller Metabase hvilke grupper dine brukere skal bli lagt til i basert på hvilken SSO-gruppe de tilhører."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
 msgid "Group Name"
-msgstr "Nome del gruppo"
+msgstr "Gruppenavn"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
 msgid "Group attribute name"
-msgstr "Nome dell'attributo del gruppo"
+msgstr "Gruppeattributtnavn"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
 msgid "Note:"
-msgstr "Nota:"
+msgstr "Notat:"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
 msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
-msgstr "Se si modifica una qualsiasi delle impostazioni di un'impostazione attiva SAML esistente, allora sarà necessario riavviare Metabase per renderla effettiva."
+msgstr "Hvis du forandrer innstillinger på et aktivt SAML-oppsett, må du starte Metabase på nytt for at endringene skal tre i kraft."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
 msgid "Allows users to login via a SAML Identity Provider."
-msgstr "Consente agli utenti di effettuare il login tramite un fornitore di identità SAML."
+msgstr "Tillat brukere å logge inn via en SAML-identitetsleverandør."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
 msgid "Allows users to login via a JWT Identity Provider."
-msgstr "Consente agli utenti di effettuare il login tramite un fornitore di identità JWT."
+msgstr "Tillat brukere å logge inn via en JWT-identitetsleverandør."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
 msgid "Enable Password Authentication"
-msgstr "Attivare l'autenticazione con password"
+msgstr "Aktiver Passordautentisering"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
 msgid "When enabled, users can additionally log in with email and password."
-msgstr "Se abilitato, gli utenti possono inoltre effettuare il login con e-mail e password."
+msgstr "Når aktivert, kan brukere logge inn automatisk med e-post og passord."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
 msgid "Notify admins of new SSO users"
-msgstr "Informare gli amministratori dei nuovi utenti SSO"
+msgstr "Varsle administratorer om nye SSO-brukere"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
 msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
-msgstr "Quando è abilitato, gli amministratori riceveranno un'e-mail la prima volta che un utente utilizza il Single Sign-On."
+msgstr "Når aktiver, vil administratorer motta en e-post første gang en bruker benytter Single Sign-On."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
 msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
-msgstr "Utilizzare le seguenti impostazioni per configurare l'SSO tramite SAML. Se avete domande, consultate il nostro {0}."
+msgstr "Bruk innstillingene nedenfor til å konfigurere SSO via SAML. Hvis du har spørsmål sjekk vårt {0}."
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
 msgid "documentation"
-msgstr "documentazione"
+msgstr "dokumentasjon"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
 msgid "SAML Identity Provider URI"
-msgstr "SAML Identity Provider URI"
+msgstr "URI for SAML-identitetsleverandør"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
 msgid "JWT Authentication"
-msgstr "Autenticazione JWT"
+msgstr "JWT-autentisering"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
 msgid "JWT Identity Provider URI"
-msgstr "JWT Identity Provider URI"
+msgstr "JWT identitetsleverandør URI"
 
 #: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
 msgid "String used by the JWT signing key"
-msgstr "Stringa utilizzata dalla chiave di firma JWT"
+msgstr "Tekststreng brukt av JWT som nøkkel for signering"
 
 #: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
 msgid "Embedding the entire Metabase app"
-msgstr "Incorporare l'intera app Metabase"
+msgstr "Innebygging av hele Metabase-appen"
 
 #: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
 msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
-msgstr "Se vuoi incorporare tutto Metabase, inserisci le origini dei siti web o delle web app dove vuoi permettere l'incorporazione in un iframe, separati da uno spazio. Ecco i {0} per ciò che può essere inserito."
+msgstr "This du vil bygge inn alt i Metabase, skriv inn opprinnelsen til nettstedene eller web-appene der du vil tillate innebygging i en iframe, skill dem med mellomrom. Her er {0} for hva som kan skrives inn."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
 msgid "Grant sandboxed access to this table"
-msgstr "Concedere l'accesso a questa tabella in sandbox"
+msgstr "Gi tilgang til tabellen i sandkassemodus"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
 msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
-msgstr "Quando gli utenti di questo gruppo visualizzano questa tabella, ne vedranno una versione filtrata dai loro attributi utente, o una vista personalizzata basata su una domanda salvata."
+msgstr "Når en bruker i denne gruppen leser tabellen vil de se en versjon av den som er filtrert på bakgrunn av deres brukerattributter, eller en tilpasset visning av den basert på et lagret spørsmål."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
 msgid "How do you want to filter this table for users in this group?"
-msgstr "Come volete filtrare questa tabella per gli utenti di questo gruppo?"
+msgstr "Hvordan vil du filtrere denne tabellen for brukere i denne gruppen?"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
 msgid "Pick a saved question that returns the custom view of this table that these users should see."
-msgstr "Scegliere una domanda salvata che restituisce la vista personalizzata di questa tabella che questi utenti dovrebbero vedere."
+msgstr "Velg et lagret spørsmål som returnerer en tilpasset visning av denne tabellen som brukerne skal kunne se."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
 msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
-msgstr "Qui si possono aggiungere opzionalmente ulteriori filtri in base agli attributi dell'utente. Questi filtri verranno applicati in aggiunta a quelli già presenti in questa domanda salvata."
+msgstr "Alternativt kan du legge til ytterlige filtre her på bakgrunn av brukerattributter. Disse filtrene vil bli brukt på toppen av andre filtre som allerede er i dette lagrede spørsmålet."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
 msgid "For this option to work, your users need to have some attributes"
-msgstr "Affinché questa opzione funzioni, i vostri utenti devono avere alcuni attributi"
+msgstr "For at dette alternativet skal fungere, må dine brukere ha noen attributter"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
 msgid "To add additional filters, your users need to have some attributes"
-msgstr "Per aggiungere ulteriori filtri, gli utenti devono avere alcuni attributi"
+msgstr "For å legge til ytterlige filtre, må brukerne dine ha noen attributter"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
 msgid "No user attributes"
-msgstr "Nessun attributo utente"
+msgstr "Ingen brukerattributter"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
 msgid "Pick a user attribute"
-msgstr "Scegliere un attributo utente"
+msgstr "Velg en brukerattributt"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
 msgid "Pick a parameter"
-msgstr "Scegliere un parametro"
+msgstr "Velg et parameter"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
 msgid "Pick a column"
-msgstr "Scegli una colonna"
+msgstr "Velg en kolonne"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
 msgid "Users in {0} can view"
-msgstr "Gli utenti in {0} possono visualizzare"
+msgstr "Brukere i {0} kan lese"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
 msgid "rows in the {0} question"
-msgstr "righe nella domanda {0}"
+msgstr "rader i spørsmål {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
 msgid "rows in the {0} table"
-msgstr "righe nella tabella {0}"
+msgstr "rader i tabell {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
 msgid "where {0} equals {1}"
-msgstr "dove {0} è uguale a {1}"
+msgstr "der {0} er lik {1}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
 msgid "and {0} equals {1}"
-msgstr "e {0} è uguale a {1}"
+msgstr "og {0} er lik {1}"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
 msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
-msgstr "È possibile aggiungere automaticamente gli attributi impostando un SSO che utilizza SAML, oppure è possibile inserirli manualmente andando nella sezione Persone e cliccando sul menu ... all'estrema destra."
+msgstr "Du kan legge til attributter automatisk ved å sette opp en SSO som benytter SAML, eller du kan legge de inn manuelt fra \"...\" menyen helt til høyre under Personer."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
 msgid "User attribute"
-msgstr "Attributo utente"
+msgstr "Brukerattributt"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
 msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
-msgstr "Possiamo ottenere automaticamente gli attributi dei vostri utenti se avete impostato l'SSO, oppure potete aggiungerli manualmente dal menu \"...\" nella sezione Persone del pannello di amministrazione."
+msgstr "Vi han hente dine brukeres attributter hvis du har satt opp SSO, eller du kan legge dem til manuelt fra \"...\" menyen under Personer i Administrasjonspanelet."
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
 msgid "Parameter or variable"
-msgstr "Parametro o variabile"
+msgstr "Parameter eller variabel"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
 msgid "equals"
-msgstr "è uguale a"
+msgstr "er lik"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
 msgid "Grant sandboxed access"
-msgstr "Concedere l'accesso in sandbox"
+msgstr "Gi tilgang i sandkassemodus"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
 msgid "Sandboxed access"
-msgstr "Accesso in sandbox"
+msgstr "Tilgang i sandkassemodus"
 
 #: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
 msgid "Edit sandboxed access"
-msgstr "Modifica accesso sandboxed"
+msgstr "Rediger tilgang til sandkassemodus"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
 msgid "Edit folder details"
-msgstr "Modifica i dettagli della cartella"
+msgstr "Rediger mappedetaljer"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
 msgid "Change permissions"
-msgstr "Modificare le autorizzazioni"
+msgstr "Endre rettigheter"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
 msgid "Create your new folder"
-msgstr "Crea la tua nuova cartella"
+msgstr "Opprett din nye mappe"
 
 #: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
 msgid "New folder"
-msgstr "Nuova cartella"
+msgstr "Ny mappe"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
 msgid "We're having trouble validating your token"
-msgstr "Abbiamo problemi a convalidare il tuo gettone"
+msgstr "Vi har trøbbel med å validere din "
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
 msgid "Please double-check that your instance can connect to Metabase's servers"
-msgstr "Si prega di verificare che la vostra istanza possa connettersi ai server di Metabase"
+msgstr "Vennligst dobbeltsjekk at instansen din kan koble til Metabases tjenere."
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
 msgid "Get help"
-msgstr "Chiedere aiuto"
+msgstr "Få hjelp"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
 msgid "Get even more out of Metabase with the Enterprise Edition"
-msgstr "Ottenere ancora di più da Metabase con l'Enterprise Edition"
+msgstr "Få mer ut av Metabase med Enterprise Edition"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
 msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
-msgstr "Tutti gli strumenti necessari per fornire in modo semplice e veloce i report per i vostri clienti, o per aiutarvi a gestire e monitorare Metabase in una grande organizzazione"
+msgstr "Alle verktøyene du trenger for å kjapt og enkelt levere rapporter til dine kunder, eller hjelpe deg å kjøre og overvåke Metabase i en stor organisasjon"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
 msgid "Activate a license"
-msgstr "Attivare una licenza"
+msgstr "Aktiver en lisens"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
 msgid "Your trial is active with these features"
-msgstr "Il tuo trial è attivo con queste caratteristiche"
+msgstr "Din prøveversjon er aktiv med disse funksjonene"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
 msgid "Trial expires {0}"
-msgstr "Il processo scade {0}"
+msgstr "Prøveversjon utløper {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
 msgid "Need help? Ready to buy?"
-msgstr "Hai bisogno di aiuto? Pronto per l'acquisto?"
+msgstr "Trenger du hjelp? Klar til å kjøpe?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
 msgid "Talk to us"
-msgstr "Parlate con noi"
+msgstr "Snakk med oss"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
 msgid "Your trial has expired"
-msgstr "Il suo processo è scaduto"
+msgstr "Prøveversjonen din har utløpt"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
 msgid "Need more time? Ready to buy?"
-msgstr "Hai bisogno di più tempo? Pronti a comprare?"
+msgstr "Trenger du mer tid? Klar til å kjøpe?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
 msgid "Your features are active!"
-msgstr "Le tue funzioni sono attive!"
+msgstr "Dine funksjoner er aktive!"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
 msgid "Your licence is valid through {0}"
-msgstr "La sua licenza è valida fino al {0}"
+msgstr "Lisensen din er gyldig til og med {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
 msgid "Your license has expired"
-msgstr "La sua licenza è scaduta"
+msgstr "Lisensen din har utløpt"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
 msgid "It expired on {0}"
-msgstr "È scaduto il {0}"
+msgstr "Den utløp {0}"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
 msgid "Want to renew your license?"
-msgstr "Vuoi rinnovare la tua licenza?"
+msgstr "Vil du fornye lisensen?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
 msgid "Learn how to use this"
-msgstr "Imparare ad usarlo"
+msgstr "Lær hvordan du bruker dette"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
 msgid "Not included in your current plan"
-msgstr "Non incluso nel vostro piano attuale"
+msgstr "Ikke inkludert i din gjeldende plan"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
 msgid "Enter the token you recieved from the store"
-msgstr "Inserisci il gettone che hai ricevuto dal negozio"
+msgstr "Skriv inn token du mottok fra lageret"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
 msgid "Activate"
-msgstr "Attivare"
+msgstr "Aktiver"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
 msgid "Need help?"
-msgstr "Hai bisogno di aiuto?"
+msgstr "Trenger du hjelp?"
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
 msgid "More info about your problem."
-msgstr "Maggiori informazioni sul vostro problema."
+msgstr "Mer informasjon om problemet ditt."
 
 #: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
 msgid "Contact support"
-msgstr "Contatta il supporto"
+msgstr "Kontakt support"
 
 #: enterprise/frontend/src/metabase-enterprise/store/index.js:7
 msgid "Enterprise"
-msgstr "Impresa"
+msgstr "Enterprise"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
 msgid "Data sandboxes"
-msgstr "Dati sandbox"
+msgstr "Sandkasser for data"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
 msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
-msgstr "Assicuratevi di mostrare alle persone giuste i dati giusti con filtri automatici e sicuri basati sugli attributi dell'utente."
+msgstr "Vær sikker på at du viser de rette personene de rette dataene med automatiske og sikre filtre basert på brukerattributter."
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
 msgid "White labeling"
-msgstr "Etichettatura bianca"
+msgstr "Hvitelisting"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
 msgid "Match Metabase to your brand with custom colors, your own logo and more."
-msgstr "Abbina Metabase al tuo marchio con colori personalizzati, il tuo logo e altro ancora."
+msgstr "Tilpass Metabase til din profil med egendefinerte farger, din egen logo og mer."
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
 msgid "Auditing"
-msgstr "Revisione contabile"
+msgstr "Reviderer"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
 msgid "Keep an eye on performance and behavior with robust auditing tools."
-msgstr "Tenete d'occhio le prestazioni e il comportamento con robusti strumenti di auditing."
+msgstr "Hold et øye med ytelse og oppførsel med robuste revisjonsverktøy."
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
 msgid "Single sign-on"
-msgstr "Singolo accesso"
+msgstr "Single sign-on"
 
 #: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
 msgid "Provide easy login that works with your exisiting authentication infrastructure."
-msgstr "Fornite un login facile che funzioni con la vostra infrastruttura di autenticazione esistente."
+msgstr "Gi enkel pålogging som fungerer med din eksisterende autentiseringsinfrastruktur."
 
 #: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
 msgid "Store"
-msgstr "Negozio"
+msgstr "Lagre"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
 msgid "Application Name"
-msgstr "Nome dell'applicazione"
+msgstr "Applikasjonsnavn"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
 msgid "Color Palette"
-msgstr "Tavolozza dei colori"
+msgstr "Fargepalett"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
 msgid "Logo"
@@ -15781,341 +15812,341 @@ msgstr "Logo"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
 msgid "Favicon"
-msgstr "Favicon"
+msgstr "Favorittikon"
 
 #: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
 msgid "Landing Page"
-msgstr "Pagina di atterraggio"
+msgstr "Landingsside"
 
 #: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
 msgid "No groups"
-msgstr "Nessun gruppo"
+msgstr "Ingen grupper"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
 msgid "Permissions for {0}"
-msgstr "Permessi per {0}"
+msgstr "Tillatelser for {0}"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
 msgid "Permissions for this folder"
-msgstr "Autorizzazioni per questa cartella"
+msgstr "Tillatelser for denne mappen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:297
 msgid "Grant Edit access"
-msgstr "Concedere l'accesso a Modifica"
+msgstr "Gi Skrivetilgang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:298
 msgid "Can modify snippets in this folder"
-msgstr "Può modificare i frammenti in questa cartella"
+msgstr "Kan modifisere utdrag i denne mappen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:303
 msgid "Grant View access"
-msgstr "Accesso Grant View"
+msgstr "Gi Lesetilgang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:304
 msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
-msgstr "Può inserire e utilizzare gli snippets in questa cartella, ma non può modificare l'SQL che contiene"
+msgstr "Kan sette inn og benytte seg av utdrag i denne mappen, men kan ikke redigere den underliggende SQL-spørringen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:310
 msgid "Can't view or insert snippets in this folder"
-msgstr "Non è possibile visualizzare o inserire frammenti in questa cartella"
+msgstr "Kan ikke se eller sette inn utdrag i denne mappen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:814
 msgid "Also change sub-folders"
-msgstr "Cambiare anche le sottocartelle"
+msgstr "Endre også undermapper"
 
 #: frontend/src/metabase/admin/settings/selectors.js:238
 msgid "First day of the week"
-msgstr "Primo giorno della settimana"
+msgstr "Første dag i uken"
 
 #: frontend/src/metabase/auth/components/GoogleButton.jsx:74
 msgid "There was an issue signing in with Google. Please contact an administrator."
-msgstr "C'è stato un problema con l'accesso a Google. Si prega di contattare un amministratore."
+msgstr "Det oppstod et problem under innlogging med Google. Vennligst kontakt en administrator."
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:133
 msgid "on the"
-msgstr "sul"
+msgstr "på den"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:191
 msgid "at"
-msgstr "all'indirizzo"
+msgstr "på"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
 msgid "Open the Metabase actions menu"
-msgstr "Aprire il menu delle azioni di Metabase"
+msgstr "Åpne Metabases handlingsmeny"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
 #: frontend/src/metabase/lib/click-behavior.js:151
 msgid "Do nothing"
-msgstr "Non fare nulla"
+msgstr "Gjør ingenting"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
 msgid "Go to a custom destination"
-msgstr "Vai a una destinazione personalizzata"
+msgstr "Gå til en egendefinert destinasjon"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
 msgid "Update a dashboard filter"
-msgstr "Aggiornare il filtro del cruscotto"
+msgstr "Oppdater filteret til en infotavle"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
 msgid "{0} updates {1} filter"
 msgid_plural "{0} updates {1} filters"
-msgstr[0] "{0} aggiornamenti {1} filtro"
-msgstr[1] "{0} aggiorna {1} i filtri"
+msgstr[0] "{0} oppdaterer {1} filter"
+msgstr[1] "{0} oppdaterer {1} filtre"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
 msgid "{0} goes to {1}"
-msgstr "...va a..."
+msgstr "{0} går til {1}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
 msgid "On-click behavior for each column"
-msgstr "Comportamento on-click per ogni colonna"
+msgstr "Oppførsel ved klikk for hver kolonne."
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
 msgid "Go to custom destination"
-msgstr "Vai alla destinazione personalizzata"
+msgstr "Gå til egendefinert destinasjon"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
 msgid "Open the actions menu"
-msgstr "Aprire il menu delle azioni"
+msgstr "Åpne handlingsmenyen"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
 msgid "Click behavior for {0}"
-msgstr "Comportamento dei clic per {0}"
+msgstr "Oppførsel ved klikk for {0}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
 msgid "Pick one or more filters to update"
-msgstr "Scegliere uno o più filtri da aggiornare"
+msgstr "Velg ett eller fler filter som skal oppdateres"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
 msgid "Saved question"
-msgstr "Domanda salvata"
+msgstr "Lagret spørsmål"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
 msgid "Link to"
-msgstr "Collegamento a"
+msgstr "Lenke til"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
 msgid "Enter a URL to link to"
-msgstr "Inserire un URL a cui collegarsi"
+msgstr "Skriv inn en URL å lenke til"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
 msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
-msgstr "È possibile inserire il valore di un filtro di colonna o di cruscotto utilizzando il suo nome, in questo modo: {{qualche_colonna}}}"
+msgstr "Du kan sette inn verdien av en kolonne eller infotavlefilter ved å bruke navn, som dette: {{some_column}}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
 msgid "e.g. http://acme.com/id/{{user_id}}"
-msgstr "ad esempio http://acme.com/id/{{{{id_utente}}}}."
+msgstr "f.eks http://acme.com/id/{{user_id}}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
 msgid "Pick a dashboard..."
-msgstr "Scegli un cruscotto..."
+msgstr "Velg en infotavle..."
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
 msgid "Pick a question..."
-msgstr "Scegli una domanda..."
+msgstr "Velg et spørsmål..."
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
 msgid "Pick a dashboard to link to"
-msgstr "Scegliere un cruscotto da collegare a"
+msgstr "Velg en infotavle å lenke til"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
 msgid "Pick a question to link to"
-msgstr "Scegliere una domanda da collegare a"
+msgstr "Velg et spørsmål å lenke til"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
 msgid "Pass values to this dashboard's filters (optional)"
-msgstr "Passa i valori ai filtri di questo cruscotto (opzionale)"
+msgstr "Send verdier til denne infotavlens filtre (valgfritt)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
 msgid "Pass values to this question's variables (optional)"
-msgstr "Passare i valori alle variabili di questa domanda (opzionale)"
+msgstr "Send verdier til dette spørsmålets variabler (valgfritt)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
 msgid "Pass values to filter this question (optional)"
-msgstr "Passare i valori per filtrare questa domanda (opzionale)"
+msgstr "Send verdier for å filtrere dette spørsmålet (valgfritt)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
 msgid "Dashboard filters"
-msgstr "Filtri del cruscotto"
+msgstr "Filter for infotavler"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
 msgid "User attributes"
-msgstr "Attributi dell'utente"
+msgstr "Brukerattributter"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
 msgid "Customize link text (optional)"
-msgstr "Personalizzare il testo del link (opzionale)"
+msgstr "Tilpasse lenketekst (valgfritt)"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
 msgid "E.x. Details for {{Column Name}}"
-msgstr "E.x. Dettagli per {{Nome della colonna}}"
+msgstr "F.eks Detaljer for {{Column Name}}"
 
 #: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
 msgid "Values you can reference"
-msgstr "Valori a cui si può fare riferimento"
+msgstr "Verdier du kan referere til"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
 msgid "No available targets"
-msgstr "Nessun obiettivo disponibile"
+msgstr "Ingen tilgjengelige mål"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
 msgid "filter"
-msgstr "filtro"
+msgstr "filter"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
 msgid "variable"
-msgstr "variabile"
+msgstr "variabel"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
 msgid "Other available filters"
-msgstr "Altri filtri disponibili"
+msgstr "Andre tilgjengelige filtre"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
 msgid "Avaliable filters"
-msgstr "Filtri disponibili"
+msgstr "Tilgjengelige filtre"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
 msgid "Other available variables"
-msgstr "Altre variabili disponibili"
+msgstr "Andre tilgjengelige variabler"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
 msgid "Avaliable variables"
-msgstr "Variabili valutabili"
+msgstr "Tilgjengelige variabler"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
 msgid "Other available columns"
-msgstr "Altre colonne disponibili"
+msgstr "Andre tilgjengelige kolonner"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
 msgid "Avaliable columns"
-msgstr "Colonne disponibili"
+msgstr "Tilgjengelige kolonner"
 
 #: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
 msgid "user attribute"
-msgstr "attributo utente"
+msgstr "brukerattributt"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:214
 msgid "Text card"
-msgstr "Scheda di testo"
+msgstr "Tekstkort"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:271
 msgid "Click behavior"
-msgstr "Comportamento dei clic"
+msgstr "Oppførsel ved klikk"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:298
 msgid "Visualization options"
-msgstr "Opzioni di visualizzazione"
+msgstr "Alternativer for visning"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:335
 msgid "Edit series"
-msgstr "Modifica serie"
+msgstr "Rediger serie"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:335
 msgid "Add series"
-msgstr "Aggiungere serie"
+msgstr "Legg til serie"
 
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:383
 msgid "On click"
-msgstr "Su clic"
+msgstr "Ved klikk"
 
 #: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
 msgid "Change title and description"
-msgstr "Cambia titolo e descrizione"
+msgstr "Endre tittel og beskrivelse"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
 msgid "You've updated embedded params and will need to update your embed code."
-msgstr "Avete aggiornato i parametri incorporati e dovrete aggiornare il vostro codice incorporato."
+msgstr "Du har oppdatert innebygde parametre og må oppdatere innebyggingskoden."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
 msgid "Add question"
-msgstr "Aggiungi domanda"
+msgstr "Legg til spørsmål"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
 msgid "You're editing this dashboard."
-msgstr "Stai modificando questo cruscotto."
+msgstr "Du redigerer denne infotavlen."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
 msgid "Column to filter on"
-msgstr "Colonna da filtrare su"
+msgstr "Kolonne å filtrere på"
 
 #: frontend/src/metabase/entities/snippet-collections.js:22
 msgid "snippet collection"
-msgstr "raccolta di frammenti"
+msgstr "utdragssamling"
 
 #: frontend/src/metabase/entities/snippet-collections.js:23
 msgid "snippet collections"
-msgstr "collezioni di frammenti"
+msgstr "utdragssamlinger"
 
 #: frontend/src/metabase/entities/snippet-collections.js:72
 msgid "Give your folder a name"
-msgstr "Date un nome alla vostra cartella"
+msgstr "Gi mappen din ett navn"
 
 #: frontend/src/metabase/entities/snippet-collections.js:73
 msgid "Something short but sweet"
-msgstr "Qualcosa di breve ma dolce"
+msgstr "Noe kort og søtt"
 
 #: frontend/src/metabase/entities/snippet-collections.js:94
 #: frontend/src/metabase/entities/snippets.js:55
 msgid "Folder this should be in"
-msgstr "Cartella questa dovrebbe essere in"
+msgstr "Mappen dette burde være i"
 
 #: frontend/src/metabase/lib/click-behavior.js:150
 msgid "Open the action menu"
-msgstr "Aprire il menu delle azioni"
+msgstr "Åpne handlingsmenyen"
 
 #: frontend/src/metabase/lib/click-behavior.js:159
 msgid "{0} column has custom behavior"
 msgid_plural "{0} columns have custom behavior"
-msgstr[0] "{0} colonna ha un comportamento personalizzato"
-msgstr[1] "{0} colonne hanno un comportamento personalizzato"
+msgstr[0] "{0} kolonne har egendefinert oppførsel"
+msgstr[1] "{0} kolonner har egendefinert oppførsel"
 
 #: frontend/src/metabase/lib/click-behavior.js:172
 msgid "Go to..."
-msgstr "Vai a..."
+msgstr "Gå til..."
 
 #: frontend/src/metabase/lib/click-behavior.js:174
 msgid "Go to dashboard"
-msgstr "Vai al cruscotto"
+msgstr "Gå til infotavle"
 
 #: frontend/src/metabase/lib/click-behavior.js:176
 msgid "Go to question"
-msgstr "Vai alla domanda"
+msgstr "Gå til spørsmål"
 
 #: frontend/src/metabase/lib/click-behavior.js:177
 msgid "Go to url"
-msgstr "Vai all'url"
+msgstr "Gå til url"
 
 #: frontend/src/metabase/lib/click-behavior.js:180
 msgid "Filter this dashboard"
-msgstr "Filtrare questo cruscotto"
+msgstr "Filtrer denne infotavlen"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
 msgid "Returns the count of rows in the selected data."
-msgstr "Restituisce il conteggio delle righe nei dati selezionati."
+msgstr "Returnerer antallet rader i valgt data."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
 msgid "The column or number to sum."
-msgstr "La colonna o il numero da sommare."
+msgstr "Kolonnen eller nummer som skal summeres."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
 msgid "The numeric column to get standard deviation of."
-msgstr "La colonna numerica di cui ottenere la deviazione standard."
+msgstr "Den numeriske kolonnen du skal beregne standardavvik av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
 msgid "The numeric column whose values to average."
-msgstr "La colonna numerica i cui valori sono in media."
+msgstr "Den numeriske kolonnen med verdiene du skal ha gjenomsnittet av"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
 msgid "Returns the smallest value found in the column"
-msgstr "Restituisce il più piccolo valore trovato nella colonna"
+msgstr "Returnerer den minste verdien i kolonnen"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Google"
@@ -16123,330 +16154,329 @@ msgstr "Google"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
 msgid "Sums up the specified column only for rows where the condition is true."
-msgstr "Somma la colonna specificata solo per le righe in cui la condizione è vera."
+msgstr "Summerer de spesifiserte kolonnene bare der betingelsen for rader er sann"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
 msgid "Returns the numeric variance for a given column."
-msgstr "Restituisce la varianza numerica per una data colonna."
+msgstr "Returnerer den numeriske variansen for en gitt kolonne."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Temperature"
-msgstr "Temperatura"
+msgstr "Temperatur"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
 msgid "The column or number to get the variance of."
-msgstr "La colonna o il numero di cui ottenere la varianza."
+msgstr "Kolonnen eller tallet du skal ha variansen av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
 msgid "Returns the median value of the specified column."
-msgstr "Restituisce il valore mediano della colonna specificata."
+msgstr "Returnerer medianverdien av spesifisert kolonne."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
 msgid "The column or number to get the median of."
-msgstr "La colonna o il numero di cui ottenere la mediana."
+msgstr "Kolonne eller nummer å hente median av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
 msgid "percentile-value"
-msgstr "valore percentile"
+msgstr "prosentverdi"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+#, fuzzy
 msgid "Returns the value of the column at the percentile value."
-msgstr "Restituisce il valore della colonna al valore del percentile."
+msgstr "Returnerer verdien av kolonnen på persentilverdien."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
 msgid "The column or number to get the percentile of."
-msgstr "La colonna o il numero di cui ottenere il percentile."
+msgstr "Kolonnen eller nummer å hente persentil av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
 msgid "The value of the percentile."
-msgstr "Il valore del percentile."
+msgstr "Verdi av persentil."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
 msgid "Returns the string of text in all lower case."
-msgstr "Restituisce la stringa di testo in tutte le minuscole."
+msgstr "Returnerer tekststrengen i små bokstaver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
 msgid "The column with values to convert to lower case."
-msgstr "La colonna con i valori da convertire in minuscolo."
+msgstr "Kolonnen med verdier som skal konverteres til små bokstaver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
 msgid "Returns the text in all upper case."
-msgstr "Restituisce il testo in tutte le maiuscole."
+msgstr "Returnerer all tekst med store bokstaver."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
 msgid "The column or text to return a portion of."
-msgstr "La colonna o il testo di cui restituire una parte."
+msgstr "Kolonnen eller tekst å returnere en del av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
 msgid "The column or text to search through."
-msgstr "La colonna o il testo da cercare."
+msgstr "Kolonnen eller teksten å søke gjennom."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
 msgid "Combine two or more strings of text together."
-msgstr "Combina due o più stringhe di testo insieme."
+msgstr "Kombinerer en eller flere tekststrenger."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
 msgid "The column or text to begin with."
-msgstr "La colonna o il testo per iniziare."
+msgstr "Kolonnen eller tekst som skal begynnes med."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
 msgid "This will be added to the end of value1, and so on."
-msgstr "Questo sarà aggiunto alla fine del valore1 e così via."
+msgstr "Dette vil bli lagt til slutten av verdi1 og så videre."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
 msgid "Enormous"
-msgstr "Enorme"
+msgstr "Enorm"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
 msgid "Gigantic"
-msgstr "Gigantesco"
+msgstr "Gigantisk"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
 msgid "Returns the number of characters in text."
-msgstr "Restituisce il numero di caratteri nel testo."
+msgstr "Returnerer antall tegn i teksten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
 msgid "The column or text you want to get the length of."
-msgstr "La colonna o il testo di cui si desidera ottenere la lunghezza."
+msgstr "Kolonnen eller teksten du vil ha lengden på."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
 msgid "The column or text you want to trim."
-msgstr "La colonna o il testo da tagliare."
+msgstr "Kolonnen eller teksten du vil trimme."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
 msgid "Returns the absolute (positive) value of the specified column."
-msgstr "Restituisce il valore assoluto (positivo) della colonna specificata."
+msgstr "Kolonnen du skal ha absolutt (positiv) verdi av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
 msgid "Debt"
-msgstr "Debito"
+msgstr "Gjeld"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
 msgid "The column or number to return absolute (positive) value of."
-msgstr "La colonna o il numero di cui restituire il valore assoluto (positivo)."
+msgstr "Kolonnen eller tallet som du skal ha absolutt (positiv) verdi av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
 msgid "Rounds a decimal number down."
-msgstr "Arrotonda un numero decimale verso il basso."
+msgstr "Runder ned et desimaltall."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
 msgid "The column or number to round down."
-msgstr "La colonna o il numero da arrotondare per difetto."
+msgstr "Kolonnen eller tallet som skal avrundes nedover."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
 msgid "Rounds a decimal number up."
-msgstr "Arrotonda un numero decimale verso l'alto."
+msgstr "Avrunder desimaltallet oppover."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
 msgid "The column or number to round up."
-msgstr "La colonna o il numero da arrotondare."
+msgstr "Kolonnen eller tallet som skal avrundes oppover."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
 msgid "Rounds a decimal number either up or down to the nearest integer value."
-msgstr "Arrotonda un numero decimale verso l'alto o verso il basso al valore intero più vicino."
+msgstr "Avrunder et desimaltall nedover eller oppover til nærmeste heltall."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
 msgid "The column or number to round to nearest integer."
-msgstr "La colonna o il numero da arrotondare al numero intero più vicino."
+msgstr "Kolonnen eller tallet som skal avrundes til nærmeste heltall."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
 msgid "Returns the square root."
-msgstr "Restituisce la radice quadrata."
+msgstr "Returnerer kvadratroten."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
 msgid "Hypotenuse"
-msgstr "Ipotenusa"
+msgstr "Hypotenusen"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
 msgid "The column or number to return square root value of."
-msgstr "La colonna o il numero di cui restituire il valore della radice quadrata."
+msgstr "Kolonnen eler tallet du skal ha kvadratroten av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
 msgid "exponent"
-msgstr "Esponente"
+msgstr "eksponent"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
 msgid "Raises a number to the power of the exponent value."
-msgstr "Alza un numero al potere del valore dell'esponente."
+msgstr "Opphøyer et tall i den angitte potensen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
 msgid "Length"
-msgstr "Lunghezza"
+msgstr "Lengde"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
 msgid "The column or number raised to the exponent."
-msgstr "La colonna o il numero elevato all'esponente."
+msgstr "Kolonnen eller nummeret som skal opphøyes."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
 msgid "The value of the exponent."
-msgstr "Il valore dell'esponente."
+msgstr "Verdien av potensen."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
 msgid "Returns the base 10 log of the number."
-msgstr "Restituisce il registro di base 10 del numero."
+msgstr "Returnerer base-10 logaritmen av tallet"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
 msgid "Value"
-msgstr "Valore"
+msgstr "Verdi"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
 msgid "The column or number to return the natural logarithm value of."
-msgstr "La colonna o il numero di cui restituire il valore logaritmico naturale."
+msgstr "Kolonnen eller nummeret å returnere den naturlige logaritmeverdien av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
 msgid "Returns Euler's number, e, raised to the power of the supplied number."
-msgstr "Restituisce il numero di Eulero, e, elevato alla potenza del numero fornito."
+msgstr "Returnerer Eulers nummer, e, opphøyd i potens lik nummeret du oppgir."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
 msgid "Interest Months"
-msgstr "Mesi di interesse"
+msgstr "Rentemåneder"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
 msgid "The column or number to return the exponential value of."
-msgstr "La colonna o il numero di cui restituire il valore esponenziale."
+msgstr "Kolonnen eller nummeret å returnere en eksponensiell verdi av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
 msgid "The column or text to check."
-msgstr "La colonna o il testo da controllare."
+msgstr "Kolonnen eller teksten som skal sjekkes."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
 msgid "Checks a date or number column's values to see if they're within the specified range."
-msgstr "Controlla i valori di una data o di una colonna numerica per vedere se sono all'interno dell'intervallo specificato."
+msgstr "Velger en dato eller en nummerkolonnes verdier for å se om de er innenfor oppgitt område."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
 msgid "Created At"
-msgstr "Creato a"
+msgstr "Opprettet"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
 msgid "The date or numeric column that should be within the start and end values."
-msgstr "La data o la colonna numerica che dovrebbe rientrare nei valori iniziali e finali."
+msgstr "Dato- eller numerisk kolonne som skal være innenfor start- og sluttverdiene."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "The beginning of the range."
-msgstr "L'inizio della gamma."
+msgstr "Starten på området."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "The end of the range."
-msgstr "La fine della gamma."
+msgstr "Slutten på området."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
 msgid "Checks a date column's values to see if they're within the relative range."
-msgstr "Controlla i valori di una colonna di data per vedere se sono all'interno dell'intervallo relativo."
+msgstr "Velger en datokolonnes verdier for å se om de er innenfor det relative området."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
 msgid "The date column to return interval of."
-msgstr "La colonna della data di ritorno dell'intervallo di."
+msgstr "Datokolonnen du vil ha intervall av."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
 msgid "Period of interval, where negative values are back in time."
-msgstr "Periodo di intervallo, in cui i valori negativi sono indietro nel tempo."
+msgstr "Intervallperiode, der negative verdier er bakover i tid."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
 msgid "Type of internal like \"day\", \"month\", \"year\"."
-msgstr "Tipo di interno come \"giorno\", \"mese\", \"anno\"."
+msgstr "Type intervall som f.eks \"dag\", \"måned\", \"år\"."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "The column or value to return."
-msgstr "La colonna o il valore da restituire."
+msgstr "Kolonnen eller verdien som skal returneres."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
 msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
-msgstr "Se il valore1 è vuoto, il valore2 viene restituito se non è vuoto, e così via."
+msgstr "Hvis verdi1 er tom, returneres verdi2 hvis den ikke er tom. Og så videre."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
 msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
-msgstr "Testa un'espressione rispetto a una lista di casi e restituisce il valore corrispondente del primo caso corrispondente, con un valore di default opzionale se non viene soddisfatto nient'altro."
+msgstr "Tester et utrykk mot en liste av saker og returerer korresponderende verdi av første match, med en valgfri standardverdi."
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
 msgid "The value that will be returned if the preceding condition is true, and so on."
-msgstr "Il valore che sarà restituito se la condizione precedente è vera, e così via."
+msgstr "Verduen som returneres hvis foregående betingelser er sann, og så videre."
 
 #: frontend/src/metabase/lib/schema_metadata.js:392
 #: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is null"
-msgstr "È nullo"
+msgstr "Er null"
 
 #: frontend/src/metabase/lib/schema_metadata.js:393
 #: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Not null"
-msgstr "Non nullo"
+msgstr "Ikke null"
 
 #: frontend/src/metabase/lib/schema_metadata.js:544
 msgid "Additive sum of all the values of a column.\n"
 "e.x. total revenue over time."
-msgstr "Somma additiva di tutti i valori di una colonna.\n"
-"e.x. il totale delle entrate nel tempo."
+msgstr "Additiv sum av alle verdier i en kolonne. F.eks totale inntekter over tid."
 
 #: frontend/src/metabase/lib/schema_metadata.js:553
 msgid "Additive count of the number of rows.\n"
 "e.x. total number of sales over time."
-msgstr "Conteggio additivo del numero di righe.\n"
-"e.x. numero totale di vendite nel tempo."
+msgstr "Additiv telling av antall rader. F.eks totalt antall salg over tid."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
 msgid "Linked filters"
-msgstr "Filtri collegati"
+msgstr "Lenkede filter"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
 msgid "Label"
-msgstr "Etichetta"
+msgstr "Etikett"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
 msgid "Default value"
-msgstr "Valore di default"
+msgstr "Standardverdi"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
 msgid "No default"
-msgstr "Nessun difetto"
+msgstr "Ingen standardverdi"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
 msgid "To view this, {0} must be connected to at least one field."
-msgstr "Per visualizzare questo, {0} deve essere collegato ad almeno un campo."
+msgstr "For å vise dette, må {0} være koblet til minst ett felt."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
 msgid "Limit this filter's choices"
-msgstr "Limitare le scelte di questo filtro"
+msgstr "Begrens valgene for dette filteret"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
 msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
-msgstr "Se si dispone di un altro filtro del cruscotto, è possibile limitare le scelte che sono elencate per questo filtro in base alla selezione dell'altro."
+msgstr "Hvis du har et annet infotavlefilter, kan du begrense valgene som vises for dette filteret basert på valgene i det andre."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
 msgid "So first, {0}."
-msgstr "Allora, prima di tutto..."
+msgstr "Men først, {0}."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
 msgid "add another dashboard filter"
-msgstr "aggiungere un altro filtro per il cruscotto"
+msgstr "legg til enda et filter på infotavlen"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
 msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
-msgstr "Se si attiva uno di questi filtri del cruscotto, la selezione di un valore per quel filtro limiterà le scelte disponibili per il filtro {0}."
+msgstr "Hvis du slår på en av disse infotavlefiltrene, vil å velge en verdi for det filteret begrense tilgjengelige alternativ for {0} filter."
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
 msgid "Filtering column"
-msgstr "Colonna di filtraggio"
+msgstr "Filterkolonne"
 
 #: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
 msgid "Filtered column"
-msgstr "Colonna filtrata"
+msgstr "Filtrert kolonne"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
 msgid "Enter user names or email addresses"
-msgstr "Inserire i nomi utente o gli indirizzi e-mail"
+msgstr "Skriv inn brukernavn eller e-postadresser"
 
 #: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
 msgid "New snippet"
-msgstr "Nuovo frammento"
+msgstr "Nytt utvalg"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
 msgid "{0}:00 PM"
@@ -16462,347 +16492,347 @@ msgstr "{0}:00 AM"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
 msgid "Hourly"
-msgstr "Ogni ora"
+msgstr "Hver time"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
 msgid "Daily at {0}"
-msgstr "Ogni giorno a {0}"
+msgstr "Daglig klokken {0}"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
 msgid "Weekly at {0} on {1}"
-msgstr "Settimanale al {0} il {1}"
+msgstr "Hver uke på {0} klokken {1}"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
 msgid "Monthly on the {0} {1} at {2}"
-msgstr "Mensile il {0} {1} a {2} al {0}"
+msgstr "Hver måned på den {0} {1} klokken {2}"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
 msgid "Delete this subscription"
-msgstr "Cancella questo abbonamento"
+msgstr "Slett dette abonnementet"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
 msgid "Subscriptions"
-msgstr "Abbonamenti"
+msgstr "Abonnement"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
 msgid "Create a dashboard subscription"
-msgstr "Creare un abbonamento al cruscotto"
+msgstr "Abonnér på infotavle"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
 msgid "Email it"
-msgstr "Invia un'e-mail"
+msgstr "Send det på e-post"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
 msgid "You can send this dashboard regularly to users or email addresses."
-msgstr "È possibile inviare questa dashboard regolarmente agli utenti o agli indirizzi e-mail."
+msgstr "Du kan sende denne infotavlen regelmessig til brukere eller e-postadresser."
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
 msgid "Send it to Slack"
-msgstr "Invia a Slack"
+msgstr "Send det til Slack"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
 msgid "Pick a channel and a schedule, and Metabase will do the rest."
-msgstr "Scegliete un canale e un programma, e Metabase farà il resto."
+msgstr "Velg en kanal og en tidsplan, Metabase gjør resten."
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
 msgid "Email this dashboard"
-msgstr "Invia questa dashboard per e-mail"
+msgstr "Send infotavlen på e-post"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
 msgid "Don't send if there aren't results"
-msgstr "Non inviare se non ci sono risultati"
+msgstr "Ikke send hvis det ikke er resultater"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
 msgid "Attach results"
-msgstr "Allega i risultati"
+msgstr "Legg ved resultater"
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
 msgid "Attachments can contain up to 2,000 rows of data."
-msgstr "Gli allegati possono contenere fino a 2.000 righe di dati."
+msgstr "Vedlegg kan inneholde opp til 2000 rader med data."
 
 #: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
 msgid "Send this dashboard to Slack"
-msgstr "Invia questo cruscotto a Slack"
+msgstr "Send infotavlen til Slack"
 
 #: src/metabase/api/dashboard.clj
 msgid "Dashboard does not have a parameter with the ID {0}"
-msgstr "Il cruscotto non ha un parametro con l'ID {0}"
+msgstr "Infotavle har ikke parameter med ID {0}"
 
 #: src/metabase/api/dashboard.clj
 msgid "Parameter {0} does not have any Fields associated with it"
-msgstr "Il parametro {0} non ha nessun campo associato"
+msgstr "Parameter {0} har ingen Felt assosiert med seg"
 
 #: src/metabase/api/database.clj
 msgid "include must be either empty or the value 'tables'"
-msgstr "includere deve essere vuoto o il valore \"tabelle\"."
+msgstr "inkludering må enten være tom eller ha verdien 'tables'"
 
 #: src/metabase/api/dataset.clj
 msgid "`database` is required for all queries whose type is not `internal`."
-msgstr "Il `database` è richiesto per tutte le query il cui tipo non è `interno`."
+msgstr "`database` kreves for alle spørringer som ikke er av type `intern`"
 
 #: src/metabase/api/session.clj
 msgid "Password login is disabled for this instance."
-msgstr "In questo caso il login con password è disabilitato."
+msgstr "Innlogging med passord er deaktivert for denne instansen."
 
 #: src/metabase/api/session.clj
 msgid "Your account is disabled. Please contact your administrator."
-msgstr "Il tuo account è disabilitato. Contatta il tuo amministratore."
+msgstr "Din konto er deaktivert. Vennligst kontakt administrator."
 
 #: src/metabase/api/session.clj
 msgid "Your account is disabled."
-msgstr "Il tuo account è disabilitato."
+msgstr "Din konto er deaktivert."
 
 #: src/metabase/api/slack.clj
 msgid "Invalid Slack token."
-msgstr "Gettone di allentamento non valido."
+msgstr "Ugyldig Slack-token."
 
 #: src/metabase/cmd.clj
 msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
-msgstr "Il comando ''{0}'' è disponibile solo in Metabase Enterprise Edition."
+msgstr "Kommandoen \"{0}\" er bare tilgjengelig i Metabase Enterprise Edition."
 
 #: src/metabase/core.clj
 msgid "Metabase Enterprise Edition extensions are PRESENT."
-msgstr "Le estensioni di Metabase Enterprise Edition sono PRESENTI."
+msgstr "Utvidelser for Metabase Enterprise Edition er TILSTEDE."
 
 #: src/metabase/core.clj
 msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
-msgstr "L'uso delle funzionalità di Metabase Enterprise Edition è soggetto alla licenza commerciale Metabase."
+msgstr "Bruk av funksjoner i Metabase Enterprise Edition er underlagt Metabase Commercial License."
 
 #: src/metabase/core.clj
 msgid "See {0} for details."
-msgstr "Vedi {0} per i dettagli."
+msgstr "Se {0} for detaljer."
 
 #: src/metabase/core.clj
 msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
-msgstr "Le estensioni di Metabase Enterprise Edition NON sono PRESENTI."
+msgstr "Utvidelser for Metabase Enterprise Edition er FRAVÆRENDE."
 
 #: src/metabase/email/messages.clj
 msgid "You''re invited to join {0}''s {1}"
-msgstr "Siete invitati ad unirvi a noi."
+msgstr "Du er invitert til å bli med i {0} sitt {1}"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a {1} account"
-msgstr "ha creato un conto"
+msgstr "{0} opprettet en {1}-konto"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their {1} invite"
-msgstr "...ha accettato il loro invito."
+msgstr "{0} aksepterte deres {1} invitasjon"
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Password Reset Request"
-msgstr "Richiesta di reimpostazione della password"
+msgstr "[{0}] Forespørsel om tilbakestilling av passord"
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Notification"
-msgstr "Notifica"
+msgstr "[{0}] Varsel"
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Help make [{1}] better."
-msgstr "Aiuta a migliorare la situazione."
+msgstr "[{0}] Hjelp å gjøre [{1}] bedre."
 
 #: src/metabase/email/messages.clj
 msgid "[{0}] Tell us how things are going."
-msgstr "Dicci come vanno le cose."
+msgstr "[{0}] Fortell oss hvordan det går."
 
 #: src/metabase/events.clj
 msgid "Error starting events listener"
-msgstr "Errore di avvio dell'ascoltatore di eventi"
+msgstr "Kunne ikke starte hendelseslytter"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Should we sync user attributes when someone logs in via LDAP?"
-msgstr "Dobbiamo sincronizzare gli attributi degli utenti quando qualcuno effettua il login tramite LDAP?"
+msgstr "Burde vi synkronisere brukerattributter når noen logger inn via LDAP?"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
-msgstr "Elenco separato da virgole degli attributi degli utenti per saltare la sincronizzazione per gli utenti LDAP."
+msgstr "Kommaseparert liste over brukerattributter for ikke skal synkroniseres for LDAP-brukere."
 
 #: src/metabase/integrations/slack.clj
 msgid "Invalid token"
-msgstr "Gettone non valido"
+msgstr "Ugyldig token"
 
 #: src/metabase/integrations/slack.clj
 msgid "Slack API error: {0}"
-msgstr "Errore API allentato: {0}"
+msgstr "Slack API-feil: {0}"
 
 #: src/metabase/integrations/slack.clj
 msgid "Slack channel named `metabase_files` is missing!"
-msgstr "Manca il canale Slack chiamato `metabase_files`!"
+msgstr "Slack-kanalen `metabase_files` mangler!"
 
 #: src/metabase/integrations/slack.clj
 msgid "Please create or unarchive the channel in order to complete the Slack integration."
-msgstr "Si prega di creare o disarchiviare il canale per completare l'integrazione Slack."
+msgstr "Vennligst opprett eller avarkiver kanalen for å fullføre Slack-integrasjonen."
 
 #: src/metabase/integrations/slack.clj
 msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
-msgstr "Il canale viene utilizzato per memorizzare i grafici che sono inclusi nelle risposte di Pulses e MetaBot."
+msgstr "Kanalen brukes for å lagre grafer som er inkludert i Pulser og MetaBot-svar."
 
 #: src/metabase/integrations/slack.clj
 msgid "Uploaded image"
-msgstr "Immagine caricata"
+msgstr "Lastet opp bilde"
 
 #: src/metabase/integrations/slack.clj
 msgid "Error uploading file to Slack:"
-msgstr "Errore nel caricamento del file su Slack:"
+msgstr "Feil ved opplasting av fil til Slack:"
 
 #: src/metabase/middleware/session.clj
 msgid "Invalid session. Expected an instance of Session."
-msgstr "Sessione non valida. Prevista un'istanza di Sessione."
+msgstr "Ugyldig sesjon. Forventet en instans av en Sesjon."
 
 #: src/metabase/middleware/session.clj
 msgid "Session cookie's SameSite is configured to \"None\", but site is"
-msgstr "Il SameSite del cookie di sessione è configurato su \"Nessuno\", ma il sito è"
+msgstr "Informasjonskapselens SameSite er konfigurert til \"Ingen\", men site er"
 
 #: src/metabase/middleware/session.clj
 msgid "served over an insecure connection. Some browsers will reject "
-msgstr "e' servita per una connessione insicura. Alcuni browser rifiutano "
+msgstr "levert over en usikker tilkobling. Noen nettlesere vil avvise "
 
 #: src/metabase/middleware/session.clj
 msgid "cookies under these conditions. "
-msgstr "cookies a queste condizioni. "
+msgstr "informasjonskapsler under disse betingelsene. "
 
 #: src/metabase/middleware/session.clj
 msgid "https://www.chromestatus.com/feature/5633521622188032"
-msgstr "https://www.chromestatus.com/feature/5633521622188032"
+msgstr " https://www.chromestatus.com/feature/5633521622188032 "
 
 #: src/metabase/models/collection.clj
 msgid "Top folder"
-msgstr "Cartella in alto"
+msgstr "Toppmappe"
 
 #: src/metabase/models/dashboard.clj
+#, fuzzy
 msgid ":parameters must be a sequence of maps with String :id keys"
-msgstr ":i parametri devono essere una sequenza di mappe con i tasti String :id"
+msgstr " :parameters må være en sekvens av oppslagsverk med Tekststreng :id nøkler"
 
 #: src/metabase/models/field_values.clj
 msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
-msgstr "Valori non validi leggibili dall'uomo: i valori devono essere una sequenza; ogni elemento deve essere nullo o una stringa"
+msgstr "Ugylding menneskelig lesbare verdier: verdier må være en sekvens, og hvert element enten nil eller en tekststreng"
 
 #: src/metabase/models/field_values.clj
 msgid ":values must be present to fetch :human_readable_values"
-msgstr ":i valori devono essere presenti per recuperare :valori_letturabili_umani"
+msgstr ":value må være tilstede for å hente :human_readable_values"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is > {0}."
-msgstr "La lunghezza totale dei valori del campo è > {0}."
+msgstr "Feltvergienes totallengde er > {0}."
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "snippet names cannot include '}' or start with spaces"
-msgstr "i nomi dei frammenti non possono includere '}' o iniziare con degli spazi"
+msgstr "navn på utdrag kan ikke ha '}' eller mellomrom i starten"
 
 #: src/metabase/models/params/chain_filter.clj
 msgid "Error executing chain filter query"
-msgstr "Errore nell'esecuzione della query del filtro a catena"
+msgstr "Feil ved eksekvering av filterspørringskjede"
 
 #: src/metabase/models/params/chain_filter.clj
 msgid "Field {0} does not exist."
-msgstr "Il campo {0} non esiste."
+msgstr "Felt {0} eksisterer ikke."
 
 #: src/metabase/models/params/chain_filter.clj
 msgid "Cannot search against non-Text Field {0} {1}"
-msgstr "Non è possibile effettuare ricerche in campi diversi da quello di testo {0} {1}"
+msgstr "Kan ikke søke på felt som ikke er tekst {0} {1}"
 
 #: src/metabase/models/permissions.clj
 msgid "Granting permissions for group {0}: {1}"
-msgstr "Concessione di autorizzazioni per il gruppo {0}: {1}"
+msgstr "Gir rettigheter til gruppe {0}: {1}"
 
 #: src/metabase/models/permissions.clj
 msgid "Revoking permissions for group {0}: {1}"
-msgstr "Revocando i permessi per il gruppo {0}: {1}"
+msgstr "Tilbakekaller rettigheter til gruppe {0}: {1}"
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
-msgstr "Autorizzazioni DB non valide: se si dispone di un accesso in scrittura per le query native, è necessario avere un accesso completo ai dati."
+msgstr "Ugyldige DB-tillatelser: Hvis du har skrivetilgang for naturlige spørringer, må du ha full datatilgang."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
-msgstr "Autorizzazioni DB non valide: se si dispone di un accesso alla query nativa di sola lettura, è necessario avere anche l'accesso ai dati."
+msgstr "Ugyldige DB-tillatelser: Hvis du har lesetilgang for naturlige spørringer, må du ha datatilgang."
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions from: {0} to: {1}"
-msgstr "Modifica delle autorizzazioni da: {0} a: {1}"
+msgstr "Endrer tillatelser fra: {0} til: {1}"
 
 #: src/metabase/models/user.clj
 msgid "login attribute keys must be a keyword or string"
-msgstr "le chiavi degli attributi di login devono essere una parola chiave o una stringa"
+msgstr "loginattributtnøkler må være nøkkelord eller tekststreng"
 
 #: src/metabase/public_settings.clj
 msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
-msgstr "Il linguaggio predefinito per tutti gli utenti attraverso l'interfaccia utente di Metabase, le e-mail di sistema, gli impulsi e gli avvisi."
+msgstr "Standardspråket for alle brukere i Metabase brukergrensesnitt, system, e-post, pulser og alarmer."
 
 #: src/metabase/public_settings.clj
 msgid "Users can individually override this default language from their own account settings."
-msgstr "Gli utenti possono sovrascrivere individualmente questa lingua predefinita dalle impostazioni del proprio account."
+msgstr "Brukere kan overstyre standardspråket i sine individuelle innstillinger."
 
 #: src/metabase/public_settings.clj
 msgid "Default page to show the user"
-msgstr "Pagina predefinita per mostrare all'utente"
+msgstr "Standardside å vise brukeren"
 
 #: src/metabase/public_settings.clj
 msgid "Allow this origin to embed the full Metabase application"
-msgstr "Permettere a questa origine di incorporare l'intera applicazione Metabase"
+msgstr "Tillat opprinnelsen å bygge inn hele Metabase-applikasjonen"
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {0} ({1}) are not allowed."
-msgstr "Non sono ammessi valori superiori a {0} ({1})."
+msgstr "Verdier større enn {0} ({1}) er ikke tillatt."
 
 #: src/metabase/public_settings.clj
 msgid "This will replace the word \"Metabase\" wherever it appears."
-msgstr "Questo sostituirà la parola \"Metabase\" ovunque essa appaia."
+msgstr "Dette vil erstatte ordet \"Metabase\" der det forekommer."
 
 #: src/metabase/public_settings.clj
 msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
-msgstr "Questi sono i colori primari utilizzati nei grafici e in tutta Metabase. Potrebbe essere necessario aggiornare il vostro browser per vedere i vostri cambiamenti avere effetto."
+msgstr "Dette er primærfargene bruk i grafer og ellers i Metabase. Du må kanskje friske opp nettleseren for å se endringene."
 
 #: src/metabase/public_settings.clj
 msgid "For best results, use an SVG file with a transparent background."
-msgstr "Per ottenere i migliori risultati, utilizzare un file SVG con uno sfondo trasparente."
+msgstr "For best resultat, bruk en SVG-fil med gjennomsiktig bakgrunn."
 
 #: src/metabase/public_settings.clj
 msgid "The url or image that you want to use as the favicon."
-msgstr "L'url o l'immagine che si vuole usare come favicon."
+msgstr "URL eller bilde du vil bruke som favorittikon."
 
 #: src/metabase/public_settings.clj
 msgid "Allow logging in by email and password."
-msgstr "Consentire l'accesso tramite e-mail e password."
+msgstr "Tillat innlogging med brukernavn og passord"
 
 #: src/metabase/public_settings.clj
 msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
 "  It won''t affect SQL queries."
-msgstr "Questo influenzerà cose come il raggruppamento per settimana o il filtraggio nelle query GUI.\n"
-"  Non influenzerà le query SQL."
+msgstr "Dette vil påvirke ting som gruppering på uke eller filtering i spørringer laget i brukergrensesnitt. Det bil ikke påvirke SQL-spørringer."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token"
-msgstr "Impossibile convalidare il gettone"
+msgstr "Kunne ikke validere token"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid."
-msgstr "Il formato del gettone non è valido."
+msgstr "Token-format er ugyldig."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token"
-msgstr "Gettone di convalida errore"
+msgstr "Feil ved validering av token"
 
 #: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
 msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
-msgstr "Filtraggio di errore contro {0} Campo: non è possibile analizzare la stringa {1} in {2}."
+msgstr "Feil ved filtrering mot Felt {0}: kunne ikke tolke Streng {1} som en {2}"
 
 #: src/metabase/task.clj
 msgid "Error fetching details for Job: {0}"
-msgstr "Errore nel reperire i dettagli di Job: {0}"
+msgstr "Kunne ikke hente detaljer for Jobb: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Starting sync task for Database {0}."
-msgstr "Avvio dell'attività di sincronizzazione per il database {0}."
+msgstr "Starter synkroniseringsoppgave for Database {0}."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Cannot sync Database {0}: Database does not exist."
-msgstr "Impossibile sincronizzare il database {0}: Il database non esiste."
+msgstr "Kan ikke synkronisere Database {0}: Database eksisterer ikke."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Update Field values task triggered for Database {0}."
-msgstr "Aggiornamento dei valori del campo attività attivata per il database {0}."
+msgstr "Oppgaven som oppdater Feltverdier er utløst for Database {0}."
 
 #: src/metabase/task/sync_databases.clj
 msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
-msgstr "Saltando l'aggiornamento, gli aggiornamenti automatici dei valori di campo sono disabilitati per il database {0}."
+msgstr "Hopper over oppdatering, oppdatering av automatiske Feltverdier for Database {0} er deaktivert."

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -30,15 +30,16 @@ msgstr "Selecteer een type database"
 
 #. Imperative: Sla op
 #. Verb: Opslaan
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -51,7 +52,7 @@ msgstr "Opslaan"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase moet je database scannen om zijn magie erop los te kunnen laten. We zullen de database ook periodiek opnieuw scannen om de metadata actueel te houden. Je kunt hieronder instellen wanneer de periodieke scans plaatsvinden."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Database synchroniseren"
 
@@ -66,7 +67,7 @@ msgstr "Dit is een licht proces dat nagaat of het database schema gewijzigd is. 
 msgid "Scan"
 msgstr "Scannen"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Aan het zoeken naar filterwaarden"
 
@@ -77,7 +78,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Wanneer moet Metabase de waarden van deze velden automatisch scannen en cachen?"
 
@@ -135,29 +136,31 @@ msgstr "VERWIJDER"
 msgid "in this box:"
 msgstr "in dit kader:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -180,9 +183,9 @@ msgstr "Verwijder"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -202,8 +205,9 @@ msgstr "Verbinding"
 msgid "Scheduling"
 msgstr "Planning"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -282,10 +286,10 @@ msgstr "Database toevoegen"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -320,10 +324,8 @@ msgid "Successfully saved!"
 msgstr "Succesvol opgeslagen!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Bewerken"
@@ -402,26 +404,29 @@ msgstr "Selecteer een speciaal type"
 msgid "Select a target"
 msgstr "Selecteer een doel"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Kolommen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Kolom"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Zichtbaarheid"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Type"
 
@@ -429,7 +434,7 @@ msgstr "Type"
 msgid "Current database:"
 msgstr "Huidige database:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Toon origineel schema:"
 
@@ -500,7 +505,7 @@ msgstr "Zoek een tabel"
 msgid "Schemas"
 msgstr "Schema's"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -517,7 +522,7 @@ msgstr "Voeg een metriek toe"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definitie"
 
@@ -585,36 +590,36 @@ msgstr " geschiedenis"
 msgid "Revision History for"
 msgstr "Revisiegeschiedenis voor"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - Veldinstellingen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Waar dit veld zichtbaar wordt via Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filteren op dit veld"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Als dit veld wordt gebruikt in een filter, wat moet men gebruiken om te filteren op de waarde die ze hebben ingevoerd?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Nog geen beschrijving voor dit veld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Originele waarde"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 #, fuzzy
 msgid "Mapped value"
 msgstr "Gekoppelde waarde"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Voer een waarde in"
 
@@ -632,32 +637,32 @@ msgid "Custom mapping"
 msgstr "Eigen koppeling"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 #, fuzzy
 msgid "Unrecognized mapping type"
 msgstr "Type voor koppeling niet herkend"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Het huidige veld is geen verwijzende sleutel of of de metadata van de doeltabel mist"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Het geselecteerde veld is geen verwijzende sleutel"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Toon waarden"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Kies om de originele waarde vanuit de database te zien of toon het veld met verwante of custom informatie."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Kies een veld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Selecteer een kolom om te gebruiken voor weergave"
 
@@ -665,16 +670,16 @@ msgstr "Selecteer een kolom om te gebruiken voor weergave"
 msgid "Tip:"
 msgstr "Tip:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Je kunt ervoor kiezen om de veldnaam aan te passen, om er zeker van te zijn dat deze nog duidelijk is, baserend op je hermapping keuzes."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Opgeslagen veldwaarden"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kan de waarden voor dit veld scannen om checkbox filters in dashboards en vragen in te schakelen."
 
@@ -702,35 +707,36 @@ msgstr "Weggooien geactiveerd!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Selecteer een tabel om het schema te zien en om metadata toe te voegen of te wijzigen."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Naam is verplicht"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Omschrijving is verplicht"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Herzieningsbericht is verplicht"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Aggregatie is benodigd"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Bewerk uw metriek"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Maak uw metriek"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Pas de meetwaarde aan en laat een verklaring achter"
 
@@ -738,46 +744,46 @@ msgstr "Pas de meetwaarde aan en laat een verklaring achter"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Je kunt opgeslagen metrieken aanmaken om een metriek optie toe tevoegen aan deze tabel. Opgeslagen metrieken omvatten het aggregatietype, het geaggregeerde veld en elk filter dat u toevoegt. Bijvoorbeeld: je kunt deze optie gebruiken voor een standaard manier voor het berekenen van een \"gemiddelde prijs\" for een bestellingen tabel."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Resultaat: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Geef uw metriek een naam"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Geef uw metriek een naam om het vindbaar te maken voor anderen."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Iets verduidelijkends maar niet te lang"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Beschrijf uw metriek"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Beschrijf uw metriek om het uit te leggen aan anderen."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Hier kun je preciezer zijn over metriken die minder duidelijk zijn"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Reden voor wijzigingen"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Laat een notitie achter, om de veranderingen uit te leggen en waarom ze nodig waren."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Dit wordt weergegeven in de revisiegeschiedenis voor deze metriek zodat de reden voor iedereen duidelijk is"
 
@@ -831,6 +837,7 @@ msgstr "Dit wordt getoond in de revisiegeschiedenis, zodat iedereen weet waarom 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -845,8 +852,7 @@ msgid "Re-scan this table"
 msgstr "Herscan deze tabel"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Toevoegen"
 
@@ -863,7 +869,7 @@ msgid "Last name"
 msgstr "Achternaam"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "E-mailadres"
@@ -872,7 +878,7 @@ msgstr "E-mailadres"
 msgid "Permission Groups"
 msgstr "Rechtengroepen"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Maak deze gebruiker een beheerder"
 
@@ -970,6 +976,8 @@ msgstr "Verwijder groep"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -982,11 +990,12 @@ msgstr "Klaar"
 msgid "Group name"
 msgstr "Groepsnaam"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Groepen"
@@ -1095,7 +1104,7 @@ msgstr "Reset"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Weet u zeker dat u dit wilt doen?"
 
@@ -1208,7 +1217,7 @@ msgstr "Er zullen geen wijzigingen in de rechten gemaakt worden."
 msgid "You've made changes to permissions."
 msgstr "U hebt aanpassingen gedaan aan rechten."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Rechten voor deze collectie"
 
@@ -1264,6 +1273,7 @@ msgstr "Limiteer toegang"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Trek toegang in"
 
@@ -1327,23 +1337,23 @@ msgstr "Beheer collectie"
 msgid "View collection"
 msgstr "Toon verzamelingen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Datatoegang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Toon tabellen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Toon schema's"
 
@@ -1414,12 +1424,15 @@ msgstr "Verzonden!"
 msgid "Clear"
 msgstr "Leeg"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Authenticatie"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Serverinstellingen"
@@ -1432,6 +1445,7 @@ msgstr "Gebruikersschema"
 msgid "Attributes"
 msgstr "Attributen"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Groepschema"
@@ -1503,6 +1517,9 @@ msgid "Add a map"
 msgstr "Voeg een kaart toe"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1512,19 +1529,19 @@ msgid "Delete custom map"
 msgstr "Verwijder aangepaste kaart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Verwijderen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1622,19 +1639,19 @@ msgstr "Koop een token"
 msgid "Enter a token"
 msgstr "Voer een token in"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Pas mappings aan"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Groep mappings"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Maak een mapping"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1874,18 +1891,27 @@ msgstr "Gebruikersfilter"
 msgid "Check your parentheses"
 msgstr "Controleer je haakjes"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Email attribuut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Voornaamattribuut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Achternaamattribuut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Groepslidmaatschappen synchroniseren"
@@ -1914,59 +1940,59 @@ msgstr "Aangepaste kaarten"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Voeg je eigen GeoJSON bestanden toe om andere regio visualisaties in te schakelen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Publiek delen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Schakel publiek delen in"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Gedeelde dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Gedeelde vragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Embedden in andere applicaties"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Embedden van Metabase in andere applicaties inschakelen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Embedding secret key"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Embedded Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Embedded Vragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Schakel caching in"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "minimale query duur"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "cache levensduur (TTL) vermenigvuldiging"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Maximale cachegrootte"
 
@@ -2008,27 +2034,27 @@ msgstr "Je hebt een beheerder nodig om een Metabase account aan te maken voordat
 msgid "Sign in with {0}"
 msgstr "Log in met {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Neem contact op met een beheerder om het wachtwoord te hertellen"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Wachtwoord vergeten"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Het e-mailadres welke je gebruikt voor je Metabase account"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Verstuur e-mail voor wachtwoordreset"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Controleer de instructies in e-mail inbox om je wachtwoord te wijzigen."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Log in in Metabase"
 
@@ -2049,11 +2075,11 @@ msgstr "Inloggen"
 msgid "I seem to have forgotten my password"
 msgstr "Het lijkt erop dat ik mijn wachtwoord vergeten ben"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "verzoek een nieuwe reset email"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Oeps... dat is een verlopen link"
 
@@ -2063,11 +2089,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 msgstr "Vanwege veiligheidsredenen verlopen de links voor het herstellen van een wachtwoord na een tijdje. \n"
 "Wanneer je nog steeds je wachtwoord wilt wijzigen kun je {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Om je data veilig te houden, wachtwoorden {0}"
 
@@ -2090,24 +2116,24 @@ msgstr "Bevestiging nieuw wachtwoord"
 msgid "Make sure it matches the one you just entered"
 msgstr "Zorg ervoor dat het overeenkomt met degene die je net hebt ingevuld"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Uw wachtwoord is opnieuw ingesteld."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Log in met uw nieuwe wachtwoord"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Opslaan mislukt"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2117,25 +2143,26 @@ msgstr "Opgeslagen"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Deze verzameling archiveren?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "De dashboards, collecties en pulsen in deze collectie zullen ook gearchiveerd worden."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Archief"
 
@@ -2260,7 +2287,7 @@ msgstr "Pins"
 msgid "Drag something here to pin it to the top"
 msgstr "Sleep iets hier om het bovenaan vast te zetten"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2289,6 +2316,7 @@ msgstr "Verplaats \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Verplaats"
@@ -2324,7 +2352,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "Sommige database-installaties kunnen alleen benaderd worden met een SSH verbinding. Deze optie zorgt ook voor een extra beveiliging wanneer een VPN niet beschikbaar is. Het inschakelen van deze optie is vaak langzamer dan een directe verbinding."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Dit is een grote database, laat mij kiezen wat Metabase moet synchroniseren en scannen."
 
@@ -2363,7 +2391,7 @@ msgstr "Om Metabase te gebruiken met deze data moet je de API toegang inschakele
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} om naar het console te gaan, wanneer je dit nog niet gedaan hebt."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Hoe wil je naar deze database verwijzen?"
 
@@ -2479,35 +2507,35 @@ msgstr "Gebaseerd op het schema"
 msgid "A look at your"
 msgstr "Bekijk uw"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Doorzoek de lijst"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Zoeken op {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " of voer een ID in"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Voer een ID in"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Voer een getal in"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Voer tekst in"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Geen overeenkomende {0} gevonden."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Het opnemen van elke optie in deze filter zal waarschijnlijk niet veel doen ..."
 
@@ -2519,7 +2547,6 @@ msgstr "Er is iets misgegaan"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Er is een fout opgetreden. Je kunt proberen de pagina te vernieuwen of gewoon teruggaan."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2530,12 +2557,12 @@ msgstr "Er is een fout opgetreden. Je kunt proberen de pagina te vernieuwen of g
 msgid "No description yet"
 msgstr "Nog geen omschrijving"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Nieuwe {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Gevraagd door {0}"
 
@@ -2556,7 +2583,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Teruggezet naar een eerdere revisie en {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Revisiegeschiedenis"
@@ -2602,7 +2631,7 @@ msgid "Questions"
 msgstr "Vragen"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Pulsen"
 
@@ -2676,52 +2705,69 @@ msgstr "Niet nu"
 msgid "Error:"
 msgstr "Fout:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Zondag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Maandag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Dinsdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Woensdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Donderdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Vrijdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Zaterdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Eerste"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Laatste"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15e (middenpunt)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Kalenderdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "uw Metabase-tijdzone"
 
@@ -2775,11 +2821,11 @@ msgstr "Aanmaken"
 msgid "Create dashboard"
 msgstr "Maak dashboard aan"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabel"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Database"
 
@@ -2854,9 +2900,9 @@ msgstr "Wat is de naam van uw kaart?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2870,15 +2916,16 @@ msgstr "Omschrijving"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Het optioneel, maar oh zo handig"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "In welke collectie moet dit komen?"
 
@@ -2918,11 +2965,11 @@ msgstr "Archiveer dashboard"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Zorg ervoor dat je voor elke serie een selectie maakt, anders werkt het filter niet op deze kaart."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Het dashboard ziet er leeg uit."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Voeg een vraag toe om het nuttig te maken!"
 
@@ -2942,7 +2989,7 @@ msgstr "Sluit volledig scherm"
 msgid "Enter fullscreen"
 msgstr "Open volledig scherm"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Aan het opslaan..."
@@ -2955,7 +3002,8 @@ msgstr "Voeg een vraag toe"
 msgid "Add a question to this dashboard"
 msgstr "Voeg een vraag toe aan dit dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Voeg een filter toe"
 
@@ -2963,7 +3011,7 @@ msgstr "Voeg een filter toe"
 msgid "Parameters"
 msgstr "Parameters"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Voeg een tekstveld toe"
 
@@ -2971,7 +3019,7 @@ msgstr "Voeg een tekstveld toe"
 msgid "Move dashboard"
 msgstr "Verplaats dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Bewerk dashboard"
 
@@ -2995,11 +3043,11 @@ msgstr "Verplaats dashboard naar..."
 msgid "Dashboard moved to {0}"
 msgstr "Dashboard verplaatst naar {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Wat wil je filteren?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Welke type filter?"
 
@@ -3071,20 +3119,22 @@ msgstr "Deze kaart heeft geen velden of parameters die kunnen worden toegewezen 
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "De waarden in dit veld overlappen niet met de waarden van andere velden die je hebt gekozen."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Geen valide velden"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Naam moet 100 tekens of minder zijn"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Kleur is verplicht"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Wat is de naam van je dashboard?"
 
@@ -3139,7 +3189,7 @@ msgstr "heeft de laatste data ontvangen van"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -3264,9 +3314,10 @@ msgstr "Je hebt recent geen dashboards of vragen bekeken"
 msgid "{0} items selected"
 msgstr "{0} items geselecteerd"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Dearchiveer"
 
@@ -3383,7 +3434,7 @@ msgid "Zip Code"
 msgstr "Postcode"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Aantal"
 
@@ -3416,11 +3467,13 @@ msgid "User"
 msgstr "Gebruiker"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Bron"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Prijs"
 
@@ -3453,21 +3506,23 @@ msgid "Subscription"
 msgstr "Abonnement"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Score"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titel"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Commentaar"
 
@@ -3521,14 +3576,14 @@ msgstr "Metabase haalt dit veld nooit op. Gebruik dit voor gevoelige of irreleva
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Aantal"
 
@@ -3536,7 +3591,7 @@ msgstr "Aantal"
 msgid "CumulativeCount"
 msgstr "CumulatiefAantal"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3554,19 +3609,19 @@ msgstr "Uniek"
 msgid "StandardDeviation"
 msgstr "StandaardDeviatie"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Gemiddelde"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3577,13 +3632,13 @@ msgstr "Max"
 msgid "sad sad panda, lexing errors detected"
 msgstr "Triest! lexing fout ontdekt."
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} seconde"
 msgstr[1] "{0} seconden"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuut"
@@ -3624,14 +3679,15 @@ msgstr "Waar ben je naar op zoek?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Rauwe data"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Cumulatief aantal"
 
@@ -3693,166 +3749,164 @@ msgstr "Waar"
 msgid "False"
 msgstr "Niet waar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Selecteer longitude"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Vul hoogste latitude in"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Vul longitude (links) in"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Vul laagste latitude in"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Vul longitude (rechts) in"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Is"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Is niet"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Is leeg"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Is niet leeg"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Niet gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Groter dan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Kleiner dan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Tussen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Groter dan of gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Kleiner dan of gelijk aan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Bevat"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Bevat geen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Begint met"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Eindigt met"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Voor"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Na"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Binnen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Gewoon een tabel met de rijen in het antwoord, geen extra bewerkingen."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Aantal rijen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Totaal aantal rijen in het antwoord."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Som van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Som van alle waarden van een kolom."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Gemiddelde van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Gemiddelde van alle waarden van een kolom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Aantal verschillende waarden van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Aantal unieke waarden van een kolom tussen alle rijen in het antwoord."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Cumulatieve som van ..."
 
@@ -3860,7 +3914,7 @@ msgstr "Cumulatieve som van ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Additieve som van alle waarden van een kolom. \\\\ Voorbeeld: totale omzet in de loop van de tijd."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Cumulatief aantal rijen"
 
@@ -3868,27 +3922,27 @@ msgstr "Cumulatief aantal rijen"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Optelling van het aantal rijen. \\\\ Voorbeeld: totaal aantal verkopen in de loop van de tijd."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Standaardafwijking van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Getal dat aangeeft hoeveel de waarden van een kolom variëren tussen alle rijen in het antwoord."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Minimum van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Minimale waarde van een kolom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Maximum van ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Maximale waarde van een kolom"
 
@@ -3904,6 +3958,8 @@ msgstr "kleine letter"
 msgid "upper case letter"
 msgstr "hoofdletter"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "aantal"
@@ -4151,7 +4207,7 @@ msgstr "Hoe maak je metrieken"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Bekijk gegevens in de loop van de tijd of als een kaart om trends of veranderingen beter te kunnen begrijpen."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Aangepast"
 
@@ -4174,7 +4230,7 @@ msgstr "Native query"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Voor meer gecompliceerde vragen kunt u uw eigen SQL- of native query schrijven."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Selecteer een standaardwaarde..."
 
@@ -4265,7 +4321,7 @@ msgstr "Deze maand"
 msgid "This Year"
 msgstr "Dit jaar"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Voer een waarde in..."
@@ -4275,7 +4331,7 @@ msgid "Enter a default value..."
 msgstr "Voer een standaard waarde in..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Een fout is opgetreden"
@@ -4533,22 +4589,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Kies de vragen welke je graag wilt versturen met deze puls"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "E-mails"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slack berichten"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Verstuurd"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} wordt verzonden om"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Berichten"
 
@@ -4620,30 +4684,30 @@ msgstr "Help iedereen in je team en blijf op de hoogte van je data"
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Pulsen kunnen vanuit Metabase verzonden worden via e-mail of Slack op een ingeplande datum naar keuze."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Na {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Voor {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Is leeg"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Niet leeg"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Altijd"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Pas toe"
 
@@ -4744,12 +4808,12 @@ msgstr[1] "Bekijk deze {0}"
 msgid "Zoom in"
 msgstr "Inzoomen"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Aangepaste expressie"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Populaire statistieken"
 
@@ -4946,7 +5010,7 @@ msgstr "doorgaans"
 msgid "Pick a segment or table"
 msgstr "Kies een segment of tabel"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Selecteer een database"
@@ -5007,7 +5071,7 @@ msgstr "Sorteer"
 msgid "Row limit"
 msgstr "Rij limiet"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Onbekend veld"
 
@@ -5015,7 +5079,7 @@ msgstr "Onbekend veld"
 msgid "field"
 msgstr "veld"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Matcht"
 
@@ -5040,11 +5104,11 @@ msgstr "Groepering toevoegen"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Data"
 
@@ -5061,11 +5125,12 @@ msgstr "Bekijk"
 msgid "Grouped By"
 msgstr "Gegroepeerd op"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Geen"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Deze vraag is geschreven in {0}."
 
@@ -5077,7 +5142,7 @@ msgstr "Verberg editor"
 msgid "Hide Query"
 msgstr "Query verbergen"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Editor openen"
 
@@ -5085,7 +5150,7 @@ msgstr "Editor openen"
 msgid "Show Query"
 msgstr "Query weergeven"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Deze metriek is gestopt. Het is niet langer beschikbaar voor gebruik."
 
@@ -5286,7 +5351,7 @@ msgstr "Terug naar laatste run"
 msgid "Visualization"
 msgstr "Visualisatie"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Geen beschrijving gezet."
 
@@ -5343,7 +5408,7 @@ msgstr "Kon de metadata van de tabel niet vinden voor het aanmaken van een nieuw
 msgid "See {0}"
 msgstr "Zie {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Metriek definitie"
 
@@ -5361,11 +5426,11 @@ msgstr "Aantal {0}"
 msgid "See all {0}"
 msgstr "Bekijk alle {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Segmentdefinitie"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Er is een fout opgetreden tijdens het laden van de tabel"
 
@@ -5373,7 +5438,7 @@ msgstr "Er is een fout opgetreden tijdens het laden van de tabel"
 msgid "See the raw data for {0}"
 msgstr "Bekijk de onbewerkte resultaten voor {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Meer"
 
@@ -5393,6 +5458,8 @@ msgstr "Veld formule"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Zie dit als het schrijven van een formule in een spreadsheetprogramma: je kunt getallen, velden in deze tabel, wiskundige symbolen zoals + en sommige functies gebruiken. Dus je zou iets kunnen typen als Subtotaal - Kosten."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5460,7 +5527,7 @@ msgstr "Onwaar"
 msgid "Add filter"
 msgstr "Filter toevoegen"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Item"
 
@@ -5579,11 +5646,11 @@ msgstr "Veld om te koppelen"
 msgid "Filter widget type"
 msgstr "Filter widget type"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Verplicht?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Standaard filter widget waarde"
 
@@ -5595,7 +5662,7 @@ msgstr "Deze vraag archiveren?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Deze vraag zal verwijderd worden van elk dashboard of puls waar deze gebruikt wordt."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Vraag"
 
@@ -5642,7 +5709,7 @@ msgstr "Veld type"
 msgid "Select a Foreign Key"
 msgstr "Selecteer een foreign key"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Bekijk de {0} formule"
 
@@ -6126,22 +6193,24 @@ msgstr "Vragen over dit segment"
 msgid "X-ray this segment"
 msgstr "X-ray dit segment"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Inloggen"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Zoeken"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nieuwe vraag"
 
@@ -6213,35 +6282,35 @@ msgstr "Alle collecties zijn volledig anoniem"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Verzameling kan op elk moment in je beheerdersinstellingen worden uitgeschakeld."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Als je er niet uitkomt"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "onze beknopte handleiding"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "is slechts een klik verwijderd."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Welkom bij Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Het lijkt er op dat alles werkt. Laten we kennis maken, verbinding maken met je data en starten met het vinden van wat antwoorden!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Laten we starten"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Je bent er helemaal klaar voor!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Breng me naar Metabase"
 
@@ -6493,39 +6562,40 @@ msgstr "Annuleer filter"
 msgid "Pin Map"
 msgstr "Kaart pinnen"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Leegmaken"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Rijen {0}-{1} van {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Gegevens afgekapt tot {0} rijen."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Kan visualisatie niet vinden"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Kan deze grafiek niet met deze gegevens weergeven."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Geen resultaten"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Nog steeds bezig met wachten..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Dit duurt meestal gemiddeld {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Dit is een beetje lang voor een dashboard)"
 
@@ -6635,7 +6705,7 @@ msgid "Highlight the whole row"
 msgstr "Markeer de hele rij"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Kleuren"
 
@@ -6721,24 +6791,50 @@ msgstr "Doel"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Doh! De gegevens van je zoekopdracht passen niet in de gekozen weergave. Deze visualisatie vereist ten minste {0} {1} aan gegevens."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "Kolom"
@@ -6770,7 +6866,7 @@ msgid "xValues missing!"
 msgstr "xWaardes missen!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X-as"
 
@@ -6779,7 +6875,7 @@ msgid "Add a series breakout..."
 msgstr "Voeg een serie breakout toe ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y-as"
 
@@ -6792,7 +6888,7 @@ msgid "Bubble size"
 msgstr "Bubble grootte"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Lijn"
 
@@ -6934,20 +7030,20 @@ msgid "Standard Deviation"
 msgstr "Standaardafwijking"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Vlak"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "vlakdiagram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Staaf"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "staaf diagram"
 
@@ -6961,7 +7057,7 @@ msgid "Funnel"
 msgstr "Trechter"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Maatstaaf"
 
@@ -6973,81 +7069,81 @@ msgstr "Trechter type"
 msgid "Bar chart"
 msgstr "Staaf diagram"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "Lijn diagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Selecteer lengte- en breedtegraadkolommen in de grafiekinstellingen."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Selecteer een regio"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Selecteer een regio en kolommen in de grafiek instellingen"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Kaart"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Kaart type"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Regio kaart"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Marker kaart"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Marker type"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Tegels"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Markers"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Latitude veld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Longitude veld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Metriek veld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Regio veld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Redius"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Blur"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Minimale doorzichtigheid"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Maximale zoom"
 
@@ -7059,7 +7155,7 @@ msgstr "Geen relaties gevonden"
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Deze {0} is verbonden aan"
 
@@ -7071,31 +7167,31 @@ msgstr "Object detail"
 msgid "object"
 msgstr "object"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Totaal"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Welke kolommen wil je gebruiken?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Taart"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimensie"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Legenda tonen"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Percentages weergeven in legende"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minimaal percentage per vlak"
 
@@ -7120,7 +7216,8 @@ msgid "Progress"
 msgstr "Vooruitgang"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Kleur"
@@ -7129,7 +7226,7 @@ msgstr "Kleur"
 msgid "Row Chart"
 msgstr "Rij grafiek"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "rij grafiek"
 
@@ -7153,15 +7250,15 @@ msgstr "Achtervoegsel toevoegen"
 msgid "Multiply by a number"
 msgstr "Vermenigvuldig met een getal"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Spreiding"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "spreidingsplot"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Draai de tabel"
 
@@ -7211,13 +7308,13 @@ msgstr "Rechts"
 msgid "Show background"
 msgstr "Achtergrond weergeven"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "bak"
 msgstr[1] "bakken"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Automatisch toegevoegd aan bak"
 
@@ -7453,10 +7550,13 @@ msgstr "Heb je veel vragen opgeslagen in {0}? Maak collecties om ze te helpen be
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7646,7 +7746,7 @@ msgstr "cumulatieve som"
 msgid "{0} and {1}"
 msgstr "{0} en {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} of {1}"
@@ -8960,11 +9060,11 @@ msgstr "Datarechten"
 msgid "Collection permissions"
 msgstr "Verzamelingsrechten"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Toon alle verzamelingsrechten"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Wijzig ook subcollecties"
 
@@ -8976,19 +9076,19 @@ msgstr "Kan deze verzameling en de inhoud ervan bewerken"
 msgid "Can view items in this collection"
 msgstr "Kan items in deze collectie bekijken"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Verzamelingstoegang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Deze groep heeft toestemming om ten minste één deelcollectie van deze verzameling te bekijken."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Deze groep heeft toestemming om ten minste één subcollectie van deze verzameling te bewerken."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Toon subverzamelingen"
 
@@ -9044,6 +9144,7 @@ msgstr "Gerelateerd"
 msgid "More X-rays"
 msgstr "Meer x-rays"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9303,10 +9404,10 @@ msgstr "Delen"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9390,7 +9491,7 @@ msgstr "Gebruik JVM tijdzone"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "We analyseren momenteel de tabellen en velden om je te helpen met het verkennen van je gegevens."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Tip:"
 
@@ -9398,7 +9499,7 @@ msgstr "Tip:"
 msgid "Select a currency type"
 msgstr "Selecteer een valutatype"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Ved type"
 
@@ -9453,6 +9554,7 @@ msgid "Currency"
 msgstr "Valuta"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Kies een gebruiker of kanaal ..."
 
@@ -9614,7 +9716,7 @@ msgstr "Welke assen?"
 msgid "Line + Bar"
 msgstr "Lijn en staaf"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "Lijn en staaf grafiek"
 
@@ -9634,15 +9736,15 @@ msgstr "Meter bereik"
 msgid "Field to show"
 msgstr "Veld om weer te geven"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "Laatste {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} was {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Groeperen bij een tijdveld om te kijken hoe dit veranderd is over de tijd"
 
@@ -9650,23 +9752,23 @@ msgstr "Groeperen bij een tijdveld om te kijken hoe dit veranderd is over de tij
 msgid "Switch positive / negative colors?"
 msgstr "Schakelen tussen positieve / negatieve kleuren?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Draaikolom"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Celkolom"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Zichtbare kolommen"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Conditionele opmaak"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Kolomtitel"
 
@@ -10104,10 +10206,10 @@ msgstr "Gebruikers per bron"
 msgid "The top external pages that brought users to your site"
 msgstr "De populairste externe pagina's die gebruikers naar je site hebben geleid"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Hoe [[this]] is gedistribueerd en meer."
 
@@ -10205,13 +10307,13 @@ msgstr "Gebeurtenissen per uur van de dag"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Top 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Laatste 5 [[this]]"
 
@@ -10224,10 +10326,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Null waardes"
 
@@ -10255,8 +10357,8 @@ msgstr "Seizoensinvloeden vergelijken"
 msgid "Average income per transaction"
 msgstr "Gemiddelde inkomen per transactie"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] per land"
 
@@ -10380,10 +10482,10 @@ msgstr "Een overzicht van je [[this]] en hoe deze is verdeeld over tijd, plaats 
 msgid "Average income per state"
 msgstr "Gemiddeld inkomen per staat"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] per [[GenericCategoryMedium]]"
 
@@ -10560,13 +10662,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Hoe [[GenericTable]] over dit tijdveld is verdeeld en of het seizoenspatronen heeft."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Overzicht"
 
@@ -10675,8 +10777,8 @@ msgstr "Hier is een nadere blik op [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Hier is een nadere blik op [[dit]] veld"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Samenvatting"
 
@@ -10740,10 +10842,10 @@ msgstr "Verkoop per bron"
 msgid "Average income per country"
 msgstr "Gemiddelde inkomen per land"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Hoe [[this]] is verdeeld"
 
@@ -10764,17 +10866,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Aantal [[GenericCategoryMedium]] per [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Een blik op [[this]]"
 
@@ -10840,10 +10942,10 @@ msgid "Transactions per source over time"
 msgstr "Transacties per bron over de tijd"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Hoe [[this] is verdeeld"
 
@@ -10872,9 +10974,9 @@ msgstr "Waar deze gebeurtenissen plaatsvinden"
 msgid "Which US states are bringing you the most business."
 msgstr "Welke Amerikaanse staten dragen het meeste bij voor je zaken."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Hoe ze vergelijken over de tijd"
 
@@ -10979,8 +11081,8 @@ msgstr "Sessies per land"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Enkele interessante statistieken over uw GA-statistieken om je op weg te helpen."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] per staat"
 
@@ -11061,12 +11163,12 @@ msgstr "Hoe deze metriek verdeeld is over verschillende nummers"
 msgid "Sessions by page where the session began"
 msgstr "Sessies per pagina wanneer de sessie begon"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Unieke waardes"
 
@@ -11129,10 +11231,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Gebeurtenissen per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "In vergelijking tot de verdeling"
@@ -11438,6 +11540,7 @@ msgstr "Dashboard dupliceren"
 msgid "Duplicate \"{0}\""
 msgstr "Dupliceer \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11535,9 +11638,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Kwartaal van het jaar"
 msgstr[1] "Kwartalen van het jaar"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} selectie"
@@ -11560,11 +11663,11 @@ msgstr "Ongeldig"
 msgid "Add a time"
 msgstr "Voeg een tijd toe"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Niets om te vergelijken voor de vorige {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "bij {0}"
 
@@ -11758,7 +11861,7 @@ msgstr "Plug-ins laden in {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Using Clojure base loader as shared context classloader: {0}"
+msgstr "Clojure-basislader gebruiken als gedeelde contextklassenlader: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
@@ -12052,9 +12155,9 @@ msgstr "Hier is een overzicht van de mensen in [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] per kwartaal van het jaar"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Hoe ze verhouden tot verschillende locaties"
 
@@ -12083,12 +12186,12 @@ msgstr "[[CreateTimestamp]] per dag van de week"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Hier is een overzicht van je [[this]] gegevens van Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Hier is een overzicht van [[this]]"
 
@@ -12166,11 +12269,11 @@ msgstr "collectie"
 msgid "collections"
 msgstr "collecties"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "dashboard"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "dashboards"
 
@@ -12420,7 +12523,7 @@ msgstr "Time-out na {0} milliseconden."
 msgid "Misfire Instruction"
 msgstr "Misfire instructie"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Dit archiveren?"
 
@@ -12440,7 +12543,7 @@ msgstr "Als je deze optie gebruikt, moet de geleverde host een FQDN zijn. Als u 
 "een Atlas-cluster, moet u deze optie mogelijk inschakelen. Als je niet weet wat dit betekent,\n"
 "laat dit uitgeschakeld."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Voer automatisch query's uit wanneer u eenvoudig filtert en samenvat"
 
@@ -12452,7 +12555,7 @@ msgstr "Wanneer dit is ingeschakeld, voert Metabase automatisch zoekopdrachten u
 msgid "Learn about this database"
 msgstr "Meer informatie over deze database"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Dit dashboard archiveren?"
 
@@ -12508,11 +12611,11 @@ msgstr "Aangepaste vraag"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Gebruik de geavanceerde notebookeditor om gegevens samen te voegen, aangepaste kolommen te maken, wiskunde uit te voeren en meer."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Basisstatistieken"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Aangepast.."
 
@@ -12697,15 +12800,15 @@ msgstr "Kies een visualisatie"
 msgid "Filter by"
 msgstr "Filteren bij"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Samenvatten bij"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Groeperen bij"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Voeg een metriek toe"
 
@@ -12716,15 +12819,15 @@ msgstr "Voeg een metriek toe"
 msgid "Profile"
 msgstr "Profiel"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Dit is meestal vrij snel, maar lijkt nu even te duren."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Combinatie"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Rij"
 
@@ -13145,7 +13248,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Kies de kolommen die je mee wilt nemen"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Wanneer dit is ingeschakeld, voert Metabase automatisch query's uit wanneer gebruikers eenvoudige verkenningen doen met de knoppen Samenvatting en Filter bij het bekijken van een tabel of diagram. Je kunt dit uitschakelen als het opvragen van deze database lang duurt. Deze instelling heeft geen invloed op drill-throughs of SQL-query's."
 
@@ -13211,7 +13314,7 @@ msgstr "Log in via e-mail"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Deze optie stelt verplicht dat de ingestelde host een FQDN is. Wanneer je verbinding probeert te maken met een Atlas kluster wil je deze optie misschien inschakelen. Wanneer je niet precies weet wat dit betekend kun je deze optie beter uitgeschakeld laten."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Standaard voert Metabase een lichte uurlijke synchronisatie uit en een dagelijkse uitgebreide scan voor veldwaardes. Wanneer je een grote database heeft bevelen we aan om deze optie aan te zetten en te bekijken wanneer en hoe vaak de veldwaarde scans uitgevoerd worden."
 
@@ -13279,11 +13382,11 @@ msgstr "Voeg niet toe"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Dit veld is niet zichtbaar of selecteerbaar in vragen die met de GUI-interfaces zijn gemaakt. Het blijft toegankelijk voor SQL / native query's."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Cumulatieve som"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Standaardafwijking"
 
@@ -13299,19 +13402,19 @@ msgstr "Moet ten minste {0} tekens lang zijn"
 msgid "Name (required)"
 msgstr "Naam (verplicht)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Voer geselecteerde tekst uit"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Voer query uit"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13661,7 +13764,7 @@ msgstr "Datum en tijden"
 msgid "Numbers"
 msgstr "Nummers"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Geen toewijsbare groepen"
 
@@ -13701,15 +13804,15 @@ msgstr "jezietergoeduitvandaag@email.com"
 msgid "Remember me"
 msgstr "Onthoud mij"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Voor beveiligingsredenen zijn verzoeken voor het herstellen van een wachtwoord maar tijdelijk beschikbaar. Wanneer je nog steeds je wachtwoord moet herstellen kun je {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Nieuw wachtwoord opslaan"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Geen overeenkomende resultaten"
 
@@ -13735,26 +13838,26 @@ msgid "or"
 msgstr "of"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "Verplicht"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Database type"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Dit is een lichtgewichtproces dat controleert op updates van het schema van deze database. In de meeste gevallen zou het goed moeten zijn als deze set elk uur wordt gesynchroniseerd."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase kan de waarden in elk veld in deze database scannen om selectievakjesfilters in dashboards en vragen in te schakelen. Dit kan een ietwat resource-intensief proces zijn, vooral bij een zeer grote database."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Collectie"
 
@@ -13801,7 +13904,7 @@ msgstr "Categorisch"
 msgid "URLs"
 msgstr "URLs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Retourneert het gemiddelde van de waarden in de kolom."
 
@@ -13810,11 +13913,13 @@ msgstr "Retourneert het gemiddelde van de waarden in de kolom."
 msgid "The column whose values to average."
 msgstr "De kolom waarvan de gemiddelde waarden gebruikt moeten worden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "begin"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "einde"
 
@@ -13826,21 +13931,19 @@ msgstr "Controleert de waarden van een datum of numerieke kolom om te zien of de
 msgid "Rating"
 msgstr "Beoordeling"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "conditie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "uitvoer"
 
@@ -13848,27 +13951,27 @@ msgstr "uitvoer"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Test een lijst met cases en retourneert de bijbehorende waarde van de eerste echte case, met een optionele standaardwaarde als aan niets anders wordt voldaan."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Gewicht"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Groot"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Medium"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Klein"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Iets dat moet evalueren als waar of onwaar."
 
@@ -13876,33 +13979,33 @@ msgstr "Iets dat moet evalueren als waar of onwaar."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "De waarde die wordt geretourneerd als de voorgaande voorwaarde waar is."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "waarde1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "waarde2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Bekijkt de waarden in elk argument in volgorde en retourneert de eerste niet-nulwaarde voor elke rij."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Opmerkingen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notities"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Geen opmerkingen"
 
@@ -13918,12 +14021,12 @@ msgstr "Als waarde1 leeg is, wordt waarde2 geretourneerd als deze niet leeg is, 
 msgid "Combines two or more strings of text together."
 msgstr "Combineert twee of meer strings samen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Achternaam"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Voornaam"
 
@@ -13935,27 +14038,27 @@ msgstr "waarde 2 wordt aan het einde hiervan toegevoegd."
 msgid "This will be added to the end of value1."
 msgstr "Dit wordt toegevoegd aan het einde van waarde1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Controleert of string1 string2 bevat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Overslaan"
 
@@ -13963,7 +14066,7 @@ msgstr "Overslaan"
 msgid "The contents of this string will be checked."
 msgstr "De inhoud van deze string wordt gecontroleerd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "De string waarnaar moet worden gezocht."
 
@@ -13971,22 +14074,22 @@ msgstr "De string waarnaar moet worden gezocht."
 msgid "Returns the count of rows in the source data."
 msgstr "Retourneert het aantal rijen in de brongegevens."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Telt alleen rijen waar de voorwaarde waar is."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Subtotaal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Het additieve totaal van rijen over een breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "De rollende som van een kolom over een breakout."
 
@@ -13995,53 +14098,57 @@ msgstr "De rollende som van een kolom over een breakout."
 msgid "The column to sum."
 msgstr "De kolom die moet worden opgeteld."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Het aantal verschillende waarden in deze kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "De kolom waarvan het aantal verschillende waarden moeten worden geteld."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "vergelijking"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retourneert true als het einde van de tekst overeenkomt met de vergelijkingstekst."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Eetlust"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hongerig"
 
@@ -14050,20 +14157,20 @@ msgstr "hongerig"
 msgid "A column or string of text to check."
 msgstr "Een kolom of string om te controleren."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "De string waarmee de oorspronkelijke tekst moet eindigen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "reguliere_expressie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Pakt overeenkomende substrings volgens een reguliere expressie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adres"
 
@@ -14071,7 +14178,7 @@ msgstr "Adres"
 msgid "The column or string of text to search though."
 msgstr "De kolom of tekenreeks om te zoeken."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "De reguliere expressie om te vinden."
 
@@ -14083,7 +14190,7 @@ msgstr "Retourneert de tekenreeks in kleine letters."
 msgid "The column with values to convert to lowercase."
 msgstr "De kolom met waarden die naar kleine letters moeten worden geconverteerd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Hiermee wordt witte ruimtes uit een string verwijderd."
 
@@ -14093,15 +14200,16 @@ msgstr "Hiermee wordt witte ruimtes uit een string verwijderd."
 msgid "The column with values you want to trim."
 msgstr "De kolom met waarden die je wilt trimmen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Retourneert de grootste waarde die in de kolom is gevonden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Leeftijd"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "De numerieke kolom waarvan je het maximum wilt vinden."
 
@@ -14109,21 +14217,21 @@ msgstr "De numerieke kolom waarvan je het maximum wilt vinden."
 msgid "Returns the smallest value found in the column."
 msgstr "Retourneert de kleinste waarde die in de kolom is gevonden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Salaris"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "De numerieke kolom waarvan je het minimum wilt vinden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "positie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "lengte"
 
@@ -14132,7 +14240,7 @@ msgstr "lengte"
 msgid "new_text"
 msgstr "nieuwe_tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Vervangt een deel van de invoertekst door nieuwe tekst."
 
@@ -14160,35 +14268,35 @@ msgstr "Het aantal tekens dat moet worden vervangen."
 msgid "The text to use in the replacement."
 msgstr "De tekst die moet worden gebruikt bij de vervanging."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Hiermee wordt witruimte aan het einde van een string verwijderd."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Retourneert het percentage rijen in de gegevens die overeenkomen met de voorwaarde, als een decimaal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retourneert true als het begin van de tekst overeenkomt met de vergelijkingstekst."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Naam van vak"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Computer wetenschappen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "De string waarmee de originele tekst moet beginnen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Berekent de standaarddeviatie van de kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Populatie"
 
@@ -14196,7 +14304,7 @@ msgstr "Populatie"
 msgid "A numeric column."
 msgstr "Een numerieke kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Retourneert een gedeelte van de opgegeven tekst."
 
@@ -14204,19 +14312,19 @@ msgstr "Retourneert een gedeelte van de opgegeven tekst."
 msgid "The text to return a portion of."
 msgstr "De tekst om een deel van te retourneren."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "De startpositie om tekens te kopiëren."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Het aantal karakters wat wordt teruggegeven."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Telt alle waardes bij elkaar op voor de kolom."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "De numerieke kolom voor het optellen."
 
@@ -14224,15 +14332,15 @@ msgstr "De numerieke kolom voor het optellen."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Vat waarden samen in een kolom waar rijen overeenkomen met de voorwaarde."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Bestelling status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Geldig"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Verwijdert witruimtes aan het begin en einde van een string."
 
@@ -14240,47 +14348,47 @@ msgstr "Verwijdert witruimtes aan het begin en einde van een string."
 msgid "Returns the string of text in all upper case."
 msgstr "Retourneert de string in hoofdletters."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "De kolom met waarden die naar hoofdletters moeten worden geconverteerd."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "moet {0} en {1} bevatten."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "moet {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "moet {0} bevatten."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "tenminste {0} karakter lang"
 msgstr[1] "tenminste {0} karakters lang"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} kleine letter"
 msgstr[1] "{0} kleine letters"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} hoofdletter"
 msgstr[1] "{0} hoofdletters"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} nummer"
 msgstr[1] "{0} nummers"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} speciale karakter"
@@ -14303,6 +14411,7 @@ msgid "Powered by {0}"
 msgstr "Aangedreven door {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Naar:"
 
@@ -14390,7 +14499,7 @@ msgstr "Waarde opmaak"
 msgid "Full"
 msgstr "Vol"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Geen veranderingen van laatste {0}"
 
@@ -14715,7 +14824,7 @@ msgstr "Fout bij het genereren van inzichten voor kolom:"
 msgid "Sending abandonment email!"
 msgstr "Verlaten e-mail verzenden!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Je kunt opgeslagen metrische gegevens maken om een genaamde metrieke optie toe te voegen. Opgeslagen metrieken bevatten onder meer het aggregatietype, het geaggregeerde veld en optioneel de filter(s) die je toevoegt. Je kunt dit bijvoorbeeld gebruiken om een officiële manier vast te leggen voor de \"Gemiddelde prijs\" van een Orders-tabel (feit)."
 
@@ -14723,15 +14832,15 @@ msgstr "Je kunt opgeslagen metrische gegevens maken om een genaamde metrieke opt
 msgid "Select and add filters to create your new segment."
 msgstr "Selecteer en voeg filters toe om een nieuw segment te maken."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alfabetisch"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Slim"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Kolommenvolgorde: {0}"
 
@@ -14783,7 +14892,7 @@ msgstr "Localisatie"
 msgid "Instance language"
 msgstr "Taal van deze installatie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Localisatieopties"
 
@@ -14855,19 +14964,20 @@ msgstr "Plak de verbindingsstring"
 msgid "Fill out individual fields"
 msgstr "Afzonderlijke velden invullen"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "SQL invoeren om later te hergebruiken"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Geef je snippet een naam"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Huidige klanten"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Beschrijving toevoegen"
 
@@ -14875,46 +14985,47 @@ msgstr "Beschrijving toevoegen"
 msgid "Use site default"
 msgstr "Standaard gebruiken"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "vinden"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "vervangen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Tekst om te vinden."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Tekst om mee te vervangen."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "{0} wijzigen"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Maak je nieuwe snippet"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Gearchiveerde snippets"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Snippets zijn herbruikbare stukjes SQL code"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Nieuwe snippet"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Snippets"
 
@@ -15193,3 +15304,1502 @@ msgstr "waarde moet een trefwoord of tekenreeks zijn."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "String moet een geldige tweeletterige ISO-taal of taal-landcode zijn, bijv. 'nl' of 'nl_NL'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Rijen {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Audit"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Gebruikersattribuut configuratie (optioneel)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Gebruikend {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "SSO met SAML instellen"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML-authenticatie"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Uw identiteisprovider (IdP) instellen"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Uw identiteitsprovider zal het volgende over Metabase moeten weten."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL waarnaar IdP zal doorsturen"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "In Okta heet dit de Single Sign On URL, in Auth0 de Application Callback URL, in OneLogin de ACS (Consumer) URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML-attributen"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "Bij meeste IdP's zult u deze waardes in het invoerveld \"Name\" van attributen moeten invoeren."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Attribuut \"Gebruikerse-mail\""
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Attribuut \"Gebruikersvoornaam\""
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Attribuut \"Gebruikersachternaam\""
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Vertel Metabase over uw identiteisprovider"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase zal het volende over uw provider moeten weten."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL van de SAML-provider"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Certificaat van de SAML-provider"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML-applicatienaam"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "SSO-aanvragen ondertekenen (optioneel)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Pad naar SAML-keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Wachtwoord van SAML-keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Shh...."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Alias binnen SAML-keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Groepslidmaatschap met uw SSO synchroniseren"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "U zult vertalingen moeten aanmaken van SSO-groepen naar Metabase-groepen, zodat gebruikers automatisch aan juiste groepen worden toegevoegd."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Groepsnaam"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Naam van het groepsattribuut"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Noot:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Als uw enige van de instellingen van een actieve SAML-setup aanpast, zult u Metabase opnieuw moeten opstarten."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Laat gebruikers via een SAML-identiteitsprovider inloggen."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Laat gebruikers via een JWT-identiteitsprovider inloggen."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Met wachtwoord laten inloggen"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Gebruikers kunnen ook met een e-mail en wachtwoord inloggen"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Nieuwe SSO-gebruikers aan beheerders melden"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Beheerders krijgen een e-mail als een gebruiker voor het eerst met Single Sign-On inlogt."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Met de instellingen hieronder stelt u SSO via SAML in. Raadpleeg {0} als u vragen hebt."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "documentatie"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI van SAML-identiteitsprovider"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT-authenticatie"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI van JWT-identiteitsprovider "
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Tekenreeks die wordt gebruikt door de JWT-ondertekeningssleutel"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "De volledige Metabase-app insluiten"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Wanneer je Metabase volledig wilt insluiten, voer je hier de oorsprong (origin) in van de websites of web-apps waar je de insluiting wilt toestaan (in een iframe), gescheiden door een spatie. Hier zijn de {0} voor wat kan worden ingevoerd."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Verleen sandbox-toegang tot deze tabel"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Wanneer gebruikers in deze groep deze tabel bekijken, zien ze een versie ervan die gefilterd is op hun gebruikersattributen, of een aangepaste weergave ervan op basis van een opgeslagen vraag."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Hoe wil je deze tabel filteren voor gebruikers in deze groep?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Kies een opgeslagen vraag die de aangepaste weergave van deze tabel retourneert die deze gebruikers zouden moeten zien."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Je kunt hier optioneel extra filters toevoegen op basis van gebruikersattributen. Deze filters worden toegepast bovenop alle filters die al in deze opgeslagen vraag staan."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Om deze optie te laten werken, hebben de gebruikers een aantal attributen nodig"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Om extra filters toe te voegen, hebben de gebruikers een aantal attributen nodig"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Geen gebruikersattributen"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Kies een gebruikerskenmerk"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Kies een parameter"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Kies een kolom"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Gebruikers in {0} kunnen bekijken"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "rijen in de {0} vraag"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "rijen in de {0} tabel"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "waar {0} gelijk is aan {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "en {0} gelijk is aan {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Je kunt automatisch attributen toevoegen door een SSO in te stellen die SAML gebruikt, of je kunt ze handmatig invoeren door naar de sectie 'Mensen' te gaan en op het menu … te klikken (helemaal rechts)."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Gebruiker attribuut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "We kunnen automatisch de kenmerken van uw gebruikers verkrijgen als je SSO hebt ingesteld, of je kunt ze handmatig toevoegen via het menu \"...\" in het gedeelte 'Mensen' van het beheerdersdashboard."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parameter of variabele"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "gelijk aan"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Verleen sandbox-toegang"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Sandbox-toegang"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Sandbox-toegang bewerken"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Bewerk mapdetails"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Rechten wijzigen"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Maak je nieuwe map aan"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nieuwe map"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "We hebben problemen met het valideren van je token"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Controleer nogmaals of de instantie verbinding kan maken met de servers van Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Verkrijg hulp"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Haal nog meer uit Metabase met de Enterprise Editie"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Alle tools die je nodig hebt om snel en eenvoudig rapporten aan je klanten te leveren, of om u te helpen Metabase in een grote organisatie op te zetten en te monitoren"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Activeer een licentie"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Je proefperiode is actief met deze functies"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Proefperiode verloopt {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Hulp nodig? Klaar om te kopen?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Praat met ons"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Je proefperiode is vervallen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Meer tijd nodig? Klaar om te kopen?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Je functies zijn actief!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Je licentie is geldig tot en met {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Je licentie is vervallen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Het is verlopen op {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Wil je de licentie verlengen?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Leer hoe je dit kunt gebruiken"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Niet inbegrepen in je huidige plan"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Voer hier de token in dat je van de winkel hebt ontvangen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Activeren"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Hulp nodig?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Meer informatie over je probleem."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Support contacteren"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Data sandboxes"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Zorg ervoor dat je de juiste mensen, de juiste gegevens laat zien met automatische en veilige filters op basis van gebruikersattributen."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "White labeling"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Stem Metabase af op je eigen merk met aangepaste kleuren, je eigen logo en meer."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Auditing"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Houd prestaties en gedrag in de gaten met robuuste controletools."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Single sign-on (SSO)"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Bied eenvoudig inloggen dat werkt met uw bestaande authenticatie-infrastructuur."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Winkel"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Applicatienaam"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Kleurenpalet"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Landing pagina website"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Geen groepen"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Rechten voor {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Rechten voor deze map"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Verleen bewerkingsrechten"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Kan fragmenten in deze map wijzigen"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Verleen Lees-toegang"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Kan fragmenten in deze map toevoegen en gebruiken, maar kan de SQL die ze bevatten niet bewerken"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Kan fragmenten in deze map niet bekijken of toevoegen"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Verander ook submappen"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Eerste dag van de week"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Er is een probleem opgetreden bij het inloggen met Google. Neem dan contact op met een administrator."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "op de"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "om"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Open het Metabase-actie menu"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Niets doen"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Ga naar een aangepaste bestemming"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Werk een dashboardfilter bij"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "filter voor {0} updates {1}"
+msgstr[1] "filters voor {0} updates {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} gaat naar {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Gedrag bij klikken voor elke kolom"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Ga naar aangepaste bestemming"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Open de actie-menu"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Klikgedrag voor {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Kies een of meer filters om bij te werken"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Opgeslagen vragen"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Linken naar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Voer een URL in om naar te linken"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Je kunt de waarde van een kolom- of dashboardfilter met de naam toevoegen, zoals: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "bijv. https://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Kies een dashboard..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Kies een vraag..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Kies een dashboard om naar te linken"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Kies een vraag om naar te linken"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Geef waarden door aan de filters van dit dashboard (optioneel)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Geef waarden door aan de variabelen van deze vraag (optioneel)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Geef waarden door om deze vraag te filteren (optioneel)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Dashboardfilters"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Gebruikersattributen"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Linktekst aanpassen (optioneel)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "Bijv. details voor {{Column Name}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Waarden waarnaar je kunt verwijzen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Geen beschikbare doelen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "variabele"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Andere beschikbare filters"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Beschikbare filters"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Andere beschikbare variabelen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Beschikbare variabelen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Andere beschikbare kolommen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Beschikbare kolommen"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "gebruikersattribuut"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Tekst-card"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Klikgedrag"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Visualisatie-opties"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Serie bewerken"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Serie toevoegen"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Bij klikken"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Verander titel en beschrijving"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Je hebt ingesloten parameters bijgewerkt en moet je insluitcode bijwerken."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Vraag toevoegen"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Je bewerkt dit dashboard."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Kolom om op te filteren"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "fragment-verzameling"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "fragment-verzamelingen"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Geef je map een naam"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Iets kort maar liefs"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Map waarin deze zich zou moeten bevinden"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Open het actie-menu"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} kolom heeft een aangepast gedrag"
+msgstr[1] "{0} kolommen hebben een aangepast gedrag"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Ga naar..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Ga naar dashboard"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Ga naar vraag"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Ga naar URL"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filter dit dashboard"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Retourneert het aantal rijen in de geselecteerde gegevens."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "De kolom of het getal dat moet worden opgeteld."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "De numerieke kolom waarvan de standaarddeviatie moet worden bepaald."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "De numerieke kolom waarvan het gemiddelde van de waarden moet worden berekend."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Retourneert de kleinste waarde die in de kolom is gevonden"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Telt de opgegeven kolom alleen op voor rijen waarvoor de voorwaarde waar is."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Retourneert de numerieke variantie voor een bepaalde kolom."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Temperatuur"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "De kolom of het getal waarvan de variantie moet worden bepaald."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Retourneert de mediaanwaarde van de opgegeven kolom."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "De kolom of het getal waarvan de mediaan moet worden bepaald."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "percentielwaarde"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Retourneert de waarde van de kolom met de percentielwaarde."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "De kolom of het getal waarvan het percentiel moet worden bepaald."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "De waarde van het percentiel."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Retourneert de tekenreeks in kleine letters."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "De kolom met waarden die naar kleine letters moeten worden geconverteerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Retourneert de tekst in hoofdletters."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "De kolom of tekst waarvan een gedeelte moet worden geretourneerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "De kolom of tekst die moet worden doorzocht."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Combineer twee of meer tekstreeksen met elkaar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "De kolom of tekst om mee te beginnen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Dit wordt toegevoegd aan het einde van waarde1, enzovoort."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Enorm"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigantisch"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Retourneert het aantal tekens in tekst."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "De kolom of tekst waarvan je de lengte wilt krijgen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "De kolom of tekst die je wilt trimmen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Retourneert de absolute (positieve) waarde van de opgegeven kolom."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Schuld"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "De kolom of het getal waarvan de absolute (positieve) waarde moet worden geretourneerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Rondt een decimaal getal naar beneden af."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "De kolom of het getal dat naar beneden moet worden afgerond."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Rondt een decimaal getal naar boven af."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "De kolom of het getal dat naar boven moet worden afgerond."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Rondt een decimaal getal naar boven of beneden af op het dichtstbijzijnde gehele getal."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "De kolom of het getal dat moet worden afgerond op het dichtstbijzijnde gehele getal."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Retourneert de (vierkants)wortel."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hypotenusa"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "De kolom of het getal waarvan de vierkantswortelwaarde moet worden geretourneerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Verhoogt een getal tot de macht van de exponentwaarde."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Lengte"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "De kolom of het getal verheven tot de exponent."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "De waarde van de exponent."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Geeft de basis 10 log van het nummer."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Waarde"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "De kolom of het getal waarvan de natuurlijke logaritme moet worden geretourneerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Retourneert het getal van Euler, e, verheven tot de macht van het opgegeven getal."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Rentemaanden"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "De kolom of het getal waarvan de exponentiële waarde moet worden geretourneerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "De kolom of tekst die moet worden gecontroleerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Controleert de waarden van een datum- of cijferkolom om te zien of ze binnen het opgegeven bereik vallen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Aangemaakt op"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "De datum of numerieke kolom die tussen de begin- en eindwaarden moet staan."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Het begin van het assortiment."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Het einde van het assortiment."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Controleert de waarden van een datumkolom om te zien of ze binnen het relatieve bereik vallen."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "De datumkolom waarvan het interval moet worden geretourneerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Intervalperiode, waarin negatieve waarden terug in de tijd zijn."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Type interval zoals \"dag\", \"maand\", \"jaar\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "De kolom of waarde die moet worden geretourneerd."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Als waarde1 leeg is, wordt waarde2 geretourneerd als deze niet leeg is, enzovoort."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Test een uitdrukking aan de hand van een lijst met gevallen en retourneert de overeenkomstige waarde van het eerste overeenkomende geval, met een optionele standaardwaarde als aan niets anders wordt voldaan."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "De waarde die wordt geretourneerd als de voorgaande voorwaarde waar is, enzovoort."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Is leeg"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Is niet leeg"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Additieve som van alle waarden van een kolom.\n"
+"Bijv. totale omzet in de loop van de tijd."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Additieve telling van het aantal rijen.\n"
+"Bijv. totaal aantal verkopen in de loop van de tijd."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Gekoppelde filters"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Label"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Standaard waarde"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Geen standaard"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Om dit te kunnen zien, moet {0} zijn verbonden met ten minste één veld."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Beperk de keuzes van dit filter"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Als je een ander dashboardfilter heeft, kun je de opties voor dit filter beperken op basis van de selectie van de keuze van het andere filter."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Dus eerst {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "voeg nog een dashboardfilter toe"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Als je een van deze dashboardfilters inschakelt, beperkt het selecteren van een waarde de beschikbare keuzes voor het {0} filter."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Filterkolom"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Gefilterde kolom"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Voer gebruikersnamen of e-mailadressen in"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Nieuw fragment"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 PM (na de middag)"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "00:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM (nacht/ochtend)"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Uurlijks"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Dagelijks om {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Wekelijks op {0} om {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Maandelijks op {0} {1} om {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Verwijder dit abonnement"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Abonnementen"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Maak een dashboardabonnement aan"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "E-mail het"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Je kunt dit dashboard regelmatig naar gebruikers of e-mailadressen sturen."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Stuur het via Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Kies een kanaal en een tijdsschema, en Metabase doet de rest."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "E-mail dit dashboard"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Stuur niet als er geen resultaten zijn"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Voeg resultaten toe als bijlage"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Bijlagen kunnen maximaal 2.000 rijen met gegevens bevatten."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Verstuur dit dashboard via Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Dashboard heeft geen parameter met de ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Aan parameter {0} zijn geen velden gekoppeld"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include moet leeg zijn of de waarde 'tables'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "`database` is vereist voor alle queries waarvan het type niet` intern` is."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Wachtwoordaanmelding is uitgeschakeld voor deze instantie."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Je account is uitgeschakeld. Neem contact op met de administrator."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Je account is uitgeschakeld."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Ongeldig Slack-token."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "De opdracht ''{0}'' is alleen beschikbaar voor de Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Metabase Enterprise Edition-extensies zijn AANWEZIG."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Het gebruik van Metabase Enterprise Edition-functies is onderhevig aan de Metabase Commercial License."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Zie {0} voor details."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Metabase Enterprise Edition-extensies zijn NIET AANWEZIG."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Je bent uitgenodigd om lid te worden van {0} 's {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} heeft een {1} account gemaakt"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} hebben hun {1} uitnodiging geaccepteerd"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] verzoek om wachtwoord opnieuw in te stellen"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Melding"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Help mee om [{1}] beter te maken."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Vertel ons hoe het gaat."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Fout bij het starten van event listener"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Moeten we gebruikersattributen synchroniseren wanneer iemand inlogt via LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Door komma's gescheiden lijst met gebruikersattributen om synchronisatie voor LDAP-gebruikers over te slaan."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Ongeldige token"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Slack API-fout: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Slack-kanaal met de naam `metabase_files` ontbreekt!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Maak een kanaal aan of haal het uit het archief om de Slack-integratie te voltooien."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Het kanaal wordt gebruikt voor het opslaan van grafieken die zijn opgenomen in Pulsen en MetaBot-antwoorden."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Geüploade afbeelding"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Fout bij uploaden van bestand naar Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Ongeldige sessie. Er werd een exemplaar van Session verwacht."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "Sessie cookie 'SameSite' is geconfigureerd op \"Geen\", maar de site is"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "geserveerd via een onveilige verbinding. Sommige browsers weigeren "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookies onder deze condities. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Bovenste map"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parameters moeten een reeks kaarten zijn met String :id toetsen"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Ongeldige door mensen leesbare waarden: waarden moeten een reeks zijn; elk item moet nul of een string zijn"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":values moeten aanwezig zijn om :human_readable_values op te halen"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "De totale lengte van de veldwaarden is > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "fragmentnamen mogen niet '}' bevatten of beginnen met spaties"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Fout bij het uitvoeren van kettingfilterquery"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Veld {0} bestaat niet."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Kan niet zoeken in niet-tekstveld {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Toestemmingen verlenen voor groep {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Rechten intrekken voor groep {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Ongeldige DB-machtigingen: als je schrijftoegang hebt voor native queries, moet je volledige gegevenstoegang hebben."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Ongeldige DB-machtigingen: als je alleen-lezen native query-toegang hebt, moet je ook gegevenstoegang hebben."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Rechten wijzigen van: {0} in: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "inlogkenmerksleutels moeten een trefwoord of tekenreeks zijn"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "De standaardtaal voor alle gebruikers in de Metabase-gebruikersinterface, systeem-e-mails, pulsen en waarschuwingen."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Gebruikers kunnen deze standaardtaal individueel overschrijven vanuit hun eigen accountinstellingen."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Standaardpagina om de gebruiker te tonen"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Sta deze origin toe om de volledige Metabase-applicatie in te sluiten"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Waarden groter dan {0} ({1}) zijn niet toegestaan."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Dit zal het woord \"Metabase\" vervangen waar het ook voorkomt."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Dit zijn de primaire kleuren die worden gebruikt in grafieken en in Metabase. Mogelijk moet u uw browser vernieuwen om uw wijzigingen door te voeren."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Gebruik voor het beste resultaat een SVG-bestand met een transparante achtergrond."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "De url of afbeelding die je als favicon wilt gebruiken."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Sta inloggen met e-mail en wachtwoord toe."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Dit heeft gevolgen voor zaken als groeperen per week of filteren in GUI-query's.\n"
+"Het heeft geen invloed op SQL-query's."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Kan token niet valideren"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Token-indeling is ongeldig."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Fout bij valideren van token"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Fout bij filteren op basis van veld {0}: kan tekenreeks {1} niet parsen naar een {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Fout bij het ophalen van details voor taak: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Synchronisatietaak starten voor Database {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Kan database {0} niet synchroniseren: database bestaat niet."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Werk veldwaarden-taak bij die is geactiveerd voor Database {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Update overslaan, automatische veldwaarde-updates zijn uitgeschakeld voor Database {0}."

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -28,15 +28,16 @@ msgstr "Przejrzyj dane"
 msgid "Select a database type"
 msgstr "Wybierz typ bazy danych"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Zapisz"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Aby wykonać część z jego magii, Metabase musi przeskanować Twoją bazę danych. Będzie również skanować ją regularnie, aby zachować aktualne metadane. Możesz ustawić poniżej, kiedy ma się odbywać regularne skanowanie."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Synchronizacja bazy danych"
 
@@ -65,7 +66,7 @@ msgstr "Jest to lekki proces, który sprawdza aktualizacje schematu tej bazy dan
 msgid "Scan"
 msgstr "Skanuj"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Skanowanie w poszukiwaniu wartości filtrów"
 
@@ -74,11 +75,10 @@ msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase  może skanować wartości znajdujące się w każdym z pól w tej bazie danych,\n"
-" aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i zapytaniach.\n"
+msgstr "Metabase  może skanować wartości znajdujące się w każdym z pól w tej bazie danych,  aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i zapytaniach.\n"
 " Może to być proces dość intensywnie korzystający z zasobów, szczególnie jeśli masz bardzo dużą bazę danych."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Kiedy Metabase powinien automatycznie skanować i buforować wartości pól?"
 
@@ -137,29 +137,31 @@ msgstr "DELETE"
 msgid "in this box:"
 msgstr "w tym polu:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -182,9 +184,9 @@ msgstr "Usuń"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -204,8 +206,9 @@ msgstr "Połączenie"
 msgid "Scheduling"
 msgstr "Planowanie"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -244,7 +247,7 @@ msgstr "Synchronizacja wyzwolona!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:223
 msgid "Re-scan field values now"
-msgstr "Ponowne skanowanie wartości pól teraz"
+msgstr "Ponownie skanuj wartości pól teraz"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:225
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
@@ -284,10 +287,10 @@ msgstr "Dodaj bazę danych"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -322,10 +325,8 @@ msgid "Successfully saved!"
 msgstr "Pomyślnie zapisane!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Edycja"
@@ -404,26 +405,29 @@ msgstr "Wybierz specjalny typ"
 msgid "Select a target"
 msgstr "Wyznacz cel"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Kolumny"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Kolumn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Widoczność"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Typ"
 
@@ -431,7 +435,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Aktualna baza danych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Pokaż oryginalny schemat"
 
@@ -507,7 +511,7 @@ msgstr "Szukaj tabeli"
 msgid "Schemas"
 msgstr "Schematy"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -524,7 +528,7 @@ msgstr "Dodaj metrykę"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definicja"
 
@@ -592,35 +596,35 @@ msgstr "Historia"
 msgid "Revision History for"
 msgstr "Historia wersji dla"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} — ustawienia pól"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Gdzie to pole pojawi się w Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrowanie w tym polu"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Kiedy to pole jest używane w filtrze, jakie osoby powinny używać do wprowadzania wartości, którą chce filtrować?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Brak opisu dla pola"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Wartość oryginalna"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Mapowane wartości"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Wpisz wartość"
 
@@ -637,31 +641,31 @@ msgid "Custom mapping"
 msgstr "Mapowanie niestandardowe"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Nierozpoznany typ mapowania"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Bieżące pole nie jest kluczem obcym lub brak jest tabeli docelowej"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Wybrane pole nie jest kluczem obcym"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Wyświetl wartości"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Wybierz aby pokazać oryginalną wartość z bazy danych lub wyświetlić pole skojarzone lub niestandardowe informacje."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Wybierz pole"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Wybierz kolumnę, której chcesz użyć do wyświetlenia."
 
@@ -669,16 +673,16 @@ msgstr "Wybierz kolumnę, której chcesz użyć do wyświetlenia."
 msgid "Tip:"
 msgstr "Porada:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Możesz zaktualizować nazwę pola, aby upewnić się, że nadal ma sens na podstawie opcji ponownego mapowania."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Buforowane wartości pola"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase może skanować wartości tego pola, aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i zapytaniach."
 
@@ -705,35 +709,36 @@ msgstr "Odrzuć wywołane!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Wybierz dowolną tabelę, aby zobaczyć jej schemat i dodać lub edytować metadane."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Nazwa jest wymagana"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Opis jest wymagany"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Wymagany jest komunikat poprawki"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Agregacja jest wymagana"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Edytuj metryki"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Utwórz metryki"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Wprowadź zmiany w metrykę i pozostaw notatkę wyjaśniającą."
 
@@ -741,46 +746,46 @@ msgstr "Wprowadź zmiany w metrykę i pozostaw notatkę wyjaśniającą."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Można utworzyć zapisane metryki, aby dodać do tej tabeli opcję o nazwie metryki. Zapisane metryki obejmują typ agregacji, pole zagregowane i opcjonalnie dowolny dodany filtr. Na przykład, można użyć tego, aby utworzyć coś jak oficjalny sposób obliczania \"Średnia cena\" dla tabeli zamówienia."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Wynik:"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Nazwij swoje metryki"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Nadaj metrykom nazwę aby ułatwić innym znalezienie jej"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Coś opisowego, ale nie za długie"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Opisz swoje metryki"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Opisz swoje metryki aby ułatwić ich zrozumienie dla innych"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Jest to dobre miejsce, aby być bardziej szczegółowe o mniej oczywiste reguły metryczne"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Powód do zmian"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Zostaw notatkę, aby wyjaśnić, jakie zmiany zostały wprowadzone i dlaczego były wymagane."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "To pojawi się w historii zmian dla tej metryki, aby pomóc wszystkim pamiętać, dlaczego rzeczy zmienił"
 
@@ -833,6 +838,7 @@ msgstr "Będzie to widoczne w historii zmian dla tego segmentu, aby pomóc wszys
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -847,8 +853,7 @@ msgid "Re-scan this table"
 msgstr "Skanuj ponownie tabele"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Dodaj"
 
@@ -865,7 +870,7 @@ msgid "Last name"
 msgstr "Nazwisko"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Adres email"
@@ -874,7 +879,7 @@ msgstr "Adres email"
 msgid "Permission Groups"
 msgstr "Grupa uprawnień"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Nadaj uprawnienia administratora"
 
@@ -975,6 +980,8 @@ msgstr "Usuń grupę"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -987,11 +994,12 @@ msgstr "Gotowe"
 msgid "Group name"
 msgstr "Nazwa grupy"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Grupy"
@@ -1100,7 +1108,7 @@ msgstr "Resetuj"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Czy jesteś pewien?"
 
@@ -1215,7 +1223,7 @@ msgstr "Nie zostaną wprowadzone żadne zmiany w uprawnieniach."
 msgid "You've made changes to permissions."
 msgstr "Wprowadzono zmiany w uprawnieniach."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Uprawnienia dla tej kolekcji"
 
@@ -1241,7 +1249,7 @@ msgstr "Każdy użytkownik Metabase należy do grupy Wszyscy użytkownicy. Jeśl
 
 #: frontend/src/metabase/admin/permissions/selectors.js:75
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBot jest botem Metabase Slack. Możesz wybrać to, jaki ma tutaj dostęp."
+msgstr "MetaBot jest botem Metabase Slack. Możesz wybrać tutaj, do czego ma dostęp."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:128
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
@@ -1271,6 +1279,7 @@ msgstr "Ogranicz dostęp"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Odbierz dostęp"
 
@@ -1334,23 +1343,23 @@ msgstr "Kolekcja kuratorów"
 msgid "View collection"
 msgstr "Zobacz kolekcję"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Dostęp do danych"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Wyświetl tabele"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "Zapytania SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Wyświetl schematy"
 
@@ -1387,12 +1396,12 @@ msgstr "Umożliwia użytkownikom w katalogu LDAP zalogować się do Metabase prz
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:76
 #: frontend/src/metabase/admin/settings/selectors.js:168
 msgid "That's not a valid email address"
-msgstr "Niepoprawy adres email"
+msgstr "To nie jest poprawny adres email"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:23
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:80
 msgid "That's not a valid integer"
-msgstr "Niepoprawna wartość liczbowa"
+msgstr "To nie jest poprawna liczba całkowita"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:30
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:164
@@ -1421,12 +1430,15 @@ msgstr "Wysłano!"
 msgid "Clear"
 msgstr "Wyczyść"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Zapisz ustawienia"
@@ -1439,6 +1451,7 @@ msgstr "Schemat użytkownika"
 msgid "Attributes"
 msgstr "Atrybuty"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Schematu grupy"
@@ -1510,6 +1523,9 @@ msgid "Add a map"
 msgstr "Dodaj mapę"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1519,19 +1535,19 @@ msgid "Delete custom map"
 msgstr "Usuń niestandardową mapę"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Usuń"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1629,19 +1645,19 @@ msgstr "Kup token"
 msgid "Enter a token"
 msgstr "Wpisz token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Edytowanie mapowań"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Mapowania grup"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Tworzenie mapowania"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1880,18 +1896,27 @@ msgstr "Filtr użytkownika"
 msgid "Check your parentheses"
 msgstr "Sprawdź nawiasy"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Ustawienie mail"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Atrybut Imienia"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Atrybut Nazwiska"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Synchronizowanie członkostwa w grupach"
@@ -1920,59 +1945,59 @@ msgstr "Dodatkowe mapy"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Dodawanie własnych plików GeoJSON w celu włączenia różnych wizualizacji map regionu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Udostępnianie publiczne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Włącz udostępnianie publiczne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Udostępnione pulpity nawigacyjne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Wspólne zapytania"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Osadzanie w innych aplikacjach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Włącz osadzanie Metabase w innych aplikacjach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Osadzanie klucza tajnego"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Osadzone pulpity nawigacyjne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Osadzone zapytania"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Buforowanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Włącz buforowanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Minimalny czas trwania kwerendy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Mnożnik czasu wygaśnięcia (TTL) pamięci podręcznej"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Maksymalny rozmiar wpisu w pamięci podręcznej"
 
@@ -2014,27 +2039,27 @@ msgstr "Aby móc korzystać z usługi Google, musisz mieć uprawnienia administr
 msgid "Sign in with {0}"
 msgstr "Zaloguj się za pomocą {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Skontaktuj się z administratorem, aby je zresetować hasło"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Zapomniałem hasła"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Adres e-mail używany do korzystania z konta Metabase"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Wyślij e-mail resetowania hasła"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Sprawdz email w poszukiwaniu instrukcji do resetu hasła"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Zaloguj do Metabase"
 
@@ -2055,11 +2080,11 @@ msgstr "Zaloguj"
 msgid "I seem to have forgotten my password"
 msgstr "Chyba zapomniałem hasła"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "zażądaj o nowy email z resetem hasła"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Ups, ten link wygasł"
 
@@ -2068,11 +2093,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Ze względów bezpieczeństwa, linki resetowania hasła wygasają po chwili. Jeśli nadal musisz zresetować hasło, możesz {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nowe hasło"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Aby zapewnić bezpieczeństwo danych, hasła {0}"
 
@@ -2095,24 +2120,24 @@ msgstr "Potwierdź nowe hasło"
 msgid "Make sure it matches the one you just entered"
 msgstr "Upewnij się że pasuje do wpisanego wcześniej"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Twoje hasło zostało zresetowane"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Zaloguj się nowym hasłem"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Zapis się nie powiódł"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2122,25 +2147,26 @@ msgstr "Zapisane"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Archiwizować tą Kolekcję?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Pulpity nawigacyjne, kolekcje i pulsy w tej kolekcji również zostaną zarchiwizowane."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Archiwum"
 
@@ -2265,7 +2291,7 @@ msgstr "Przypięcia"
 msgid "Drag something here to pin it to the top"
 msgstr "Przeciągnij coś tutaj, aby przypiąć go do góry"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2296,6 +2322,7 @@ msgstr "Przenieść \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Przesuń"
@@ -2333,7 +2360,7 @@ msgstr "Do niektórych instalacji baz danych można uzyskać dostęp tylko poprz
 "Ta opcja zapewnia również dodatkową warstwę zabezpieczeń, gdy sieć VPN nie jest dostępna.\n"
 "Włączenie tego jest zwykle wolniejsze niż bezpośrednie połączenie."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Jest to duża baza danych, więc pozwól mi wybrać, kiedy Metabase synchronizuje i skanuje"
 
@@ -2373,7 +2400,7 @@ msgstr "Aby użyć Metabase z tymi danymi, należy włączyć dostęp do interfe
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0}, aby przejść do konsoli, jeśli jeszcze tego nie zrobiono."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Jak chcesz referować do tej bazy?"
 
@@ -2489,35 +2516,35 @@ msgstr "Na podstawie schematu"
 msgid "A look at your"
 msgstr "Przegląd twojej"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Wyszukiwanie na liście"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Szukaj według {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " lub wprowadź ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Wipsz IP"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Wpisz numer"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Wpisz jakiś tekst"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Nie znaleziono pasującego elementu {0}."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Włączenie wszystkich opcji w Twoim filtrze nie wygląda na najlepszy pomysł…"
 
@@ -2529,7 +2556,6 @@ msgstr "Coś poszło nie tak"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Ups… znaleźliśmy błąd. Możesz spróbować odświeżyć tę stronę lub wrócić do poprzedniej."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2540,12 +2566,12 @@ msgstr "Ups… znaleźliśmy błąd. Możesz spróbować odświeżyć tę stron�
 msgid "No description yet"
 msgstr "Brak opisu"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Nowy {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Zapytał {0}"
 
@@ -2566,7 +2592,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Przywrócono wcześniejszą wersję i {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Historia zmian"
@@ -2612,7 +2640,7 @@ msgid "Questions"
 msgstr "Pytanie"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Pulsy"
 
@@ -2686,52 +2714,69 @@ msgstr "Nie teraz"
 msgid "Error:"
 msgstr "Error:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Niedziela"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Poniedziałek"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Wtorek"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Środa"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Czwartek"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Piątek"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Sobota"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Pierwszy"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Ostatni"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15. (punkt środkowy)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Dzień kalendarzowy"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "strefa czasowa tej instancji Metabase"
 
@@ -2785,11 +2830,11 @@ msgstr "Utwórz"
 msgid "Create dashboard"
 msgstr "Utwórz panel"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabela"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Baza danych"
 
@@ -2864,9 +2909,9 @@ msgstr "Jaka jest nazwa Twojej zakładki?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2880,15 +2925,16 @@ msgstr "Opis"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Jest to opcjonalne, ale jakże pomocne"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Której kolekcja powinna to trafić?"
 
@@ -2928,11 +2974,11 @@ msgstr "Zarchiwizuj panel"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Upewnij się, że dokonano wyboru dla każdej serii bo filtr nie będzie działać na tej zakładce."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Ten panel jest pusty"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Dodaj zapytanie, aby zaczęło być przydatne!"
 
@@ -2952,7 +2998,7 @@ msgstr "Wyłącz tryb pełnoekranowy"
 msgid "Enter fullscreen"
 msgstr "Włącz tryb pełnoekranowy"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Zapisywanie..."
@@ -2965,7 +3011,8 @@ msgstr "Dodaj pytanie"
 msgid "Add a question to this dashboard"
 msgstr "Dodaj zapytanie do tego pulpitu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Dodaj filtr"
 
@@ -2973,7 +3020,7 @@ msgstr "Dodaj filtr"
 msgid "Parameters"
 msgstr "Parametry"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Dodaj pole tekstowe"
 
@@ -2981,7 +3028,7 @@ msgstr "Dodaj pole tekstowe"
 msgid "Move dashboard"
 msgstr "Przenieś pulpit"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Edytuj pulpit"
 
@@ -3005,11 +3052,11 @@ msgstr "Przenieś panel do..."
 msgid "Dashboard moved to {0}"
 msgstr "Panel przeniesiony do {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Co chcesz filtrować?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Jaki rodzaj filtra?"
 
@@ -3081,20 +3128,22 @@ msgstr "Ta zakładka nie ma żadnych pól lub parametrów, które mogą być map
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Wartości w tym polu nie pokrywają się z wartościami pozostałych wybranych pól."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Brak prawidłowych pól"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Imię i nazwisko musi mieć nie więcej niż 100 znaków"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Kolor jest wymagany"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Jaka jest nazwa tego panelu?"
 
@@ -3149,7 +3198,7 @@ msgstr "odebrano najnowsze dane z"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Nieznany"
 
@@ -3274,9 +3323,10 @@ msgstr "Ostatnio nie przeglądałeś(aś) żadnych pulpitów lub zapytań"
 msgid "{0} items selected"
 msgstr "{0} wybrane elementy"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Przywróć"
 
@@ -3393,7 +3443,7 @@ msgid "Zip Code"
 msgstr "Kod pocztowy"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Ilość"
 
@@ -3426,11 +3476,13 @@ msgid "User"
 msgstr "Użytkownik"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Źródło"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Cena"
 
@@ -3463,21 +3515,23 @@ msgid "Subscription"
 msgstr "Subskrypcja"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Wynik"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Tytuł"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -3531,14 +3585,14 @@ msgstr "Metabase nigdy nie będzie pobierać tego pola. Użyj tego dla informacj
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Count"
 
@@ -3546,7 +3600,7 @@ msgstr "Count"
 msgid "CumulativeCount"
 msgstr "LicznikŁączny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3564,19 +3618,19 @@ msgstr "Distinct"
 msgid "StandardDeviation"
 msgstr "OdchyleniaStandardowe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Average"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3587,7 +3641,7 @@ msgstr "Max"
 msgid "sad sad panda, lexing errors detected"
 msgstr "smutna, smutna panda, wykryła błędy składniowe"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} sekund"
@@ -3595,7 +3649,7 @@ msgstr[1] "{0} sekund"
 msgstr[2] "{0} sekund"
 msgstr[3] "{0} sekunda"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuta"
@@ -3638,14 +3692,15 @@ msgstr "Co byś się chciał dowiedzieć?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dane"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Skumulowany licznik"
 
@@ -3707,166 +3762,164 @@ msgstr "Prawda"
 msgid "False"
 msgstr "Fałsz"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Wybierz pole długości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Podaj górną granicę szerokości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Podaj lewą granicę długości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Podaj dolną granicę szerokości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Podaj prawą granicę długości geograficznej"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Jest"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Nie jest"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Jest puste"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Nie jest puste"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Równa się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Nie równa się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Większe od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Mniejsze od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Pomiędzy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Większe lub równe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Mniejsze lub równe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Zawiera"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Nie zawiera"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Zaczyna się od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Kończy się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Przed"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "W"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Tylko tabela z wierszami, bez dodatkowych operacji."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Ilość wierszy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Całkowita liczba wierszy."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Suma z "
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Suma wszystkich wartości kolumny."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Średnia z…"
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Średnia wszystkich wartości kolumny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Liczba różnych wartości..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Liczba unikatowych wartości w kolumnie ze wszystkich wierszy odpowiedzi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Skumulowana suma..."
 
@@ -3874,7 +3927,7 @@ msgstr "Skumulowana suma..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Addytywna suma wszystkich wartości kolumny. \\\\nnp. całkowity przychód w czasie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Skumulowana liczba wierszy"
 
@@ -3882,27 +3935,27 @@ msgstr "Skumulowana liczba wierszy"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Addytywna liczba wierszy.\\\\nnp. łączna ilość transakcji w czasie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Odchylenie standardowe…"
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Numer, który pokazuje jak bardzo wartości danej kolumny różnią się między sobą."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Minimum..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Minimalna wartość dla kolumny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Maksimum..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Maksymalna wartość dla kolumny"
 
@@ -3918,6 +3971,8 @@ msgstr "mała litera"
 msgid "upper case letter"
 msgstr "wielka litera"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "numer"
@@ -4165,7 +4220,7 @@ msgstr "Jak utworzyć metryki"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Wyświetlanie danych w czasie, jako mapę lub z tabelę przestawną by ułatwić Ci analizę trendów lub zmian."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Własny"
 
@@ -4188,7 +4243,7 @@ msgstr "Zapytanie natywne"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "W przypadku bardziej skomplikowanych zapytań można użyć własnej kwerendę w SQL lub natywnych zapytaniach."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Wybierz wartość domyślną…"
 
@@ -4285,7 +4340,7 @@ msgstr "Ten miesiąc"
 msgid "This Year"
 msgstr "Ten rok"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Wpisz wartość..."
@@ -4295,7 +4350,7 @@ msgid "Enter a default value..."
 msgstr "Wpisz wartość domyślną.."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Wystąpił błąd"
@@ -4556,22 +4611,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Wybierz zapytania, które chcesz wysłać w tym pulsie"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Emaile"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
-msgstr "Widomości Slack"
+msgstr "Wiadomości Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Wysłane"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} zostanie wysłane w"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Wiadomości"
 
@@ -4641,32 +4704,32 @@ msgstr "Pomóż wszystkim w zespole pozostać zsynchronizowanym z Twoimi danymi.
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:31
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Pulsy umożliwiają wysyłanie danych z Metabase do wiadomości e-mail lub zapasu czasu według wybranego harmonogramu."
+msgstr "Pulsy umożliwiają wysyłanie danych z Metabase na adres email lub Slack według wybranego harmonogramu."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Po {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Przed {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Jest pusty"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Nie jest pusty"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Zawsze"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Zastosuj"
 
@@ -4769,12 +4832,12 @@ msgstr[3] "Pokaż {0}"
 msgid "Zoom in"
 msgstr "Przybliż"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Wyrażenia niestandardowe"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Wspólne metryki"
 
@@ -4971,7 +5034,7 @@ msgstr "zazwyczaj"
 msgid "Pick a segment or table"
 msgstr "Wybierz segment lub tabelę"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Wybierz bazę danych"
@@ -5032,7 +5095,7 @@ msgstr "Sortuj"
 msgid "Row limit"
 msgstr "Limit wierszy"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Nieznane pole"
 
@@ -5040,7 +5103,7 @@ msgstr "Nieznane pole"
 msgid "field"
 msgstr "pole"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Pasuje"
 
@@ -5065,11 +5128,11 @@ msgstr "Dodaj grupowanie"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dane"
 
@@ -5086,11 +5149,12 @@ msgstr "Wyświetl"
 msgid "Grouped By"
 msgstr "Pogrupowane po"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Żadne"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "To zapytanie jest napisane w {0}."
 
@@ -5102,7 +5166,7 @@ msgstr "Ukryj Edytor"
 msgid "Hide Query"
 msgstr "Ukryj kwerendę"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Otwórz Edytor"
 
@@ -5110,7 +5174,7 @@ msgstr "Otwórz Edytor"
 msgid "Show Query"
 msgstr "Pokaż kwerendę"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Ten parametr został wycofany.  Nie jest już dostępny do użytku."
 
@@ -5313,7 +5377,7 @@ msgstr "Powrót do ostatniego uruchomienia"
 msgid "Visualization"
 msgstr "Wizualizacja"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Brak zestawu opis."
 
@@ -5370,7 +5434,7 @@ msgstr "Nie można odnaleźć metadanych tabeli przed utworzeniem nowego zapytan
 msgid "See {0}"
 msgstr "Zobacz {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Definicja Metryki"
 
@@ -5388,11 +5452,11 @@ msgstr "Liczba {0}"
 msgid "See all {0}"
 msgstr "Zobacz wszystkie {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Definicja segmentu"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Podczas ładowania tabeli wystąpił błąd"
 
@@ -5400,7 +5464,7 @@ msgstr "Podczas ładowania tabeli wystąpił błąd"
 msgid "See the raw data for {0}"
 msgstr "Zobacz dane dla {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Więcej"
 
@@ -5420,6 +5484,8 @@ msgstr "Pole formuły"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pomyśl o tym jako o rodzaju jak pisanie formuły w programie arkusza kalkulacyjnego: można użyć liczby, pola w tabeli, symbole matematyczne jak +, i niektóre funkcje. Więc można wpisać coś w stylu podsumy kosztów."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5487,7 +5553,7 @@ msgstr "fałsz"
 msgid "Add filter"
 msgstr "Dodaj filtr"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Element"
 
@@ -5606,11 +5672,11 @@ msgstr "Pole do mapowania na"
 msgid "Filter widget type"
 msgstr "Typ widżetu Filtruj"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Wymagane?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Domyślna wartość widżetu filtr"
 
@@ -5622,7 +5688,7 @@ msgstr "Archiwizować to zapytanie?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "To zapytanie zostanie usunięte z wszelkich pulpitów nawigacyjnych lub pulsów, używając go."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Pytanie"
 
@@ -5669,7 +5735,7 @@ msgstr "Typ pola"
 msgid "Select a Foreign Key"
 msgstr "Wybierz klucz obcy"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Wyświetlanie formuły {0}"
 
@@ -6153,22 +6219,24 @@ msgstr "Zapytania dotyczące tego segmentu"
 msgid "X-ray this segment"
 msgstr "Prześwietl X-ray ten segment"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Zaloguj się"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Szukaj"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Kokpit"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nowe zapytanie"
 
@@ -6240,35 +6308,35 @@ msgstr "Cała kolekcja jest całkowicie anonimowa."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Kolekcja może być wyłączona w dowolnym momencie w ustawieniach administratora."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Jeśli czujesz że utknąłeś"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "nasz przewodnik dla początkujących"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "znajduje się zaledwie kilka kliknięć stąd."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Witamy w Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Wygląda na to, że wszystko działa. Teraz niech cię poznać, połączyć się z danymi, i zacząć znaleźć kilka odpowiedzi!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Zacznijmy"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Wszystko ustawione!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Zabierz mnie do Metabase"
 
@@ -6520,39 +6588,40 @@ msgstr "Anuluj filtr"
 msgid "Pin Map"
 msgstr "Przypinanie mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Nie ustawiono"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Wiersze {0}-{1} z {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Dane obcięte do {0} wierszy."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Nie można odnaleźć wizualizacji"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Nie można wyświetlić tego wykresu z tymi danymi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Wciąż czekam..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Zazwyczaj trwa to średnio {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(jest to trochę za dużo dla pulpitu)"
 
@@ -6662,7 +6731,7 @@ msgid "Highlight the whole row"
 msgstr "Podświetl cały wiersz"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Kolory"
 
@@ -6748,24 +6817,50 @@ msgstr "Cel"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Doh! Dane z zapytania nie pasują do wybranego wyboru wyświetlania. Ta Wizualizacja wymaga co najmniej {0} {1} danych."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "kolumna"
@@ -6799,7 +6894,7 @@ msgid "xValues missing!"
 msgstr "brakuje wartości X!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Oś X"
 
@@ -6808,7 +6903,7 @@ msgid "Add a series breakout..."
 msgstr "Dodaj serię przełamania..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Oś Y"
 
@@ -6821,7 +6916,7 @@ msgid "Bubble size"
 msgstr "Rozmiar bąbelka"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Linia"
 
@@ -6963,20 +7058,20 @@ msgid "Standard Deviation"
 msgstr "Odchylenie standardowe"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Obszar"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "wykres warstwowy"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Słupek"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "wykres słupkowy"
 
@@ -6990,7 +7085,7 @@ msgid "Funnel"
 msgstr "Lejek"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Wykonaj pomiar"
 
@@ -7002,81 +7097,81 @@ msgstr "Typ lejka"
 msgid "Bar chart"
 msgstr "Wykres słupkowy"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "wykres liniowy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Proszę wybrać kolumny długości i szerokości geograficznej w ustawieniach wykresu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Proszę wybrać mapę regionu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Wybierz kolumny region i metryczne w ustawieniach wykresu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Rodzaj mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Mapa regionu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Przypinanie mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Typ przypięcia"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Kafelki"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Oznaczenia"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Pole szerokości geograficznej"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Pole długości geograficznej"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Pole metryczne"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Pole region"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Promień"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Rozmycie"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Min. krycie"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Max powiększenie"
 
@@ -7088,7 +7183,7 @@ msgstr "Nie znaleziono relacji."
 msgid "via {0}"
 msgstr "przez {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Obiekt {0} jest połączony z:"
 
@@ -7100,31 +7195,31 @@ msgstr "Szczegóły obiektu"
 msgid "object"
 msgstr "element"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Razem"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Które kolumny chcesz użyć?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Wykres kołowy"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Wymiary"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Pokaż legendę"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Pokaż procenty w legendzie"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minimalna wartość procentowa fragmentu"
 
@@ -7149,7 +7244,8 @@ msgid "Progress"
 msgstr "Postęp"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Kolor"
@@ -7158,7 +7254,7 @@ msgstr "Kolor"
 msgid "Row Chart"
 msgstr "Wykres rzędowy"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "wykres wierszowy"
 
@@ -7182,15 +7278,15 @@ msgstr "Dodaj sufiks"
 msgid "Multiply by a number"
 msgstr "Pomnóż przez liczbę"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Wykres bąbelkowy"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "wykres bąbelkowy"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Przestawianie tabeli"
 
@@ -7241,7 +7337,7 @@ msgstr "Prawa"
 msgid "Show background"
 msgstr "Pokaż tło"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} kosz"
@@ -7249,7 +7345,7 @@ msgstr[1] "{0} kosze"
 msgstr[2] "{0} koszy"
 msgstr[3] "{0} koszy"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Automatycznie sortowane"
 
@@ -7485,10 +7581,13 @@ msgstr "Masz dużo zapisanych zapytań w {0}? Twórz kolekcje, aby ułatwić zar
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7686,7 +7785,7 @@ msgstr "skumulowana suma"
 msgid "{0} and {1}"
 msgstr "{0} i {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
@@ -8185,7 +8284,7 @@ msgstr "Token API Slack otrzymany z https://API.Slack.com/Web#authentication"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "Włącz MetaBot, który umożliwia wyszukiwanie i Wyświetlanie zapisanych pytań bezpośrednio przez Slack."
+msgstr "Włącz MetaBot, który umożliwia wyszukiwanie i wyświetlanie zapisanych pytań bezpośrednio przez Slack."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
@@ -9001,11 +9100,11 @@ msgstr "Uprawnienia do danych"
 msgid "Collection permissions"
 msgstr "Uprawnienia do kolekcji"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Zobacz wszystkie uprawnienia do kolekcji"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Również zmienić kolekcje podrzędne"
 
@@ -9017,19 +9116,19 @@ msgstr "Można edytować tej kolekcji i jej zawartość"
 msgid "Can view items in this collection"
 msgstr "Można przeglądać elementy w tej kolekcji"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Dostęp do kolekcji"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Ta grupa ma uprawnienia do wyświetlania co najmniej jeden podzbiór tej kolekcji."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Ta grupa ma uprawnienia do edytowania co najmniej jeden podzbiór tej kolekcji."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Wyświetl kolekcje podrzędne"
 
@@ -9085,6 +9184,7 @@ msgstr "Połączone"
 msgid "More X-rays"
 msgstr "Więcej X-rays"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9344,10 +9444,10 @@ msgstr "Udostępnianie"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9431,7 +9531,7 @@ msgstr "Użyj strefy czasowej JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Obecnie analizujemy tabele i pola aby pomóc ci w analizie twoich danych"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Wskazówka:␣"
 
@@ -9439,7 +9539,7 @@ msgstr "Wskazówka:␣"
 msgid "Select a currency type"
 msgstr "Wybierz typ waluty"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Typ Pola"
 
@@ -9494,6 +9594,7 @@ msgid "Currency"
 msgstr "waluta"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Wybierze użytkownika lub kanał..."
 
@@ -9655,7 +9756,7 @@ msgstr "Która oś?"
 msgid "Line + Bar"
 msgstr "Linia + Słupek"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "wykres słupkowo-liniowy"
 
@@ -9675,15 +9776,15 @@ msgstr "Zakres wskaźnika"
 msgid "Field to show"
 msgstr "Pola do pokazania"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "ostatni {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} było {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Grupuj według pola czasowego, aby zobaczyć, jak to się zmieniło w czasie"
 
@@ -9691,23 +9792,23 @@ msgstr "Grupuj według pola czasowego, aby zobaczyć, jak to się zmieniło w cz
 msgid "Switch positive / negative colors?"
 msgstr "Zamienieć kolory dodatnie / ujemne?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Kolumna przestawna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Kolumna komórki"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Kolumna widoczna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Formatowanie warunkowe"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Tytuł kolumny"
 
@@ -10146,10 +10247,10 @@ msgstr "Użytkownicy na źródło"
 msgid "The top external pages that brought users to your site"
 msgstr "Najlepsze zewnętrzne strony, które przyciągnęły użytkowników do twojej witryny"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Jak [this]]  jest dystrybuowany i więcej."
 
@@ -10247,13 +10348,13 @@ msgstr "Zdarzenia na godzinę dnia"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Pierwsze 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Ostatnie 5 [[this]]"
 
@@ -10266,10 +10367,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Wartości puste"
 
@@ -10297,8 +10398,8 @@ msgstr "W jaki sposób porównują sezonowość"
 msgid "Average income per transaction"
 msgstr "Średni dochód na transakcję"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] per państwo"
 
@@ -10422,10 +10523,10 @@ msgstr "Omówienie [[this]] i sposobu jego dystrybucji w czasie, miejscu i kateg
 msgid "Average income per state"
 msgstr "Średni dochód na stan"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] na [[GenericCategoryMedium]]"
 
@@ -10602,13 +10703,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "W jaki sposób [[GenericTable]] są dystrybuowane w tym polu czasowym i czy ma jakieś wzorce sezonowe."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Przegląd"
 
@@ -10717,8 +10818,8 @@ msgstr "Oto bliższe spojrzenie na twoje [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Oto bliższe spojrzenie na twoje [[this]] pole"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Streszczenie"
 
@@ -10782,10 +10883,10 @@ msgstr "Sprzedaż według źródła"
 msgid "Average income per country"
 msgstr "Średni dochód według państwa"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Jak [[this]] jest dystrybuowane"
 
@@ -10806,17 +10907,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Liczba [[GenericCategoryMedium]] na [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Spójrz na swoją [[this]]"
 
@@ -10882,10 +10983,10 @@ msgid "Transactions per source over time"
 msgstr "Transakcje według źródła w czasie"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "W jaki sposób [[this]] jest dystrybuowany"
 
@@ -10914,9 +11015,9 @@ msgstr "Gdzie te zdarzenia się dzieją"
 msgid "Which US states are bringing you the most business."
 msgstr "Które stany USA przynoszą ci najwięcej biznesu."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "W jaki sposób porównują w czasie"
 
@@ -11021,8 +11122,8 @@ msgstr "Sesje według kraju"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Kilka ciekawych danych na temat statystyk GA, które pomogą Ci zacząć."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] na stan"
 
@@ -11103,12 +11204,12 @@ msgstr "W jaki sposób dane są rozłożone na różne liczby"
 msgid "Sessions by page where the session began"
 msgstr "Sesje według strony, na której rozpoczęła się sesja"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Unikalne wartosci"
 
@@ -11171,10 +11272,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Zdarzenia według [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Jak porównać przez dystrybucję"
@@ -11480,6 +11581,7 @@ msgstr "Powiel pulpit"
 msgid "Duplicate \"{0}\""
 msgstr "Powiel \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11595,9 +11697,9 @@ msgstr[1] "Kwartały roku"
 msgstr[2] "Kwartałów roku"
 msgstr[3] "Kwartałów roku"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} wybór"
@@ -11622,11 +11724,11 @@ msgstr "Niepoprawne"
 msgid "Add a time"
 msgstr "Dodaj czas"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nic do porównania dla poprzedniego {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "przez {0}"
 
@@ -12114,9 +12216,9 @@ msgstr "Oto przegląd osób w [[this]]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] według kwartału roku"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Jak porównują pomiędzy lokalizacjami"
 
@@ -12145,12 +12247,12 @@ msgstr "[[CreateTimestamp]] według dnia w miesiącu"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Oto przegląd danych [[this]] z Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Oto przegląd twoich [[this]]"
 
@@ -12228,11 +12330,11 @@ msgstr "kolekcja"
 msgid "collections"
 msgstr "kolekcje"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "pulpit"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "pulpity"
 
@@ -12483,7 +12585,7 @@ msgstr "Przekroczono limit czasu po {0} milisekundach."
 msgid "Misfire Instruction"
 msgstr "Instrukcja niewypału"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Zarchiwizować to?"
 
@@ -12502,7 +12604,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 msgstr "Korzystanie z tej opcji wymaga, aby podany host był nazwą FQDN. Jeśli łączysz się z Atlas Cluster, może być konieczne włączenie tej opcji. Jeśli nie wiesz co to znaczy,\n"
 "pozostaw to wyłączone."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Automatycznie uruchamiaj zapytania podczas prostego filtrowania i podsumowywania"
 
@@ -12514,7 +12616,7 @@ msgstr "Po włączeniu tej opcji Metabasa automatycznie uruchamia zapytania, gdy
 msgid "Learn about this database"
 msgstr "Dowiedz się o tej bazie danych"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Zarchiwizować ten pulpit?"
 
@@ -12572,11 +12674,11 @@ msgstr "Niestandardowe zapytanie"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Korzystaj z zaawansowanego edytora notatników, aby łączyć dane, tworzyć niestandardowe kolumny, wykonywać matematykę i wykonywać inne czynności."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Podstawowe Metryki"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Własne..."
 
@@ -12765,15 +12867,15 @@ msgstr "Wybierz wizualizację"
 msgid "Filter by"
 msgstr "Fitruj po"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Sumuj po"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Grupuj po"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Dodaj metrykę"
 
@@ -12784,15 +12886,15 @@ msgstr "Dodaj metrykę"
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Zazwyczaj jest to dość szybkie, ale wydaje się, że zajmuje to teraz trochę czasu."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Combo"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "wiersz"
 
@@ -13213,7 +13315,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Wybierz kolumny, które chcesz uwzględnić"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Gdy ta opcja jest włączona, Metabase automatycznie uruchamia zapytania, gdy użytkownicy wykonują proste eksploracje za pomocą przycisków Podsumuj i Filtruj podczas przeglądania tabeli lub wykresu. Możesz to wyłączyć, jeśli odpytywanie tej bazy danych jest powolne. To ustawienie nie wpływa na drążenie wszerz lub zapytania SQL."
 
@@ -13280,7 +13382,7 @@ msgstr "Zaloguj się przez e-mail"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Korzystanie z tej opcji wymaga, aby podany host był nazwą FQDN. W przypadku łączenia się z klastrem Atlas może być konieczne włączenie tej opcji. Jeśli nie wiesz, co to oznacza, pozostaw to wyłączone."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Domyślnie Metabase wykonuje lekką synchronizację godzinową i intensywny codzienny skan wartości pól. Jeśli masz dużą bazę danych, zalecamy włączenie tej opcji i sprawdzenie, kiedy i jak często skanowane są wartości pola."
 
@@ -13348,11 +13450,11 @@ msgstr "Nie zawiera"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "To pole nie będzie widoczne ani możliwe do wyboru w pytaniach utworzonych za pomocą interfejsów użytkownika GUI. Będzie nadal dostępny w zapytaniach SQL."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Skumulowana suma"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Odchylenie standardowe"
 
@@ -13368,19 +13470,19 @@ msgstr "Musi mieć co najmniej {0} znaków"
 msgid "Name (required)"
 msgstr "Nazwa (wymagane)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Uruchom zaznaczony tekst"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Uruchom zapytanie"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13728,7 +13830,7 @@ msgstr "Daty i godziny"
 msgid "Numbers"
 msgstr "Numery"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Brak grup, które można zmapować"
 
@@ -13768,15 +13870,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "Zapamiętaj mnie"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Ze względów bezpieczeństwa linki do resetowania hasła wygasają po określonym czasie. Jeśli nadal musisz zresetować hasło, możesz {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Zapisz nowe hasło"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Brak pasujących wyników"
 
@@ -13802,26 +13904,26 @@ msgid "or"
 msgstr "lub"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "wymagany"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Typ bazy danych"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Jest to proces, który sprawdza dostępność aktualizacji schematu tej bazy danych. W większości przypadków powinieneś pozostawić ten zestaw do synchronizacji co godzinę."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase może skanować wartości obecne w każdym polu w tej bazie danych, aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i pytaniach. Może to być proces bardzo obciążający zasoby, szczególnie jeśli masz bardzo dużą bazę danych."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Kolekcja"
 
@@ -13868,7 +13970,7 @@ msgstr "Kategoryczny"
 msgid "URLs"
 msgstr "ULRs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Zwraca średnią wartości z kolumny."
 
@@ -13877,11 +13979,13 @@ msgstr "Zwraca średnią wartości z kolumny."
 msgid "The column whose values to average."
 msgstr "Kolumna, której wartości mają być uśrednione."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "start"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "koniec"
 
@@ -13893,21 +13997,19 @@ msgstr "Sprawdza wartości daty lub wartości liczbowych kolumn, aby sprawdzić,
 msgid "Rating"
 msgstr "Ocena"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "warunek"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "wynik"
 
@@ -13915,27 +14017,27 @@ msgstr "wynik"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testuje listę przypadków i zwraca odpowiednią wartość pierwszego prawdziwego przypadku, z opcjonalną wartością domyślną, jeśli nic więcej nie jest spełnione."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Waga"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Duży"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Średni"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Mały"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Coś, co powinno być ocenione na prawdziwe lub fałszywe."
 
@@ -13943,33 +14045,33 @@ msgstr "Coś, co powinno być ocenione na prawdziwe lub fałszywe."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Wartość, która zostanie zwrócona, jeśli powyższy warunek jest spełniony."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "wartość1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "wartość2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Sprawdza wartości w każdym argumencie w kolejności i zwraca pierwszą wartość inną niż null dla każdego wiersza."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Komentarze"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notatki"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Bez komentarza"
 
@@ -13985,12 +14087,12 @@ msgstr "Jeśli wartość1 jest pusta, zwracana jest wartość2 , jeśli nie jest
 msgid "Combines two or more strings of text together."
 msgstr "Łączy dwa lub więcej ciągów tekstu razem."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Nazwisko"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Imię"
 
@@ -14002,27 +14104,27 @@ msgstr "wartość2 zostanie dodana na końcu tego."
 msgid "This will be added to the end of value1."
 msgstr "Zostanie to dodane na końcu wartości 1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "ciąg1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "ciąg2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Sprawdza, czy ciąg1 zawiera w sobie ciąg2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Zdane"
 
@@ -14030,7 +14132,7 @@ msgstr "Zdane"
 msgid "The contents of this string will be checked."
 msgstr "Zawartość tego ciągu zostanie sprawdzona."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Ciąg tekstu do wyszukania."
 
@@ -14038,22 +14140,22 @@ msgstr "Ciąg tekstu do wyszukania."
 msgid "Returns the count of rows in the source data."
 msgstr "Zwraca liczbę wierszy w danych źródłowych."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Liczy tylko wiersze, w których warunek jest spełniony."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Suma częściowa"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Łączna suma wierszy w rozbiciu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "Łączna suma kolumny w rozbiciu."
 
@@ -14062,53 +14164,57 @@ msgstr "Łączna suma kolumny w rozbiciu."
 msgid "The column to sum."
 msgstr "Kolumna do zsumowania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Liczba różnych wartości w tej kolumnie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Kolumna, której odrębne wartości należy policzyć."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "porównanie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Zwraca prawkę, jeśli koniec tekstu pasuje do tekstu porównawczego."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Apetyt"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "głodny"
 
@@ -14117,20 +14223,20 @@ msgstr "głodny"
 msgid "A column or string of text to check."
 msgstr "Kolumna lub ciąg tekstu do sprawdzenia."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Ciąg tekstu, którym powinien kończyć się tekst oryginalny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "wyrażenie_regularne"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Wyodrębnia pasujące podciągi zgodnie z wyrażeniem regularnym."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adres"
 
@@ -14138,7 +14244,7 @@ msgstr "Adres"
 msgid "The column or string of text to search though."
 msgstr "Jednak kolumna lub ciąg tekstu do wyszukiwania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Dopasowane wyrażenie regularne."
 
@@ -14150,7 +14256,7 @@ msgstr "Zwraca ciąg tekstu małymi literami."
 msgid "The column with values to convert to lowercase."
 msgstr "Kolumna z wartościami do konwersji na małe litery."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Usuwa wiodące białe znaki z ciągu tekstu."
 
@@ -14160,15 +14266,16 @@ msgstr "Usuwa wiodące białe znaki z ciągu tekstu."
 msgid "The column with values you want to trim."
 msgstr "Kolumna z wartościami, które chcesz przyciąć."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Zwraca największą wartość znalezioną w kolumnie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Wiek"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Kolumna numeryczna, której maksimum chcesz znaleźć."
 
@@ -14176,21 +14283,21 @@ msgstr "Kolumna numeryczna, której maksimum chcesz znaleźć."
 msgid "Returns the smallest value found in the column."
 msgstr "Zwraca najmniejszą wartość znalezioną w kolumnie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Wynagrodzenie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Kolumna numeryczna, której minimum chcesz znaleźć."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "pozycja"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "długość"
 
@@ -14199,7 +14306,7 @@ msgstr "długość"
 msgid "new_text"
 msgstr "nowy_tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Zamienia część tekstu wejściowego na nowy tekst."
 
@@ -14227,35 +14334,35 @@ msgstr "Liczba znaków do zastąpienia."
 msgid "The text to use in the replacement."
 msgstr "Tekst używany w zamianie."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Usuwa końcowe puste znaki z ciągu tekstu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Zwraca procent wierszy w danych, które pasują do warunku, w postaci dziesiętnej."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Zwraca prawdę, jeśli początek tekstu pasuje do tekstu porównawczego."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Nazwa kursu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Informatyka"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Ciąg tekstu, od którego powinien zaczynać się tekst oryginalny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Oblicza odchylenie standardowe kolumny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Populacja"
 
@@ -14263,7 +14370,7 @@ msgstr "Populacja"
 msgid "A numeric column."
 msgstr "Kolumna numeryczna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Zwraca część dostarczonego tekstu."
 
@@ -14271,19 +14378,19 @@ msgstr "Zwraca część dostarczonego tekstu."
 msgid "The text to return a portion of."
 msgstr "Tekst do zwrócenia części."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Miejsce do rozpoczęcia kopiowania znaków."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Liczba znaków do zwrócenia."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Dodaje wszystkie wartości kolumny."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Kolumna numeryczna do zsumowania."
 
@@ -14291,15 +14398,15 @@ msgstr "Kolumna numeryczna do zsumowania."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Sumuje wartości w kolumnie, w której wiersze odpowiadają warunkowi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Status zamówienia"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Poprawny"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Usuwa początkowe i końcowe puste spacje z ciągu tekstu."
 
@@ -14307,23 +14414,23 @@ msgstr "Usuwa początkowe i końcowe puste spacje z ciągu tekstu."
 msgid "Returns the string of text in all upper case."
 msgstr "Zwraca ciąg tekstu wielkimi literami."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Kolumna z wartościami do konwersji na wielkie litery."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "musi być {0} i zawierać {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "musi być {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "musi zawierać {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "co najmniej {0} znak"
@@ -14331,7 +14438,7 @@ msgstr[1] "co najmniej {0} znaki"
 msgstr[2] "co najmniej {0} znaków"
 msgstr[3] "co najmniej {0} znaków"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} mała litera"
@@ -14339,7 +14446,7 @@ msgstr[1] "{0} małe litery"
 msgstr[2] "{0} małych liter"
 msgstr[3] "{0} małych liter"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} mała litera"
@@ -14347,7 +14454,7 @@ msgstr[1] "{0} małe litery"
 msgstr[2] "{0} małych liter"
 msgstr[3] "{0} małych liter"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} numer "
@@ -14355,7 +14462,7 @@ msgstr[1] "{0} numery"
 msgstr[2] "{0} numerów"
 msgstr[3] "{0} numerów"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "(0} znak specjalny"
@@ -14380,6 +14487,7 @@ msgid "Powered by {0}"
 msgstr "Obsługiwane przez {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Do:"
 
@@ -14467,7 +14575,7 @@ msgstr "Formatowanie wartości"
 msgid "Full"
 msgstr "Pełny"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Bez zmian od ostatniego {0}"
 
@@ -14563,7 +14671,7 @@ msgstr "Wyłącz auto-commit..."
 
 #: src/metabase/db.clj
 msgid "Set default db connection with connection pool..."
-msgstr "Ustaw domyślne połączenie db z pulą połączeń..."
+msgstr "Ustaw domyślne połączenie db z pulą połączeń ..."
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
@@ -14792,7 +14900,7 @@ msgstr "Błąd podczas generowania statystyk dla kolumny:"
 msgid "Sending abandonment email!"
 msgstr "Wysyłanie wiadomości e-mail o rezygnacji!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Możesz utworzyć zapisane metryki, aby dodać nazwaną opcję metryki. Zapisane dane obejmują typ agregacji, pole agregacji i opcjonalnie każdy dodany filtr. Jako przykład możesz użyć tego do stworzenia czegoś w rodzaju oficjalnego sposobu obliczania „średniej ceny” dla tabeli zamówień."
 
@@ -14800,15 +14908,15 @@ msgstr "Możesz utworzyć zapisane metryki, aby dodać nazwaną opcję metryki. 
 msgid "Select and add filters to create your new segment."
 msgstr "Wybierz i dodaj filtry, aby utworzyć nowy segment."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alfabetycznie"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Inteligentne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Kolejność kolumn: {0}"
 
@@ -14860,7 +14968,7 @@ msgstr "Lokalizacja"
 msgid "Instance language"
 msgstr "Język instancji"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Opcje lokalizacji"
 
@@ -14932,19 +15040,20 @@ msgstr "Wklej string połączenia"
 msgid "Fill out individual fields"
 msgstr "Wypełnij wszystkie pola"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Wpisz tutaj SQL aby móc go użyć później ponownie"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Nadaj swojemu fragmentowi nazwę"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Obecni Klienci"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Dodaj opis"
 
@@ -14952,46 +15061,47 @@ msgstr "Dodaj opis"
 msgid "Use site default"
 msgstr "Użyj domyślnych"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "szukaj"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "zamień"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Wyszukiwany tekst"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Tekst używany do zamiany"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Edytowanie {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Utwórz nowy fragment"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Archiwalne fragmenty"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Fragmenty to reużywalne cząstki SQL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Utwórz fragment"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Fragmenty"
 
@@ -15270,3 +15380,1509 @@ msgstr "wartość musi być słowem kluczowym lub stringiem"
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Łańcuch musi być poprawnym dwuliterowym językiem ISO lub kodem języka kraju, np. „en” lub „en_US”."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Rzędy {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Audyt"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Konfiguracja atrybutów użytkownika (opcjonalnie)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Używając {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Utwórz SSO na bazie SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML Uwierzytelnianie"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Skonfiguruj swojego dostawcę tożsamości (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Twój dostawca tożsamości będzie potrzebował następujących informacji o Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL, który IdP powinien przekierować z powrotem do"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Nazywa się to Single Sign On URL w Okta, Application Callback URL w Auth0,\n"
+"oraz URL ACS (Consumer) w OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "Atrybuty SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "W większości identyfikatorów trzeba umieścić każdy z nich w pudełku z etykietami.\n"
+"\"Nazwa\" w sekcji zestawień atrybutów."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Atrybut poczty elektronicznej użytkownika"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Atrybut \"Imię użytkownika"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Atrybut nazwiska użytkownika"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Powiedz Metabase o swoim dostawcy tożsamości"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabaza będzie potrzebowała następujących informacji o twoim dostawcy."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML URL dostawcy tożsamości"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Certyfikat SAML Identity Provider"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML Nazwa aplikacji"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Podpisywanie wniosków o SSO (opcjonalnie)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML Keystore Path"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "SAML Keystore Password"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Shh..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML Keystore Alias"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Synchronizacja członkostwa grupowego z Twoim OSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Aby to umożliwić, należy utworzyć mapowania, które powiedzą Metabase, która grupa (grupy) użytkowników powinna (powinny) być\n"
+"być dodane do grupy SSO, w której się znajdują."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Nazwa grupy"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Nazwa atrybutu grupy"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Uwaga:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Jeśli zmienisz którekolwiek z ustawień istniejącej aktywnej konfiguracji SAML, będziesz musiał zrestartować Metabase, aby mogły one wejść w życie."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Pozwala użytkownikom na logowanie się za pośrednictwem SAML Identity Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Pozwala użytkownikom na logowanie się za pośrednictwem dostawcy usług identyfikacji JWT."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Włączanie uwierzytelniania hasłem"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Po włączeniu tej opcji użytkownicy mogą dodatkowo logować się za pomocą poczty elektronicznej i hasła."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Powiadamiać administratorów o nowych użytkownikach SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Po włączeniu tej opcji, administratorzy otrzymają wiadomość e-mail przy pierwszym użyciu funkcji Single Sign-On."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Użyj poniższych ustawień, aby skonfigurować swoje SSO przez SAML. Jeśli masz jakieś pytania, sprawdź nasze {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "Dokumentacja"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML Identity Provider URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "Uwierzytelnianie JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT Identity Provider URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Sznur używany przez klucz do podpisywania JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Osadzanie całej aplikacji Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Jeśli chcesz osadzić wszystkie Metabase, wprowadź pochodzenie stron lub aplikacji internetowych, w których chcesz zezwolić na osadzanie w iframe, oddzielone spacją. Poniżej znajduje się {0} dla tego, co można wpisać."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Udzielenie dostępu do tej tabeli w piaskownicy"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Kiedy użytkownicy w tej grupie zobaczą tę tabelę, zobaczą jej wersję, która jest filtrowana przez ich atrybuty użytkownika, lub niestandardowy widok na podstawie zapisanego pytania."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Jak chcesz filtrować tę tabelę dla użytkowników z tej grupy?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Wybierz zapisane pytanie, które zwróci niestandardowy widok tej tabeli, który powinni zobaczyć ci użytkownicy."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Można tu opcjonalnie dodać dodatkowe filtry w oparciu o atrybuty użytkownika. Filtry te zostaną zastosowane na wszystkich filtrach, które znajdują się już w tym zapisanym pytaniu."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Aby ta opcja działała, Twoi użytkownicy muszą posiadać pewne atrybuty"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Aby dodać dodatkowe filtry, Twoi użytkownicy muszą posiadać pewne atrybuty"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Brak atrybutów użytkownika"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Wybierz atrybut użytkownika"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Wybierz parametr"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Wybierz kolumnę"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Użytkownicy w {0} mogą przeglądać"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "wiersze w pytaniu {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "wiersze w tabeli {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "gdzie {0} równa się {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "i {0} równa się {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Możesz dodawać atrybuty automatycznie, ustawiając SSO, które używa SAML, lub wprowadzić je ręcznie, przechodząc do sekcji Ludzie i klikając na ... menu po prawej stronie."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Atrybut użytkownika"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Możemy automatycznie uzyskać atrybuty użytkowników, jeśli ustawiłeś SSO, lub możesz dodać je ręcznie z menu \"...\" w sekcji Ludzie w Panelu Administratora."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parametr lub zmienna"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "równa się"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Udzielanie dostępu do piaskownicy"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Dostęp do piaskownicy"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Edycja dostępu do piaskownicy"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Edycja szczegółów folderu"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Zmiana uprawnień"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Stwórz swój nowy folder"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nowy folder"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Mamy problem z zatwierdzeniem twojego żetonu."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Upewnij się, że Twoja instancja może połączyć się z serwerami Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Uzyskać pomoc"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Jeszcze więcej z Metabase z Enterprise Edition"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Wszystkie narzędzia potrzebne do szybkiego i łatwego tworzenia raportów dla klientów lub do pomocy w prowadzeniu i monitorowaniu Bazy Metabase w dużej organizacji"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Aktywuj licencję"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Twoja próba jest aktywna z tymi cechami"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Próba wygasa {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Potrzebujesz pomocy? Gotowi do kupna?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Porozmawiaj z nami"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Twój proces zakończył się"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Potrzebujesz więcej czasu? Gotowy do kupna?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Twoje funkcje są aktywne!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Twoja licencja jest ważna przez {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Twoja licencja wygasła"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Wygasł w dniu {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Chcesz odnowić licencję?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Dowiedz się, jak tego używać"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Nie zawarte w aktualnym planie"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Wprowadź token, który otrzymałeś od sklepu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Aktywuj"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Potrzebujesz pomocy?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Więcej informacji o twoim problemie."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Wsparcie w zakresie kontaktów"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Przedsiębiorstwo"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Piaskownice danych"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Upewnij się, że pokazujesz właściwym osobom odpowiednie dane za pomocą automatycznych i bezpiecznych filtrów opartych na atrybutach użytkownika."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Białe etykiety"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Dopasuj Metabase do swojej marki za pomocą niestandardowych kolorów, własnego logo i innych elementów."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Audyt"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Uważaj na wydajność i zachowanie dzięki solidnym narzędziom audytowym."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Pojedyncze logowanie"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Zapewnij łatwe logowanie, które współpracuje z wychodzącą infrastrukturą uwierzytelniania."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Sklep"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Nazwa wniosku"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Paleta kolorów"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Strona startowa"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Brak grup"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Zezwolenia na {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Uprawnienia do tego folderu"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Dostęp do Grant Edit"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Może modyfikować fragmenty w tym folderze"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Udzielanie dostępu do widoku"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Może wstawiać i używać snippetów w tym folderze, ale nie może edytować SQL, który zawierają"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Nie można wyświetlać ani wstawiać fragmentów w tym folderze"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Zmień również podfoldery"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Pierwszy dzień tygodnia"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Pojawił się problem z zalogowaniem się do Google. Prosimy o kontakt z administratorem."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "w sprawie"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "na stronie"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Otwórz menu akcji bazy metadanych"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Nie rób nic"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Przejdź do niestandardowego miejsca przeznaczenia"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Aktualizacja filtra tablicy rozdzielczej"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} aktualizacje {1} filtr"
+msgstr[1] "{0} aktualizacje {1} filtrów"
+msgstr[2] "{0} aktualizacje {1} filtrów"
+msgstr[3] "{0} aktualizacje {1} filtrów"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} idzie do {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Zachowanie po kliknięciu dla każdej kolumny"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Przejdź do niestandardowego miejsca przeznaczenia"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Otwórz menu akcji"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Kliknij na zachowanie dla {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Wybierz jeden lub więcej filtrów do aktualizacji"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Zapisane pytanie"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Związek z"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Wpisz adres URL, aby połączyć się z"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Możesz wstawić wartość kolumny lub filtra tablicy rozdzielczej używając jego nazwy, w ten sposób: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "np. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Wybierz deskę rozdzielczą..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Wybierz pytanie..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Wybierz tablicę rozdzielczą, aby połączyć się z"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Wybierz pytanie, które chcesz połączyć z"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Przekaż wartości do filtrów tej tablicy rozdzielczej (opcjonalnie)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Należy przekazać wartości zmiennych tego pytania (nieobowiązkowo)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Podaj wartości do filtrowania tego pytania (opcjonalnie)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filtry deski rozdzielczej"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Atrybuty użytkownika"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Dostosuj tekst łącza (opcjonalnie)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. Szczegóły dla {{nazwa kolumny}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Wartości, do których można się odnieść"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Brak dostępnych celów"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "Filtr"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "zmienna"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Inne dostępne filtry"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Avaliable filters"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Inne dostępne zmienne"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Dostępne zmienne"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Inne dostępne kolumny"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Dostępne kolumny"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "parametr użytkownika"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Karta tekstowa"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Zachowanie po kliknięciu"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Opcje wizualizacji"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Serie edycyjne"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Dodaj serię"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Na kliknięcie"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Zmiana tytułu i opisu"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Zaktualizowałeś parametry wbudowane i będziesz musiał zaktualizować swój kod wbudowany."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Dodaj pytanie"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Edytujesz tę tablicę rozdzielczą."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Kolumna do filtrowania na"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "kolekcja skrawków"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "zbiory skrawków"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Nadaj swojemu folderowi nazwę"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Coś krótkiego, ale słodkiego"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Folder ten powinien być w"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Otwórz menu akcji"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} kolumna ma niestandardowe zachowanie"
+msgstr[1] "{0} kolumny mają niestandardowe zachowanie"
+msgstr[2] "{0} kolumny mają niestandardowe zachowanie"
+msgstr[3] "{0} kolumny mają niestandardowe zachowanie"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Idź do..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Idź do tablicy rozdzielczej"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Przejdź do pytania"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Przejdź do url"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Przefiltruj tę tablicę rozdzielczą"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Zwraca liczbę wierszy w wybranych danych."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Kolumna lub liczba do zsumowania."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Kolumna numeryczna, aby uzyskać odchylenie standardowe."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Kolumna numeryczna, której wartości są uśredniane."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Zwraca najmniejszą wartość znajdującą się w kolumnie"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Podsumowuje określoną kolumnę tylko dla wierszy, w których warunek jest prawdziwy."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Zwraca wartość wariancji numerycznej dla danej kolumny."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Kolumna lub numer do uzyskania wariancji."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Zwraca wartość mediany określonej kolumny."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Kolumna lub numer do uzyskania mediany."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "wartość percentyla"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Zwraca wartość kolumny przy wartości percentyla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Kolumna lub liczba, którą należy uzyskać percentyl."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Wartość percentyla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Zwraca ciąg tekstu we wszystkich małych literach."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Kolumna z wartościami do konwersji na małe litery."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Zwraca tekst dużą literą."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Kolumna lub tekst do zwrotu części."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Kolumna lub tekst do przeszukania."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Połączyć ze sobą dwa lub więcej ciągów tekstu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Kolumna lub tekst na początek."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Zostanie to dodane do końca wartości1, i tak dalej."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Ogromny"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigantyczny"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Zwraca liczbę znaków w tekście."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Kolumna lub tekst, którego długość chcesz uzyskać."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Kolumna lub tekst, który chcesz przyciąć."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Zwraca bezwzględną (dodatnią) wartość podanej kolumny."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Zadłużenie"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Kolumna lub liczba, która zwraca bezwzględną (dodatnią) wartość."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Zaokrąglił liczbę dziesiętną w dół."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Kolumna lub numer do zaokrąglenia w dół."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Zaokrąglił liczbę dziesiętną w górę."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Kolumna lub numer do zaokrąglenia w górę."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Zaokrągla liczbę dziesiętną w górę lub w dół do najbliższej wartości całkowitej."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "Kolumna lub liczba w zaokrągleniu do najbliższej liczby całkowitej."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Zwraca pierwiastek kwadratowy."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hipoteneza"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Kolumna lub liczba, która zwraca pierwiastkową wartość kwadratową."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "Wykładnik"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Zwiększa liczbę do potęgi wartości wykładnika."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Długość"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Kolumna lub liczba podniesiona do wykładnika."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Wartość wykładnika."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Zwraca bazowe 10 logów numeru."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Wartość"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Kolumna lub liczba, która zwraca wartość logarytmu naturalnego."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Zwraca numer Eulera, e, podniesiony do mocy dostarczonego numeru."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Miesiące odsetkowe"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Kolumna lub numer, który ma zwrócić wartość wykładniczą."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Kolumna lub tekst do sprawdzenia."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Sprawdza wartości w kolumnie daty lub numeru, aby sprawdzić, czy mieszczą się w określonym zakresie."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Utworzony w"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Data lub kolumna numeryczna, która powinna zawierać się w wartościach początkowych i końcowych."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Początek zasięgu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Koniec zasięgu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Sprawdza wartości w kolumnie daty, aby sprawdzić, czy znajdują się one w zakresie względnym."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Kolumna z datą do zwrotu odstępu czasu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Okres interwału, w którym wartości ujemne są cofane w czasie."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Typ wewnętrzny jak \"dzień\", \"miesiąc\", \"rok\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Kolumna lub wartość do zwrotu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Jeśli wartość1 jest pusta, to zwracana jest wartość2, jeśli nie jest pusta, i tak dalej."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Testuje wyrażenie względem listy przypadków i zwraca odpowiednią wartość pierwszego pasującego przypadku, z opcjonalną wartością domyślną, jeśli nic innego nie jest spełnione."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Wartość, która zostanie zwrócona, jeśli poprzedni warunek jest prawdziwy, i tak dalej."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Jest nieważny"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Nie nieważne"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Dodatkowa suma wszystkich wartości danej kolumny.\n"
+"e.x. całkowite dochody w czasie."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Dodatkowa liczba wierszy.\n"
+"e.x. całkowita liczba sprzedaży w czasie."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Połączone filtry"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Etykieta"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Wartość domyślna"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Nie ma żadnego zaniedbania"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Aby to zobaczyć, {0} musi być podłączone do co najmniej jednego pola."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Ograniczenie wyboru tego filtra"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Jeśli posiadasz inny filtr tablicy rozdzielczej, możesz ograniczyć wybór, który jest wymieniony dla tego filtra na podstawie wyboru drugiego."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Więc najpierw, {0}"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "dodać kolejny filtr do tablicy rozdzielczej"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Jeśli włączysz jeden z tych filtrów tablicy rozdzielczej, wybór wartości dla tego filtra ograniczy dostępne opcje dla filtra {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Kolumna filtrująca"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Kolumna filtrowana"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Wprowadź nazwy użytkowników lub adresy e-mail"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Nowy skrawek"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 RANO"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 RANO"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Co godzinę"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Codziennie o {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Tygodniowo o {0} na {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Miesięcznie na {0} {1} o {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Usuń tę subskrypcję"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Abonamenty"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Tworzenie subskrypcji tablicy rozdzielczej"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Wyślij go pocztą elektroniczną"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Możesz regularnie wysyłać tę tablicę rozdzielczą do użytkowników lub na adresy e-mail."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Wyślij to do Slack'a"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Wybierz kanał i harmonogram, a Metabase zajmie się resztą."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Wyślij tę tablicę rozdzielczą pocztą elektroniczną"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Nie wysyłaj, jeśli nie ma wyników."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Załączyć wyniki"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Załączniki mogą zawierać do 2.000 wierszy danych."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Wyślij tę deskę rozdzielczą do Slack'a"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Tablica rozdzielcza nie ma parametru z ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Parametr {0} nie ma żadnych powiązanych z nim pól"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "zawierać musi być albo puste, albo wartość \"tabele\"."
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "`baza danych` jest wymagana dla wszystkich zapytań, których typ nie jest `wewnętrzny`."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Hasło do logowania jest w tym przypadku wyłączone."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Twoje konto jest nieaktywne. Prosimy o kontakt z administratorem."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Twoje konto jest nieaktywne."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Nieważny żeton Slack'a."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "Polecenie ''{0}'' jest dostępne tylko w Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Rozszerzenia Metabase Enterprise Edition są PRESENTNE."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Korzystanie z funkcji Metabase Enterprise Edition podlega licencji Metabase Commercial License."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Zobacz {0} po szczegóły."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Rozszerzenia Metabase Enterprise Edition NIE są PREZENTNE."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Jesteś zaproszony do przyłączenia się {0}''s {1}'."
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} założył konto {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} zaakceptował ich {1} zaproszenie"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "Prośba o zresetowanie hasła."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "Powiadomienie"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Pomóż zrobić [{1}] lepszy."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "Powiedz nam, jak się sprawy mają."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Błąd startu zdarzeń słuchacz"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Czy powinniśmy synchronizować atrybuty użytkownika, gdy ktoś loguje się za pomocą LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Oddzielona przecinkami lista atrybutów użytkownika do pominięcia synchronizacji dla użytkowników LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Nieważny token"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Błąd API Slack: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Brakuje kanału o nazwie `metabase_files`!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Prosimy o utworzenie lub niezarchiwizowanie kanału w celu zakończenia integracji Slack."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Kanał ten służy do przechowywania wykresów, które są zawarte w odpowiedziach Pulsów i MetaBota."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Wgrany obraz"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Błąd w przesyłaniu pliku do Slack'a:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Nieważna sesja. Spodziewałem się przykładu sesji."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "Session cookie's SameSite jest skonfigurowana na \"Brak\", ale strona jest"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "obsługiwanego przez niepewne połączenie. Niektóre przeglądarki odrzucą "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "ciasteczka na tych warunkach. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Folder górny"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":Parametry muszą być sekwencją map z klawiszami String :id"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Niewłaściwe wartości czytelne dla człowieka: wartości muszą być sekwencją; każda pozycja musi być zerowa lub ciągiem znaków."
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":wartości muszą być obecne, aby pobrać :human_readable_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Całkowita długość pola wynosi > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "nazwy fragmentów nie mogą zawierać \"}\" ani zaczynać się od spacji"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Błąd wykonywania zapytań o filtr łańcuchowy"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Pole {0} nie istnieje."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "{0} {1} Nie można przeszukiwać nietekstowego pola {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Udzielanie pozwoleń dla grupy {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Cofnięcie uprawnień dla grupy {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Nieważne uprawnienia DB: jeśli masz dostęp do zapisu dla zapytań rodzimych, musisz mieć pełny dostęp do danych."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Nieważne uprawnienia DB: jeśli masz dostęp do zapytań tylko do odczytu, musisz mieć również dostęp do danych."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Zmiana uprawnień z: {0} do: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "klucze atrybutów logowania muszą być słowem kluczowym lub ciągiem znaków"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Domyślny język dla wszystkich użytkowników w obrębie Metabase UI, systemowych wiadomości e-mail, impulsów i alarmów."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Użytkownicy mogą indywidualnie zmieniać ten domyślny język z własnych ustawień konta."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Strona domyślna do wyświetlania użytkownika"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Pozwolić temu pochodzeniu na umieszczenie pełnej aplikacji Metabase"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Wartości większe niż {0} ({1}) nie są dozwolone."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "To zastąpi słowo \"Metabaza\", gdziekolwiek się pojawi."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Są to podstawowe kolory używane na wykresach i w całej Metabase. Być może konieczne będzie odświeżenie przeglądarki, aby zmiany odniosły skutek."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Aby uzyskać najlepsze rezultaty, należy użyć pliku SVG z przezroczystym tłem."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "Adres url lub obrazek, który chcesz użyć jako favicon."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Pozwól na logowanie się za pomocą poczty elektronicznej i hasła."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Będzie to miało wpływ na takie rzeczy jak grupowanie według tygodni lub filtrowanie zapytań w interfejsie graficznym.\n"
+"  Nie będzie to miało wpływu na zapytania SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Nie można zatwierdzić tokena"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Format tokenowy jest nieważny."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Błędny token zatwierdzający"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "{0} Pole: nie można przetworzyć String {1} do {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Szczegóły pobierania błędów do pracy: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Uruchomienie zadania synchronizacji dla Bazy Danych {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Nie można zsynchronizować Bazy Danych {0}: Baza danych nie istnieje."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Aktualizacja Zadanie Aktualizacja wartości pól wyzwolone dla Bazy danych {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Pomijając aktualizację, automatyczne aktualizacje wartości pól są wyłączone dla Bazy Danych {0}."

--- a/locales/pt.po
+++ b/locales/pt.po
@@ -28,15 +28,16 @@ msgstr "Explorar esses dados"
 msgid "Select a database type"
 msgstr "Selecione um tipo de banco de dados"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Salvar"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Para fazer um pouco de sua mágica, o Metabase precisa varrer o seu banco de dados. Faremos isso periodicamente para manter os metadados atualizados. Você pode controlar quando as revisões periódicas são feitas a seguir."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Sincronizando Banco de Dados"
 
@@ -64,7 +65,7 @@ msgstr "Este é um processo rápido que procura atualizações no esquema deste 
 msgid "Scan"
 msgstr "Escanear"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Procurando por Valores de Filtro"
 
@@ -76,7 +77,7 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase pode varrer os valores presentes em cada \n"
 "campo neste banco de dados para ativar filtros checkbox em painéis e perguntas. Isso pode ser um processo que consome muitos recursos, especialmente se você tiver um banco de dados grande."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Quando o Metabase deve verificar e armazenar automaticamente os valores dos campos?"
 
@@ -115,7 +116,7 @@ msgstr "Excluir este banco de dados?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Todas as questões, métricas e segmentos que dependem desse banco de dados será perdido"
+msgstr "Todas as perguntas, métricas e segmentos que dependem desse banco de dados serão perdidos."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
@@ -135,29 +136,31 @@ msgstr "DELETE"
 msgid "in this box:"
 msgstr "nesta caixa:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -181,9 +184,9 @@ msgstr "Excluir"
 #. Existem alguns campos traduzidos como Bancos de dados e outros como base de dados. Para seguir o padrão, ajustei para Banco de dados
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -203,8 +206,9 @@ msgstr "Conexão"
 msgid "Scheduling"
 msgstr "Agendamento"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -283,10 +287,10 @@ msgstr "Adicionar banco de dados"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -321,10 +325,8 @@ msgid "Successfully saved!"
 msgstr "Salvo com sucesso!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Editar"
@@ -405,26 +407,29 @@ msgstr "Selecione um tipo especial"
 msgid "Select a target"
 msgstr "Selecione uma referência"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Colunas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Coluna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Tipo"
 
@@ -432,7 +437,7 @@ msgstr "Tipo"
 msgid "Current database:"
 msgstr "Banco de dados atual:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Mostrar esquema original"
 
@@ -502,7 +507,7 @@ msgstr "Encontre uma tabela"
 msgid "Schemas"
 msgstr "Esquemas"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -519,7 +524,7 @@ msgstr "Adicione uma métrica"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definição"
 
@@ -587,35 +592,35 @@ msgstr " História"
 msgid "Revision History for"
 msgstr "Histórico de revisão para"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - configuração"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Onde este campo aparecerá no Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrando neste campo"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quando esse campo é usado em um filtro, quais valores ele deve aceitar?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Ainda não há descrição para este campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Valor original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Valor atribuído"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Insira um valor"
 
@@ -632,31 +637,31 @@ msgid "Custom mapping"
 msgstr "Mapeamento personalizado"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Tipo de mapeamento não reconhecido"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "O campo atual não é uma chave estrangeira ou os metadados principais estão ausentes idioma estrangeiro na tabela de destino"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "O campo selecionado não é uma chave estrangeira"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Valores exibidos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Escolha se você deseja mostrar o valor original do banco de dados ou mostrar informações associadas ou personalizadas."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Escolha um campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Selecione uma coluna para mostrar"
 
@@ -664,18 +669,18 @@ msgstr "Selecione uma coluna para mostrar"
 msgid "Tip:"
 msgstr "Conselho:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Você pode querer atualizar o nome do campo para ter certeza de que ainda tem significado dependendo das opções de alocação."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Valores de campo no cache"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "o Metabase pode digitalizar os valores nesse campo para habilitar Filtros da caixa de seleção em painéis e perguntas."
+msgstr "O Metabase pode digitalizar os valores nesse campo para habilitar Filtros da caixa de seleção em painéis e perguntas."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
@@ -700,35 +705,36 @@ msgstr "Limpeza iniciada!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Selecione qualquer tabela para ver seu esquema e adicionar ou editar metadados."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Nome é obrigatório"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Descrição é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Mensagem da revisão é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "A agregação é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Edite sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Crie sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Faça alterações na sua métrica e deixe uma nota explicativa."
 
@@ -736,46 +742,46 @@ msgstr "Faça alterações na sua métrica e deixe uma nota explicativa."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Você pode criar métricas e salvá-las como um campo calculado nessa tabela. As métricas salvas incluem o tipo de agregação, o campo agregado e opcionalmente, qualquer filtro que você adicionar. Por exemplo, você pode usar esse para definir a forma oficial de calcular o \"Preço Médio\" para una Tabela Pedidos."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Resultado: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Nomeie sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Dê um nome à sua métrica para ajudar outras pessoas a encontrarem."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Algo descritivo, mas não muito longo"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Descreva sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Dê uma descrição à sua métrica para ajudar os outros a entender o que é tente"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Este é um bom lugar para ser mais específico sobre as regras de métrica menos óbvio"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Razão para alterações"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deixe uma nota para explicar que alterações você fez e por que elas foram necessário."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Isso aparecerá no histórico de revisão dessa métrica para ajudar todos para lembrar por que a mudança foi feita"
 
@@ -828,6 +834,7 @@ msgstr "Isso aparecerá no histórico de revisão deste segmento para ajudar tod
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -835,15 +842,14 @@ msgstr "Configuração"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:84
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "o Metabase pode ler os valores nesta tabela para ativar filtros caixas de seleção em painéis e perguntas."
+msgstr "O Metabase pode ler os valores nesta tabela para ativar filtros caixas de seleção em painéis e perguntas."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Re-scan this table"
 msgstr "Releia esta tabela"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Adicionar"
 
@@ -860,7 +866,7 @@ msgid "Last name"
 msgstr "Sobrenome"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Endereço de e-mail"
@@ -869,7 +875,7 @@ msgstr "Endereço de e-mail"
 msgid "Permission Groups"
 msgstr "Grupos de Permissões"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Converta este usuário para administrador"
 
@@ -967,6 +973,8 @@ msgstr "Excluir grupo"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -979,11 +987,12 @@ msgstr "Feito"
 msgid "Group name"
 msgstr "Nome do Grupo"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Grupos"
@@ -1092,7 +1101,7 @@ msgstr "Redefinir"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Tem certeza de que quer fazer isso?"
 
@@ -1205,7 +1214,7 @@ msgstr "Nenhuma alteração será feita nas permissões."
 msgid "You've made changes to permissions."
 msgstr "Você fez alterações nas permissões."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Permissões para esta coleção"
 
@@ -1261,6 +1270,7 @@ msgstr "Limite de acesso"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Revogar acesso"
 
@@ -1325,23 +1335,23 @@ msgstr "Curar a coleção"
 msgid "View collection"
 msgstr "Ver coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Acesso aos dados"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Veja as tabelas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "Consultas SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Veja esquemas"
 
@@ -1412,12 +1422,15 @@ msgstr "Enviado!"
 msgid "Clear"
 msgstr "Limpar"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autenticação"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Configuração do Servidor"
@@ -1430,6 +1443,7 @@ msgstr "Esquema do usuário"
 msgid "Attributes"
 msgstr "Atributos"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Esquema de grupo"
@@ -1501,6 +1515,9 @@ msgid "Add a map"
 msgstr "Adicione um mapa"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1510,19 +1527,19 @@ msgid "Delete custom map"
 msgstr "Remover mapa personalizado"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Excluir"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1620,19 +1637,19 @@ msgstr "Compre um token"
 msgid "Enter a token"
 msgstr "Digite um token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Editar atribuições"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Trabalhos de grupo"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Crie uma tarefa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1871,18 +1888,27 @@ msgstr "Filtro do usuário"
 msgid "Check your parentheses"
 msgstr "Verifique os parênteses"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Atributo do e-mail"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Atributo do nome"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Atributo do sobrenome"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Sincronizar membros do grupo"
@@ -1911,59 +1937,59 @@ msgstr "Mapas personalizados"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Adicione seus próprios arquivos GeoJSON para permitir diferentes visualizações de mapas da região"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Compartilhamento público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Ativar o compartilhamento público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Painéis compartilhados"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Perguntas compartilhadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Incorporar em outras aplicações"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar incorporação do Metabase em outros aplicativos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Chave secreta de incorporação"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Painéis embutidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Perguntas incorporadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Ativar cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Duração mínima da consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Cache do Time-to-Live Multiplier (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Tamanho máximo de entrada de cache"
 
@@ -2005,27 +2031,27 @@ msgstr "Você precisará de um administrador para criar uma conta do Metabase an
 msgid "Sign in with {0}"
 msgstr "Entre com {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Entre em contato com um administrador para redefinir sua senha"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Esqueci minha senha"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "O e-mail que você usa para sua conta no Metabase"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Enviar e-mail de redefinição de senha"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Consulte o seu e-mail para obter instruções sobre como redefinir sua senha"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Entre no Metabase"
 
@@ -2046,11 +2072,11 @@ msgstr "Entrar"
 msgid "I seem to have forgotten my password"
 msgstr "Parece que esqueci minha senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "solicitar envio de e-mail de redefinição de senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Oops, esse é um link expirado"
 
@@ -2060,11 +2086,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 msgstr "Por razões de segurança, links de redefinição de senha expiram depois de um tempo. \n"
 "Se você ainda precisar redefinir sua senha, você pode {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nova senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Para manter seus dados seguros, senhas {0}"
 
@@ -2087,24 +2113,24 @@ msgstr "Confirme a nova senha"
 msgid "Make sure it matches the one you just entered"
 msgstr "Tem que combinar com o que você acabou de colocar"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Sua senha foi redefinida."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Entre com sua nova senha"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Falhou"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2114,25 +2140,26 @@ msgstr "Salvo"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Arquivar esta coleção?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Os painéis, coleções e notificações nesta coleção também serão arquivados."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Arquivo"
 
@@ -2257,7 +2284,7 @@ msgstr "Fixados"
 msgid "Drag something here to pin it to the top"
 msgstr "Arraste algo aqui para fixar no topo da página."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2286,6 +2313,7 @@ msgstr "Mover \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Mover"
@@ -2323,7 +2351,7 @@ msgstr "Algumas instalações de banco de dados só podem ser acessadas conectan
 "Esta opção também fornece uma camada adicional de segurança quando não você tem uma VPN. \n"
 "Isso geralmente é mais lento que uma conexão direta."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Este é um grande banco de dados, então deixe-me escolher quando o Metabase sincronizar e digitalizar"
 
@@ -2363,7 +2391,7 @@ msgstr "Para usar o Metabase com esses dados, você deve ativar o acesso à API 
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} para ir ao console, se você ainda não fez isso."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Como você gostaria de chamar esse banco de dados?"
 
@@ -2481,35 +2509,35 @@ msgstr "Baseado no schema"
 msgid "A look at your"
 msgstr "Uma olhada em"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Pesquise na lista"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Pesquise por {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr "ou insira um ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Insira um ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Digite um número"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Digite um texto"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Nenhuma correspondência {0} foi encontrada."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Incluindo cada opção no seu filtro provavelmente não vai fazer muito..."
 
@@ -2521,7 +2549,6 @@ msgstr "Algo deu errado."
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Encontramos um erro. Você pode tentar atualizar a página, ou voltar."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2532,12 +2559,12 @@ msgstr "Encontramos um erro. Você pode tentar atualizar a página, ou voltar."
 msgid "No description yet"
 msgstr "Ainda sem descrição"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Novo {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Perguntado por {0}"
 
@@ -2558,7 +2585,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertido para uma revisão anterior e {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Histórico de revisão"
@@ -2604,7 +2633,7 @@ msgid "Questions"
 msgstr "Perguntas"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Notificações"
 
@@ -2678,52 +2707,69 @@ msgstr "Agora não"
 msgid "Error:"
 msgstr "Erro:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Domingo"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Segunda-feira"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Terça-feira"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Quarta-feira"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Quinta-feira"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Sexta-feira"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Sábado"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Primeiro"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Último"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15 (ponto médio)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Dia do calendário"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "o seu fuso horário no Metabase"
 
@@ -2777,11 +2823,11 @@ msgstr "Criar"
 msgid "Create dashboard"
 msgstr "Criar um painel"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabela"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Banco de dados"
 
@@ -2856,9 +2902,9 @@ msgstr "Qual é o nome do seu cartão?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2872,15 +2918,16 @@ msgstr "Descrição"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "É opcional, mas tão útil"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Em que coleção isso deveria ir?"
 
@@ -2920,11 +2967,11 @@ msgstr "Arquivar Painel"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Certifique-se de fazer uma seleção para cada série ou o filtro não funcionará neste cartão."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Este painel parece estar vazio."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Adicione uma pergunta para torná-lo útil!"
 
@@ -2944,7 +2991,7 @@ msgstr "Desativar tela cheia"
 msgid "Enter fullscreen"
 msgstr "Ativar tela cheia"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Salvando..."
@@ -2957,7 +3004,8 @@ msgstr "Adicione uma pergunta"
 msgid "Add a question to this dashboard"
 msgstr "Adicione uma pergunta a este painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Adicionar filtro"
 
@@ -2965,7 +3013,7 @@ msgstr "Adicionar filtro"
 msgid "Parameters"
 msgstr "Parâmetros"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Adicionar uma caixa de texto"
 
@@ -2973,7 +3021,7 @@ msgstr "Adicionar uma caixa de texto"
 msgid "Move dashboard"
 msgstr "Mover painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Editar painel"
 
@@ -2997,11 +3045,11 @@ msgstr "Mover painel para..."
 msgid "Dashboard moved to {0}"
 msgstr "Painel movido para {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "O que você deseja filtrar?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Que tipo de filtro?"
 
@@ -3073,20 +3121,22 @@ msgstr "Este cartão ainda não tem campos ou parâmetros que podem ser mapeados
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Os valores nesse campo não sobrepõe os valores de outros campos que você escolheu."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Não há campos válidos"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "O nome deve ter 100 caracteres ou menos"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Cor é obrigatório"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Qual é o nome do seu painel?"
 
@@ -3141,7 +3191,7 @@ msgstr "recebeu os dados mais recentes de"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -3266,9 +3316,10 @@ msgstr "Você não olhou nenhum painel ou pergunta recentemente"
 msgid "{0} items selected"
 msgstr "{0} itens selecionados"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Desarquivar"
 
@@ -3385,7 +3436,7 @@ msgid "Zip Code"
 msgstr "Código postal"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Quantidade"
 
@@ -3418,11 +3469,13 @@ msgid "User"
 msgstr "Usuário"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Fonte"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Preço"
 
@@ -3456,21 +3509,23 @@ msgid "Subscription"
 msgstr "Assinatura"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Pontuação"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Título"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Comentário"
 
@@ -3524,14 +3579,14 @@ msgstr "O Metabase nunca recuperará este campo. Use-o para informações confi
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Contagem"
 
@@ -3539,7 +3594,7 @@ msgstr "Contagem"
 msgid "CumulativeCount"
 msgstr "Contagem cumulativa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3557,19 +3612,19 @@ msgstr "Diferente"
 msgid "StandardDeviation"
 msgstr "Desvio padrão"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Média"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Mínimo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3580,13 +3635,13 @@ msgstr "Máximo"
 msgid "sad sad panda, lexing errors detected"
 msgstr "Panda triste triste, erros lexicais detectados"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} segundo"
 msgstr[1] "{0} segundos"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
@@ -3628,14 +3683,15 @@ msgstr "O que você quer saber?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dados brutos"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Contagem cumulativa"
 
@@ -3697,168 +3753,166 @@ msgstr "Verdadeiro"
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Selecione o campo longitude"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Latitude Superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Longitude Esquerdo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Latitude Inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Longitude certo"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "É"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Não é"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Vazio"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Não vazio"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Igual à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Diferente"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Maior do que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Menos que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Maior que ou igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Menor ou igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Contém"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Não contém"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Comece com"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Termina em"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Antes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Depois"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Dentro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Apenas uma tabela com as linhas na resposta, sem operações adicionais."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Número de linhas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Número total de linhas na resposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Soma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Soma de todos os valores de uma coluna."
 
-#. Acho que a agregação de "Medium of.... " está ficando errada, pois traduz em 
+#. Acho que a agregação de "Medium of.... " está ficando errada, pois traduz em
 #. "Média de... de" mas vou deixar a tradução assim por enquanto
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Média de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Média de todos os valores em uma coluna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Número de valores diferentes de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Número de valores exclusivos de uma coluna entre todas as linhas na resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Soma acumulada de ..."
 
@@ -3867,7 +3921,7 @@ msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over t
 msgstr "Soma aditiva de todos os valores em uma coluna. \n"
 " por exemplo, receita total ao longo do tempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Contagem cumulativa de linhas"
 
@@ -3876,27 +3930,27 @@ msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over
 msgstr "Contagem aditiva do número de linhas. \n"
 " por exemplo, número total de vendas ao longo do tempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Desvio padrão de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Número que expressa o quanto os valores de uma coluna variam entre todos os linhas na resposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Mínimo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Valor Mínimo de uma Coluna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Máximo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Valor máximo de uma coluna"
 
@@ -3912,6 +3966,8 @@ msgstr "letra minúscula"
 msgid "upper case letter"
 msgstr "letra maiúscula"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "número"
@@ -4159,7 +4215,7 @@ msgstr "Como criar métricas"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Verifique os dados ao longo do tempo, como um mapa, ou gire-os para ajudar você a entender tendências ou mudanças."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -4182,7 +4238,7 @@ msgstr "Consulta nativa"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Para perguntas mais complicadas, você pode escrever sua própria consulta SQL ou nativo"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Selecione um valor padrão..."
 
@@ -4273,7 +4329,7 @@ msgstr "Este mês"
 msgid "This Year"
 msgstr "Este ano"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Digite um valor..."
@@ -4283,7 +4339,7 @@ msgid "Enter a default value..."
 msgstr "Digite um valor padrão..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ocorreu um erro"
@@ -4541,22 +4597,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Escolha as perguntas que você gostaria de enviar nesta notificação"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "E-mails"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Mensagens Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Enviado"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} será enviado para"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Mensagens"
 
@@ -4628,30 +4692,30 @@ msgstr "Ajude toda a sua equipe a permanecer em sincronia com seus dados."
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "As notificações permitem que você envie dados do Metabase para o e-mail ou Slack na hora que você quiser."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Depois de {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Antes de {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Vazio"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Não vazio"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Todo o tempo"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -4753,12 +4817,12 @@ msgstr[1] "Veja estes {0}"
 msgid "Zoom in"
 msgstr "Aumentar Zoom"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Expressão personalizada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Métricas Comuns"
 
@@ -4955,7 +5019,7 @@ msgstr "geralmente"
 msgid "Pick a segment or table"
 msgstr "Escolha um segmento ou tabela"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Selecione um banco de dados"
@@ -5016,7 +5080,7 @@ msgstr "Ordenar"
 msgid "Row limit"
 msgstr "Limite de linha"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Campo Desconhecido"
 
@@ -5024,7 +5088,7 @@ msgstr "Campo Desconhecido"
 msgid "field"
 msgstr "campo"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Combinações"
 
@@ -5049,11 +5113,11 @@ msgstr "Adicione um grupo"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dados"
 
@@ -5070,11 +5134,12 @@ msgstr "Ver"
 msgid "Grouped By"
 msgstr "Agrupado por"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Nenhum"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Esta questão está escrita em {0}."
 
@@ -5086,7 +5151,7 @@ msgstr "Ocultar editor"
 msgid "Hide Query"
 msgstr "Esconder consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Abrir editor"
 
@@ -5094,7 +5159,7 @@ msgstr "Abrir editor"
 msgid "Show Query"
 msgstr "Mostrar consulta"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Esta métrica foi removida. Não está mais disponível para uso."
 
@@ -5295,7 +5360,7 @@ msgstr "Retornar para a última execução"
 msgid "Visualization"
 msgstr "Display"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Sem descrição"
 
@@ -5352,7 +5417,7 @@ msgstr "Os metadados na tabela não foram encontrados antes de criar um novo que
 msgid "See {0}"
 msgstr "Veja {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Definição de Métrica"
 
@@ -5370,11 +5435,11 @@ msgstr "Número de {0}"
 msgid "See all {0}"
 msgstr "Ver todos {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Definição de Segmento"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Ocorreu um erro ao carregar a tabela"
 
@@ -5382,7 +5447,7 @@ msgstr "Ocorreu um erro ao carregar a tabela"
 msgid "See the raw data for {0}"
 msgstr "Veja os dados brutos de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Mais"
 
@@ -5402,6 +5467,8 @@ msgstr "Campo fórmula"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pense nisso como algo como escrever uma fórmula em um programa de planilhas: você pode usar números, campos nesta tabela, símbolos matemáticos como +, e algumas funções. Então você poderia escrever algo como Subtotal &minus; Custo."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5469,13 +5536,17 @@ msgstr "falso"
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Element"
 
+#. The best translation to "Previous 30 days" in portuguese is "30 dias anteriores". But is registred "Anterior 30 dias", that has no meaning in portuguese.
+#. To fit this format and achieve the meaning, I suggest use another translation: "Últimos 30 dias"
+#. This is more like "Past 30 days", but has the same context.
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
+#, fuzzy
 msgid "Previous"
-msgstr "Anterior"
+msgstr "Últimos"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
@@ -5588,11 +5659,11 @@ msgstr "Campo para mapear para"
 msgid "Filter widget type"
 msgstr "Tipo de filtro"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Obrigatório?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Valor padrão do filtro"
 
@@ -5604,7 +5675,7 @@ msgstr "Arquivar esta pergunta?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Esta questão será removida de qualquer painel ou notificação que a utilize."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Pergunta"
 
@@ -5651,7 +5722,7 @@ msgstr "Tipo do campo"
 msgid "Select a Foreign Key"
 msgstr "Selecione uma chave estrangeira"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Veja a fórmula para {0}"
 
@@ -6135,22 +6206,24 @@ msgstr "Perguntas sobre este segmento"
 msgid "X-ray this segment"
 msgstr "Aplique raios-X a este segmento"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Iniciar sessão"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Pesquisar"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Painel"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nova pergunta"
 
@@ -6222,35 +6295,35 @@ msgstr "Toda a informação obtida é completamente anônima."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "A coleção pode ser desativada a qualquer momento na seção de configuração"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Se você se sentir sobrecarregado"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "nosso guia inicial"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "É um único clique."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Bem vindo ao Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Parece que tudo está funcionando. Agora vamos conhecê-lo, conecte-se com o seu dados e comece a encontrar algumas respostas!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Vamos começar"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Estás pronto!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Leve-me para o Metabase"
 
@@ -6503,39 +6576,40 @@ msgstr "Cancelar filtro"
 msgid "Pin Map"
 msgstr "Fixar mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Desmarcar"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Linhas {0}-{1} de {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Dados truncados para {0} linhas."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "A visualização não pôde ser encontrada"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Não foi possível mostrar este gráfico com essas informações."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Nenhum resultado!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Ainda esperando..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Isso geralmente leva cerca de {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Isso é um pouco demorado para um painel)"
 
@@ -6646,7 +6720,7 @@ msgid "Highlight the whole row"
 msgstr "Realçar"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Cores"
 
@@ -6732,24 +6806,50 @@ msgstr "Meta"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Epa! Os dados em sua consulta não correspondem à opção de exibição escolhida. Esta visualização requer pelo menos {0} {1} de dados."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "coluna"
@@ -6781,7 +6881,7 @@ msgid "xValues missing!"
 msgstr "xValores ausentes!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Eixo X"
 
@@ -6790,7 +6890,7 @@ msgid "Add a series breakout..."
 msgstr "Adicione um detalhamento da série..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Eixo Y"
 
@@ -6803,9 +6903,9 @@ msgid "Bubble size"
 msgstr "Tamanho da bolha"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
-msgstr "Line"
+msgstr "Linha"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
@@ -6945,20 +7045,20 @@ msgid "Standard Deviation"
 msgstr "Desvio padrão"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Área"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "gráfico de área"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "gráfico de barras"
 
@@ -6972,7 +7072,7 @@ msgid "Funnel"
 msgstr "Funil"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Medida"
 
@@ -6984,81 +7084,81 @@ msgstr "Tipo de Funil"
 msgid "Bar chart"
 msgstr "Gráfico de barras"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
-msgstr "gráfico de linhas"
+msgstr "gráfico de linha"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Selecione as colunas de longitude e latitude na configuração do gráfico"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Por favor, selecione um mapa da região."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Selecione as colunas e métricas da região nas configurações do gráfico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Tipo de mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Mapa da região"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Fixar mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Tipo de pino"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Azulejos"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Marcadores"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Campo de latitude"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Campo de longitude"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Campo métrico"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Campo de região"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Rádio"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Borrão"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Opacidade mínima"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Zoom máximo"
 
@@ -7070,7 +7170,7 @@ msgstr "Nenhum relacionamento foi encontrado."
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Este {0} está conectado a:"
 
@@ -7082,31 +7182,31 @@ msgstr "Detalhe do Objeto"
 msgid "object"
 msgstr "objeto"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Quais colunas você deseja usar?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pizza"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimensão"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Mostrar legenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Mostrar percentagens na legenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Percentagem mínima de porção"
 
@@ -7131,7 +7231,8 @@ msgid "Progress"
 msgstr "Progresso"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Cor"
@@ -7140,7 +7241,7 @@ msgstr "Cor"
 msgid "Row Chart"
 msgstr "Gráfico de linhas"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "gráfico de linha"
 
@@ -7164,15 +7265,15 @@ msgstr "Adicione um sufixo"
 msgid "Multiply by a number"
 msgstr "Multiplique por um número"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Dispersão"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "gráfico de dispersão"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Converter em tabela dinâmica"
 
@@ -7222,13 +7323,13 @@ msgstr "Direita"
 msgid "Show background"
 msgstr "Mostrar fundo"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} agrupamento"
 msgstr[1] "{0} agrupamentos"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Auto agrupado"
 
@@ -7467,10 +7568,13 @@ msgstr "Você tem muitas perguntas salvas em {0}? Crie coleções para ajudar G
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7488,7 +7592,7 @@ msgstr "Criar segmentos"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "Mantém todos na mesma página, criando conjuntos filtros canônicos que qualquer um pode usar ao fazer perguntas."
+msgstr "Mantém todos na mesma página, criando conjuntos de filtros canônicos que qualquer um pode usar ao fazer perguntas."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
@@ -7660,7 +7764,7 @@ msgstr "incremento"
 msgid "{0} and {1}"
 msgstr "{0} e {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
@@ -8975,11 +9079,11 @@ msgstr "Permissão de dados"
 msgid "Collection permissions"
 msgstr "Permissão de coleções"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Ver todas as permissões de coleções"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Mude também as sub-coleções"
 
@@ -8991,19 +9095,19 @@ msgstr "Pode editar essa coleção e seu conteúdo"
 msgid "Can view items in this collection"
 msgstr "Pode ver os itens dessa coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Acesso à coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Este grupo tem permissão para ver ao menos uma sub-coleção desta coleção."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Este grupo tem permissão para editar ao menos uma sub-coleção desta coleção."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Ver sub-coleções"
 
@@ -9059,6 +9163,7 @@ msgstr "Relacionado"
 msgid "More X-rays"
 msgstr "Mais Raios-X"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9317,10 +9422,10 @@ msgstr "Compartilhamento"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9405,7 +9510,7 @@ msgstr "Use o fuso horário da JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Nós estamos atualmente analisando as tabelas e campos para ajudar-lhe a explorar seus dados."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Dica: "
 
@@ -9413,7 +9518,7 @@ msgstr "Dica: "
 msgid "Select a currency type"
 msgstr "Selecione um tipo de moeda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Tipo de Campo"
 
@@ -9468,6 +9573,7 @@ msgid "Currency"
 msgstr "Moeda"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Selecione um usuário ou canal..."
 
@@ -9629,7 +9735,7 @@ msgstr "Qual eixo?"
 msgid "Line + Bar"
 msgstr "Linha + Coluna"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "gráfico de linha e coluna"
 
@@ -9649,15 +9755,15 @@ msgstr "Intervalo do indicador"
 msgid "Field to show"
 msgstr "Campo a ser mostrado"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "último {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} era {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Agrupe por um campo contendo data/tempo para ver como foi a alteração ao longo do tempo"
 
@@ -9665,23 +9771,23 @@ msgstr "Agrupe por um campo contendo data/tempo para ver como foi a alteração 
 msgid "Switch positive / negative colors?"
 msgstr "Alternar cores positivas / negativas?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Coluna eixo"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Coluna da célula"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Colunas visíveis"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Formatação Condicional"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Título da coluna"
 
@@ -10119,10 +10225,10 @@ msgstr "Usuários por fonte"
 msgid "The top external pages that brought users to your site"
 msgstr "As maiores páginas externas que trouxeram usuários para o seu site"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Como [[this]] é distribuído e mais"
 
@@ -10220,13 +10326,13 @@ msgstr "Eventos por hora do dia"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Maiores 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Últimos 5 [[this]]"
 
@@ -10239,10 +10345,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Por [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Valores nulos"
 
@@ -10270,8 +10376,8 @@ msgstr "Como eles se comparam por sazonalidade"
 msgid "Average income per transaction"
 msgstr "Média de renda por transação"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] por estado"
 
@@ -10395,10 +10501,10 @@ msgstr "Uma visão global do seu [[this]] e como é distribuído ao longo do tem
 msgid "Average income per state"
 msgstr "Média de renda por estado"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] por [[GenericCategoryMedium]]"
 
@@ -10575,13 +10681,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Como [[GenericTable]] são distribuidos por esse campo tempo, e se tiver algum padrão sazonal"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Visão global"
 
@@ -10690,8 +10796,8 @@ msgstr "Um olhar mais atento para você [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Um olhar mais atendo para você sobre o campo [[this]]"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Resumo"
 
@@ -10755,10 +10861,10 @@ msgstr "Vendas por fonte"
 msgid "Average income per country"
 msgstr "Média de renda por país"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Como [[this]] é distríbuido"
 
@@ -10779,17 +10885,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Contagem de [[GenericCategoryMedium]] por [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Uma olhada no seu [[this]]"
 
@@ -10855,10 +10961,10 @@ msgid "Transactions per source over time"
 msgstr "Transações por fonte ao longo do tempo"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Como [[this]] é distribuído"
 
@@ -10887,9 +10993,9 @@ msgstr "Onde esses eventos estão acontecendo"
 msgid "Which US states are bringing you the most business."
 msgstr "Quais estados do EUA estão trazendo a maioria do seu negócio"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Como eles se comparam ao longo do tempo"
 
@@ -10995,8 +11101,8 @@ msgstr "Sessões por País"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Alguns métricas interessantes sobre seus dados do GA para começar."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] por estado"
 
@@ -11077,12 +11183,12 @@ msgstr "Como essa métrica é distribuída através de diferentes números"
 msgid "Sessions by page where the session began"
 msgstr "Sessões por página onde essa sessão começou"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Valores distintos"
 
@@ -11145,10 +11251,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Eventos por [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Como eles comparam por distribuição"
@@ -11363,7 +11469,7 @@ msgstr "JWT `alg` não pode ser `none`."
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "A chave secreta embutida não foi configurada."
+msgstr "Chave secreta de incorporação não foi definida."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
@@ -11454,6 +11560,7 @@ msgstr "Duplicar painel"
 msgid "Duplicate \"{0}\""
 msgstr "Duplicar \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11472,14 +11579,22 @@ msgstr "Este {0}"
 msgid "Next {0}"
 msgstr "Próximo {0}"
 
+#. The best translation to "Previous 30 days" in portuguese is "30 dias anteriores". But is registred "Anterior 30 dias", that has no meaning in portuguese.
+#. To fit this format and achieve the meaning, I suggest use another translation: "Últimos 30 dias"
+#. This is more like "Past 30 days", but has the same context.
 #: frontend/src/metabase/lib/query_time.js:135
 #: src/metabase/pulse/render/datetime.clj
+#, fuzzy
 msgid "Previous {0}"
-msgstr "Anterior {0}"
+msgstr "Últimos {0}"
 
+#. The best translation to "Previous 30 days" in portuguese is "30 dias anteriores". But is registred "Anterior 30 dias", that has no meaning in portuguese.
+#. To fit this format and achieve the meaning, I suggest use another translation: "Últimos 30 dias"
+#. This is more like "Past 30 days", but has the same context.
 #: frontend/src/metabase/lib/query_time.js:139
+#, fuzzy
 msgid "Previous {0} {1}"
-msgstr "Anterior {0} {1}"
+msgstr "Últimos {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
@@ -11551,9 +11666,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Trimestre do ano"
 msgstr[1] "Trimestres do ano"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seleção"
@@ -11576,11 +11691,11 @@ msgstr "Inválido"
 msgid "Add a time"
 msgstr "Adicionar um horário"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nada a comparar para o anterior"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "por {0}"
 
@@ -12068,9 +12183,9 @@ msgstr "Aqui está uma visão global sobre pessoa em seu [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] por trimestre do ano"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Como eles se comparam através dos lugares"
 
@@ -12099,12 +12214,12 @@ msgstr "[[CreateTimestamp]] por dia da semana"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Aqui está uma visão geral sobre os dados de seu [[this]] vindos do Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Aqui está uma visão geral sobre seu [[this]]"
 
@@ -12182,11 +12297,11 @@ msgstr "coleção"
 msgid "collections"
 msgstr "coleções"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "painel"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "painéis"
 
@@ -12436,7 +12551,7 @@ msgstr "Tempo esgotado após {0} milissegundos "
 msgid "Misfire Instruction"
 msgstr "Falha de instrução"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Arquivar?"
 
@@ -12454,7 +12569,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Utilizar essa opção requer que o host seja um FQDN. Caso esteja conectando-se a um cluster Atlas, você talvez precise habilitar essa opção. Se não souber o que isso significa, deixe-a desativada."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Execute queries automaticamente ao filtrar ou sumarizar"
 
@@ -12467,7 +12582,7 @@ msgstr "Com essa opção ativa, o Metabase irá automaticamente rodar consultas 
 msgid "Learn about this database"
 msgstr "Aprenda sobre essa base de dados"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Arquivar este dashboard?"
 
@@ -12523,11 +12638,11 @@ msgstr "Pergunta customizada"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Use o editor de texto avançado para juntar dados, criar colunas customizadas, efetuar cálculos e muito mais."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Métricas Básicas"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Customizado..."
 
@@ -12712,15 +12827,15 @@ msgstr "Escolha uma visualização"
 msgid "Filter by"
 msgstr "Filtrado por"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Resumido por"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Agrupado por"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Adicione uma métrica"
 
@@ -12731,15 +12846,15 @@ msgstr "Adicione uma métrica"
 msgid "Profile"
 msgstr "Perfil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Isso normalmente é bem rápido mas parece estar demorando um pouco agora"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Combo"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Linha"
 
@@ -13155,12 +13270,12 @@ msgstr "Falha ao agendar tarefas para o Banco de Dados {0}"
 msgid "All elements must be distinct."
 msgstr "Todos os elementos devem ser distintos."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Selecione as colunas que quer incluir"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Quando ativado, essa opção faz com que o Metabase realize consultas quando usuários fazem explorações de dados simples com os botões de Resumir e Filtrar. Você pode desabilitar se as consultas ao banco estão lentas. Isso não afeta as consultas SQL ou drill-throughs."
 
@@ -13226,7 +13341,7 @@ msgstr "Login com e-mail"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Esta opção existe que o host informado seja um FQDN (Fully Qualified Domain Name). Se estiver se conectando a um cluster no Atlas, você pode precisar habilitar esta opção. Caso não saiba o que isso significa, deixe esta opção desabilitada."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Por padrão, o Metabase faz uma leve sincronização de hora em hora e uma varredura intensa diariamente dos valores dos campos. Se você possui um grande banco de dados, nos recomendamos que ative isso e analise quando e quão frequente a varredura do valor do campo acontece."
 
@@ -13294,11 +13409,11 @@ msgstr "Não incluir"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Este campo não estará visível ou selecionável em perguntas criadas à partir da interface de usuário. Ele ainda estará acessível em SQL/queries nativas."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Soma acumulada"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Desvio padrão"
 
@@ -13314,19 +13429,19 @@ msgstr "Deve ter pelo menos {0} caracteres"
 msgid "Name (required)"
 msgstr "Nome (obrigatório)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Executar texto selecionado"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Executar consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13674,7 +13789,7 @@ msgstr "Datas e Horários"
 msgid "Numbers"
 msgstr "Números"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 #, fuzzy
 msgid "No mappable groups"
 msgstr "Nenhum grupo mapeável"
@@ -13715,15 +13830,15 @@ msgstr "voceestaincrivelhoje@email.com"
 msgid "Remember me"
 msgstr "Lembre-me"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Por motivos de segurança, os links de redefinição de senha expiram após alguns instantes. Se você ainda precisar redefinir sua senha, poderá {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Salve a nova senha"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Nenhum resultado correspondente"
 
@@ -13749,26 +13864,26 @@ msgid "or"
 msgstr "ou"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "requerido"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Tipo base de dados"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Esse é um processo ligeiro que verifica se há atualizações no esquema desse banco de dados. Na maioria dos casos, você deve deixar esse conjunto  de dados sincronizando a cada hora."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase pode varrer os valores presentes em cada campo deste banco de dados para ativar filtros de caixas de seleção em painéis e perguntas. Esse pode ser um processo que consome muitos recursos, principalmente se você tiver um banco de dados muito grande."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Coleção"
 
@@ -13815,7 +13930,7 @@ msgstr "Categórico"
 msgid "URLs"
 msgstr "URLs"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Retorna a média dos valores na coluna."
 
@@ -13824,11 +13939,13 @@ msgstr "Retorna a média dos valores na coluna."
 msgid "The column whose values to average."
 msgstr "A coluna cujos valores são médios"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "início"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "fim"
 
@@ -13840,21 +13957,19 @@ msgstr "Verifica se os valores de uma data ou coluna numérica estão dentro do 
 msgid "Rating"
 msgstr "Classificando"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "condição"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "saída"
 
@@ -13862,27 +13977,27 @@ msgstr "saída"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testa uma lista de casos e retorna o valor correspondente ao primeiro caso verdadeiro, com um valor padrão opcional se nada for encontrado."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Peso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Grande"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Médio"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Pequeno"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Algo que deve ser avaliado como verdadeiro ou falso."
 
@@ -13890,33 +14005,33 @@ msgstr "Algo que deve ser avaliado como verdadeiro ou falso."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "O valor que será retornado se a condição anterior for verdadeira."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "valor1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "valor2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Examina os valores em cada argumento em ordem e retorna o primeiro valor não nulo para cada linha."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Comentários"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notas"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Sem comentários"
 
@@ -13932,12 +14047,12 @@ msgstr "Se valor1 é vazio, valor2 irá retornar se não for vazio, e assim por 
 msgid "Combines two or more strings of text together."
 msgstr "Combina duas ou mais strings de texto juntas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Sobrenome"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Primeiro Nome"
 
@@ -13949,27 +14064,27 @@ msgstr "valor2 será adicionado no final disso."
 msgid "This will be added to the end of value1."
 msgstr "Isso será adicionado ao final do valor1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Verifica se string1 contém string2 em seu interior."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Senha"
 
@@ -13977,7 +14092,7 @@ msgstr "Senha"
 msgid "The contents of this string will be checked."
 msgstr "O conteúdo dessa string será checado"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "A string de texto para pesquisar"
 
@@ -13985,22 +14100,22 @@ msgstr "A string de texto para pesquisar"
 msgid "Returns the count of rows in the source data."
 msgstr "Retorna a contagem de linhas da fonte de dados"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Somente conta as linhas quando a condição for verdadeira"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "O somatório de linhas através de uma quebra"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "A soma parcial de uma coluna através de uma quebra"
 
@@ -14009,53 +14124,57 @@ msgstr "A soma parcial de uma coluna através de uma quebra"
 msgid "The column to sum."
 msgstr "A coluna para somar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "O número de valores distintos nessa coluna"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "A coluna para contar os distintos valores"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "texto"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "comparação"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Retorna verdadeiro se o final do texto corresponde ao texto de comparação"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Apetite"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "faminto"
 
@@ -14064,20 +14183,20 @@ msgstr "faminto"
 msgid "A column or string of text to check."
 msgstr "Uma coluna ou string de texto para checar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "A sequência de texto com a qual o texto original deve terminar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "expressão_regular"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrai substrings correspondentes de acordo com uma expressão regular."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Endereço"
 
@@ -14085,7 +14204,7 @@ msgstr "Endereço"
 msgid "The column or string of text to search though."
 msgstr "A coluna ou sequência de texto a ser pesquisada."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "A expressão regular a combinar."
 
@@ -14097,7 +14216,7 @@ msgstr "Retorna a sequência de texto em minúsculas."
 msgid "The column with values to convert to lowercase."
 msgstr "A coluna com valores a serem convertidos em minúsculas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Remove o espaço em branco à esquerda de uma sequência de texto."
 
@@ -14107,15 +14226,16 @@ msgstr "Remove o espaço em branco à esquerda de uma sequência de texto."
 msgid "The column with values you want to trim."
 msgstr "A coluna com os valores que você deseja cortar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Retorna o maior valor encontrado na coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Idade"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "A coluna numérica cujo valor máximo você deseja encontrar."
 
@@ -14123,21 +14243,21 @@ msgstr "A coluna numérica cujo valor máximo você deseja encontrar."
 msgid "Returns the smallest value found in the column."
 msgstr "Retorna o menor valor encontrado na coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Salário"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "A coluna numérica cujo mínimo você deseja encontrar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "posição"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "comprimento"
 
@@ -14146,7 +14266,7 @@ msgstr "comprimento"
 msgid "new_text"
 msgstr "novo_texto"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Substitui uma parte do texto de entrada por um novo texto."
 
@@ -14174,35 +14294,35 @@ msgstr "O número de caracteres para substituir."
 msgid "The text to use in the replacement."
 msgstr "O texto a ser usado na substituição."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Remove o espaço em branco à direita de uma sequência de texto."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Retorna a porcentagem de linhas nos dados que correspondem à condição, como um decimal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Retorna verdadeiro se o início do texto corresponder ao texto de comparação."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Nome do curso"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Ciência da Computação"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "A sequência de texto com a qual o texto original deve começar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Calcula o desvio padrão da coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "População"
 
@@ -14210,7 +14330,7 @@ msgstr "População"
 msgid "A numeric column."
 msgstr "Uma coluna numérica"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Retorna uma parte do texto fornecido."
 
@@ -14218,19 +14338,19 @@ msgstr "Retorna uma parte do texto fornecido."
 msgid "The text to return a portion of."
 msgstr "O texto para o qual retornar uma parte."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "A posição para começar a copiar caracteres."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Um número de caracteres para retorno."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Adiciona todos os valores da coluna."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "A coluna numérica para somar."
 
@@ -14238,15 +14358,15 @@ msgstr "A coluna numérica para somar."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Soma os valores em uma coluna onde as linhas correspondem à condição."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Status do pedido"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Válido"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Remove os espaços em branco iniciais e finais de uma sequência de texto."
 
@@ -14254,47 +14374,47 @@ msgstr "Remove os espaços em branco iniciais e finais de uma sequência de text
 msgid "Returns the string of text in all upper case."
 msgstr "Retorna a sequência de texto em maiúsculas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "A coluna com valores para converter em maiúsculas."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "deve ser {0} e incluir {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "deve ser {0}"
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "deve incluirr {0}"
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "pelo menos {0} caractere"
 msgstr[1] "pelo menos {0} caracteres"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} letra minúscula"
 msgstr[1] "{0} letras minúsculas"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} letra maiúscula"
 msgstr[1] "{0} letras maiúsculas"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] " {0} número"
 msgstr[1] " {0} números"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] " {0} caractere especial"
@@ -14317,6 +14437,7 @@ msgid "Powered by {0}"
 msgstr "Desenvolvido por {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Para:"
 
@@ -14404,7 +14525,7 @@ msgstr "Formatação valor"
 msgid "Full"
 msgstr "Cheio"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Nenhuma alteração desde o último {0}"
 
@@ -14729,7 +14850,7 @@ msgstr "Erro ao gerar informações para a coluna:"
 msgid "Sending abandonment email!"
 msgstr "Enviando email de abandono!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Você pode criar métricas salvas para adicionar uma opção de métrica nomeada. As métricas salvas incluem: o tipo de agregação, o campo agregado e, opcionalmente, qualquer filtro que você adicionar. Como exemplo, você pode usar isso para criar algo como a maneira padrão de calcular o \"Preço médio\" para uma tabela de pedidos."
 
@@ -14737,15 +14858,15 @@ msgstr "Você pode criar métricas salvas para adicionar uma opção de métrica
 msgid "Select and add filters to create your new segment."
 msgstr "Selecione e adicione filtros para criar seu novo segmento."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alfabetico"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Inteligente"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Ordem da coluna: {0}"
 
@@ -14797,7 +14918,7 @@ msgstr "Idioma"
 msgid "Instance language"
 msgstr "Idioma da instância"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Opções de idioma"
 
@@ -14869,19 +14990,20 @@ msgstr "Cole uma string de conexão"
 msgid "Fill out individual fields"
 msgstr "Preencha os campos individuais"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Digite um trecho SQL aqui para poder reutilizá-lo mais tarde"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Dê um nome ao seu trecho"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Clientes atuais"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Adicione uma descrição"
 
@@ -14889,46 +15011,47 @@ msgstr "Adicione uma descrição"
 msgid "Use site default"
 msgstr "Use site padrão"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "encontrar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "substitua"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "O texto para encontrar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "O texto a ser usado como substituto."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Editando {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Crie seu novo trecho"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Trechos arquivados"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Trechos são pedaços reutilizáveis de SQL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Crie um trecho"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Trechos"
 
@@ -15191,7 +15314,7 @@ msgstr "Erro ao reduzir {0}"
 
 #: src/metabase/sync/analyze/fingerprint/insights.clj
 msgid "Error generating timeseries insight keyed by: {0}"
-msgstr "Erro ao gerar insight de séries temporais digitado por: {0}"
+msgstr "Erro ao gerar insight de séries temporais de chave: {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
@@ -15209,3 +15332,1504 @@ msgstr "valor precisa ser uma palavra-chave ou texto."
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "A sequência deve ser um idioma ISO válido de duas letras ou um código de idioma do país, por exemplo. 'pt' ou 'pt_BR'."
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Registros {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Auditar"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Configuração de atributo de usuário (opcional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Usando {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Configurar SSO baseado em SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "Autenticação SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Configure seu provedor de autenticação (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Seu provedor de autenticação irá precisar das seguintes informações sobre o Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL the IdP devería redirecionar de volta para"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Isso é chamado de URL de Logon Único no Okta, URL de retorno de chamada do aplicativo no Auth0,\n"
+"e o URL ACS (consumidor) em OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "Atributos SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "Na maioria dos IdPs, você precisará colocar cada um deles em uma caixa de entrada rotulada\n"
+"\"Nome\" na seção de instruções de atributo."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Atributo de e-mail do usuário "
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Atributo de primeiro nome do usuário "
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Atributo de último nome do usuário "
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Diga ao Metabase qual é o seu provedor de autenticação"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase irá precisar das seguintes informações sobre seu provedor "
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL do provedor de identidade SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Certificado de Provedor de Identidade SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Nome da aplicação SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Habilitar solicitações SSO (opcional)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Caminho do SAML Keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Senha do SAML Keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Xii..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Apelido do SAML Keystore"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Sincronizar associação de grupo com seu SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Para habilitar isso, você precisará criar mapeamentos para informar ao Metabase qual (is) grupo (s) seus usuários devem\n"
+"ser adicionado com base no grupo SSO em que está."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Nome do grupo"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Nome de atributo de grupo"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Observação:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Se mudar qualquer informação da atual configuração SAML, terá que reiniciar o Metabase for que as novas informações tenham efeito."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Permitir a usuários loggear via um fornecedor de identidade SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Permitir a usuários loggear via um fornecedor de identidade JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Ativar autenticação de contrasenha"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Quando ativado, os usuários poderão também fazer login usando e-mail e senha."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Notificar admins sobre os novos usuários SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Quando ativado, administradores irão receber um e-mail na primeira vez que um usuário usar o Single Sign-On "
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Use as configurações abaixo para configurar seu SSO via SAML. Se houver qualquer dúvida, verifique nossa {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "Documentação"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI do fornecedor de identidade SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "Autenticação JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI do provedor de identidade JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Texto usado pela chave de assinatura JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Incorporar o aplicativo Metabase completo"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Se você deseja incorporar o aplicativo Metabase completo, insira os websites ou web apps que você deseja permitir a incoração em um iframe, separados por espaço. Aqui estão os {0} do que pode ser inserido."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Conceda acesso em sandbox a esta tabela"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Quando os usuários neste grupo visualizam esta tabela, eles verão uma versão dela que é filtrada por seus atributos de usuário, ou uma visualização personalizada dela com base em uma pergunta salva."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Como você deseja filtrar esta tabela para os usuários deste grupo?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Escolha uma pergunta salva que retorne a visualização personalizada desta tabela que esses usuários devem ver."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Você pode opcionalmente adicionar filtros adicionais aqui com base nos atributos do usuário. Esses filtros serão aplicados em cima de quaisquer filtros que já estejam nesta pergunta salva."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Para que esta opção funcione, seus usuários precisam ter alguns atributos"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Para adicionar filtros adicionais, seus usuários precisam ter alguns atributos"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Sem atributos de usuário"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Escolha um atributo de usuário"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Escolha um parâmetro"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Escolha uma coluna"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Os usuários en {0} podem ver"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "Fileiras na pergunta {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "Fileiras na tabla {0} "
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "Onde {0} igual a {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "e {0} igual a {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Você pode adicionar atributos automaticamente configurando um SSO que usa SAML ou pode inseri-los manualmente acessando a seção Pessoas e clicando no menu… à direita."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Atributo de usuário"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Podemos obter automaticamente os atributos de seus usuários se você configurou o SSO ou pode adicioná-los manualmente no menu \"...\" na seção Pessoas do Painel de administração."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parâmetro ou variável"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "igual"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Conceder acesso em sandbox"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Acesso em sandbox"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Editar acesso em sandbox"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Editar detalhes da pasta"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Trocar permissões"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Crie sua nova pasta"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nova pasta"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Estamos com problemas para validar seu token"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Verifique novamente se sua instancia pode se conectar aos servidores do Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Obter ajuda"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Obtenha ainda mais do Metabase com a versão Enterprise Edition"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Todas as ferramentas de que você precisa para fornecer relatórios para seus clientes de forma rápida e fácil ou para ajudá-lo a executar e monitorar a Metabase em uma grande organização"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Ativar uma licença"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Seu trial está ativo com esses recursos"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "O acesso em trial expira em {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Precisa de ajuda? Pronto para comprar?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Fale conosco"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Seu período de teste expirou"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Necessita de mais tempo? Pronto para comprar?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Seus recursos estão ativos!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Sua licença é válida através de {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Sua licença expirou"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Expirou em {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Quer renovar a sua licença?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Aprenda como usar isto"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Não incluído em seu plano atual"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Insira o token que você recebeu da loja"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Ativar"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Precisa de ajuda?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Mais informações sobre o seu problema."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Contate o suporte"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Dados de sandboxes"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Certifique-se de que está a mostrar às pessoas certas os dados certos com filtros automáticos e seguros baseados nos atributos do utilizador."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Rotulagem branca"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Faça corresponder o Metabase à sua marca com cores personalizadas, o seu próprio logótipo e muito mais."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Auditar"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Fique de olho no desempenho e comportamento com ferramentas de auditoria robustas."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Autenticação única (Single sign-on)"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Forneça um login fácil que funcione com a sua infra-estrutura de autenticação existente."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Loja"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Nome da aplicação"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Paleta de cores"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Landing Page"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Sem grupos"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Permissões para {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Permissões para essa pasta"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Conceda acesso de edição"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Pode modificar snippets nesta pasta"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Conceda acesso de visualização"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Pode inserir e usar snippets nesta pasta, mas não pode editar o SQL que eles contêm"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Não consigo ver ou inserir trechos nesta pasta"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Altere também as subpastas"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Primeiro dia da semana"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Ocorreu um problema ao fazer login pelo Google. Por favor contate um administrador"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "no"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "em"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Abra o menu de ações no Metabase"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Não faça nada"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Vá para um destino personalizado"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Atualize um filtro de painel"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} atualiza {1} filtro"
+msgstr[1] "Plural: {0} atualiza {1} filtros"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} vai para {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Comportamento ao clicar para cada coluna"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Vá para um destino personalizado"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Abra o menu de ações"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Clique em comportamento para {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Escolha um ou mais filtros para atualizar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Pergunta salva"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Linkar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Digite a URL para linkar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Você pode inserir o valor de um filtro de coluna ou painel de instrumentos usando seu nome, assim: {{algumas_colunas}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "ex. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Escolha um painel..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Escolha uma pergunta..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Escolha um painel para linkar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Escolha uma pergunta para linkar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Passe valores para os filtros deste painel (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Passar valores para as variáveis desta pergunta (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Passar valores para filtrar esta pergunta (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filtros do painel"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Atributos do usuário"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Customizar texto do link (opcional)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. Detalhes para {{{Nome da coluna}}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Valores que você pode referenciar"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Sem destinos disponíveis"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filtro"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "variável"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Outros filtros disponíveis"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Filtros disponíveis"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Outras variáveis disponíveis"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Variáveis disponíveis"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Outras colunas disponíveis"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Colunas disponíveis"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "atributo do usuário"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Cartão de texto"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Comportamento do clique"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Opções de visualizações"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Editar série"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Adicionar série"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Em clique"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Alterar título e descrição"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Você alterou os parâmetros de incorporação e deve atualizar seu código de incorporação"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Adicionar pergunta"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Você está editando esse painel."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Coluna a filtrar em"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "colecção de snippets"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "colectâneas de fragmentos"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Dê um nome para sua pasta"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Algo curto mas doce"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Pasta que isso deve estar"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Abra o menu de ação"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} a coluna tem comportamento personalizado"
+msgstr[1] "{0} as colunas têm comportamento personalizado"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Ir para..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Ir para painel"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Ir para pergunta"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Ir para url"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filtrar esse painel"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Retorna a contagem de linhas nos dados selecionados."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "A coluna ou número para somar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "A coluna numérica para obter o desvio padrão de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "A coluna numérica cujos valores para a média."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Devolve o menor valor encontrado na coluna"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Soma na coluna especificada apenas para as linhas onde a condição é verdadeira."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Retorna a variação numérica para uma determinada coluna."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "A coluna ou número para obter a variação de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Retorna o valor mediano da coluna especificada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "A coluna ou número para obter a mediana de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "valor percentil"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Retorna o valor da coluna no valor do percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "A coluna ou número para obter o percentil de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "O valor do percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Retorna a seqüência de texto em todas as letras minúsculas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "A coluna com valores a converter para minúsculas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Retorna o texto em todas as maiúsculas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "A coluna ou texto para devolver uma parte."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "A coluna ou texto a pesquisar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Combine duas ou mais cordas de texto juntas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "A coluna ou texto para começar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Isto será adicionado ao fim do valor1, e assim por diante."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Enorme"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigante"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Retorna o número de caracteres no texto."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "A coluna ou texto que você quer obter o comprimento de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "A coluna ou texto que você quer aparar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Retorna o valor absoluto (positivo) da coluna especificada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Dívida"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "A coluna ou número para retornar valor absoluto (positivo) de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Arredonda um número decimal para baixo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "A coluna ou número a arredondar para baixo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Arredonda um número decimal para cima."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "A coluna ou número a arredondar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Arredonda um número decimal para cima ou para baixo para o valor inteiro mais próximo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "A coluna ou número a arredondar para o número inteiro mais próximo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Devolve a raiz quadrada."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hipotenusa"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "A coluna ou número para retornar o valor da raiz quadrada de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "expoente"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Eleva um número para o poder do expoente de valor."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Comprimento"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "A coluna ou número elevado para o expoente."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "O valor do expoente."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Devolve o log base 10 do número."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Valor"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "A coluna ou número para retornar o logaritmo natural do valor."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Devolve o número de Euler, e, elevado à potência do número fornecido."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Meses de juros"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "A coluna ou número para devolver o valor exponencial de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Coluna ou texto para verificar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Verifica os valores de uma coluna de datas ou números para ver se estão dentro do intervalo especificado."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Criado em"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "A data ou coluna numérica que deve estar dentro dos valores inicial e final."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "O início da gama."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "O fim do alcance."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Verifica os valores de uma coluna de datas para ver se estão dentro do intervalo relativo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "A coluna de data de retorno do intervalo de."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Período de intervalo, onde os valores negativos estão de volta no tempo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Tipo de interno como \"dia\", \"mês\", \"ano\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Coluna ou valor para retornar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Se o valor1 estiver vazio, o valor2 é devolvido se não estiver vazio, e assim por diante."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Testa uma expressão contra uma lista de casos e retorna o valor correspondente ao primeiro caso correspondente, com um valor padrão opcional se nada mais for cumprido."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "O valor que será devolvido se a condição anterior for verdadeira, e assim por diante."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "É nullo"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Não é nullo"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Soma aditiva de todos os valores de uma coluna.\n"
+"e.x. receita total ao longo do tempo."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Contagem aditiva do número de filas.\n"
+"e.x. número total de vendas ao longo do tempo."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Filtros vinculados"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Etiqueta"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Valor padrão"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Sem padrão"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Para ver isto, {0} deve estar ligado a pelo menos um campo."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Limitar as escolhas deste filtro"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Se você tiver outro filtro do painel, você pode limitar as escolhas listadas para este filtro com base na seleção do outro."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Então, primeiro, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "adicionar outro filtro do painel de instrumentos"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Se você alternar em um desses filtros de painel, a seleção de um valor para esse filtro limitará as escolhas disponíveis para o filtro {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Filtrando coluna"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Coluna filtrada"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Digite nomes de usuário ou endereços de e-mail"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Novo snippet"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "0:00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "De hora em hora"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Diariamente em {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Semanalmente em {0} em {1}."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Mensalmente no {0} {1} em {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Eliminar esta subscrição"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Assinaturas"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Criar uma assinatura de painel de instrumentos"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Envie por e-mail"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Você pode enviar este painel regularmente aos usuários ou endereços de e-mail."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Enviar para o Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Escolha um canal e um horário, e o Metabase fará o resto."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Enviar esse painel por e-mail"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Não envie se não tiver resultados"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Anexar resultados"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Anexos podem conter até 2.000 linhas de dados."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Enviar esse painel para o Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "O painel não tem um parâmetro com o ID {0}."
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "O parâmetro {0} não tem nenhum campo associado a ele"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "incluir deve estar vazio ou o valor 'tabelas'."
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "É necessária uma \"base de dados\" para todas as consultas cujo tipo não seja \"interno\"."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "O login com senha está desativado para esta instância."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Sua conta está desabilitada. Por favor contate seu administrador."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Sua conta está desabilitada."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Token do Slack inválido."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "O comando ''{0}'' só está disponível na Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "As extensões da Metabase Enterprise Edition são APRESENTADAS."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "O uso das funcionalidades do Metabase Enterprise Edition está sujeito à Licença Comercial do Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Veja {0} para detalhes."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "As extensões da Metabase Enterprise Edition NÃO são APRESENTADAS."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Você está convidado a juntar-se aos {0}''s {1}."
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} criou uma conta {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} aceitou o convite do {1}"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "Pedido de redefinição de senha"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[0]] Notificação"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "Ajudar a melhorar."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "Diga-nos como vão as coisas."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Erro ao iniciar eventos ouvinte"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Devemos sincronizar os atributos do usuário quando alguém faz o login via LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Lista separada por vírgula de atributos do usuário para pular a sincronização para usuários LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Token inválido"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Erro da API do Slack: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Falta o canal de \"arquivos_metabase\"!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Por favor, crie ou desarquive o canal a fim de completar a integração Slack."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "O canal é utilizado para armazenar gráficos que são incluídos em Pulses e respostas MetaBot."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Imagem enviada"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Erro ao enviar arquivo para o Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Sessão inválida. Esperava uma instância de Sessão."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "O SameSite do cookie de sessão está configurado para \"Nenhum\", mas o site é"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "servida por uma ligação insegura. Alguns navegadores vão rejeitar "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookies sob estas condições. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Pasta superior"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parâmetros devem ser uma sequência de mapas com String :id keys"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Valores inválidos de leitura humana: os valores devem ser uma sequência; cada item deve ser nulo ou uma cadeia"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr "Valores :têm de estar presentes para obter :valores_mais_legíveis"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "O comprimento total dos valores de campo é > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "Os nomes dos trechos não podem incluir '}' ou começar com espaços"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Erro ao executar consulta de filtro em cadeia"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Campo {0} não existe."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Não é possível pesquisar contra campo não-Texto {0} {1} {2} {3}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Conceder permissões para o grupo {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Revogação das permissões para o grupo {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Permissões de BD inválidas: se você tem acesso por escrito para consultas nativas, você deve ter acesso total aos dados."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Permissões de BD inválidas: se você tiver acesso de consulta nativa somente para leitura, você também deve ter acesso aos dados."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Alterando permissão de: {0} para: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "as chaves de atributo de login devem ser uma palavra-chave ou string"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "O idioma padrão para todos os utilizadores na interface do Metabase, e-mails do sistema, pulsos e alertas."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Os usuários podem substituir individualmente este idioma padrão a partir das configurações de sua própria conta."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Página predefinida para mostrar ao utilizador"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Permitir que esta origem incorpore o aplicativo Metabase completo"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Valores maiores que {0} ({1}) não são permitidos."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Isto irá substituir a palavra \"Metabase\" onde quer que ela apareça."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Estas são as cores primárias usadas nos gráficos e em todo o Metabase. Talvez precise de actualizar o seu browser para ver as suas alterações a terem efeito."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Para melhores resultados, use um arquivo SVG com fundo transparente."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "A url ou imagem que deseja usar como favicon."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Permitir o login por e-mail e senha."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Isto irá afectar coisas como agrupar por semana ou filtrar em consultas GUI.\n"
+"  Isso não afetará as consultas SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Não foi possível validar o token"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Formato do token é inválido."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Erro ao validar token"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Erro de filtragem contra {0} Field: unable to parse String {1} to a {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Detalhes de erro de busca de trabalho: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Iniciar tarefa de sincronização para Base de Dados {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Não é possível sincronizar a base de dados {0}: A base de dados não existe."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Tarefa Atualizar valores de campo acionados para Banco de Dados {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Saltando atualização, as atualizações automáticas de valor de campo são desativadas para o Banco de Dados {0}."

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -28,15 +28,16 @@ msgstr "Исследовать данные"
 msgid "Select a database type"
 msgstr "Выберите тип базы данных"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Сохранить"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Мы должны просканировать вашу базу данных. Мы так же будем периодически повторять это действие для поддержки актуальности данных. Ниже вы можете управлять периодичностью."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "База данных синхронизируется"
 
@@ -64,7 +65,7 @@ msgstr "Это лёгкий процесс проверяющий структу
 msgid "Scan"
 msgstr "Сканирование"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Сканирование для значения фильтров"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase может просканировать значения каждого поля базы данных и сделать доступными checkbox-фильтры на панелях индикаторов и в вопросах. Процесс достаточно ресурсозатратный, особенно, если речь идет об очень большой базе данных."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Когда Metabase должен автоматически сканировать и кэшировать значения?"
 
@@ -90,7 +91,7 @@ msgstr "Только при добавлении виджета фильтра"
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Когда пользователь добавляет новый фильтр к дэшборду или SQL запрос, Метабэйз сканирует поля связанные с этим фильтром для отображения опций"
+msgstr "Когда пользователь добавляет новый фильтр к дэшборду или SQL запрос, Metabase сканирует поля связанные с этим фильтром для отображения опций"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:62
 msgid "Never, I'll do this manually if I need to"
@@ -133,29 +134,31 @@ msgstr "УДАЛИТЬ"
 msgid "in this box:"
 msgstr "в этом поле:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -178,9 +181,9 @@ msgstr "Удалить"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -200,8 +203,9 @@ msgstr "Подключение"
 msgid "Scheduling"
 msgstr "Расписание"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -280,10 +284,10 @@ msgstr "Добавить базу данных"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -318,10 +322,8 @@ msgid "Successfully saved!"
 msgstr "Сохранено!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Изменить"
@@ -400,26 +402,29 @@ msgstr "Выбрать специальный тип"
 msgid "Select a target"
 msgstr "Выбрать цель"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Столбцы"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Столбец"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Видимость"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Тип"
 
@@ -427,7 +432,7 @@ msgstr "Тип"
 msgid "Current database:"
 msgstr "Текущая база данных:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Показать оригинальную схему"
 
@@ -503,7 +508,7 @@ msgstr "Найти таблицу"
 msgid "Schemas"
 msgstr "Схемы"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -520,7 +525,7 @@ msgstr "Добавить Метрику"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Определение"
 
@@ -588,35 +593,35 @@ msgstr " История"
 msgid "Revision History for"
 msgstr "История изменений за"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} – установки поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Где это поле будет отображено в системе"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Фильтрация этого поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Если это поле используется как фильтр, какой вид информации должны использовать пользователи для фильтрации?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Для этого поля пока нет описания"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Оригинальное значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Связанное значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Введите значение"
 
@@ -633,31 +638,31 @@ msgid "Custom mapping"
 msgstr "Своя связь"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Неопознанный вид связи"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Данное поле не является внешним ключем либо метаданные другой таблицы, содержащей внешний ключ, отсутствуют"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Выбранное поле не является внешнем ключём"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Показать значения"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Выберите, что отобразить в поле: исходное значение из базы данных, ассоциированную или иную настраиваемую информацию."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Выберите поле"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Пожалуйста, выберете столбец для отображения."
 
@@ -665,16 +670,16 @@ msgstr "Пожалуйста, выберете столбец для отобр�
 msgid "Tip:"
 msgstr "Подсказка:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Возможно, вы захотите обновить наименование поля, чтобы убедиться, что оно соответствует выбранному варианту переназначения связи."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Кэшированные значения полей"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase может сканировать значения данного поля и включить возможность использования checkbox-фильтров на панели индикаторов и в вопросах."
 
@@ -701,35 +706,36 @@ msgstr "Сброс значений начался!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Выбрать базу данных что бы увидеть её схему или изменить мета данные."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Имя обязательно"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Описание обязательно"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Описание внесенных изменений обязательно"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Агрегация обязательна"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Изменить Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Создать Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Внесите изменения в метрику и оставьте к ним пояснение."
 
@@ -737,46 +743,46 @@ msgstr "Внесите изменения в метрику и оставьте 
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Вы можете создать сохраненные метрики, чтобы использовать их в данной таблице. Сохраненные метрики включают тип агрегации, агрегированное поле и, при необходимости, любой фильтр. Например, вы можете использовать их, чтобы создать что-то вроде единственного официального способа вычисления \"Средней цены\" для таблицы \"Заказы\"."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Результаты: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Имя вашей Метрики"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Задайте имя для вашей метрики, чтобы другие пользователи смогли ее найти."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Что-нибудь описательное, но не слишком длинное"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Опишите вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Укажите описание вашей метрики, чтобы помочь другим понять о чем она."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Это идеальное место, чтобы быть более конкретным в отношении менее очевидных правил вычисления метрики"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Причина изменений"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Оставьте описание внесенных вами изменений и почему они были необходимы."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Данное сообщение появится в истории изменений метрики и поможет всем восстановить ход событий"
 
@@ -829,6 +835,7 @@ msgstr "Данное сообщение появится в истории из�
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -843,8 +850,7 @@ msgid "Re-scan this table"
 msgstr "Пересканировать эту таблицу"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Добавить"
 
@@ -862,7 +868,7 @@ msgstr "Фамилия"
 
 #. Строка "Email" есть ниже.
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Адрес электронной почты"
@@ -873,7 +879,7 @@ msgstr "Адрес электронной почты"
 msgid "Permission Groups"
 msgstr "Группы Разрешений"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Определить администратором"
 
@@ -973,6 +979,8 @@ msgstr "Удалить группу"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -985,11 +993,12 @@ msgstr "Готово"
 msgid "Group name"
 msgstr "Имя группы"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Группы"
@@ -1099,7 +1108,7 @@ msgstr "Сбросить"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Вы уверены что хотите выполнить это действие?"
 
@@ -1215,7 +1224,7 @@ msgstr "Никаких изменений доступа выполнено не
 msgid "You've made changes to permissions."
 msgstr "Вы внесли изменения в настройки доступа."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Разрешения для этой коллекции"
 
@@ -1271,6 +1280,7 @@ msgstr "Ограничить доступ"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Отозвать доступ"
 
@@ -1334,23 +1344,23 @@ msgstr "Управлять коллекцией"
 msgid "View collection"
 msgstr "Посмотреть коллекцию"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Доступ к данным"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Посмотреть таблицы"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL запросы"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Посмотреть схемы"
 
@@ -1421,12 +1431,15 @@ msgstr "Отправлено!"
 msgid "Clear"
 msgstr "Очистить"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Аутентификация"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Настройки сервера"
@@ -1439,6 +1452,7 @@ msgstr "Пользовательская Схема"
 msgid "Attributes"
 msgstr "Атрибуты"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Схема Группы"
@@ -1489,7 +1503,7 @@ msgstr "Пока вы здесь, дайте имя и нажмите {0}. За�
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:17
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "Вы последнюю версию запустили Metanase {0}, которая великолепна!"
+msgstr "У вас установлена Metabase {0} — самая свежая и прекрасная!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
@@ -1510,6 +1524,9 @@ msgid "Add a map"
 msgstr "Добавить карту"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "Ссылка"
@@ -1519,19 +1536,19 @@ msgid "Delete custom map"
 msgstr "Удалить текущую карту"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Удалить"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1629,19 +1646,19 @@ msgstr "Купить токен"
 msgid "Enter a token"
 msgstr "Ввести токен"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Изменить сопоставления"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Групповое сопоставление"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Создать сопоставление"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1880,18 +1897,27 @@ msgstr "Пользовательский фильтр"
 msgid "Check your parentheses"
 msgstr "Проверьте круглые скобки"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Email аттрибут"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Атрибут имени"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Атрибут фамилии"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Синхронизировать членство в группе"
@@ -1920,59 +1946,59 @@ msgstr "Пользовательская карта"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Добавьте собственные GeoJSON файлы для возможности визуализации различных регионов на картах"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Общий доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Включить общий доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Публичные дашборды"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Публичные запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Встраивание в других Приложениях"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Включить встраивание Metabase в других Приложениях"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Секретный ключ для встраивания"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Встраиваемые дашборды"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Встраиваемые запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Кэширование"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Включить кэширование"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Минимальное время запроса"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Множитель Cache Time-To-Live (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Максимальный объем записи в кеш"
 
@@ -2014,27 +2040,27 @@ msgstr "Свяжитесь с администратором для исполь
 msgid "Sign in with {0}"
 msgstr "Зайти с {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Свяжитесь с администратором для сброса вашего пароля"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Забыли пароль"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Email, который вы используете с вашим Metabase аккаунта"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Послать емаил для сброса пароля"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Послать емаил с инструкцией как сбросить пароль."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Войти в Metabase"
 
@@ -2055,11 +2081,11 @@ msgstr "Войти"
 msgid "I seem to have forgotten my password"
 msgstr "Похоже что я забыл свой пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "запросить новое письмо с запросом на сброс пароля"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Уууупс, кажется эта ссылку устарела."
 
@@ -2069,11 +2095,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 msgstr "По соображениям безопасности, ссылки на сброс пароля через некоторое время истекают.\n"
 "Если вам все еще нужно сбросить пароль, вы можете {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Новый пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Ради безопасности, пароли {0}"
 
@@ -2096,24 +2122,24 @@ msgstr "Подтвердите новый пароль"
 msgid "Make sure it matches the one you just entered"
 msgstr "Удостоверьтесь что он соответствует тому который вы уже ввели"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Ваш пароль был сброшен."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Зайди с вашим новым паролем"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Сохранение не удалось"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2123,25 +2149,26 @@ msgstr "Сохранено"
 msgid "Ok"
 msgstr "Ок"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Переместить коллекцию в архив?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Дашборды, коллекции и пульсы в этой коллекции так же будут премещены в архив."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Архив"
 
@@ -2266,7 +2293,7 @@ msgstr "Прикрепленные"
 msgid "Drag something here to pin it to the top"
 msgstr "Переместите что-то для того чтобы закрепить наверху"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2297,6 +2324,7 @@ msgstr "Переместить \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Переместить"
@@ -2334,7 +2362,7 @@ msgstr "Некоторые инсталляции баз данных могут
 "Эта опция так же предоставляет дополнительный уровень безопасности, когда недоступен VPN. \n"
 "Использование может снизить скорость в сравнении с прямым соединением."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Это большая база данных, так что дайте я выберу когда Мэтабэйз синхронизирует и сканирует"
 
@@ -2374,7 +2402,7 @@ msgstr "Вам необходимо разрешить доступ по API в 
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} перейдите в консоль, если вы этого еще не сделали"
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Как бы вы хотели обращаться к этой базе данных?"
 
@@ -2490,35 +2518,35 @@ msgstr "Основано на схеме"
 msgid "A look at your"
 msgstr "Взгляните на"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Поиск в списке"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Искать по {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " или введитеь ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Введите ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Ведите номер"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Введите текст"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Не найдено сходст в {0}."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Предположу, что выбор всех значений фильтра делу не поможет…"
 
@@ -2530,7 +2558,6 @@ msgstr "Что-то пошло не так"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Мы столкнулись с ошибкой. Попробуйте обновить страницу или просто вернитесь назад."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2541,12 +2568,12 @@ msgstr "Мы столкнулись с ошибкой. Попробуйте об
 msgid "No description yet"
 msgstr "Описание не заполнено"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Новый {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Задан {0}"
 
@@ -2567,7 +2594,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Возвращен к более ранней редакции и {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "История ревизий"
@@ -2613,7 +2642,7 @@ msgid "Questions"
 msgstr "Запросы"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Пульсы"
 
@@ -2687,52 +2716,69 @@ msgstr "Не сейчас"
 msgid "Error:"
 msgstr "Ошибка:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Воскресенье"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Понедельник"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Вторник"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Среда"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Четверг"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Пятница"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Суббота"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Первый"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Последний"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15-ое (середина)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "День календаря"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "часовой пояс вашего Metabase"
 
@@ -2786,11 +2832,11 @@ msgstr "Создать"
 msgid "Create dashboard"
 msgstr "Создать дашборд"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Таблица"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "База данных"
 
@@ -2865,9 +2911,9 @@ msgstr "Как называется ваша карточка?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2881,15 +2927,16 @@ msgstr "Описание"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Это не обязательно, но может быть полезным"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "В какую коллекцию следует это включить?"
 
@@ -2929,11 +2976,11 @@ msgstr "Архивировать Панель индикаторов"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Убедитесь что сделан выбор для каждой из серий, иначе фильтр не будет работать на этой карточке."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Панель индикаторов кажется пустоватой."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Добавьте запрос и сделайте его полезным!"
 
@@ -2953,7 +3000,7 @@ msgstr "Выход из полноэкранного режима"
 msgid "Enter fullscreen"
 msgstr "Полноэкранный режим"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Сохранение..."
@@ -2966,7 +3013,8 @@ msgstr "Добавить запрос"
 msgid "Add a question to this dashboard"
 msgstr "Добавить запрос на этот дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Добавить фильтр"
 
@@ -2974,7 +3022,7 @@ msgstr "Добавить фильтр"
 msgid "Parameters"
 msgstr "Параметры"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Добавить текстовое поле"
 
@@ -2982,7 +3030,7 @@ msgstr "Добавить текстовое поле"
 msgid "Move dashboard"
 msgstr "Переместить дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Изменить дашборд"
 
@@ -3006,11 +3054,11 @@ msgstr "Переместить дашборд..."
 msgid "Dashboard moved to {0}"
 msgstr "Дашборд перемещен в {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Что вы хотите отфильтровать?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Какой тип фильтра?"
 
@@ -3082,20 +3130,22 @@ msgstr "Карточка не содержит полей или парамет�
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Значение этого поля не покрывают значения никаких полей, которые вы выбрали."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Нет корректных полей"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Имя не должно превышать 100 символов"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Цвет обязателен"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Как называется ваш дашборд?"
 
@@ -3150,7 +3200,7 @@ msgstr "последние данные получены"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -3275,9 +3325,10 @@ msgstr "В последнее время, вы не смотрели ни на �
 msgid "{0} items selected"
 msgstr "{0} элементов выбрано"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Разархивировать"
 
@@ -3394,7 +3445,7 @@ msgid "Zip Code"
 msgstr "ZIP-код"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Количество"
 
@@ -3428,11 +3479,13 @@ msgid "User"
 msgstr "Пользователь"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Источник"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Цена"
 
@@ -3465,21 +3518,23 @@ msgid "Subscription"
 msgstr "Подписка"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Результат"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Заголовок"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -3533,14 +3588,14 @@ msgstr "Metabase никогда не получит это поле. Испол�
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Количество"
 
@@ -3548,7 +3603,7 @@ msgstr "Количество"
 msgid "CumulativeCount"
 msgstr "Накопительное количество"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3567,19 +3622,19 @@ msgstr "Уникальные"
 msgid "StandardDeviation"
 msgstr "Стандартное отклонение"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Среднее"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Минимальное"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3590,7 +3645,7 @@ msgstr "Максимальное"
 msgid "sad sad panda, lexing errors detected"
 msgstr "грустная грустная панда, обнаружены лексические ошибки"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} секунда"
@@ -3598,7 +3653,7 @@ msgstr[1] "{0} секунд"
 msgstr[2] "{0} секунд"
 msgstr[3] "{0} секунды"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} минута"
@@ -3641,14 +3696,15 @@ msgstr "Что вас интересует?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Исходные данные"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Накопительное количество"
 
@@ -3710,166 +3766,164 @@ msgstr "Истина"
 msgid "False"
 msgstr "Ложь"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Выберите поле с долготой"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Введите верхнюю широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Введите левую долготу"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Введите нижнюю широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Введите правую долготу"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "-"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Не"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Пусто"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Не пусто"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Не равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Больше чем"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Меньше чем"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Между"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Больше или равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Меньше или равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Содержит"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Не содержит"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Начинается с"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Заканчивается"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "До"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "После"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Внутри"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Просто таблица со строками результатов, без дополнительных операций."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Количество записей"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Общее количество записей в ответе"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
-msgstr "Количество ..."
+msgstr "Сумма ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
-msgstr "Количество всех значений колонки."
+msgstr "Сумма всех значений в колонке."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Среднее ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Среднее всех значений колонки."
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Уникальные значения..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Количество уникальных значений столбца среди всех записей в ответе."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Сумма нарастащим итогом…"
 
@@ -3878,7 +3932,7 @@ msgstr "Сумма нарастащим итогом…"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Совокупное сумма всех значений столбца.\\\\ne.x. всего доход за временной интервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Нарастающий итог"
 
@@ -3886,28 +3940,28 @@ msgstr "Нарастающий итог"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Совокупное количество записей.\\\\ne.x. всего продаж за временной интервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Стандартное отклонение…"
 
 #. Кривая формулировка получилась, нужно уточнение.
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Число, отражающее насколько значения столбца отклоняются от всех записей ответа."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Минимум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Минимальное значение столбца"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Максимум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Максимальное значение колонки"
 
@@ -3923,6 +3977,8 @@ msgstr "буква в нижнем регистре"
 msgid "upper case letter"
 msgstr "буква в верхнем регистре"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "число"
@@ -4170,7 +4226,7 @@ msgstr "Как создать метрики"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Смотрите данные по времени, как карту, сводную таблицу для того чтобы понять тренды или изменения."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Произвольный"
 
@@ -4193,7 +4249,7 @@ msgstr "Прямой запрос"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Для более сложных запросов, вы можете написать собственный SQL или прямой запрос."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Выберите значение по-умолчанию..."
 
@@ -4290,7 +4346,7 @@ msgstr "Этот месяц"
 msgid "This Year"
 msgstr "Этот год"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Введите значение..."
@@ -4300,7 +4356,7 @@ msgid "Enter a default value..."
 msgstr "Введите значение по-умолчания..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Возникла ошибка"
@@ -4560,22 +4616,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Выберите запросы, которые будут приходить в этом пульсе"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Электронные адреса"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Сообщения Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Отправлено"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} будет отправлено на"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Сообщения"
 
@@ -4647,30 +4711,30 @@ msgstr "Помогите вашей команде оставаться в ку�
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Пульсы позволяют отправлять данные из Metabase по электронной почте или в Slack по заданному вами расписанию."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "После {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "До {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Пусто"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Не пусто"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Все время"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Применить"
 
@@ -4773,12 +4837,12 @@ msgstr[3] "Показать {0}"
 msgid "Zoom in"
 msgstr "Приблизить"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Произвольное выражение"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Общие Метрики"
 
@@ -4975,7 +5039,7 @@ msgstr "обычно"
 msgid "Pick a segment or table"
 msgstr "Прикрепите сегмент или таблицу"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Выберите базу данных"
@@ -5036,7 +5100,7 @@ msgstr "Сортировка"
 msgid "Row limit"
 msgstr "Количество строк"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Неизвестное поле"
 
@@ -5044,7 +5108,7 @@ msgstr "Неизвестное поле"
 msgid "field"
 msgstr "поле"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Совпадения"
 
@@ -5069,11 +5133,11 @@ msgstr "Добавить группировку"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Данные"
 
@@ -5090,11 +5154,12 @@ msgstr "Просмотр"
 msgid "Grouped By"
 msgstr "Сгруппировано по"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Ничего"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Этот запрос написан в {0}."
 
@@ -5106,7 +5171,7 @@ msgstr "Скрыть Редактор"
 msgid "Hide Query"
 msgstr "Скрыть Запрос"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Открыть Редактор"
 
@@ -5114,7 +5179,7 @@ msgstr "Открыть Редактор"
 msgid "Show Query"
 msgstr "Показать Запрос"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Эта метрика была удалена. Она более не доступна для использования."
 
@@ -5318,7 +5383,7 @@ msgstr "Вернуться к последнему запуску"
 msgid "Visualization"
 msgstr "Визуализация"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Описание не задано."
 
@@ -5375,7 +5440,7 @@ msgstr "Не удалось найти метаданные таблицы до 
 msgid "See {0}"
 msgstr "Посмотреть {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Определение метрики"
 
@@ -5393,11 +5458,11 @@ msgstr "Число {0}"
 msgid "See all {0}"
 msgstr "Смотреть все {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Определение сегмента"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "При загрузке таблицы произошла ошибка"
 
@@ -5405,7 +5470,7 @@ msgstr "При загрузке таблицы произошла ошибка"
 msgid "See the raw data for {0}"
 msgstr "Посмотреть исходные данные для {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Больше"
 
@@ -5425,6 +5490,8 @@ msgstr "Формула поля"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Подумайте об этом как о том, как написать формулу в программе для работы с электронными таблицами: вы можете использовать числа, поля таблицы, математические символы, такие как +, и некоторые функции. Таким образом, вы можете ввести что-то вроде Итого - Стоимость."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5492,7 +5559,7 @@ msgstr "ложь"
 msgid "Add filter"
 msgstr "Добавить фильтр"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Элемент"
 
@@ -5611,11 +5678,11 @@ msgstr "Связующие поля"
 msgid "Filter widget type"
 msgstr "Тип фильтра виджета"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Обязательно?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Значение по-умолчанию для фильтра виджета"
 
@@ -5627,7 +5694,7 @@ msgstr "Переместить этот запрос в архив?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Этот запрос будет удален со всех дашбордов или пульсов, где он был добавлен."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Запрос"
 
@@ -5675,7 +5742,7 @@ msgstr "Тип поля"
 msgid "Select a Foreign Key"
 msgstr "Выберите внешний ключ"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Просмотреть формулу {0}"
 
@@ -6160,22 +6227,24 @@ msgstr "Запросы с этим сегментом"
 msgid "X-ray this segment"
 msgstr "Просканировать этот сегмент"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Логин"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Поиск"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Дашборд"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Новый запрос"
 
@@ -6247,35 +6316,35 @@ msgstr "Все коллекции полностью анонимны."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Коллекция может быть отключена в любой момент в настройках администратора."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Если вы застряли"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "наше руководство по началу работы"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "всего в одном клике от вас."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Добро пожаловать в Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Похоже, все работает. Теперь давайте познакомимся поближе: настройте подключение к данным и пойдем искать ответы!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Начнем"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Все настроено!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Покажите мне Metabase"
 
@@ -6527,39 +6596,40 @@ msgstr "Отменить фильтр"
 msgid "Pin Map"
 msgstr "Закрепить карту"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Снять выбор"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Записи {0}-{1} из {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Данные сокращены до {0} строк."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Невозможно найти визуализацию"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Невозможно отобразить график с текущими данным."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Ожидание..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Это в среднем занимает {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Это несколько длинновато для дашборда)"
 
@@ -6669,7 +6739,7 @@ msgid "Highlight the whole row"
 msgstr "Подсветить всю строку"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Цвета"
 
@@ -6756,24 +6826,50 @@ msgid "Doh! The data from your query doesn't fit the chosen display choice. This
 msgstr "Ой! Данные из запроса не подходят к выбранной визуализации. Эта визуализация требует минимум {0} \n"
 " {1} данных"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "столбец"
@@ -6807,7 +6903,7 @@ msgid "xValues missing!"
 msgstr "X-значения отсутствуют!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Ось абсцисс"
 
@@ -6816,7 +6912,7 @@ msgid "Add a series breakout..."
 msgstr "Добавить разрыв серии..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Ось ординат"
 
@@ -6829,7 +6925,7 @@ msgid "Bubble size"
 msgstr "Размер пузырька"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Линия"
 
@@ -6971,20 +7067,20 @@ msgid "Standard Deviation"
 msgstr "Стандартное отклонение"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Область"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "область графика"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Гистограмма"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "гистограмма"
 
@@ -6998,7 +7094,7 @@ msgid "Funnel"
 msgstr "Воронка"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Измерение"
 
@@ -7010,81 +7106,81 @@ msgstr "Тип воронки"
 msgid "Bar chart"
 msgstr "Гистограмма"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "График"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Пожалуйста выберите колонки, содержащие широту и долготу для настройки графика."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Пожалуйста выберите карту региона."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Пожалуйста выберите область и столбцы показателей в настройках графика."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Карта"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Тип карты"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Карта региона"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Закрепить карту"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Тип значка"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Плитка"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Маркеры"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Поле широты"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Поле долготы"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Поле измерения"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Поле региона"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Радиус"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Размытие"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Минимальная прозрачность"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Максимальное приближение"
 
@@ -7096,7 +7192,7 @@ msgstr "Связи не найдены."
 msgid "via {0}"
 msgstr "через {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "{0} связано с:"
 
@@ -7108,31 +7204,31 @@ msgstr "Детали объекта"
 msgid "object"
 msgstr "объект"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Всего"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Какие колонки вы хотите использовать?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Пирог"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Измерение"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Показать легенду"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Показать процентовку в легенде"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Минимальный процентаж среза"
 
@@ -7157,7 +7253,8 @@ msgid "Progress"
 msgstr "Прогресс"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Цвет"
@@ -7166,7 +7263,7 @@ msgstr "Цвет"
 msgid "Row Chart"
 msgstr "Линейная диаграмма"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "линейная диаграмма"
 
@@ -7190,15 +7287,15 @@ msgstr "Добавить суффикс"
 msgid "Multiply by a number"
 msgstr "Умножить на число"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Разброс"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "точечная диаграмма"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Свод таблицы"
 
@@ -7248,7 +7345,7 @@ msgstr "Право"
 msgid "Show background"
 msgstr "Показать фон"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "контейнер"
@@ -7256,7 +7353,7 @@ msgstr[1] "контейнеров"
 msgstr[2] "контейнеры"
 msgstr[3] "контейнер"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Авт. скомпоновано"
 
@@ -7492,10 +7589,13 @@ msgstr "У вас множество сохраненных запросов в 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7693,7 +7793,7 @@ msgstr "накопительная сумма"
 msgid "{0} and {1}"
 msgstr "{0} и {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} из {1}"
@@ -9013,11 +9113,11 @@ msgstr "Доступ к данным"
 msgid "Collection permissions"
 msgstr "Разрешения для коллекций"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Посмотреть разрешения для всех коллекций"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Так же изменить под-коллекции"
 
@@ -9029,19 +9129,19 @@ msgstr "Может редактировать коллекцию и содерж
 msgid "Can view items in this collection"
 msgstr "Может смотреть содержимое этой коллекции"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Доступ к коллекции"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "У этой группы есть разрешение на просмотре как минимум одного подмножества этой коллекции."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "У этой группы есть разрешение на редактирование как минимум одного подмножества этой коллекции."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Просмотр под-коллекций"
 
@@ -9097,6 +9197,7 @@ msgstr "Связанные"
 msgid "More X-rays"
 msgstr "Больше X-ray"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9317,7 +9418,7 @@ msgstr "Домен Windows"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:543
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:549
 msgid "Labels"
-msgstr "Заголовки"
+msgstr "Метки"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
@@ -9355,17 +9456,17 @@ msgstr "Поделиться"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "Отображение"
+msgstr "Вид"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:402
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:437
@@ -9441,7 +9542,7 @@ msgstr "Использовать часовой пояс JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Сейчас мы анализируем таблицы и поля чтобы помочь вам изучать свои данные"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Подсказка: "
 
@@ -9449,7 +9550,7 @@ msgstr "Подсказка: "
 msgid "Select a currency type"
 msgstr "Выберите тип валюты"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Тип поля"
 
@@ -9476,7 +9577,7 @@ msgstr "Логи обработки ошибок"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "Пытаешься докопаться до сути? В этом разделе показаны журналы фоновых задач Метабазы, которые могут помочь пролить свет на происходящее."
+msgstr "Пытаешься докопаться до сути? В этом разделе показаны журналы фоновых задач Metabase, которые могут помочь пролить свет на происходящее."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
@@ -9504,6 +9605,7 @@ msgid "Currency"
 msgstr "Валюта"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Выберите пользователя или канал..."
 
@@ -9665,7 +9767,7 @@ msgstr "Какая ось?"
 msgid "Line + Bar"
 msgstr "Линия + Столбец"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "линейные и Столбчатые диаграммы"
 
@@ -9685,15 +9787,15 @@ msgstr "Диапазоны прибора"
 msgid "Field to show"
 msgstr "Поле для отображения"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "Последняя {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} был {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Группа по полю времени, чтобы увидеть, как это изменилось с течением времени"
 
@@ -9701,23 +9803,23 @@ msgstr "Группа по полю времени, чтобы увидеть, к
 msgid "Switch positive / negative colors?"
 msgstr "Переключить позитивные / негативные цвета?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Колонка таблицы"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Ячейка столбца"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Видимые столбцы"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Условное форматирование"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Заголовок столбца"
 
@@ -10155,10 +10257,10 @@ msgstr "Пользователи по источнику"
 msgid "The top external pages that brought users to your site"
 msgstr "Лучшие внешние страницы, которые привели пользователей на ваш сайт"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Как [[this]] распространяется и т.д."
 
@@ -10256,13 +10358,13 @@ msgstr "События по часу дня"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Верхние 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Нижние 5 [[this]]"
 
@@ -10275,10 +10377,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "В [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Пустые значения"
 
@@ -10306,8 +10408,8 @@ msgstr "Как они сравниваются по сезонности"
 msgid "Average income per transaction"
 msgstr "Средний доход по транзакции"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] по странам"
 
@@ -10431,10 +10533,10 @@ msgstr "Обзор вашего [[this]] и того, как он распред
 msgid "Average income per state"
 msgstr "Средняя выручка по штату"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] по [[GenericCategoryMedium]]"
 
@@ -10611,13 +10713,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Как [[GenericTable]] распределяется по этому временному полю, и имеет ли он какие-либо сезонные закономерности."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Обзор"
 
@@ -10726,8 +10828,8 @@ msgstr "Более близкий взгляд на ваш [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Более близкий взгляд на ваше [[this]] поле"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Всего"
 
@@ -10791,10 +10893,10 @@ msgstr "Продажи по источникам"
 msgid "Average income per country"
 msgstr "Средняя выручка по странам"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Как [[this]] распространяется"
 
@@ -10815,17 +10917,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Количество [[GenericCategoryMedium]] по [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Взгляд на ваш [[this]]"
 
@@ -10891,10 +10993,10 @@ msgid "Transactions per source over time"
 msgstr "Транзакции по источникам во времени"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Как [[this]] распространяется"
 
@@ -10923,9 +11025,9 @@ msgstr "Где происходят эти события"
 msgid "Which US states are bringing you the most business."
 msgstr "Какие штаты принесли вам наибольшую прибыль."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Как они сравниваются во времени"
 
@@ -11030,8 +11132,8 @@ msgstr "Сессии по странам"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Некоторые интересные показатели о вашей статистике GA, чтобы вы начали."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] по штату"
 
@@ -11112,12 +11214,12 @@ msgstr "Как эта метрика распределяется по разн�
 msgid "Sessions by page where the session began"
 msgstr "Сессии за страницей, где сессия началась"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Уникальный значения"
 
@@ -11180,10 +11282,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "События по [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Как они сравниваются по распределению"
@@ -11326,7 +11428,7 @@ msgstr "Не могли бы вы пройти быстрый опрос из 5 
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Мы надеемся, что вы наслаждались метабазой."
+msgstr "Мы надеемся, что вы наслаждались Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
@@ -11489,6 +11591,7 @@ msgstr "Дублировать Панель Управления"
 msgid "Duplicate \"{0}\""
 msgstr "Дублировать \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11604,9 +11707,9 @@ msgstr[1] "Кварталы года"
 msgstr[2] "Кварталы года"
 msgstr[3] "Кварталы года"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} выборка"
@@ -11631,11 +11734,11 @@ msgstr "Некорректный"
 msgid "Add a time"
 msgstr "Добавить время"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Нечего сравнивать с предыдущим {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "по {0}"
 
@@ -12124,9 +12227,9 @@ msgstr "Здесь обзор людей в вашем [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] по кварталу года"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Как они сравниваются по расположению"
 
@@ -12155,12 +12258,12 @@ msgstr "[[CreateTimestamp]] по дням недели"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Здесь обзор ваших [[this]] данных из Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Вот краткий обзор вашего [[this]]"
 
@@ -12238,11 +12341,11 @@ msgstr "коллекция"
 msgid "collections"
 msgstr "коллекции"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "дашборд"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "дашборды"
 
@@ -12492,7 +12595,7 @@ msgstr "Тайм-аут после {0} миллисекунд."
 msgid "Misfire Instruction"
 msgstr "Пропустить инструкцию"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Архивировать это?"
 
@@ -12510,7 +12613,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Использование этой опции требует предоставить FQDN хост. При подключении к Atlas cluster, вам потребуется разрешить эту опцию. Если вы не знаете что это значит - оставьте отключенным."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Автоматически запускать запросы при простой фильтрации и суммировании"
 
@@ -12522,7 +12625,7 @@ msgstr "Когда это включено, Metabase будет автомати
 msgid "Learn about this database"
 msgstr "Узнать об этой базе данных"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Архивировать этот дашборд?"
 
@@ -12580,11 +12683,11 @@ msgstr "Пользовательский запрос"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Используйте расширенный редактор записной книжки, чтобы объединять данные, создавать пользовательские столбцы, выполнять математические операции и многое другое."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Базовые метрики"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Произвольный..."
 
@@ -12773,15 +12876,15 @@ msgstr "Выбор визуализации"
 msgid "Filter by"
 msgstr "Фильтровать по"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Обобщать по"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Группировать по"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Добавить метрику"
 
@@ -12792,15 +12895,15 @@ msgstr "Добавить метрику"
 msgid "Profile"
 msgstr "Профиль"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Это обычно довольно быстро, но, похоже, сейчас потребует чуть больше времени."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Комбо"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Строка"
 
@@ -13221,7 +13324,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Выберите столбцы которые хотите включить"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Когда это включено, Metabase будет автоматически запускать запросы, когда пользователи выполняют простые исследования с помощью кнопок Итоги и Фильтр при просмотре таблицы или диаграммы. Вы можете отключить это, если запросы к этой базе данных выполняются медленно. Этот параметр не влияет на детализацию или запросы SQL."
 
@@ -13287,7 +13390,7 @@ msgstr "Войти с помощью Email"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Для использования этого параметра необходимо, чтобы указанный хост являлся полным доменным именем. При подключении к кластеру Atlas может потребоваться включить эту опцию. Если вы не знаете, что это значит, оставьте это отключенным."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "По умолчанию Metabase выполняет легкую часовую синхронизацию и интенсивное ежедневное сканирование значений полей. Если у вас большая база данных, мы рекомендуем включить ее и проверить, когда и как часто происходит сканирование значений поля."
 
@@ -13355,11 +13458,11 @@ msgstr "Не включать"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Это поле не будет отображаться или выбираться в вопросах, созданных с помощью интерфейсов GUI. Он все еще будет доступен в SQL / нативных запросах."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Накопленная сумма"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Стандартное отклонение"
 
@@ -13375,19 +13478,19 @@ msgstr "Должно быть длиной не менее {0} символов"
 msgid "Name (required)"
 msgstr "Имя (обязательно)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Запустить выделенный текст"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Выполнить запрос"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13735,7 +13838,7 @@ msgstr "Даты и время"
 msgid "Numbers"
 msgstr "Числа"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Нет связанных групп"
 
@@ -13775,15 +13878,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "Запомните меня"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "В целях безопасности, срок действия ссылок для сброса пароля истекает через некоторое время. Если вам все еще нужно сбросить пароль, вы можете {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Сохранить новый пароль"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Совпадений не найдено"
 
@@ -13809,26 +13912,26 @@ msgid "or"
 msgstr "или"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "required"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Тип базы данных"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Это легкий процесс, который проверяет наличие обновлений схемы этой базы данных. В большинстве случаев вполне можно использовать этот режим для синхронизации каждый час."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
-msgstr "Метабаза может сканировать значения, присутствующие в каждом поле в этой базе данных, чтобы включить фильтры флажков на сводных панелях и в вопросах. Это может быть несколько ресурсоемким процессом, особенно если у вас ОЧЕНЬ большая база данных."
+msgstr "Metabase может сканировать значения, присутствующие в каждом поле в этой базе данных, чтобы включить фильтры флажков на сводных панелях и в вопросах. Это может быть несколько ресурсоемким процессом, особенно если у вас ОЧЕНЬ большая база данных."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Коллекция"
 
@@ -13875,7 +13978,7 @@ msgstr "Категорийный"
 msgid "URLs"
 msgstr "URL-ы"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Возвращает среднее значение в столбце."
 
@@ -13884,11 +13987,13 @@ msgstr "Возвращает среднее значение в столбце."
 msgid "The column whose values to average."
 msgstr "Столбец, значения которого для усреднения."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "начало"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "конец"
 
@@ -13900,21 +14005,19 @@ msgstr "Проверяет дату или числовые значения с�
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "условие"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "вывод"
 
@@ -13922,27 +14025,27 @@ msgstr "вывод"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Проверяет список случаев и возвращает соответствующее значение первого истинного случая с необязательным значением по умолчанию, если больше ничего не встречается."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Вес"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Большой"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Средний"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Малый"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Что-то, что следует оценивать как истинное или ложное."
 
@@ -13950,33 +14053,33 @@ msgstr "Что-то, что следует оценивать как истин�
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Значение, которое будет возвращено, если предыдущее условие истинно."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "значение1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "значение2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Просматривает значения в каждом аргументе по порядку и возвращает первое ненулевое значение для каждой строки."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Комментарии"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Заметки"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Нет комментариев"
 
@@ -13992,12 +14095,12 @@ msgstr "Если значение1 пусто, значение2 возвращ�
 msgid "Combines two or more strings of text together."
 msgstr "Объединяет две или более строки текста вместе."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Фамилия"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Имя"
 
@@ -14009,27 +14112,27 @@ msgstr "Значение2 будет добавлено в конце этого
 msgid "This will be added to the end of value1."
 msgstr "Это будет добавлено в конец значения1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "строка1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "строка2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Проверяет, содержит ли string1 строку string2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Статус"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Pass"
 
@@ -14037,7 +14140,7 @@ msgstr "Pass"
 msgid "The contents of this string will be checked."
 msgstr "Содержимое этой строки будет проверено."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Строка текста для поиска."
 
@@ -14045,22 +14148,22 @@ msgstr "Строка текста для поиска."
 msgid "Returns the count of rows in the source data."
 msgstr "Возвращает количество строк в исходных данных."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Подсчитывает только те строки, в которых выполняется условие."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Подытог"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "The additive total of rows across a breakout."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "The rolling sum of a column across a breakout."
 
@@ -14069,53 +14172,57 @@ msgstr "The rolling sum of a column across a breakout."
 msgid "The column to sum."
 msgstr "Столбец для суммирования."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Количество различных значений в этом столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Столбец, чьи отдельные значения считать."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "текст"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "сравнение"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Возвращает true, если конец текста совпадает с текстом сравнения."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Аппетит"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "голоден"
 
@@ -14124,20 +14231,20 @@ msgstr "голоден"
 msgid "A column or string of text to check."
 msgstr "Столбец или строка текста для проверки."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Строка текста, которой должен заканчиваться исходный текст."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "регулярное_выражение"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Извлекает соответствующие подстроки согласно регулярному выражению."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Адрес"
 
@@ -14145,7 +14252,7 @@ msgstr "Адрес"
 msgid "The column or string of text to search though."
 msgstr "Столбец или строка текста для поиска."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Регулярное выражение для соответствия."
 
@@ -14157,7 +14264,7 @@ msgstr "Возвращает строку текста в нижнем реги�
 msgid "The column with values to convert to lowercase."
 msgstr "Столбец со значениями для преобразования в нижний регистр."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Удаляет начальные пробелы из строки текста."
 
@@ -14167,15 +14274,16 @@ msgstr "Удаляет начальные пробелы из строки те�
 msgid "The column with values you want to trim."
 msgstr "Столбец со значениями, которые вы хотите обрезать."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Возвращает наибольшее значение, найденное в столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Период"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Числовой столбец, максимум которого вы хотите найти."
 
@@ -14183,21 +14291,21 @@ msgstr "Числовой столбец, максимум которого вы 
 msgid "Returns the smallest value found in the column."
 msgstr "Возвращает наименьшее значение, найденное в столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Оплата"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Числовой столбец, минимум которого вы хотите найти."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "position"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "длина"
 
@@ -14206,7 +14314,7 @@ msgstr "длина"
 msgid "new_text"
 msgstr "новый_текст"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Заменяет часть входного текста новым текстом."
 
@@ -14234,35 +14342,35 @@ msgstr "Количество символов для замены."
 msgid "The text to use in the replacement."
 msgstr "Текст для использования в замене."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Удаляет завершающие пробелы из строки текста."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Возвращает процент строк в данных, соответствующих условию, в виде десятичной дроби."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Возвращает true, если начало текста совпадает с текстом сравнения."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Название курса"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Компьютерная наука"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Строка текста, с которой должен начинаться исходный текст."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Вычисляет стандартное отклонение в столбце."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Population"
 
@@ -14270,7 +14378,7 @@ msgstr "Population"
 msgid "A numeric column."
 msgstr "Числовой столбец."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Возвращает часть предоставленного текста."
 
@@ -14278,19 +14386,19 @@ msgstr "Возвращает часть предоставленного тек�
 msgid "The text to return a portion of."
 msgstr "Текст для возврата части."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Позиция для начала копирования символов."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Количество возвращаемых символов."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Суммирует все значения столбца."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Числовой столбец для суммирования."
 
@@ -14298,15 +14406,15 @@ msgstr "Числовой столбец для суммирования."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Суммирует значения в столбце, где строки соответствуют условию."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Статус заказа"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Действительный"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Удаляет начальные и конечные пробелы из строки текста."
 
@@ -14314,23 +14422,23 @@ msgstr "Удаляет начальные и конечные пробелы и�
 msgid "Returns the string of text in all upper case."
 msgstr "Возвращает строку текста в верхнем регистре."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Столбец со значениями для преобразования в верхний регистр."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "должно быть {0} и включать {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "должно быть {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "должно включать {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "длиной не менее {0} символа"
@@ -14338,7 +14446,7 @@ msgstr[1] "длиной не менее {0} символов"
 msgstr[2] "длиной не менее {0} символов"
 msgstr[3] "длиной не менее {0} символов"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} строчная буква"
@@ -14346,7 +14454,7 @@ msgstr[1] "{0} строчные буквы"
 msgstr[2] "{0} строчных букв"
 msgstr[3] "{0} строчных букв"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} заглавная буква"
@@ -14354,7 +14462,7 @@ msgstr[1] "{0} заглавные буквы"
 msgstr[2] "{0} заглавных букв"
 msgstr[3] "{0} заглавных букв"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} цифра"
@@ -14362,7 +14470,7 @@ msgstr[1] "{0} цифры"
 msgstr[2] "{0} цифр"
 msgstr[3] "{0} цифр"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} специальный символ"
@@ -14387,6 +14495,7 @@ msgid "Powered by {0}"
 msgstr "Работает на {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Кому:"
 
@@ -14474,7 +14583,7 @@ msgstr "Форматирование значения"
 msgid "Full"
 msgstr "Полностью"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Без изменений с прошлого {0}"
 
@@ -14544,7 +14653,7 @@ msgstr "Требуется обновление базы данных"
 
 #: src/metabase/db.clj
 msgid "NOTICE: Your database requires updates to work with this version of Metabase."
-msgstr "ВНИМАНИЕ: вашей базе данных требуются обновления для работы с этой версией метабазы."
+msgstr "ВНИМАНИЕ: вашей базе данных требуются обновления для работы с этой версией Metabase."
 
 #: src/metabase/db.clj
 msgid "Please execute the following sql commands on your database before proceeding."
@@ -14587,11 +14696,11 @@ msgstr "Подзапрос из ссылочного вопроса № {0} не
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
-msgstr "ВНИМАНИЕ: Метабаза официально поддерживает только MySQL {0} / MariaDB {1} и выше."
+msgstr "ВНИМАНИЕ: Metabase официально поддерживает только MySQL {0} / MariaDB {1} и выше."
 
 #: src/metabase/driver/mysql.clj
 msgid "All Metabase features may not work properly when using an unsupported version."
-msgstr "Все функции метабазы могут работать некорректно при использовании неподдерживаемой версии."
+msgstr "Все функции Metabase могут работать некорректно при использовании неподдерживаемой версии."
 
 #: src/metabase/driver/sql/parameters/substitute.clj
 msgid "Unable to substitute parameters"
@@ -14799,7 +14908,7 @@ msgstr "Ошибка при создании информации для сто�
 msgid "Sending abandonment email!"
 msgstr "Отправка письма об отказе!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Вы можете создать сохраненные метрики, чтобы добавить именованный параметр метрики. Сохраненные метрики включают тип агрегации, агрегированное поле и, при необходимости, любой фильтр, который вы добавляете. Например, вы можете использовать это, чтобы создать что-то вроде официального способа расчета «средней цены» для таблицы «Заказы»."
 
@@ -14807,15 +14916,15 @@ msgstr "Вы можете создать сохраненные метрики, 
 msgid "Select and add filters to create your new segment."
 msgstr "Выберите и добавьте фильтры для создания нового сегмента."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "По алфавиту"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Умная"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Порядок столбцов: {0}"
 
@@ -14867,7 +14976,7 @@ msgstr "Локализация"
 msgid "Instance language"
 msgstr "Язык экземпляра"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Варианты локализации"
 
@@ -14939,19 +15048,20 @@ msgstr "Вставить строку подключения"
 msgid "Fill out individual fields"
 msgstr "Заполните отдельные поля"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Введите здесь какой-нибудь SQL, чтобы вы могли использовать его позже"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Дайте вашему фрагменту имя"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Текущие пользователи"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Добавить описание"
 
@@ -14959,46 +15069,47 @@ msgstr "Добавить описание"
 msgid "Use site default"
 msgstr "Использовать сайт по умолчанию"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "найти"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "заменить"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Текст для поиска"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Текст для замены"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Редактирование {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Создайте свой новый фрагмент"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Архивные фрагменты"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Фрагменты для многократного использования в SQL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Создать фрагмент"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Фрагменты"
 
@@ -15277,4 +15388,1504 @@ msgstr "значение должно быть ключевым словом и�
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Строка должна быть действительным двухбуквенным языком ISO или кодом страны-страны, например, 'en' или 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Строки {0} - {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Аудит"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Конфигурация атрибута пользователя (необязательно)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Использование {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Как настроить систему единого входа на базе SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML аутентификация"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Настройте своего поставщика удостоверений (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Вашему провайдеру удостоверений потребуется следующая информация о Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL-адрес, на который IdP должен перенаправить обратно"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Это называется URL-адресом единого входа в Okta, URL-адресом обратного вызова приложения в Auth0 и URL-адресом ACS (Consumer) в OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "Атрибуты SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "В большинстве IdP вам нужно будет поместить каждый из них в поле ввода с меткой «Name» в разделе атрибутов."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Атрибут электронной почты пользователя"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Атрибут имени пользователя"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Атрибут фамилии пользователя"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Сообщите Metabase о своем провайдере идентификации"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase потребуется следующая информация о вашем провайдере."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL-адрес поставщика удостоверений SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Сертификат поставщика удостоверений SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Имя приложения SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Подписывать запросы SSO (необязательно)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Путь к хранилищу ключей SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Пароль хранилища ключей SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Тсс..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Псевдоним хранилища ключей SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Синхронизируйте членство в группе с вашим SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Чтобы включить это, вам необходимо создать сопоставления, чтобы сообщить Metabase, в какие группы должны быть добавлены ваши пользователи, в зависимости от группы SSO, в которой они находятся."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Название группы"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Имя атрибута группы"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Заметка:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Если вы измените какие-либо параметры существующей активной настройки SAML, вам нужно будет перезапустить Metabase, чтобы они вступили в силу."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Позволяет пользователям входить в систему через SAML Identity Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Позволяет пользователям входить в систему через JWT Identity Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Включить аутентификацию по паролю"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Если этот параметр включен, пользователи могут дополнительно входить в систему с помощью электронной почты и пароля."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Уведомлять администраторов о новых пользователях системы единого входа"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Если этот параметр включен, администраторы будут получать электронное письмо при первом использовании системы единого входа."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Используйте приведенные ниже настройки, чтобы настроить систему единого входа через SAML. Если у вас есть какие-либо вопросы, посетите наш {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "документация"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI поставщика удостоверений SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT аутентификация"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI поставщика удостоверений JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Строка, используемая ключом подписи JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Встраивание всего приложения Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Если вы хотите встроить всю Metabase, введите происхождение веб-сайтов или веб-приложений, для которых вы хотите разрешить встраивание, в iframe, через пробел. Вот {0}, что можно ввести."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Предоставить изолированный доступ к этой таблице"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Когда пользователи в этой группе просматривают эту таблицу, они видят ее версию, отфильтрованную по их пользовательским атрибутам, или ее настраиваемое представление на основе сохраненного вопроса."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Как вы хотите отфильтровать эту таблицу для пользователей в этой группе?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Выберите сохраненный вопрос, который возвращает пользовательское представление этой таблицы, которое должны видеть эти пользователи."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "При желании вы можете добавить сюда дополнительные фильтры на основе атрибутов пользователя. Эти фильтры будут применяться поверх любых фильтров, которые уже есть в этом сохраненном вопросе."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Чтобы эта опция работала, у ваших пользователей должны быть некоторые атрибуты"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Чтобы добавить дополнительные фильтры, у ваших пользователей должны быть некоторые атрибуты"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Нет атрибутов пользователя"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Выберите атрибут пользователя"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Выберите параметр"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Выбрать столбец"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Пользователи в {0} могут просматривать"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "строки в вопросе {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "строки в таблице {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "где {0} равно {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "и {0} равно {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Вы можете добавлять атрибуты автоматически, настроив систему единого входа, использующую SAML, или можете ввести их вручную, перейдя в раздел «Люди» и щелкнув меню… справа."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Атрибут пользователя"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Мы можем автоматически получить атрибуты ваших пользователей, если вы настроили систему единого входа, или вы можете добавить их вручную из меню «…» в разделе «Люди» панели администратора."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Параметр или переменная"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "равные"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Предоставить доступ в изолированной среде"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Изолированный доступ"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Изменить доступ в изолированной среде"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Изменить информацию о директории"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Изменить разрешения"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Создать новую папку"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Новая папка"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "У нас возникли проблемы с проверкой вашего токена"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Убедитесь, что ваш экземпляр может подключаться к серверам Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Получить помощь"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Получите еще больше от Metabase с Enterprise Edition"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Все инструменты, необходимые для быстрого и простого предоставления отчетов для ваших клиентов или для помощи в запуске и мониторинге Metabase в большой организации"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Активировать лицензию"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Ваша пробная версия активна с этими функциями"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Пробный период истекает"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Нужна помощь? Готовы купить?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Свяжитесь с нами"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Пробный период истек!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Нужно больше времени? Готовы купить?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Ваши функции активны!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Ваша лицензия действительна до {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Срок действия вашей лицензии истёк"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Срок его действия истек {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Хотите продлить лицензию?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Узнайте, как использовать это"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Не входит в ваш текущий план"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Введите полученный токен в магазине"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Активировать"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Нужна помощь?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Подробнее о вашей проблеме."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Написать оператору"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Песочницы данных"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Убедитесь, что вы показываете нужным людям нужные данные с помощью автоматических и безопасных фильтров, основанных на пользовательских атрибутах."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Белая этикетка"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Подберите Metabase к своему бренду, выбрав индивидуальные цвета, собственный логотип и многое другое."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Проведение проверок."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Следите за производительностью и поведением с помощью надежных инструментов аудита."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Единый вход"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Обеспечьте простой вход в систему, который работает с вашей существующей инфраструктурой аутентификации."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Компания"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Название приложения"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Цветовая палитра"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Логотип"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Значок сайта"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Лендинг-страница"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Группы отсутствуют"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Разрешения для {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Разрешения для этой папки"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Предоставить доступ для редактирования"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Можно изменять фрагменты в этой папке"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Предоставить доступ к просмотру"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Может вставлять и использовать фрагменты в этой папке, но не может редактировать SQL, который они содержат"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Невозможно просмотреть или вставить фрагменты в эту папку"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Также измените подпапки"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Первый день недели"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "При входе в Google возникла проблема. Обратитесь к администратору."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "на"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "в"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Меню Действия"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Ничего не делать"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Перейти в другое место"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Обновите фильтр панели инструментов"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} обновления {1} фильтр"
+msgstr[1] "{0} обновления {1} фильтра"
+msgstr[2] "{0} обновления {1} фильтров"
+msgstr[3] "{0} обновления {1} фильтров"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} переходит к {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Поведение при нажатии для каждого столбца"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Перейти в другое место"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Меню Действия"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Поведение кликов для {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Выберите один или несколько фильтров для обновления"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Сохраненный вопрос"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Ссылка на"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Введите URL-адрес для ссылки на"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Вы можете вставить значение фильтра столбца или панели мониторинга, используя его имя, например: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "например http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Выберите приборную панель ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Выберите вопрос ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Выберите панель управления, на которую нужно ссылаться"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Выберите запрос для ссылки"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Передавать значения в фильтры этой панели (необязательно)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Передайте значения в переменные этого вопроса (необязательно)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Передайте значения для фильтрации этого вопроса (необязательно)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Фильтры приборной панели"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Атрибуты пользователя"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Настроить текст ссылки (необязательно)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "Детали Ex для {{Column Name}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Значения, на которые вы можете ссылаться"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Нет доступных целей"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "фильтр"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "переменные"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Другие доступные фильтры"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Доступные фильтры"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Другие доступные переменные"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Доступные переменные"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Другие доступные столбцы"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Доступные столбцы"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "атрибут пользователя"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Текстовая карточка"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Поведение при нажатии"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Варианты визуализации"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Редактировать серию"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "или"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "По клику"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Изменить название и описание"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Вы обновили встроенные параметры, и вам необходимо обновить встроенный код."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Добавить запрос"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Вы редактируете эту панель."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Столбец для фильтрации"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "коллекция фрагментов"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "коллекции фрагментов"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Дайте вашей папке имя"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Что-то короткое, но сладкое"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Папка должна быть в"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Меню Действие"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "Столбец {0} имеет настраиваемое поведение"
+msgstr[1] "Столбцы {0} имеют настраиваемое поведение"
+msgstr[2] "Столбцы {0} имеют настраиваемое поведение"
+msgstr[3] "Столбцы {0} имеют настраиваемое поведение"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Перейти к..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Перейти к приборной панели"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Перейти к запросу"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Перейти по ссылке"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Отфильтровать эту панель"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Возвращает количество строк в выбранных данных."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Столбец или число для суммирования."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Числовой столбец, для которого требуется получить стандартное отклонение."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Числовой столбец, значения которого необходимо усреднить."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Возвращает наименьшее значение, найденное в столбце."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Суммирует указанный столбец только для строк, для которых выполняется условие."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Возвращает числовую дисперсию для данного столбца."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Температура"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Столбец или число, для которого требуется получить дисперсию."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Возвращает медианное значение указанного столбца."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Столбец или число, для которого требуется получить медианное значение."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "Значение процентиля"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Возвращает значение столбца в виде процентиля."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Столбец или число, для которого требуется получить процентиль."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Значение процентиля."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Возвращает строку текста в нижнем регистре."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Столбец со значениями, которые нужно преобразовать в нижний регистр."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Возвращает текст в верхнем регистре."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Столбец или текст, часть которого требуется вернуть."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Столбец или текст для поиска."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Объедините две или более строк текста вместе."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Столбец или текст, с которого нужно начать."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Это будет добавлено в конец value1 и так далее."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Огромный"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Гигантский"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Возвращает количество символов в тексте."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Столбец или текст, длину которого нужно получить."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Столбец или текст, который нужно обрезать."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Возвращает абсолютное (положительное) значение указанного столбца."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Долг"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Столбец или число, для которого требуется вернуть абсолютное (положительное) значение."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Округляет десятичное число в меньшую сторону."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Столбец или число, которое нужно округлить в меньшую сторону."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Округляет десятичное число в большую сторону."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Столбец или число, которое нужно округлить."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Округляет десятичное число в большую или меньшую сторону до ближайшего целого числа."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "Столбец или число, округляемое до ближайшего целого числа."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Возвращает гиперболический арктангенс arg, т.е. значение, чей гиперболический тангенс равен arg."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Гипотенуза"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Столбец или число, из которого нужно вернуть значение квадратного корня."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "экспонента"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Возводит число в степень значения экспоненты."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Длина"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Столбец или число, возведенное в степень."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Значение показателя степени."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Возвращает десятичный логарифм числа."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Значение"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Столбец или число, для которого нужно вернуть значение натурального логарифма."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Возвращает число Эйлера e, возведенное в степень переданного числа."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Процентные месяцы"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Столбец или число, для которого нужно вернуть экспоненциальное значение."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Столбец или текст для проверки."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Проверяет значения столбца даты или числа, чтобы убедиться, что они находятся в указанном диапазоне."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Создан"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Дата или числовой столбец, который должен находиться в пределах начального и конечного значений."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Начало диапазона."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Конец диапазона."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Проверяет значения столбца даты, чтобы убедиться, что они находятся в относительном диапазоне."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Столбец даты для возврата интервала."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Период интервала, когда отрицательные значения возвращаются во времени."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Тип внутреннего типа «день», «месяц», «год»."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Столбец или значение, которое нужно вернуть."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Если значение1 пусто, возвращается значение2, если оно не пусто, и так далее."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Проверяет выражение на соответствие списку наблюдений и возвращает соответствующее значение первого совпадающего случая с необязательным значением по умолчанию, если ничего другого не встречается."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Значение, которое будет возвращено, если предыдущее условие выполнено, и так далее."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Пустой"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Не пустой"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Аддитивная сумма всех значений столбца. ex общий доход с течением времени."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Аддитивный счет количества строк. ex общее количество продаж с течением времени."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Связанные фильтры"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Ярлык"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Значение по умолчанию "
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Нет умолчаний"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Для просмотра этого {0} должен быть подключен хотя бы к одному полю."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Ограничьте выбор этого фильтра"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Если у вас есть другой фильтр панели мониторинга, вы можете ограничить варианты, перечисленные для этого фильтра, на основе выбора другого."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Итак, сначала {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "добавить еще один фильтр панели инструментов"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Если вы включите один из этих фильтров панели мониторинга, выбор значения для этого фильтра ограничит доступные варианты для фильтра {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Столбец для фильтрации"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Отфильтрованный столбец"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Введите имена пользователей или адреса электронной почты"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Новая вставка"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Каждый час"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Ежедневно в {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Еженедельно в {0} {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Ежемесячно в {0} {1} в {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Удалить эту подписку"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Подписчики"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Создать подписку на дашборд"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Отправить по электронной почте"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Вы можете регулярно рассылать эту панель пользователям или адресам электронной почты."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Отправить в Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Выберите канал и расписание, а Metabase сделает все остальное."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Отправить эту панель по электронной почте"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Не отправлять, если нет результатов"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Прикрепите результаты"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Вложения могут содержать до 2000 строк данных."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Отправить эту панель в Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "На панели инструментов нет параметра с идентификатором {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Параметр {0} не имеет связанных с ним полей."
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include должен быть пустым или иметь значение \"таблицы\""
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "База данных требуется для всех запросов, тип которых не является внутренним."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Пароль для входа в систему отключен для этого экземпляра."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Ваша учетная запись отключена. Обратитесь к своему администратору."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Ваша учетная запись отключена."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Неверный токен Slack."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "Команда \"{0}\" доступна только в Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Расширения Metabase Enterprise Edition ПРИСУТСТВУЮТ."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Использование функций Metabase Enterprise Edition регулируется коммерческой лицензией Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Подробнее см. {0}."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Расширения Metabase Enterprise Edition НЕТ."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Вас приглашают присоединиться к {0} {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} создал аккаунт {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} принял их {1} приглашение"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Запрос на сброс пароля"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Уведомление"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Помогите сделать [{1}] лучше."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Расскажите, как у вас дела."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Ошибка запуска прослушивателя событий"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Должны ли мы синхронизировать атрибуты пользователя, когда кто-то входит в систему через LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Разделенный запятыми список атрибутов пользователя для пропуска синхронизации для пользователей LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Невалидный токен"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Ошибка Slack API: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Канал Slack с именем `metabase_files` отсутствует!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Пожалуйста, создайте или разархивируйте канал, чтобы завершить интеграцию со Slack."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Канал используется для хранения графиков, которые входят в ответы Pulses и MetaBot."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Загруженное изображение"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Ошибка при загрузке файла в Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Недействительный сеанс. Ожидается экземпляр сеанса."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "SameSite сеансовых файлов cookie настроен на \"Нет\", но сайт"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "обслуживается через небезопасное соединение. Некоторые браузеры отклонят"
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "файлы cookie в этих условиях."
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Верхняя папка"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ": параметры должны быть последовательностью карт с ключами String: id"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Недопустимые удобочитаемые значения: значения должны быть последовательностью; каждый элемент должен быть нулем или строкой"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ": значения должны присутствовать для получения: human_readable_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Общая длина значений поля> {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "имена фрагментов не могут включать '}' или начинаться с пробелов"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Ошибка при выполнении запроса фильтра цепочки"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Поле {0} не существует."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Невозможно выполнить поиск в нетекстовом поле {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Предоставление разрешений группе {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Отзыв разрешений для группы {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Недействительные разрешения БД: если у вас есть права на запись для собственных запросов, у вас должен быть полный доступ к данным."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Недопустимые разрешения БД: если у вас есть доступ только для чтения к собственным запросам, у вас также должен быть доступ к данным."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Изменение разрешений с: {0} на: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "Ключи атрибутов входа в систему должны быть ключевым словом или строкой"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Язык по умолчанию для всех пользователей пользовательского интерфейса Metabase, системных сообщений электронной почты, импульсов и предупреждений."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Пользователи могут индивидуально изменить этот язык по умолчанию в настройках своей учетной записи."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Страница по умолчанию для показа пользователю"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Разрешить этому источнику встраивать полное приложение Metabase"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Значения больше {0} ({1}) не допускаются."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Это заменит слово «Metabase» везде, где оно встречается."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Это основные цвета, используемые в диаграммах и во всей Metabase. Возможно, вам потребуется обновить страницу в браузере, чтобы изменения вступили в силу."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Для наилучшего результата следует взять квадратный образец в формате PNG с прозрачным фоном."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "URL-адрес или изображение, которое вы хотите использовать в качестве значка."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Разрешить вход по электронной почте и паролю."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Это повлияет на такие вещи, как группировка по неделям или фильтрация в запросах графического интерфейса. Это не повлияет на запросы SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Невозможно проверить токен"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Формат токена недействителен."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Ошибка проверки токена"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Ошибка фильтрации в отношении поля {0}: невозможно проанализировать строку {1} в {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Ошибка при получении сведений о задании: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Запуск задачи синхронизации для базы данных {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Невозможно синхронизировать базу данных {0}: база данных не существует."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Задача обновления значений полей запущена для базы данных {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Пропуск обновления, автоматические обновления значений полей отключены для базы данных {0}."
 

--- a/locales/sk.po
+++ b/locales/sk.po
@@ -28,15 +28,16 @@ msgstr "Prezrieť data"
 msgid "Select a database type"
 msgstr "Vyberte typ databázy"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Uložiť"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Ak chcete urobiť niečo zo svojej analýzy, Metabase potrebuje prehľadať vašu databázu. Pravidelne ju znova preskúmavame, aby boli metadáta aktuálne. Nižšie môžete určiť, kedy sa budú skenovania opakovať."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Databáza sa synchronizuje"
 
@@ -64,7 +65,7 @@ msgstr "Toto je proces, ktorý kontroluje aktualizácie schémy tejto databázy.
 msgid "Scan"
 msgstr "Skenovať"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Vyhľadávanie hodnôt filtra"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase môže skenovať hodnoty vo všetkých poliach v tejto databáze. Povoľte to zaškrtnutím checkboxov v dashboardoch a otázkach. Tento proces može byť náročný hlavne na zdroje, hlavne ak mate viac databáz."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Kedy má Metabase automaticky skenovať a ukladať polia do vyrovnávacej pamäte?"
 
@@ -134,29 +135,31 @@ msgstr "DELETE"
 msgid "in this box:"
 msgstr "do tohto poľa:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -179,9 +182,9 @@ msgstr "Zmazať"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -201,8 +204,9 @@ msgstr "Spojenie"
 msgid "Scheduling"
 msgstr "Plánovanie"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -281,10 +285,10 @@ msgstr "Pridať databázu"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -319,10 +323,8 @@ msgid "Successfully saved!"
 msgstr "Úspešne uložené!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Upraviť"
@@ -401,26 +403,29 @@ msgstr "Vyberte špeciálny typ"
 msgid "Select a target"
 msgstr "Vyberte cieľ"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Stĺpce"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Stĺpec"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Viditeľnosť"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Typ"
 
@@ -428,7 +433,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Aktuálna databáza:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Zobraziť originálnu schému"
 
@@ -504,7 +509,7 @@ msgstr "Nájdi tabuľku"
 msgid "Schemas"
 msgstr "Schéma"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -521,7 +526,7 @@ msgstr "Pridaj metriku"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definícia"
 
@@ -589,35 +594,35 @@ msgstr " História"
 msgid "Revision History for"
 msgstr "História revízií pre"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} – Nastavenia poľa"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Kde sa toto pole objaví v Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrovanie v tomto poli"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Keď sa toto pole použije vo filtri, aký typ hodnoty by ľudia mali používať, ak chcú v tomto poli filtrovať?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Žiaden popis tohto poľa"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Originálna hodnota"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Namapovaná hodnota"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Zadajte hodnotu"
 
@@ -634,31 +639,31 @@ msgid "Custom mapping"
 msgstr "Vlastné mapovanie"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Nerozpoznaný typ mapovania"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Aktuálne pole nie je cudzí kľúč alebo chýbajú metadáta cieľovej tabuľky s cudzím kľúčom"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Vybraté pole nie je cudzí kľúč"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Zobraziť hodnoty"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Vyberte, či chcete zobraziť pôvodnú hodnotu z databázy, alebo nechať toto pole zobraziť priradenú alebo vlastnú informáciu."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Vyberte pole"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Vyberte stĺpec, ktorý chcete použiť na zobrazenie."
 
@@ -666,16 +671,16 @@ msgstr "Vyberte stĺpec, ktorý chcete použiť na zobrazenie."
 msgid "Tip:"
 msgstr "Tip:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Možno budete chcieť aktualizovať názov poľa, aby sa ubezpečil, že má stále zmysel na základe vašich možností premapovania."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Hodnoty poľa vo vyrovnávacej pamäti"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase môže skontrolovať hodnoty tohto poľa a povoliť filtre checkboxov políčok na dashboardoch a otázkach."
 
@@ -702,35 +707,36 @@ msgstr "Čistenie spustené!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Vyberte ľubovoľnú tabuľku, aby sa zobrazila jej schéma a pridajte alebo upravte metadáta."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Meno je povinné"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Popis je povinný"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Správa pri revízií je povinná"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Agregácia je povinná"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Upraviť vaše metriky"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Vytvorte svoje metriky"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Vykonajte zmeny v metrike a pridajte vysvetľujúcu poznámku."
 
@@ -738,46 +744,46 @@ msgstr "Vykonajte zmeny v metrike a pridajte vysvetľujúcu poznámku."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Môžete vytvoriť uložené metriky a pridať do tejto tabuľky voľbu pomenovanej metriky. Medzi uložené metriky patrí typ agregácie, agregované pole a prípadne akýkoľvek filter, ktorý pridáte. Ako príklad môžete použiť na vytvorenie niečoho ako oficiálny spôsob výpočtu „priemernej ceny“ pre tabuľku Objednávky."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Výsledok:"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Meno vašej metriky"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Pridajte meno pre vašu metriku "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Niečo popisné, ale nie príliš dlhé"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Popíšte svoju metriku"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Zadajte popis svojej metriky, aby ste ostatným pomohli pochopiť, o čo ide."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Toto je dobré miesto na presnejšie vymedzenie menej zrejmých metrických pravidiel"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Dôvod zmeny"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Pridajte poznámku a vysvetlite, aké zmeny ste vykonali a prečo boli potrebné."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Toto sa zobrazí v histórii revízií pre túto metriku, aby všetci vedeli prečo sa veci zmenili"
 
@@ -830,6 +836,7 @@ msgstr "Toto sa objaví v histórii revízií pre tento segment, aby všetci ved
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -844,8 +851,7 @@ msgid "Re-scan this table"
 msgstr "Znovu naskenujte túto tabuľku"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Pridať"
 
@@ -862,7 +868,7 @@ msgid "Last name"
 msgstr "Priezvisko"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Emailová adresa"
@@ -871,7 +877,7 @@ msgstr "Emailová adresa"
 msgid "Permission Groups"
 msgstr "Skupiny povolení"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Nastaviť tohto používateľa ako správcu"
 
@@ -972,6 +978,8 @@ msgstr "Odstrániť skupinu"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -984,11 +992,12 @@ msgstr "Hotovo"
 msgid "Group name"
 msgstr "Názov skupiny"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Skupiny"
@@ -1099,7 +1108,7 @@ msgstr "Obnoviť"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Naozaj to chcete urobiť?"
 
@@ -1214,7 +1223,7 @@ msgstr "V povoleniach sa nevykonajú žiadne zmeny"
 msgid "You've made changes to permissions."
 msgstr "Zmenili ste povolenia"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Povolenia pre túto kolekciu"
 
@@ -1270,6 +1279,7 @@ msgstr "Obmedziť prístup"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Odobrať prístup"
 
@@ -1333,23 +1343,23 @@ msgstr "Opraviť kolekciu"
 msgid "View collection"
 msgstr "Zobraziť kolekciu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Prístup k údajom"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Zobraziť tabuľky"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL dotaz"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Zobraziť schému"
 
@@ -1420,12 +1430,15 @@ msgstr "Odoslané!"
 msgid "Clear"
 msgstr "Čisté"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Overenie"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Nastavenie servra"
@@ -1438,6 +1451,7 @@ msgstr "Schéma používateľa"
 msgid "Attributes"
 msgstr "Atribúty"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Schéma skupiny"
@@ -1509,6 +1523,9 @@ msgid "Add a map"
 msgstr "Pridajte mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1518,19 +1535,19 @@ msgid "Delete custom map"
 msgstr "Odstránte vlastnú mapu"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Odstrániť"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1629,19 +1646,19 @@ msgstr "Kúpiť token"
 msgid "Enter a token"
 msgstr "Vožiť token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Upraviť mapovanie"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Skupinové mapovanie"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Vytvoriť mapovanie"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1881,18 +1898,27 @@ msgstr "Používateľský filter"
 msgid "Check your parentheses"
 msgstr "Skontrolujte zátvorky"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Atribút emailu"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Atribút krstné meno"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Atribút priezvisko"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Synchronizujte členstvo v skupinách"
@@ -1921,59 +1947,59 @@ msgstr "Voliteľné mapy"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Pridajte vlastné súbory GeoJSON, aby ste povolili rôzne vizualizácie máp regiónov"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Verejné zdieľanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Zapnúť verejné zdieľanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Zdieľaný dashboard"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Zdieľané otázky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Vložiť do inej aplikácie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Povoľte vkladanie Metabase do iných aplikácií"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Kľúč pre zdieľanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Vložený dashboardy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Vložené otázky"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Uloženie do dočasnej pamäte"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Zapnúť ukladanie do dočasnej pamäte"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Minimálne trvanie dopytu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Násobiteľ času dočasnej pamäte (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Maximálna veľkosť vstupu do dočasnej pamäte"
 
@@ -2015,27 +2041,27 @@ msgstr "Predtým, ako sa budete môcť prihlásiť pomocou Google, budete potreb
 msgid "Sign in with {0}"
 msgstr "Prihlásiť sa pomocou {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Prosím kontaktujte administrátora aby vám resetoval heslo."
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Zabudol som heslo"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Email ktorý používate pre svoj účet v Metabase"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Poslať email na reset hesla"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Pozrite si svoj email s inštrukciami ako si resetovať heslo."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Prihlásiť sa do Metabase"
 
@@ -2056,11 +2082,11 @@ msgstr "Prihlásiť sa"
 msgid "I seem to have forgotten my password"
 msgstr "Zdá sa, že som zabudol svoje heslo"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "požiadať o nový resetovací email"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Platnosť tohto odkazu už vypršala"
 
@@ -2069,11 +2095,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Z bezpečnostných dôvodov platnosť odkazov na obnovenie hesla vyprší o chvíľu. Ak stále potrebujete obnoviť svoje heslo, môžete {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nové heslo"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Ak chcete zachovať bezpečnosť svojich údajov, heslá {0}"
 
@@ -2096,24 +2122,24 @@ msgstr "Potvrďte nové heslo"
 msgid "Make sure it matches the one you just entered"
 msgstr "Skontrolujte, či sa zhoduje s hodnotou, ktorú ste práve zadali"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Vaše heslo bolo resetované."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Prihláste sa pomocou nového hesla."
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Uloženie zlyhalo"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2123,25 +2149,26 @@ msgstr "Uložené"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Archivovať túto kolekciu?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Dashboardy, kolekcie a impulzy v tejto kolekcii sa tiež archivujú."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Archivovať"
 
@@ -2266,7 +2293,7 @@ msgstr "Pripnúť"
 msgid "Drag something here to pin it to the top"
 msgstr "Potiahnite niečo sem a pripnite to hore"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2297,6 +2324,7 @@ msgstr "Presunúť \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Presunúť"
@@ -2333,7 +2361,7 @@ msgid "Some database installations can only be accessed by connecting through an
 msgstr "Prístup k niektorým inštaláciám databázy je možný iba pripojením cez SSH tunel.\n"
 "Táto voľba tiež poskytuje ďalšiu úroveň zabezpečenia, keď nie je k dispozícii sieť VPN. Povolenie je zvyčajne pomalšie ako priame pripojenie."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Táto databáza je  veľká, takže nastavte kedy má Metabase spustiť synchronizáciu a skenovanie"
 
@@ -2372,7 +2400,7 @@ msgstr "Ak chcete používať Metabase s týmito údajmi, musíte povoliť prís
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} prejdite na konzolu, ak ste tak ešte neurobili."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Ako by ste chceli odkazovať na túto databázu?"
 
@@ -2488,35 +2516,35 @@ msgstr "Postavené na schéme"
 msgid "A look at your"
 msgstr "Pozrite sa na svoje"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Nájsť zoznam"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Hľadať podľa {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " alebo zadajte ID "
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Zadajte ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Zadajte číslo"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Zadajte text"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Žiadna zhoda pre {0} sa nenašla."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Zahrnutie každej možnosti do filtra pravdepodobne neurobí veľa ..."
 
@@ -2528,7 +2556,6 @@ msgstr "Niečo sa pokazilo"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Došlo k chybe. Skúste obnoviť stránku, alebo stlačte tlačidlo späť."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2539,12 +2566,12 @@ msgstr "Došlo k chybe. Skúste obnoviť stránku, alebo stlačte tlačidlo spä
 msgid "No description yet"
 msgstr "Žiadny popis"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Nový {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Otázka od {0}"
 
@@ -2565,7 +2592,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Vrátiť na skoršiu revíziu a {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "História revízií"
@@ -2611,7 +2640,7 @@ msgid "Questions"
 msgstr "Otázky"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Impulzy"
 
@@ -2685,52 +2714,69 @@ msgstr "Nie teraz"
 msgid "Error:"
 msgstr "Chyba:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Nedeľa"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Pondelok"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Utorok"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Streda"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Štvrtok"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Piatok"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Sobota"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Prvý"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Posledný"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15. (v strede)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Kalendárny deň"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "vaše Metabase časové pásmo"
 
@@ -2784,11 +2830,11 @@ msgstr "Vytvoriť"
 msgid "Create dashboard"
 msgstr "Vytvoriť dashboard"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabuľka"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Databáza"
 
@@ -2863,9 +2909,9 @@ msgstr "Aký je názov vašej karty?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2879,15 +2925,16 @@ msgstr "Popis"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Nie je to povinné, ale pomáha to pri rozlišovaný"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Do ktoréj kolekcie to chcete zaradiť?"
 
@@ -2927,11 +2974,11 @@ msgstr "Archivovaný dashboard"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Nezabudnite urobiť výber pre každú sériu, inak nebude filter na tejto karte fungovať."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Tento dashboard je prázdny."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Pridajte otázku."
 
@@ -2951,7 +2998,7 @@ msgstr "Opustiť režim celej obrazovky"
 msgid "Enter fullscreen"
 msgstr "Režim celej obrazovky"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Ukladám..."
@@ -2964,7 +3011,8 @@ msgstr "Pridať otázku"
 msgid "Add a question to this dashboard"
 msgstr "Pridať otázku do tohto dashboardu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Pridať filter"
 
@@ -2972,7 +3020,7 @@ msgstr "Pridať filter"
 msgid "Parameters"
 msgstr "Parametre"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Pridať textové pole"
 
@@ -2980,7 +3028,7 @@ msgstr "Pridať textové pole"
 msgid "Move dashboard"
 msgstr "Presunúť dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Upraviť dashboard"
 
@@ -3004,11 +3052,11 @@ msgstr "Presunúť dashboard do..."
 msgid "Dashboard moved to {0}"
 msgstr "Dashboard bol presnutý do {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Čo chcete filtrovať?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "What kind of filter?"
 
@@ -3080,20 +3128,22 @@ msgstr "Táto karta neobsahuje polia ani parametre, ktoré je možné mapovať n
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Hodnoty v tomto poli sa nezhodujú s hodnotami iných polí, ktoré ste vybrali."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Žiadne platné polia"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Meno môže mať max. 100 znakov"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Farba je povinná"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Aké je meno vášho dashboardu?"
 
@@ -3148,7 +3198,7 @@ msgstr "boli pridané dáta z"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Neznáme"
 
@@ -3273,9 +3323,10 @@ msgstr "Nedávno ste sa nepozerali na žiadne informačné panely alebo otázky"
 msgid "{0} items selected"
 msgstr "{0} vybraných položiek"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Zrušiť archiváciu"
 
@@ -3392,7 +3443,7 @@ msgid "Zip Code"
 msgstr "PSČ"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Počet"
 
@@ -3425,11 +3476,13 @@ msgid "User"
 msgstr "Používateľ"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Zdroj"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Cena"
 
@@ -3462,21 +3515,23 @@ msgid "Subscription"
 msgstr "Predplatné"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Skóre"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Nadpis"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Komentár"
 
@@ -3530,14 +3585,14 @@ msgstr "Metabase toto pole nikdy nezíska. Použite na citlivé alebo irelevantn
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Počet"
 
@@ -3545,7 +3600,7 @@ msgstr "Počet"
 msgid "CumulativeCount"
 msgstr "Kumulovaný počet"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3563,19 +3618,19 @@ msgstr "Jednoznačný"
 msgid "StandardDeviation"
 msgstr "Štandardná odchýlka"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Priemer"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3586,7 +3641,7 @@ msgstr "Max"
 msgid "sad sad panda, lexing errors detected"
 msgstr "Bola detekovaná slovníkova chyba"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} sekúnd"
@@ -3594,7 +3649,7 @@ msgstr[1] "{0} sekundy"
 msgstr[2] "{0} sekúnd"
 msgstr[3] "{0} sekúnd"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minúta"
@@ -3637,14 +3692,15 @@ msgstr "Čo chcete zistiť?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Čisté data"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Kumulatívny počet"
 
@@ -3706,166 +3762,164 @@ msgstr "Pravdivý"
 msgid "False"
 msgstr "Nepravdivý"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Vyberte pole zemepisnej dĺžky"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Zadajte hornú zemepisnú šírku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Zadajte ľavú zemepisnú dĺžku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Zadajte dolnú zemepisnú šírku"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Zadajte pravú zemepisnú dĺžku"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Je"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Nie je"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Je prázdne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Nie je prázdne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Rovná sa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Nerovná sa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Väčšie ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Menšie ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Medzi"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Väčšie alebo rovné ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Menšie alebo rovné ako"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Obsahuje"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Neobsahuje"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Začína s"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Končí s"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Pred"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Za"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Vnútri"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Iba tabuľka s riadkami v odpovedi, žiadne ďalšie operácie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Počet riadkov"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Celkový počet riadkov v odpovedi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Súčet ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Súčet všetkých hodnôt v stĺpci."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Priemerná hodnota ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Priemerná hodnota všetkých hodôt v stĺpci"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Počet rôznych hodnôt ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Počet jedinečných hodnôt v stĺpci medzi všetkými riadkami v odpovedi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Kumulatívna suma ..."
 
@@ -3873,7 +3927,7 @@ msgstr "Kumulatívna suma ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Aditívny súčet všetkých hodnôt v stĺpci."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Kumulatívny počet riadkov"
 
@@ -3881,27 +3935,27 @@ msgstr "Kumulatívny počet riadkov"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Aditívny počet riadkov."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Štandardná odchýlka ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Číslo, ktoré vyjadruje, do akej miery sa hodnoty stĺpca líšia medzi všetkými riadkami v odpovedi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Minimálna hodnota ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Minimálna hodnota stĺpca"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Maximálna hodnota ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Maximálna hodnota stĺpca"
 
@@ -3917,6 +3971,8 @@ msgstr "malé písmeno"
 msgid "upper case letter"
 msgstr "veľké písmeno"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "číslo"
@@ -4164,7 +4220,7 @@ msgstr "Ako vytvoriť metriku"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Zobrazte údaje v priebehu času, aby vám pomohli pochopiť trendy alebo zmeny."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Voliteľný"
 
@@ -4187,7 +4243,7 @@ msgstr "Natívny dotaz"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Pre zložitejšie otázky môžete napísať svoj vlastný SQL alebo natívny dotaz."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Vyberte predvolenú hodnotu ..."
 
@@ -4284,7 +4340,7 @@ msgstr "Aktuálny mesiac"
 msgid "This Year"
 msgstr "Aktuálny rok"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Zadajte hodnotu..."
@@ -4294,7 +4350,7 @@ msgid "Enter a default value..."
 msgstr "Zadajte prednastavenú hodnotu..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Nastala chyba"
@@ -4554,22 +4610,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Vyberte otázky, ktoré chcete poslať v tomto impulze"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Emaily"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Spravy pre Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Odoslať"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} bude odoslaný na"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Správy"
 
@@ -4641,30 +4705,30 @@ msgstr "Pomôžte všetkým v tíme aby boli synchronizované s vašimi údajmi.
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Impulzy vám umožňujú odosielať údaje z Metabase na email alebo Slack podľa plánu a podľa vášho výberu."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Po {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Pred {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Je prázdny"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Nie je prázdny"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Vždy"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Aplikovať"
 
@@ -4767,12 +4831,12 @@ msgstr[3] "Zobraziť {0}"
 msgid "Zoom in"
 msgstr "Priblížiť"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Vlastná hodnota"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Základne metriky"
 
@@ -4969,7 +5033,7 @@ msgstr "zvyčajne"
 msgid "Pick a segment or table"
 msgstr "Vyberte segment alebo tabuľku"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Vyberte databázu"
@@ -5030,7 +5094,7 @@ msgstr "Zoradiť"
 msgid "Row limit"
 msgstr "Limit riadkov"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Neznáme pole"
 
@@ -5038,7 +5102,7 @@ msgstr "Neznáme pole"
 msgid "field"
 msgstr "pole"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Zhody"
 
@@ -5063,11 +5127,11 @@ msgstr "Pridajte skupinu"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Data"
 
@@ -5084,11 +5148,12 @@ msgstr "Zobraziť"
 msgid "Grouped By"
 msgstr "Zoskupiť podľa"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Žiadne"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Táto otázka je napísaná v {0}."
 
@@ -5100,7 +5165,7 @@ msgstr "Skryť editor"
 msgid "Hide Query"
 msgstr "Skryť dotaz"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Otvoriť editor"
 
@@ -5108,7 +5173,7 @@ msgstr "Otvoriť editor"
 msgid "Show Query"
 msgstr "Zobraziť dotaz"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Táto metrika už bola zrušená. Už nie je k dispozícii na ďalšie použitie."
 
@@ -5311,7 +5376,7 @@ msgstr "Späť na posledné spustenie"
 msgid "Visualization"
 msgstr "Vizualizácia"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Žiaden popis"
 
@@ -5368,7 +5433,7 @@ msgstr "Nepodarilo sa nájsť metadáta tabuľky pred vytvorením novej otázky"
 msgid "See {0}"
 msgstr "Zobraziť {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Definícia metriky"
 
@@ -5386,11 +5451,11 @@ msgstr "Počet {0}"
 msgid "See all {0}"
 msgstr "Zobraziť všetko {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Definícia segmentu"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Pri načítavaní tabuľky sa vyskytla chyba"
 
@@ -5398,7 +5463,7 @@ msgstr "Pri načítavaní tabuľky sa vyskytla chyba"
 msgid "See the raw data for {0}"
 msgstr "Zobraziť nespracované údaje {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Viac"
 
@@ -5418,6 +5483,8 @@ msgstr "Vzorec poľa"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Myslite na to, akoby to bolo ako písanie vzorca v tabuľkovom programe: môžete použiť čísla, polia v tejto tabuľke, matematické symboly ako + a niektoré funkcie. Môžete teda zadať niečo ako medzisúčet - náklady."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5485,7 +5552,7 @@ msgstr "nepravda"
 msgid "Add filter"
 msgstr "Pridať filter"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Položka"
 
@@ -5604,11 +5671,11 @@ msgstr "Pole na priradenie do"
 msgid "Filter widget type"
 msgstr "Typ filtra"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Povinné?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Predvolená hodnota widget filtra"
 
@@ -5620,7 +5687,7 @@ msgstr "Archivovať  túto otázku?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Táto otázka bude odstránená zo všetkých dashboardov alebo impulzov, ktoré ju používajú."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Otázka"
 
@@ -5667,7 +5734,7 @@ msgstr "Typ poľa"
 msgid "Select a Foreign Key"
 msgstr "Vyberte cudzí kľúč"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Prezrite si vzorec {0}"
 
@@ -6151,22 +6218,24 @@ msgstr "Otázky týkajúce sa tohto segmentu"
 msgid "X-ray this segment"
 msgstr "Preskúmať tento segment"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Prihlásiť sa"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Vyhľadávanie"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Nová otázka"
 
@@ -6238,35 +6307,35 @@ msgstr "Celá zbierka je úplne anonymná."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Zbieranie môžete kedykoľvek vypnúť v nastaveniach správcu."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Ak sa cítite zaseknutý"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "náš sprievodca Začíname"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "je vzdialený len na jedno kliknutie."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Vitajte v Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Vyzerá to, že všetko funguje. Teraz sa s vami zoznámime, pripojíme sa k vašim údajom a začneme prehľadávať dáta."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Začnime"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Všetci ste pripravení!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Ukážte mi Metabase"
 
@@ -6519,39 +6588,40 @@ msgstr "Zrušiť filter"
 msgid "Pin Map"
 msgstr "Pripnúť mapu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Zrušiť"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Riadky {0} - {1} z {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Údaje boli skrátené na {0} riadky."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Nepodarilo sa nájsť vizualizáciu"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Tento graf sa nedal zobraziť s týmito údajmi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Žiadne výsledky!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Stále čakám..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Zvyčajne to trvá v priemere {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Je to trochu dlhá doba pre dashboard)"
 
@@ -6662,7 +6732,7 @@ msgid "Highlight the whole row"
 msgstr "Zvýraznite celý riadok"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Farby"
 
@@ -6748,24 +6818,50 @@ msgstr "Cieľ"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Údaje z vášho dotazu sa nezhodujú s vybranou voľbou zobrazenia. Táto vizualizácia vyžaduje najmenej {0} {1} údajov."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "stĺpec"
@@ -6799,7 +6895,7 @@ msgid "xValues missing!"
 msgstr "Chýba hodnota pre os X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "os X"
 
@@ -6808,7 +6904,7 @@ msgid "Add a series breakout..."
 msgstr "Pridať koniec do série..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "os Y"
 
@@ -6821,7 +6917,7 @@ msgid "Bubble size"
 msgstr "Veľkosť bubliny"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "riadok"
 
@@ -6963,20 +7059,20 @@ msgid "Standard Deviation"
 msgstr "Štandardná odchýlka"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Oblasť"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "Pločný graf"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Stĺpec"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "stĺpcový graf"
 
@@ -6990,7 +7086,7 @@ msgid "Funnel"
 msgstr "Zúženie"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Opatrenia"
 
@@ -7002,81 +7098,81 @@ msgstr "Typ zúženia"
 msgid "Bar chart"
 msgstr "Stĺpcový graf"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "čiarový graf"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "V nastaveniach grafu vyberte stĺpce zemepisnej výšky a šírky."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Vyberte mapu regiónu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "V nastaveniach grafu vyberte stĺpce regiónov a metrík."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Typ mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Mapa regiónu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Pripnúť mapu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Typ špendlíka"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Dlaždice"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Značky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Pole zemepisnej šírky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Pole zemepisnej dĺžky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Pole metriky"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Pole regiónu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Uhol"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Rozmazať"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Min. krytie"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Max. priblíženie"
 
@@ -7088,7 +7184,7 @@ msgstr "Nenašli sa žiadne vzťahy."
 msgid "via {0}"
 msgstr "prostredníctvom {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Toto {0} je spojené s:"
 
@@ -7100,31 +7196,31 @@ msgstr "Detail objektu"
 msgid "object"
 msgstr "objekt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Celkom"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Ktoré stĺpce chcete použiť?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Koláčový"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "rozmer"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Zobraziť legendu"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Zobraziť percentá v legende"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minimálne percento rezov"
 
@@ -7149,7 +7245,8 @@ msgid "Progress"
 msgstr "Pokrok"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Farba"
@@ -7158,7 +7255,7 @@ msgstr "Farba"
 msgid "Row Chart"
 msgstr "Riadkový graf"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "riadkový graf"
 
@@ -7182,15 +7279,15 @@ msgstr "Pridajte príponu"
 msgid "Multiply by a number"
 msgstr "Vynásobte číslom"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Bodový"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "bodový diagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Vedúca tabuľka"
 
@@ -7240,7 +7337,7 @@ msgstr "Vpravo"
 msgid "Show background"
 msgstr "Zobraziť pozadie"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} kôš"
@@ -7248,7 +7345,7 @@ msgstr[1] "{0} koše"
 msgstr[2] "{0} košov"
 msgstr[3] "{0} košov"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Automaticky ukladať do koša"
 
@@ -7484,10 +7581,13 @@ msgstr "Máte veľa uložených otázok v {0}? Vytvorte kolekcie, ktoré im pom�
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7685,7 +7785,7 @@ msgstr "kumulatívna suma"
 msgid "{0} and {1}"
 msgstr "{0} a {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
@@ -9000,11 +9100,11 @@ msgstr "Povolenia na údaje"
 msgid "Collection permissions"
 msgstr "Kolekcia práv"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Zobraziť všetky povolenia v kolekcii"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Zmeniť aj podskupiny"
 
@@ -9016,19 +9116,19 @@ msgstr "Môže upravovať túto kolekciu a jej obsah"
 msgid "Can view items in this collection"
 msgstr "Môže zobraziť položky v tejto kolekcii"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Prístup k inkasu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Táto skupina má povolenie na zobrazenie aspoň jednej podskupiny tejto kolekcii."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Táto skupina má povolenie na úpravu aspoň jednej podskupiny tejto kolekcie."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Zobraziť podskupiny"
 
@@ -9084,6 +9184,7 @@ msgstr "Príbuzný"
 msgid "More X-rays"
 msgstr "Preskúmať viac"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9342,10 +9443,10 @@ msgstr "Zdieľanie"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9428,7 +9529,7 @@ msgstr "Použite časové pásmo JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Momentálne analyzujeme tabuľky a polia, ktoré vám pomôžu preskúmať vaše údaje."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Tip: "
 
@@ -9436,7 +9537,7 @@ msgstr "Tip: "
 msgid "Select a currency type"
 msgstr "Vyberte typ meny"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Typ poľa"
 
@@ -9491,6 +9592,7 @@ msgid "Currency"
 msgstr "Mena"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Vyberte používateľa alebo kanál ..."
 
@@ -9652,7 +9754,7 @@ msgstr "Ktorá os?"
 msgid "Line + Bar"
 msgstr "Riadok + stĺpec"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "čiarový a stĺpcový graf"
 
@@ -9672,15 +9774,15 @@ msgstr "Rozsah mierky"
 msgid "Field to show"
 msgstr "Pole na zobrazenie"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "posledný {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} bolo {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Zoskupením podľa časového poľa zistíte, ako sa to časom zmenilo"
 
@@ -9688,23 +9790,23 @@ msgstr "Zoskupením podľa časového poľa zistíte, ako sa to časom zmenilo"
 msgid "Switch positive / negative colors?"
 msgstr "Prepnúť pozitívne / negatívne farby?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Vedúci stĺpec"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Bunka stĺpca"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Viditeľné stĺpce"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Podmienené formátovanie"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Názov stĺpca"
 
@@ -10142,10 +10244,10 @@ msgstr "Používatelia podľa zdroja"
 msgid "The top external pages that brought users to your site"
 msgstr "Najlepšie externé stránky, ktoré priviedli používateľov na váš web"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Ako je [[this]] distribuované a viac."
 
@@ -10243,13 +10345,13 @@ msgstr "Udalosti za hodinu počas dňa"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Top 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Spodných 5 [[this]]"
 
@@ -10262,10 +10364,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Cez [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Nulové hodnoty"
 
@@ -10293,8 +10395,8 @@ msgstr "Ako sa porovnávajú podľa sezónnosti"
 msgid "Average income per transaction"
 msgstr "Priemerný príjem na transakciu"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[toto]] na krajinu"
 
@@ -10418,10 +10520,10 @@ msgstr "Prehľad vášho [[this]] a jeho distribúcie v čase, mieste a kategór
 msgid "Average income per state"
 msgstr "Priemerný príjem na štát"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] od [[GenericCategoryMedium]]"
 
@@ -10598,13 +10700,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Ako sú [[GenericTable]] distribuované v tomto časovom poli a či má nejaké sezónne vzorce."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Prehľad"
 
@@ -10713,8 +10815,8 @@ msgstr "Tu je bližší pohľad na vaše [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Tu je bližší pohľad na vaše [[this]] pole"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Súhrn"
 
@@ -10778,10 +10880,10 @@ msgstr "Predaj podľa jednotlivých zdrojov"
 msgid "Average income per country"
 msgstr "Priemerný príjem na krajinu"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Ako je [[this]] distribuované"
 
@@ -10802,17 +10904,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Počet [[GenericCategoryMedium]] od [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Pozrite sa na [[this]]"
 
@@ -10878,10 +10980,10 @@ msgid "Transactions per source over time"
 msgstr "Transakcie zo zdroja v priebehu času"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Ako je [[this]] distribuovaný"
 
@@ -10910,9 +11012,9 @@ msgstr "Kde sa tieto udalosti dejú"
 msgid "Which US states are bringing you the most business."
 msgstr "Ktoré štáty USA vám prinášajú najviac do vášho podnikania."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Ako sa porovnávajú v čase"
 
@@ -11017,8 +11119,8 @@ msgstr "Relácie podľa krajín"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Niekoľko zaujímavých metrík o vašich štatistikách GA, ktoré vám pomôžu začať."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] na štát"
 
@@ -11099,12 +11201,12 @@ msgstr "Ako je táto metrika rozdelená medzi rôzne čísla"
 msgid "Sessions by page where the session began"
 msgstr "Relácie podľa stránky, kde sa relácia začala"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Charakteristické hodnoty"
 
@@ -11167,10 +11269,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Udalosti za [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Ako porovnávajú podľa distribúcie"
@@ -11476,6 +11578,7 @@ msgstr "Duplikátny dashboard"
 msgid "Duplicate \"{0}\""
 msgstr "Duplikát \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11591,9 +11694,9 @@ msgstr[1] "Kvartály z roku"
 msgstr[2] "Kvartálov z roku"
 msgstr[3] "Kvartálov z roku"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} vybraný"
@@ -11618,11 +11721,11 @@ msgstr "Neplatný"
 msgid "Add a time"
 msgstr "Pridať čas"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nič pre porovnanie z predchádzajúcich {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "do {0}"
 
@@ -12110,9 +12213,9 @@ msgstr "Tu je prehľad ľudí vo vašom [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] vo štvrťroku roka"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Ako porovnávajú naprieč polohou"
 
@@ -12141,12 +12244,12 @@ msgstr "[[CreateTimestamp]] podľa dňa v týždni"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Tu je prehľad vašich [[this]] údajov zo služby Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Tu je prehľad vašich [[this]]"
 
@@ -12224,11 +12327,11 @@ msgstr "kolekcia"
 msgid "collections"
 msgstr "kolekcie"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "dashboard"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "dashboardy"
 
@@ -12478,7 +12581,7 @@ msgstr "Časový limit vyprší po {0} milisekundách."
 msgid "Misfire Instruction"
 msgstr "Pokyny k vynechaniu pri štarte"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Archivovať to?"
 
@@ -12496,7 +12599,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Použitie tejto voľby vyžaduje, aby poskytnutý host bol úplný názov domény. Ak sa pripájate k Atlas cluster bude pravdepodobne potrebné túto možnosť povoliť. Ak neviete, čo to znamená,nechajte túto možnosť vypnutú."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Automaticky spúšťať dotazy pri jednoduchom filtrovaní a sumarizácii"
 
@@ -12508,7 +12611,7 @@ msgstr "Ak je táto možnosť zapnutá, Metabase automaticky spúšťa dotazy, k
 msgid "Learn about this database"
 msgstr "Ďalšie informácie o tejto databáze"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Archivovať tento informačný panel?"
 
@@ -12566,11 +12669,11 @@ msgstr "Vlastná otázka"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Použite pokročilý editor poznámok na pripojenie údajov, vytváranie vlastných stĺpcov, výpočty a ďalšie."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Základné metriky"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Vlastné ..."
 
@@ -12759,15 +12862,15 @@ msgstr "Vyberte vizualizáciu"
 msgid "Filter by"
 msgstr "Triediť podľa"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Sumarizovať podľa"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Zoskupiť podľa"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Pridajte metriku"
 
@@ -12778,15 +12881,15 @@ msgstr "Pridajte metriku"
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "To je zvyčajne dosť rýchle, ale zdá sa, že to chvíľu trvá."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Kombinácia"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Riadok"
 
@@ -13207,7 +13310,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Vyberte stĺpce, ktoré chcete zahrnúť"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Keď je toto zapnuté, Metabase automaticky spúšťa dotazy, keď používatelia robia jednoduché prieskumy pomocou tlačidiel Sumarizovať a Filtrovať pri prezeraní tabuľky alebo grafu. Túto možnosť môžete vypnúť, ak je vyhľadávanie v tejto databáze pomalé. Toto nastavenie nemá vplyv na dotazy SQL."
 
@@ -13273,7 +13376,7 @@ msgstr "Prihlásiť sa pomocou emailu"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Použitie tejto voľby vyžaduje, aby poskytnutý hostiteľ bol úplný názov domény. Ak sa pripájate ku Atlas klastru, možno bude potrebné túto možnosť povoliť. Ak neviete, čo to znamená, nechajte to vypnuté."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Metabase predvolene vykonáva rýchlu hodinovú synchronizáciu a intenzívne denné skenovanie hodnôt polí. Ak máte rozsiahlu databázu, odporúčame vám zapnúť skenovanie a skontrolovať kedy a ako často sa uskutoční kontrola hodnôt polí."
 
@@ -13341,11 +13444,11 @@ msgstr "Nezahŕňa"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Toto pole nebude viditeľné ani voliteľné pri otázkach vytvorených pomocou grafických rozhraní. Bude stále prístupná v SQL / natívnych dotazoch."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Kumulatívna suma"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Štandardná odchýlka"
 
@@ -13361,19 +13464,19 @@ msgstr "Musí mať aspoň {0} znakov"
 msgid "Name (required)"
 msgstr "Meno (povinné)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Spustiť vybraný text"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Spustiť dotaz"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13721,7 +13824,7 @@ msgstr "Dátum a čas"
 msgid "Numbers"
 msgstr "Čísla"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Žiadna primovateľná skupina"
 
@@ -13761,15 +13864,15 @@ msgstr "dnesvyzerasdobre@email.com"
 msgid "Remember me"
 msgstr "Zapamätať si ma"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Z bezpečnostných dôvodov platnosť odkazov na obnovenie hesla vyprší o chvíľu. Ak stále potrebujete obnoviť svoje heslo, môžete {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Uložiť nové heslo"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Žiadny zodpovedajúci výsledok"
 
@@ -13795,26 +13898,26 @@ msgid "or"
 msgstr "alebo"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "povinné"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Typ databázy"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Toto je ľahký proces, ktorý zisťuje aktualizácie schémy tejto databázy. Vo väčšine prípadov by to malo byť v poriadku, ak necháte tento proces synchronizovať každú hodinu."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase môže skenovať hodnoty prítomné v každom poli v tejto databáze. Môže to byť proces, ktorý je trochu náročný na prostriedky, najmä ak máte veľmi veľkú databázu."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Zbierka"
 
@@ -13861,7 +13964,7 @@ msgstr "Kategorický"
 msgid "URLs"
 msgstr "odkaz"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Vráti priemer hodnôt v stĺpci."
 
@@ -13870,11 +13973,13 @@ msgstr "Vráti priemer hodnôt v stĺpci."
 msgid "The column whose values to average."
 msgstr "Stĺpec, ktorého hodnoty sa majú spriemerovať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "štart"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "koniec"
 
@@ -13886,21 +13991,19 @@ msgstr "Kontroluje hodnoty dátumu alebo číselného stĺpca a zisťuje, či sa
 msgid "Rating"
 msgstr "Hodnotenie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "podmienka"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "výstup"
 
@@ -13908,27 +14011,27 @@ msgstr "výstup"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testuje zoznam prípadov a vracia zodpovedajúcu hodnotu prvého skutočného prípadu s voliteľnou predvolenou hodnotou, ak nie je splnené nič iné."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Váha"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Veľkosť"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Stredná"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Malá"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Niečo, čo by sa malo vyhodnocovať ako pravda alebo nepravda."
 
@@ -13936,33 +14039,33 @@ msgstr "Niečo, čo by sa malo vyhodnocovať ako pravda alebo nepravda."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Hodnota, ktorá sa vráti, ak je predchádzajúca podmienka splnená."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "hodnota1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "hodnota2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Pozrie hodnoty v každom argumente v poradí a vráti prvú nenulovú hodnotu pre každý riadok."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Komentáre"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Poznámky"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Žiadne komentáre"
 
@@ -13978,12 +14081,12 @@ msgstr "Ak je hodnota1 prázdna, hodnota2 sa vráti, ak nie je prázdna, atď."
 msgid "Combines two or more strings of text together."
 msgstr "Kombinuje dva alebo viac reťazcov textu dohromady."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Priezvisko"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Meno"
 
@@ -13995,27 +14098,27 @@ msgstr "value2 sa pridá na koniec."
 msgid "This will be added to the end of value1."
 msgstr "Toto sa pripočíta na koniec hodnoty1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "reťazec1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "reťazec2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Skontroluje, či reťazec1 obsahuje v sebe reťazec2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Skončiť sa"
 
@@ -14023,7 +14126,7 @@ msgstr "Skončiť sa"
 msgid "The contents of this string will be checked."
 msgstr "Obsah tohto reťazca sa skontroluje."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Reťazec textu, ktorý treba hľadať."
 
@@ -14031,22 +14134,22 @@ msgstr "Reťazec textu, ktorý treba hľadať."
 msgid "Returns the count of rows in the source data."
 msgstr "Vráti počet riadkov v zdrojových dátach."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Počíta sa iba riadok, v ktorom je podmienka splnená."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Medzisúčet"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Doplnkový celkový počet riadkov naprieč dokončením."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "Kumulatívny súčet naprieč stĺpcom."
 
@@ -14055,53 +14158,57 @@ msgstr "Kumulatívny súčet naprieč stĺpcom."
 msgid "The column to sum."
 msgstr "Stĺpec na súčet."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Počet rôznych hodnôt v tomto stĺpci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Stĺpec, ktorého hodnoty sa majú počítať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "porovnanie"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Vráti pravdivú hodnotu, ak sa koniec textu zhoduje s textom porovnania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Chuť"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hladný"
 
@@ -14110,20 +14217,20 @@ msgstr "hladný"
 msgid "A column or string of text to check."
 msgstr "Stĺpec alebo reťazec textu na kontrolu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Reťazec textu, ktorým by mal pôvodný text končiť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "regulárny_výraz"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Extrahuje zodpovedajúce podreťazce podľa regulárneho výrazu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adresa"
 
@@ -14131,7 +14238,7 @@ msgstr "Adresa"
 msgid "The column or string of text to search though."
 msgstr "Stĺpec alebo reťazec textu, ktorý sa má prehľadávať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Regulárny výraz, ktorý sa má zhodovať."
 
@@ -14143,7 +14250,7 @@ msgstr "Vráti reťazec textu v malých písmenách."
 msgid "The column with values to convert to lowercase."
 msgstr "Stĺpec s hodnotami na prevod na malé písmená."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Odstráni úvodné medzery z reťazca textu."
 
@@ -14153,15 +14260,16 @@ msgstr "Odstráni úvodné medzery z reťazca textu."
 msgid "The column with values you want to trim."
 msgstr "Stĺpec s hodnotami, ktoré chcete orezať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Vráti najväčšiu hodnotu nachádzajúcu sa v stĺpci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Vek"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Číselný stĺpec, ktorého maximum chcete nájsť."
 
@@ -14169,21 +14277,21 @@ msgstr "Číselný stĺpec, ktorého maximum chcete nájsť."
 msgid "Returns the smallest value found in the column."
 msgstr "Vráti najmenšiu hodnotu nachádzajúcu sa v stĺpci."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Plat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Číselný stĺpec, ktorého minimum chcete nájsť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "pozícia"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "dĺžka"
 
@@ -14192,7 +14300,7 @@ msgstr "dĺžka"
 msgid "new_text"
 msgstr "nový_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Nahradí časť vstupného textu novým textom."
 
@@ -14220,35 +14328,35 @@ msgstr "Počet znakov, ktoré sa majú nahradiť."
 msgid "The text to use in the replacement."
 msgstr "Text, ktorý sa má použiť ako náhrada."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Odstráni koncové medzery z textového reťazca."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Vráti percento riadkov v údajoch, ktoré zodpovedajú podmienke, ako číslo."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Vráti hodnotu pravda, ak sa začiatok textu zhoduje s textom porovnania."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Názov kurzu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Počítačová veda"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Reťazec textu, s ktorým by mal pôvodný text začínať."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Vypočíta smerodajnú odchýlku stĺpca."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Populácia"
 
@@ -14256,7 +14364,7 @@ msgstr "Populácia"
 msgid "A numeric column."
 msgstr "Číselný stĺpec."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Vráti časť dodaného textu."
 
@@ -14264,19 +14372,19 @@ msgstr "Vráti časť dodaného textu."
 msgid "The text to return a portion of."
 msgstr "Text na vrátenie časti."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Pozícia na začatie kopírovania znakov."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Počet znakov, ktoré sa majú vrátiť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Sčíta všetky hodnoty stĺpca."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Číselný stĺpec, ktorý sa má sčítať."
 
@@ -14284,15 +14392,15 @@ msgstr "Číselný stĺpec, ktorý sa má sčítať."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Sčítava hodnoty v stĺpci, kde riadky zodpovedajú podmienkam."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Stav objednávky"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Platná"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Odstráni úvodné a koncové medzery z reťazca textu."
 
@@ -14300,23 +14408,23 @@ msgstr "Odstráni úvodné a koncové medzery z reťazca textu."
 msgid "Returns the string of text in all upper case."
 msgstr "Vráti reťazec textu vo veľkých písmenách."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Stĺpec s hodnotami pre prevod na veľké písmená."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "musí byť {0} a musí obsahovať {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "musí byť {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "musí obsahoavť {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "najmenej {0} znak"
@@ -14324,7 +14432,7 @@ msgstr[1] "najmenej {0} znaky"
 msgstr[2] "najmenej {0} znakov"
 msgstr[3] "najmenej {0} znakov"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} malé písmeno"
@@ -14332,7 +14440,7 @@ msgstr[1] "{0} malé písmena"
 msgstr[2] "{0} malých písmen"
 msgstr[3] "{0} malých písmen"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} veľké písmeno"
@@ -14340,7 +14448,7 @@ msgstr[1] "{0} veľké písmena"
 msgstr[2] "{0} veľkých písmen"
 msgstr[3] "{0} veľkých písmen"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} číslo"
@@ -14348,7 +14456,7 @@ msgstr[1] "{0} čísla"
 msgstr[2] "{0} čísel"
 msgstr[3] "{0} čísel"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} špeciálny znak"
@@ -14373,6 +14481,7 @@ msgid "Powered by {0}"
 msgstr "Beží na {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Pre:"
 
@@ -14460,7 +14569,7 @@ msgstr "Formátovanie hodnoty"
 msgid "Full"
 msgstr "Plný"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Žiadna zmena od poslednej {0}"
 
@@ -14785,7 +14894,7 @@ msgstr "Chyba pri generovaní štatistík pre stĺpec:"
 msgid "Sending abandonment email!"
 msgstr "Odosielame e-mail o opustení účtu!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Ak chcete pridať pomenovanú možnosť metriky, môžete vytvoriť uložené metriky. Medzi uložené metriky patrí typ agregácie, agregované pole a prípadne akýkoľvek filter, ktorý pridáte. Ako príklad môžete použiť na vytvorenie niečoho ako oficiálny spôsob výpočtu „priemernej ceny“ pre tabuľku Objednávky."
 
@@ -14793,15 +14902,15 @@ msgstr "Ak chcete pridať pomenovanú možnosť metriky, môžete vytvoriť ulo�
 msgid "Select and add filters to create your new segment."
 msgstr "Vyberte a pridajte filtre na vytvorenie nového segmentu."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "abecedne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "šikovný"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Poradie stĺpcov: {0}"
 
@@ -14853,7 +14962,7 @@ msgstr "lokalizácia"
 msgid "Instance language"
 msgstr "Jazyk inštancie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Možnosti lokalizácie"
 
@@ -14925,19 +15034,20 @@ msgstr "Prilepte pripojovací reťazec"
 msgid "Fill out individual fields"
 msgstr "Vyplňte jednotlivé polia"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Sem zadajte nejaký SQL, aby ste ho mohli znova použiť neskôr"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Zadajte svoj úryvok"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Súčasní zákazníci"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "pridaj popis"
 
@@ -14945,46 +15055,47 @@ msgstr "pridaj popis"
 msgid "Use site default"
 msgstr "Použiť predvolené nastavenie lokality"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "Nájsť"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "vymeniť"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Text, ktorý treba nájsť."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Text, ktorý sa má použiť ako náhrada."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Úpravy {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Vytvorte si nový útržok"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Archivované úryvky"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Útržky sú opakovane použiteľné bity SQL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Vytvorte úryvok"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "úryvky"
 
@@ -15263,3 +15374,1509 @@ msgstr "hodnota musí byť kľúčové slovo alebo reťazec."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Reťazec musí byť platným dvojpísmenovým jazykom ISO alebo jazykovým kódom krajiny, napr. 'en' alebo 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Riadky {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Audit"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Konfigurácia používateľskeho atribútu (voliteľné)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Použitie {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Nastavte jednotné prihlásenie na základe SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "Autentifikácia SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Konfigurácia poskytovateľa identity (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Váš poskytovateľ identity bude potrebovať nasledujúce informácie o metabázi."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL, na ktoré by mal sprostredkovateľ identity presmerovať späť"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Toto sa nazýva adresa URL jednotného prihlásenia v Okte, adresa URL spätného volania aplikácie v Auth0,\n"
+"a ACS (spotrebiteľská) adresa URL vo OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "Atribúty SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "Vo väčšine poskytovateľov pôžičiek je potrebné umiestniť každé z nich do vstupného poľa s označením\n"
+"„Názov“ v sekcii výpisov atribútov."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "E-mailový atribút používateľa"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Atribút krstného mena používateľa"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Atribút priezviska používateľa"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Povedzte spoločnosti Metabase o svojom poskytovateľovi identity"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabáza bude potrebovať nasledujúce informácie o vašom poskytovateľovi."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL poskytovateľa identity SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Certifikát poskytovateľa identity SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Názov aplikácie SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Podpísať žiadosti o jednotné prihlásenie (voliteľné)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Cesta skladu kľúčov SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Heslo úložiska kľúčov SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Ticho...."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML Keystore Alias"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Synchronizujte členstvo v skupine so svojím SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Ak to chcete povoliť, budete musieť vytvoriť priradenia, ktoré metabázi povedia, ktoré skupiny by mali vaši používatelia používať\n"
+"byť pridaní do na základe skupiny SSO, v ktorej sú."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Názov skupiny"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Názov atribútu skupiny"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Poznámka:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Ak zmeníte ktorékoľvek z nastavení existujúceho aktívneho nastavenia SAML, budete musieť reštartovať Metabázu, aby sa prejavili."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Umožňuje používateľom prihlásiť sa prostredníctvom poskytovateľa identity SAML."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Umožňuje používateľom prihlásiť sa prostredníctvom poskytovateľa identity JWT."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Povoliť overenie hesla"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Ak je táto možnosť povolená, používatelia sa môžu navyše prihlásiť pomocou e-mailu a hesla."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Informujte správcov o nových používateľoch jednotného prihlásenia"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Ak je táto možnosť povolená, správcovia dostanú e-mail pri prvom použití nástroja Single Sign-On."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Pomocou nasledujúcich nastavení nakonfigurujte svoje SSO pomocou SAML. Ak máte nejaké otázky, pozrite si naše {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "dokumentácia"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "Identifikátor URI poskytovateľa identity SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "Autentifikácia JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "Identifikátor URI poskytovateľa identity JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Reťazec používaný podpisovým kľúčom JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Vkladá sa celá aplikácia Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Ak chcete vložiť celú metabázu, zadajte pôvod webov alebo webových aplikácií, kde chcete povoliť vkladanie do prvku iframe oddeleného medzerou. Tu je {0}, čo je možné zadať."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Poskytnite tejto tabuľke prístup v karanténe"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Keď používatelia v tejto skupine zobrazia túto tabuľku, zobrazí sa jej verzia, ktorá je filtrovaná podľa ich používateľských atribútov, alebo jej vlastné zobrazenie na základe uloženej otázky."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Ako chcete filtrovať túto tabuľku pre používateľov v tejto skupine?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Vyberte uloženú otázku, ktorá vráti vlastné zobrazenie tejto tabuľky, ktoré by sa týmto používateľom malo zobraziť."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Môžete tu voliteľne pridať ďalšie filtre na základe atribútov používateľa. Tieto filtre sa použijú na všetky filtre, ktoré sa už nachádzajú v tejto uloženej otázke."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Aby táto možnosť fungovala, musia vaši používatelia mať niektoré atribúty"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Ak chcete pridať ďalšie filtre, musia vaši používatelia mať niektoré atribúty"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Žiadne atribúty používateľa"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Vyberte atribút používateľa"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Vyberte parameter"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Vyberte stĺpec"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Používatelia v doméne {0} môžu zobraziť"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "riadky v otázke {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "riadky v tabuľke {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "kde {0} sa rovná {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "a {0} sa rovná {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Atribúty môžete pridať automaticky nastavením SSO, ktoré používa SAML, alebo ich môžete zadať ručne tak, že prejdete do sekcie Ľudia a kliknete na ponuku ... úplne vpravo."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Atribút používateľa"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Ak ste nastavili jednotné prihlásenie, môžeme automaticky získať atribúty vašich používateľov, alebo ich môžete pridať manuálne z ponuky „…“ v sekcii Ľudia na paneli správcov."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parameter alebo premenná"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "rovná sa"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Udeliť prístup v karanténe"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Sandboxovaný prístup"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Upraviť prístup v karanténe"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Upravte podrobnosti priečinka"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Zmena povolení"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Vytvorte nový priečinok"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Nový priečinok"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Problémy s overením vášho tokenu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Skontrolujte, či sa vaša inštancia môže pripojiť k serverom Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Získajte pomoc"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Získajte ešte viac z Metabázy s Enterprise Edition"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Všetky nástroje, ktoré potrebujete na rýchle a ľahké poskytnutie prehľadov zákazníkom alebo na pomoc pri spustení a sledovaní Metabázy vo veľkej organizácii"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Aktivujte licenciu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Skúšobná verzia je aktívna s týmito funkciami"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Platnosť skúšobnej verzie vyprší {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Potrebujete pomoc? Ste pripravení kúpiť?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Porozprávajte sa s nami"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Platnosť vašej skúšobnej verzie vypršala"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Potrebujete viac času? Ste pripravení kúpiť?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Vaše funkcie sú aktívne!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Vaša licencia je platná do {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Platnosť vašej licencie uplynula"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Platnosť vypršala {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Chcete si predĺžiť licenciu?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Naučte sa, ako to používať"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Nie je súčasťou vášho súčasného plánu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Zadajte token, ktorý ste dostali z obchodu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Aktivovať"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Potrebujete pomoc?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Viac informácií o vašom probléme."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Kontaktujte podporu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Dátové karantény"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Uistite sa, že tým správnym ľuďom zobrazujete správne údaje pomocou automatických a zabezpečených filtrov podľa atribútov používateľov."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Biele označenie"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Priraďte metabázu k svojej značke pomocou vlastných farieb, vlastného loga a ďalších."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Auditovanie"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Sledujte výkon a správanie pomocou robustných nástrojov na audit."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Jednotné prihlásenie"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Poskytnite jednoduché prihlásenie, ktoré funguje s vašou existujúcou autentifikačnou infraštruktúrou."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Uložiť"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Názov aplikácie"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Paleta farieb"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Cieľová stránka"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Žiadne skupiny"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Povolenia pre {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Povolenia pre tento priečinok"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Udeliť prístup na úpravy"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "V tomto priečinku môžete upravovať úryvky"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Udeliť prístup"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "V tomto priečinku môžete vkladať a používať úryvky, ale nemôžete upravovať SQL, ktoré obsahujú"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "V tomto priečinku nie je možné zobraziť ani vložiť úryvky"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Zmeňte tiež podpriečinky"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Prvý deň v týždni"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Nastal problém s prihlásením pomocou Google. Kontaktujte správcu."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "na"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "o"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Otvorte ponuku akcií metabázy"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Nerob nič"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Prejdite na vlastný cieľ"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Aktualizujte filter informačného panela"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "Filter {0} aktualizácií {1}"
+msgstr[1] "{0} aktualizácie {1} filtrov"
+msgstr[2] "{0} aktualizácie {1} filtrov"
+msgstr[3] "{0} aktualizácie {1} filtrov"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} prejde na {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Správanie po kliknutí pre každý stĺpec"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Prejdite na vlastné miesto určenia"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Otvorte ponuku akcií"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Správanie kliknutí pre {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Vyberte jeden alebo viac filtrov, ktoré chcete aktualizovať"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Uložená otázka"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Odkaz na"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Zadajte adresu URL, na ktorú chcete vytvoriť odkaz"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Hodnotu filtra stĺpca alebo informačného panela môžete vložiť pomocou jeho názvu, napríklad takto: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "napr. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Vyberte informačný panel ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Vyberte otázku ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Vyberte informačný panel, na ktorý chcete vytvoriť odkaz"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Vyberte otázku, na ktorú chcete odkazovať"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Odošlite hodnoty do filtrov tohto informačného panela (voliteľné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Predajte hodnoty do premenných tejto otázky (voliteľné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Predajte hodnoty na filtrovanie tejto otázky (voliteľné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filtre palubnej dosky"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Atribúty používateľa"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Prispôsobiť text odkazu (voliteľné)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. Podrobnosti pre {{Názov stĺpca}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Hodnoty, na ktoré sa môžete odvolávať"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Nie sú k dispozícii žiadne ciele"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "premenná"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Ďalšie dostupné filtre"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Dostupné filtre"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Ďalšie dostupné premenné"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Dostupné premenné"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Ďalšie dostupné stĺpce"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Dostupné stĺpce"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "atribút používateľa"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Textová karta"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Správanie kliknutí"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Možnosti vizualizácie"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Upraviť sériu"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Pridajte sériu"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Po kliknutí"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Zmeňte názov a popis"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Aktualizovali ste vložené parametre a bude potrebné aktualizovať váš kód na vloženie."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Pridať otázku"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Upravujete tento informačný panel."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Stĺpec na filtrovanie"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "zbierka úryvkov"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "zbierky úryvkov"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Pomenujte priečinok"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Niečo krátke, ale sladké"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Priečinok, v ktorom by mal byť tento priečinok"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Otvorte ponuku akcií"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "Stĺpec {0} má vlastné správanie"
+msgstr[1] "{0} stĺpce majú vlastné správanie"
+msgstr[2] "{0} stĺpce majú vlastné správanie"
+msgstr[3] "{0} stĺpce majú vlastné správanie"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Ísť do..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Prejdite na informačný panel"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Choď na otázku"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Prejdite na adresu URL"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filtrovať tento informačný panel"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Vráti počet riadkov vo vybratých údajoch."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Stĺpec alebo číslo, ktoré sa má sčítať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Číselný stĺpec, ktorý získa smerodajnú odchýlku."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Číselný stĺpec, ktorého hodnoty sa majú spriemerovať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Vráti najmenšiu hodnotu nájdenú v stĺpci"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Sčíta zadaný stĺpec iba pre riadky, kde je podmienka splnená."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Vráti číselnú odchýlku pre daný stĺpec."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Teplota"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Stĺpec alebo číslo, na ktoré sa má odchýlka dostať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Vráti strednú hodnotu zadaného stĺpca."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Stĺpec alebo číslo, ktoré chcete získať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "percentilová hodnota"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Vráti hodnotu stĺpca s hodnotou percentilu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Stĺpec alebo číslo, z ktorého chcete získať percentil."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Hodnota percentilu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Vráti reťazec textu malými písmenami."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Stĺpec s hodnotami, ktoré sa majú previesť na malé písmená."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Vráti text napísaný veľkými písmenami."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Stĺpec alebo text, ktorý má vrátiť časť."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Stĺpec alebo text, cez ktorý sa má prehľadávať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Spojte dva alebo viac reťazcov textu dohromady."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Stĺpec alebo text na začiatok."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Toto bude pridané na koniec hodnoty1 atď."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Obrovský"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Obrovský"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Vráti počet znakov v texte."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Stĺpec alebo text, ktorého dĺžku chcete získať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Stĺpec alebo text, ktorý chcete orezať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Vráti absolútnu (kladnú) hodnotu zadaného stĺpca."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Dlh"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Stĺpec alebo číslo, ktoré má vrátiť absolútnu (kladnú) hodnotu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Zaokrúhli desatinné číslo nadol."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Stĺpec alebo číslo na zaokrúhlenie nadol."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Zaokrúhli desatinné číslo nahor."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Stĺpec alebo číslo na zaokrúhlenie nahor."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Zaokrúhli desatinné číslo nahor alebo nadol na najbližšiu celočíselnú hodnotu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "Stĺpec alebo číslo na zaokrúhlenie na najbližšie celé číslo."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Vráti druhú odmocninu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hypotenziu"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Stĺpec alebo číslo, ktoré má vrátiť druhú odmocninu hodnoty."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Zvyšuje číslo na hodnotu exponentovej hodnoty."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Dĺžka"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Stĺpec alebo číslo zvýšené na exponent."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Hodnota exponenta."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Vráti základný 10 protokol čísla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Hodnota"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Stĺpec alebo číslo, ktoré vráti prirodzenú hodnotu logaritmu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Vráti Eulerovo číslo, e, zdvihnuté na hodnotu dodaného čísla."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Úrokové mesiace"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Stĺpec alebo číslo, ktoré vráti exponenciálnu hodnotu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Stĺpec alebo text, ktorý sa má skontrolovať."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Skontroluje hodnoty stĺpca s dátumom alebo číslom, či sú v zadanom rozsahu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Vytvorené v"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Dátum alebo číselný stĺpec, ktorý by mal byť v začiatočnej a konečnej hodnote."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Začiatok rozsahu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Koniec rozsahu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Skontroluje hodnoty stĺpca s dátumom, či sú v relatívnom rozmedzí."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Stĺpec dátumu, ktorý sa má vrátiť."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Obdobie, v ktorom sú záporné hodnoty späť v čase."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Typ interného zdroja, napríklad „deň“, „mesiac“, „rok“."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Stĺpec alebo hodnota, ktorá sa má vrátiť."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Ak je hodnota1 prázdna, hodnota2 sa vráti, ak nie je prázdna, atď."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Testuje výraz proti zoznamu prípadov a vráti zodpovedajúcu hodnotu prvého zodpovedajúceho prípadu s voliteľnou predvolenou hodnotou, ak nie je splnené nič iné."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Hodnota, ktorá sa vráti, ak je splnená predchádzajúca podmienka, atď."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Je neplatné"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Nie null"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Súčet všetkých hodnôt stĺpca.\n"
+"napr. celkový príjem v priebehu času."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Sčítaný počet riadkov.\n"
+"napr. celkový počet predajov v čase."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Prepojené filtre"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Štítok"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Predvolená hodnota"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Žiadne predvolené nastavenie"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Ak to chcete zobraziť, musí byť doména {0} pripojená k aspoň jednému poľu."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Obmedzte možnosti tohto filtra"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Ak máte iný filter informačného panela, môžete obmedziť možnosti, ktoré sú uvedené pre tento filter, na základe výberu toho druhého."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Najprv teda, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "pridať ďalší filter palubnej dosky"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Ak prepnete jeden z týchto filtrov informačného panela, výber hodnoty pre tento filter obmedzí dostupné možnosti filtra {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Filtračný stĺpec"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Filtrovaný stĺpec"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Zadajte používateľské mená alebo e-mailové adresy"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Nový úryvok"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}: 00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "0:00 hod"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}: 00:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Každú hodinu"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Denne o {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Každý týždeň o {0}, {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Mesačne, {0} {1} o {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Odstrániť tento odber"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Predplatné"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Vytvorte predplatné informačného panela"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Pošlite to e-mailom"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Tento informačný panel môžete pravidelne posielať používateľom alebo na e-mailové adresy."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Pošlite to Slackovi"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Vyberte kanál a plán a o zvyšok sa postará Metabáza."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Odošlite e-mailom tento informačný panel"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Ak výsledky nie sú, neposielajte"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Pripojte výsledky"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Prílohy môžu obsahovať až 2 000 riadkov údajov."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Pošlite tento informačný panel spoločnosti Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Informačný panel nemá parameter s ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "S parametrom {0} nie sú spojené žiadne polia"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "zahrnutie musí byť buď prázdne, alebo hodnota „tabuľky“"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "`databáza` sa vyžaduje pre všetky dotazy, ktorých typ nie je ʻvnútorný`."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Prihlasovacie meno je pre túto inštanciu zakázané."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Váš účet je deaktivovaný. Kontaktujte svojho správcu."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Váš účet je deaktivovaný."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Neplatný token rezervácie."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "Príkaz „{0}“ je k dispozícii iba v Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Rozšírenia Metabase Enterprise Edition sú PRÍTOMNÉ."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Používanie funkcií Metabase Enterprise Edition podlieha komerčnej licencii Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Podrobnosti nájdete na {0}."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Rozšírenia Metabase Enterprise Edition NIE SÚ PRÍTOMNÉ."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Ste pozvaní, aby ste sa pripojili k položke {1} používateľa {0}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "Používateľ {0} vytvoril účet {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} prijal (a) svoje pozvanie {1}"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Žiadosť o obnovenie hesla"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Oznámenie"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Pomôžte nám vylepšiť [{1}]."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Povedzte nám, čo sa deje."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Chyba pri spustení poslucháča udalostí"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Mali by sme synchronizovať používateľské atribúty, keď sa niekto prihlási cez LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Zoznam atribútov používateľa oddelených čiarkami, aby sa preskočila synchronizácia pre používateľov LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Neplatný Token"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Chyba Slack API: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Voľný kanál s názvom `metabase_files` chýba!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Vytvorte alebo zrušte archiváciu kanála, aby sa dokončila integrácia Slacku."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Kanál sa používa na ukladanie grafov, ktoré sú obsiahnuté v odpovediach Pulses a MetaBot."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Nahraný obrázok"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Chyba pri nahrávaní súboru na Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Neplatná relácia. Očakávala sa inštancia relácie."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "SameSite súboru cookie relácie je nakonfigurovaný na hodnotu „Žiadne“, ale web je"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "slúžil cez nezabezpečené spojenie. Niektoré prehliadače odmietnu "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookies za týchto podmienok. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Horný priečinok"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ": parametre musia byť postupnosťou máp s kľúčmi String: id"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Neplatné hodnoty čitateľné človekom: hodnoty musia byť postupnosť; každá položka musí byť nulová alebo reťazec"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ": na načítanie musia byť hodnoty: human_readable_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Celková dĺžka hodnôt poľa je> {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "názvy úryvkov nemôžu obsahovať znak „}“ ani začínať medzerami"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Chyba pri vykonávaní dotazu na reťazový filter"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Pole {0} neexistuje."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Nie je možné vyhľadávať podľa netextového poľa {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Udeľovanie povolení pre skupinu {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Odvolávanie povolení pre skupinu {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Neplatné povolenia DB: ak máte prístup na zápis pre natívne dotazy, musíte mať úplný prístup k údajom."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Neplatné povolenia DB: ak máte prístup iba na natívne dotazy, musíte mať aj prístup k údajom."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Zmena povolení z: {0} na: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "kľúče prihlasovacích atribútov musia byť kľúčové slovo alebo reťazec"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Predvolený jazyk pre všetkých používateľov v používateľskom rozhraní Metabázy, systémových e-mailov, impulzov a výstrah."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Používatelia môžu tento predvolený jazyk individuálne prepísať z vlastných nastavení účtu."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Predvolená stránka na zobrazenie používateľa"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Povoliť tomuto pôvodu vložiť úplnú aplikáciu Metabase"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Hodnoty väčšie ako {0} ({1}) nie sú povolené."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Toto nahradí slovo „metabáza“ všade, kde sa objaví."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Toto sú základné farby používané v grafoch a v celej metabázi. Možno bude potrebné aktualizovať prehliadač, aby sa zmeny prejavili."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Najlepšie výsledky dosiahnete, keď použijete súbor SVG s priehľadným pozadím."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "Adresa URL alebo obrázok, ktorý chcete použiť ako favicon."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Povoliť prihlásenie pomocou e-mailu a hesla."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Ovplyvní to napríklad zoskupenie podľa týždňa alebo filtrovanie v dotazoch GUI.\n"
+"  Neovplyvní to dotazy SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Token sa nepodarilo overiť"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Formát tokenu je neplatný."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Chyba pri overovaní tokenu"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Chyba pri filtrovaní podľa poľa {0}: nie je možné analyzovať reťazec {1} na pole {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Chyba pri načítaní podrobností úlohy: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Spúšťa sa úloha synchronizácie pre databázu {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Databázu nie je možné synchronizovať {0}: Databáza neexistuje."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Úloha Aktualizovať hodnoty poľa spustená pre databázu {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Preskočenie aktualizácie, automatické aktualizácie hodnôt poľa sú pre databázu {0} zakázané."

--- a/locales/sv.po
+++ b/locales/sv.po
@@ -28,15 +28,16 @@ msgstr "Utforska denna data"
 msgid "Select a database type"
 msgstr "Välj en databastyp"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Spara"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "För att göra sin magi behöver Metabase skanna din databas. Vi kommer göra detta regelbundet för att hålla data uppdaterat. Ni kan kontrollera intervallen nedan."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Databas synkar"
 
@@ -64,7 +65,7 @@ msgstr "Denna process kontrollerar databasens schema, och är inte dataintensiv.
 msgid "Scan"
 msgstr "Skanna"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Skanna efter filtervärden"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase kan skanna värden i varje databasfält för att tillåta användning checkboxval i dashboards och frågor. Det kan vara en hyfsat dataintensiv process, speciellt om databasen är väldigt stor."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "När ska Metabase automatiskt skanna och cacha fältvärden?"
 
@@ -133,29 +134,31 @@ msgstr "RADERA"
 msgid "in this box:"
 msgstr "här i rutan:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -178,9 +181,9 @@ msgstr "Radera"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -200,8 +203,9 @@ msgstr "Anslutning"
 msgid "Scheduling"
 msgstr "Schemaläggning"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -280,10 +284,10 @@ msgstr "Lägg till databas"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -318,10 +322,8 @@ msgid "Successfully saved!"
 msgstr "Lyckades spara!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Ändra"
@@ -401,26 +403,29 @@ msgstr "Välj en special-typ"
 msgid "Select a target"
 msgstr "Välj mål"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Kolumner"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Kolumn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Synlighet"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Typ"
 
@@ -428,7 +433,7 @@ msgstr "Typ"
 msgid "Current database:"
 msgstr "Vald databas:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Visa ursprungligt schema"
 
@@ -498,7 +503,7 @@ msgstr "Hitta tabell"
 msgid "Schemas"
 msgstr "Scheman"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -515,7 +520,7 @@ msgstr "Lägg till mått"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Definition"
 
@@ -583,35 +588,35 @@ msgstr "Logg"
 msgid "Revision History for"
 msgstr "Versionshistorik"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - Fältinställning"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Där detta fält kommer synas inom Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrera på detta fält"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "När detta fält används i ett filter, vad skall användarna använda för värde att filtrera på?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Ingen beskrivning finns för detta fält ännu"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Ursprungligt värde"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Mappat värde"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Ange värde"
 
@@ -628,31 +633,31 @@ msgid "Custom mapping"
 msgstr "Anpassad mappning"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Okänd mappningstyp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Detta fält är inte en \"främmande nyckel\" eller FK måltabells metadata saknas"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Valt fält är inte en \"främmande nyckel\""
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Visa värden"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Välj att visa orginal värde från databasen, eller välj att visa fältets associerade eller anpassad information."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Välj fält"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Välj en kolumn för visning."
 
@@ -660,16 +665,16 @@ msgstr "Välj en kolumn för visning."
 msgid "Tip:"
 msgstr "Tips:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Du rekommenderas att uppdatera fältnamnen för att säkerställa att de fortfarande stämmer baserat på dina mappningsval"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Sparade fält värden"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kan skanna värdena i detta fält för att aktivera kryssrute-filter i instrumentpaneler och frågor"
 
@@ -696,35 +701,36 @@ msgstr "Radering påbörjad"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Välj en tabell för att se dess schema och lägga till eller redigera metadata."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Namn är obligatoriskt"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Beskrivning är obligatorisk"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Revisionsmeddelande är obligatorisk"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Aggregering krävs"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Ändra ditt mått"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Skapa ditt mått"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Gör förändringar till din metrik och skriv en beskrivande anteckning."
 
@@ -732,46 +738,46 @@ msgstr "Gör förändringar till din metrik och skriv en beskrivande anteckning.
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Du kan skapa sparade mått för att lägga till namngivna mått-alternativ till denna tabell. Sparade mått innehåller typ av sammanslagning, det sammanslagna fältet och ev. några filter du vill lägga till. Till exempel kan du använda detta för att skapa någon som det officiella sättet att räkna ut snittpris i en ordertabell."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Resultat:"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Namnge ditt mått"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Ge ditt mått ett namn så andra kan hitta den."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Något beskrivande, men inte för långt"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Beskriv ditt mått"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Ge ditt mått en beskrivning så att andra användare kan förstå vad det handlar om."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Detta är en bra plats att detaljerat beskriva icke självklara måttregler."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Orsak till ändring"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Skriv ett kort meddelande som beskriver vilka ändringar du gjort och varför de var nödvändiga."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Detta kommer visas i revisionshistoriken för detta mått för att hjälpa alla att komma ihåg varför saker ändrats"
 
@@ -824,6 +830,7 @@ msgstr "Detta kommer att synas i revisionshistoriken för detta segment för att
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -838,8 +845,7 @@ msgid "Re-scan this table"
 msgstr "Åter-skanna denna tabell"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Lägg till"
 
@@ -856,7 +862,7 @@ msgid "Last name"
 msgstr "Efternamn"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Epost-adress"
@@ -865,7 +871,7 @@ msgstr "Epost-adress"
 msgid "Permission Groups"
 msgstr "Behörighetsgrupper"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Gör denna användare till administratör"
 
@@ -962,6 +968,8 @@ msgstr "Radera grupp"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -974,11 +982,12 @@ msgstr "Klart"
 msgid "Group name"
 msgstr "Gruppnamn"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Grupper"
@@ -1087,7 +1096,7 @@ msgstr "Återställ"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Är du säker på att du vill  göra detta?"
 
@@ -1200,7 +1209,7 @@ msgstr "Inga förändingar i rättigheter kommer att göras."
 msgid "You've made changes to permissions."
 msgstr "Du har gjort ändringar i rättigheter."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Rättigheter för denna samling"
 
@@ -1256,6 +1265,7 @@ msgstr "Begränsa åtkomst"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Upphäv åtkomst"
 
@@ -1319,23 +1329,23 @@ msgstr "Utvald samling"
 msgid "View collection"
 msgstr "Visa samling"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Dataåtkomst"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Visa tabeller"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL-frågor"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Visa scheman"
 
@@ -1406,12 +1416,15 @@ msgstr "Skickat!"
 msgid "Clear"
 msgstr "Rensa"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Autentisering"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Server-inställningar"
@@ -1424,6 +1437,7 @@ msgstr "Användar-schema"
 msgid "Attributes"
 msgstr "Egenskaper"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Grupp-schema"
@@ -1495,6 +1509,9 @@ msgid "Add a map"
 msgstr "Lägg till en karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1504,19 +1521,19 @@ msgid "Delete custom map"
 msgstr "Ta bort anpassad karta"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Ta bort"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1614,19 +1631,19 @@ msgstr "Köp ett värdebevis"
 msgid "Enter a token"
 msgstr "Använd ett värdebevis"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Redigera inbäddade objekt"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Mappade grupper"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Skapa en mappning"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1865,18 +1882,27 @@ msgstr "Användarfilter"
 msgid "Check your parentheses"
 msgstr "Kontrollera dina parenteser"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Epost-attribut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Förnamn-attribut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Efternamn-attribut"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Synkronisera grupptillhörigheter"
@@ -1905,59 +1931,59 @@ msgstr "Egna kartor"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Lägg till dina egna GeoJSON-filer för att aktivera olika visningar av kartregioner"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Dela publikt"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Aktivera publik delning"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Delade kontrollpaneler"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Delade frågor"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Inbäddning i andra applikationer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Aktivera inbäddning i andra applikationer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Hemlig nyckel för inbäddning"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Inbäddade kontrollpaneler"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Inbäddade frågor"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Aktivera cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Minsta tid för fråga"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplikator för \"Cache Time-To-Live (TTL) \""
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Maximal cache-storlek"
 
@@ -1999,27 +2025,27 @@ msgstr "Du behöver en administratör för att skapa ett Metabase-konto innan du
 msgid "Sign in with {0}"
 msgstr "Logga in med {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Kontakta en administratör och låt dem återställa ditt lösenord"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Glömt lösenord"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Epost-adressen du använder för ditt Metabase-konto"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Skicka epost om återställning av lösenord"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Kontrollera instruktionerna i din epost för hur du återstället lösenordet."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Logga in i Metabase"
 
@@ -2040,11 +2066,11 @@ msgstr "Logga in"
 msgid "I seem to have forgotten my password"
 msgstr "Jag verkar ha glömt lösenordet"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "begär ny återställning via epost"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Hoppsan, den länken är inte längre giltig"
 
@@ -2053,11 +2079,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Av säkerhetsskäl upphör länkar för återställning av lösenord efter ett tag. Om du fortfarande behöver återställa lösenord kan du {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Nytt lösenord"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Lösenord behöver {0} för att vara data ska vara säkra"
 
@@ -2080,24 +2106,24 @@ msgstr "Bekräfta nytt lösenord"
 msgid "Make sure it matches the one you just entered"
 msgstr "Se till att det matchar det du nyss angav"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Ditt lösenord har återställts."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Logga in med ditt nya lösenord"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Det gick inte att spara"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2107,25 +2133,26 @@ msgstr "Sparat"
 msgid "Ok"
 msgstr "Okej"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Arkivera denna samling?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Instrumentpaneler, samlingar och ögonblicksbilder i denna samling kommer också att arkiveras."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Arkiv"
 
@@ -2250,7 +2277,7 @@ msgstr "Fästnålar"
 msgid "Drag something here to pin it to the top"
 msgstr "Dra något hit för att fästa det högst upp"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2279,6 +2306,7 @@ msgstr "Flytta \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Flytta"
@@ -2314,7 +2342,7 @@ msgid "Some database installations can only be accessed by connecting through an
 "Enabling this is usually slower than a direct connection."
 msgstr "Vissa databas-installationer kan bara kommas åt via en en SSH-server. Detta alternativ ger också ett extra lager av säkerhet när VPN inte finns tillgängligt. Detta alternativ är oftast långsammare än en direktanslutning."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Detta är en stor databas, så låt mig välja när Metabase synkar och skannar"
 
@@ -2353,7 +2381,7 @@ msgstr "För att använda Metabase med detta data måste du aktivera API-åtkoms
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} för att gå till kontrollpanelen om det inte redan är gjort."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Under vilket namn vill du referera till denna databas?"
 
@@ -2469,35 +2497,35 @@ msgstr "Baserat på schemat"
 msgid "A look at your"
 msgstr "En titt på din"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Sök i listan"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Sök via {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr "eller ange ett ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Ange ett ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Ange en siffra"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Ange någon text"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Ingen matchande {0} hittades"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Genom att ta med varje alternativ i ditt sökfilter uppnår du inte så mycket..."
 
@@ -2509,7 +2537,6 @@ msgstr "Något gick fel"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Vi har stött på ett fel. Du kan prova att ladda om sida eller gå tillbaka."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2520,12 +2547,12 @@ msgstr "Vi har stött på ett fel. Du kan prova att ladda om sida eller gå till
 msgid "No description yet"
 msgstr "Ingen beskrivning ännu"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Ny {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Efterfrågad av {0}"
 
@@ -2546,7 +2573,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Återgått till en tidigare revision av {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Revisionshistorik"
@@ -2592,7 +2621,7 @@ msgid "Questions"
 msgstr "Frågor"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Ögonblicksbilder"
 
@@ -2666,52 +2695,69 @@ msgstr "Inte nu"
 msgid "Error:"
 msgstr "Fel:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Söndag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Måndag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Tisdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Onsdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Torsdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Fredag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Lördag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Första"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Sista"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15:e (halvtid)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Dag i månaden"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "Tidszonen i din Metabase"
 
@@ -2765,11 +2811,11 @@ msgstr "Skapa"
 msgid "Create dashboard"
 msgstr "Skapa instrumentpanel"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tabell"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Databas"
 
@@ -2844,9 +2890,9 @@ msgstr "Vad kallas din lista?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2860,15 +2906,16 @@ msgstr "Beskrivning"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Det är valfritt, men till stor hjälp"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Vilken samling ska detta tillhöra?"
 
@@ -2908,11 +2955,11 @@ msgstr "Kontrollpanel arkiv"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Se till att göra ett urval i varje serie, annars kommer inte filtret att fungera i denna lista."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Kontrollpanelen verkar tom."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Lägg till en fråga för att göra den användbar."
 
@@ -2932,7 +2979,7 @@ msgstr "Stäng fullskärmsläge"
 msgid "Enter fullscreen"
 msgstr "Öppna fullskärmsläge"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Sparar..."
@@ -2945,7 +2992,8 @@ msgstr "Lägg till en fråga"
 msgid "Add a question to this dashboard"
 msgstr "Lägg till en fråga till denna kontrollpanel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Lägg till ett filter"
 
@@ -2953,7 +3001,7 @@ msgstr "Lägg till ett filter"
 msgid "Parameters"
 msgstr "Parametrar"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Lägg till en textruta"
 
@@ -2961,7 +3009,7 @@ msgstr "Lägg till en textruta"
 msgid "Move dashboard"
 msgstr "Flytta instrumentpanel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Redigera instrumentpanel"
 
@@ -2985,11 +3033,11 @@ msgstr "Flytta instrumentpanel till..."
 msgid "Dashboard moved to {0}"
 msgstr "Instrumentpanel flyttad till {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Vad vill du filtrera?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Vilken sorts filter?"
 
@@ -3061,20 +3109,22 @@ msgstr "Denna lista har inga fält eller parametrar som kan mappas till denna pa
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Värdena i detta fält överlappar inte värdena i något annat valt fält."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Inga giltiga fält"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Namnet får bara vara max 100 tecken"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Färg krävs"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Vad kallas din instrumentpanel?"
 
@@ -3129,7 +3179,7 @@ msgstr "mottog senaste data från"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Okänd"
 
@@ -3254,9 +3304,10 @@ msgstr "Du har inte tittat på några instrumentpaneler eller frågor nyligen"
 msgid "{0} items selected"
 msgstr "{0} poster valda"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Av-arkivera"
 
@@ -3373,7 +3424,7 @@ msgid "Zip Code"
 msgstr "Postnummer"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Kvantitet"
 
@@ -3406,11 +3457,13 @@ msgid "User"
 msgstr "Användare"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Källa"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Pris"
 
@@ -3443,21 +3496,23 @@ msgid "Subscription"
 msgstr "Prenumeration"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Poäng"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Titel"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -3511,14 +3566,14 @@ msgstr "Metabase kommer aldrig att hämta detta fält. Använd detta för känsl
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Antal"
 
@@ -3526,7 +3581,7 @@ msgstr "Antal"
 msgid "CumulativeCount"
 msgstr "Summerat antal"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3544,19 +3599,19 @@ msgstr "Distinkt"
 msgid "StandardDeviation"
 msgstr "Standardavvikelse"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Genomsnittlig"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3567,13 +3622,13 @@ msgstr "Max"
 msgid "sad sad panda, lexing errors detected"
 msgstr "ledsen panda, stavfel hittades"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} sekund"
 msgstr[1] "{0} sekunder"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minut"
@@ -3614,14 +3669,15 @@ msgstr "Vad vill du hitta?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Rådata"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Summerat antal"
 
@@ -3683,166 +3739,164 @@ msgstr "Sann"
 msgid "False"
 msgstr "Falsk"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Välj longitud-fält"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Ange övre latitud"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Ange vänster longitud"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Ange nedre latitud"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Ange höger longitud"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Är"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Är inte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Är tom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Inte tom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Lika med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Inte lika med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Större än"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Mindre än"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Mellan"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Större än eller lika med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Mindre än eller lika med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Innehåller"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Innehåller inte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Börjar med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Slutar med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Före"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Efter"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Innehåller"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Bara en tabell med raderna i svaret, inga fler moment"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Antal rader"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Totalt antal rader i svaret"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Summan av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Summan av alla värdena i en kolumn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Genomsnitttet av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Genomsnittet av alla värden i en kolumn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Antal distinkta värden av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Antal unika värden i en kolumn jämsides med alla raderna i svaret"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Sammanslagen summa av ..."
 
@@ -3850,7 +3904,7 @@ msgstr "Sammanslagen summa av ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Ökande summa av alla värden i en kolumn. \\n T.ex total intäkt över tid."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Sammanslaget antal rader"
 
@@ -3858,27 +3912,27 @@ msgstr "Sammanslaget antal rader"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Ökande antal rader.\\n T.ex totalt antal försäljningar över tid"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Standardavvikelse över ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Siffra som visar hur mycket värdena i en kolumn avviker bland alla rader i svaret."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Min.värde av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Min.värde av en kolumn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Maxvärde av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Maxvärde av en kolumn"
 
@@ -3894,6 +3948,8 @@ msgstr "gemena"
 msgid "upper case letter"
 msgstr "versaler"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "antal"
@@ -4141,7 +4197,7 @@ msgstr "Hur man definierar mått"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Se data över tid, som en karta eller pivot-tabell för att hjälpa dig förstå trender och förändringar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Anpassad"
 
@@ -4164,7 +4220,7 @@ msgstr "Inbyggd fråga"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "För mera komplicerade frågor kan du skriva din egen SQL eller inbyggda fråga."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Sätt ett förvalt värde..."
 
@@ -4255,7 +4311,7 @@ msgstr "Denna månad"
 msgid "This Year"
 msgstr "Detta år"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Ange ett värde..."
@@ -4265,7 +4321,7 @@ msgid "Enter a default value..."
 msgstr "Ange ett förvalt värde..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ett fel uppstod"
@@ -4523,22 +4579,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Välj frågor som du vill skicka i denna ögonblicksbild"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Epost"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slack-meddelanden"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Skickat"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} kommer att skickas"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Meddelanden"
 
@@ -4610,30 +4674,30 @@ msgstr "Hjälp alla i din grupp att hålla sig ajour med dina data"
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Ögonblicksbilder låter dig skicka data från Metabase via epost eller till Slack enligt angivet tidsschema."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Efter {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Före {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Är tom"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Inte tom"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Alltid"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Tillämpa"
 
@@ -4734,12 +4798,12 @@ msgstr[1] "Visa dessa {0}"
 msgid "Zoom in"
 msgstr "Zooma in"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Anpassat uttryck"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Vanliga mått"
 
@@ -4936,7 +5000,7 @@ msgstr "vanligen"
 msgid "Pick a segment or table"
 msgstr "Välj ett segment eller en tabell"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Välj en databas"
@@ -4997,7 +5061,7 @@ msgstr "Sortera"
 msgid "Row limit"
 msgstr "Radgräns"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Okänt fält"
 
@@ -5005,7 +5069,7 @@ msgstr "Okänt fält"
 msgid "field"
 msgstr "fält"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Matchar"
 
@@ -5030,11 +5094,11 @@ msgstr "Lägg till en gruppering"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Data"
 
@@ -5051,11 +5115,12 @@ msgstr "Visa"
 msgid "Grouped By"
 msgstr "Grupperad på"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Inga"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Denna fråga är skriven i {0}."
 
@@ -5067,7 +5132,7 @@ msgstr "Dölj editor"
 msgid "Hide Query"
 msgstr "Dölj fråga"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Öppna editor"
 
@@ -5075,7 +5140,7 @@ msgstr "Öppna editor"
 msgid "Show Query"
 msgstr "Visa fråga"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Detta mått är inte aktivt. Det går inte längre att använda."
 
@@ -5276,7 +5341,7 @@ msgstr "Tillbaka till senaste körningen"
 msgid "Visualization"
 msgstr "Visualisering"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Ingen beskrivning gjord"
 
@@ -5333,7 +5398,7 @@ msgstr "Kunde inte hitta tabellens beskrivning för att kunna påbörja en ny fr
 msgid "See {0}"
 msgstr "Visa {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Mått-definitioner"
 
@@ -5351,11 +5416,11 @@ msgstr "Antal {0}"
 msgid "See all {0}"
 msgstr "Visa alla {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Segment-definitioner"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Ett fel uppstod när tabellen laddades"
 
@@ -5363,7 +5428,7 @@ msgstr "Ett fel uppstod när tabellen laddades"
 msgid "See the raw data for {0}"
 msgstr "Visa rådata för {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Mer"
 
@@ -5383,6 +5448,8 @@ msgstr "Fältdefinition"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Tänk på detta som att skriva en formel i ett kalkyprogram. Du kan använda siffror, fält i tabellen, matematiska symboler som +, och några funktioner. Så du skulle kunna skriva något i stil med Subtotal - kost."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5450,7 +5517,7 @@ msgstr "falskt"
 msgid "Add filter"
 msgstr "Lägg till filter"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Post"
 
@@ -5569,11 +5636,11 @@ msgstr "Fält att koppla"
 msgid "Filter widget type"
 msgstr "Typ av filterruta"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Obligatorisk?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Förvald värde i filter-ruta"
 
@@ -5585,7 +5652,7 @@ msgstr "Arkivera denna fråga?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Denna fråga kommer att tas bort från instrumentpaneler och ögonblicksbilder som använder den."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Fråga"
 
@@ -5632,7 +5699,7 @@ msgstr "Fälttyp"
 msgid "Select a Foreign Key"
 msgstr "Välj en extern nyckel"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Visa formeln {0}"
 
@@ -6116,22 +6183,24 @@ msgstr "Frågor om detta segment"
 msgid "X-ray this segment"
 msgstr "Genomlys detta segment"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Inloggning"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Sök"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Instrumentpanel"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Ny fråga"
 
@@ -6203,35 +6272,35 @@ msgstr "All insamling är helt anonym"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Insamling kan när som helst slås av i admin-inställningarna."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Om du har fastnat"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "vår start-guide"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "når du med bara ett klick"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Välkommen till Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Det ser ut som allting fungerar. Låt oss nu lära känna dig, samla ihop data och börja hitta svar!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Låt oss komma igång"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Nu är allt klart!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Gå vidare till Metabase"
 
@@ -6483,39 +6552,40 @@ msgstr "Avbryt filter"
 msgid "Pin Map"
 msgstr "Knappnålskarta"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Avmarkera"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Raderna {0}-{1} av {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Datat förkortades till {0} rader."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Kunde inte visa grafiskt"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Kunde inte visa diagrammet med denna data"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Inga resultat!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Väntar fortfarande..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Detta tar oftas ungefär {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "Detta är lite långt för en instrumentpanel"
 
@@ -6625,7 +6695,7 @@ msgid "Highlight the whole row"
 msgstr "Markera hela raden"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Färger"
 
@@ -6711,24 +6781,50 @@ msgstr "Mål"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Såklart! Datat i din fråga passar inte denna visning. Den kräver minst {0} {1} data."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "kolumn"
@@ -6760,7 +6856,7 @@ msgid "xValues missing!"
 msgstr "X-värden saknas!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X-axeln"
 
@@ -6769,7 +6865,7 @@ msgid "Add a series breakout..."
 msgstr "Lägg till en talföljd för utbrytning"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y-axeln"
 
@@ -6782,7 +6878,7 @@ msgid "Bubble size"
 msgstr "Bubbel-storlek"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Linje"
 
@@ -6924,20 +7020,20 @@ msgid "Standard Deviation"
 msgstr "Standardavvikelse"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Area"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "Area-diagram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Stapel"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "Stapeldiagram"
 
@@ -6951,7 +7047,7 @@ msgid "Funnel"
 msgstr "Tratt"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Mätetal"
 
@@ -6963,81 +7059,81 @@ msgstr "Typ av tratt"
 msgid "Bar chart"
 msgstr "Stapeldiagram"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "linje-diagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Välj kolumner för longitud och latitud i diagraminställningarna"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Välj en region-karta"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Välj region- och mått-kolumner i diagraminställningarna"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Karta"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Karttyp"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Regionkarta"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Knappnålskarta"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Knappnålstyp"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Plattor"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Markörer"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Latitud-fält"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Longitud-fält"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Meter-fält"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Region-fält"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Radie"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Suddighet"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Minsta genomskinlighet"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Maximal zoom"
 
@@ -7049,7 +7145,7 @@ msgstr "Hittade inga relationer"
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Denna {0} är kopplad till:"
 
@@ -7061,31 +7157,31 @@ msgstr "Objektdetaljer"
 msgid "object"
 msgstr "objekt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Totalt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Vilka kolumner vill du använda?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Paj"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimension"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Visa teckenförklaring"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Visa procenttal i teckenförklaring"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minsta procenttal i pajdel"
 
@@ -7110,7 +7206,8 @@ msgid "Progress"
 msgstr "Framsteg"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Färg"
@@ -7119,7 +7216,7 @@ msgstr "Färg"
 msgid "Row Chart"
 msgstr "Rad-diagram"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "rad-diagram"
 
@@ -7143,15 +7240,15 @@ msgstr "Lägg till ett suffix"
 msgid "Multiply by a number"
 msgstr "Multiplicera med en siffra"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Spridning"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "spridningspunkt"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Tillämpa pivot på tabell"
 
@@ -7201,13 +7298,13 @@ msgstr "Höger"
 msgid "Show background"
 msgstr "Visa bakgrund"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "behållare {0}"
 msgstr[1] "behållarna {0}"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Automatiskt lagd i behållare"
 
@@ -7443,10 +7540,13 @@ msgstr "Har du ett stort antal frågor sparade i {0}? Skapa samlingar för att h
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7636,7 +7736,7 @@ msgstr "ackumulerad summa"
 msgid "{0} and {1}"
 msgstr "{0} och {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} av {1}"
@@ -8949,11 +9049,11 @@ msgstr "Datarättigheter"
 msgid "Collection permissions"
 msgstr "Samlingsrättigheter"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Visa alla samlingsrättigheter"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Ändra också under-samlingar"
 
@@ -8965,19 +9065,19 @@ msgstr "Kan redigera denna samling och dess innehåll"
 msgid "Can view items in this collection"
 msgstr "Kan visa delar av denna samling"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Tillgång till samling"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Denna grupp har rättighet att visa minst en av delarna i denna samling."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Denna grupp har rättighet att redigera minst en av delarna i denna samling."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Visa under-samlingar"
 
@@ -9033,6 +9133,7 @@ msgstr "Relaterade"
 msgid "More X-rays"
 msgstr "Flera genomlysningar"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9291,10 +9392,10 @@ msgstr "Delning"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9377,7 +9478,7 @@ msgstr "Använd tidszon från JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Vi analyserar tabeller och och fält för att hjälpa dig utforska dina data."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Tips: "
 
@@ -9385,7 +9486,7 @@ msgstr "Tips: "
 msgid "Select a currency type"
 msgstr "Välj en valutatyp"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Fälttyp"
 
@@ -9440,6 +9541,7 @@ msgid "Currency"
 msgstr "Valuta"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Välj en användare eller kanal..."
 
@@ -9601,7 +9703,7 @@ msgstr "Vilken axel?"
 msgid "Line + Bar"
 msgstr "Linje + stapel"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "Linje- och stapeldiagram"
 
@@ -9621,15 +9723,15 @@ msgstr "Räknaromfång"
 msgid "Field to show"
 msgstr "Fält att visa"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "senaste {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} var {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Grupperat på ett tidsfält för att se hur detta har ändrats över tid"
 
@@ -9637,23 +9739,23 @@ msgstr "Grupperat på ett tidsfält för att se hur detta har ändrats över tid
 msgid "Switch positive / negative colors?"
 msgstr "Byta posittiva / negativa färger?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Pivot-kolumn"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Cell-kolumn"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Synliga kolumner"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Villkorad formattering"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Kolumnrubrik"
 
@@ -10091,10 +10193,10 @@ msgstr "Användare per källa"
 msgid "The top external pages that brought users to your site"
 msgstr "De översta externa sidorna som drog användare till din sajt"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Hur [[this]] är fördelat och mer."
 
@@ -10192,13 +10294,13 @@ msgstr "Händelser per timme"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "De 5 högsta [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "De 5 lägsta [[this]]"
 
@@ -10211,10 +10313,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Tomma värden"
 
@@ -10242,8 +10344,8 @@ msgstr "Hur de kan jämföras per säsong"
 msgid "Average income per transaction"
 msgstr "Genomsnittlig förtjänst per transaktion"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] per land"
 
@@ -10367,10 +10469,10 @@ msgstr "En översikt över din [[this]] och hur det fördelas över tid, plats o
 msgid "Average income per state"
 msgstr "Genomsnittlig förtjänst mer stat"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] per [[GenericCategoryMedium]]"
 
@@ -10547,13 +10649,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Hur [[GenericTable]] fördelas över detta tidsfält och om det har skillnader per säsong."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Översikt"
 
@@ -10662,8 +10764,8 @@ msgstr "Här är en närmare titt på din [[this]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Här är en närmare titt på ditt fält [[this]]"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Summering"
 
@@ -10727,10 +10829,10 @@ msgstr "Försäljning per källa"
 msgid "Average income per country"
 msgstr "Genomsnittlig förtjänst per land"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Hur [[this]] är fördelat"
 
@@ -10751,17 +10853,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Antal [[GenericCategoryMedium]] per [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "En titt på din [[this]]"
 
@@ -10827,10 +10929,10 @@ msgid "Transactions per source over time"
 msgstr "Transaktioner per källa över tid"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "Hur [[this]] är fördelat"
 
@@ -10859,9 +10961,9 @@ msgstr "Var dessa händelser sker"
 msgid "Which US states are bringing you the most business."
 msgstr "Vilka amerikanska stater som går bäst."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Hur de kan jämföras över tid"
 
@@ -10966,8 +11068,8 @@ msgstr "Sessioner per land"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Några intressanta mått om dina \"GA stats\" för att komma igång."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] per stat"
 
@@ -11048,12 +11150,12 @@ msgstr "Hur detta mått fördelas över olika siffror"
 msgid "Sessions by page where the session began"
 msgstr "Sessioner per sida där sessionen började"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Distinkta värden"
 
@@ -11116,10 +11218,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Händelser per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Hur de fördelas"
@@ -11425,6 +11527,7 @@ msgstr "Duplicera kontrollpanel"
 msgid "Duplicate \"{0}\""
 msgstr "Duplicera \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11522,9 +11625,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Kvartal"
 msgstr[1] "Kvartal"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "Selektion {0}"
@@ -11547,11 +11650,11 @@ msgstr "Felaktig"
 msgid "Add a time"
 msgstr "Lägg till en tid"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Inget att jämföra för den föregående {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "per {0}"
 
@@ -12039,9 +12142,9 @@ msgstr "Här är en översikt över personerna i din [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] per kvartal"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Hur de kan jämföras mellan platser"
 
@@ -12070,12 +12173,12 @@ msgstr "[[CreateTimestamp]] per veckodag"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Här är en översikt över din [[this]]-data från Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Här är en översikt över din [[this]]"
 
@@ -12153,11 +12256,11 @@ msgstr "samling"
 msgid "collections"
 msgstr "samlingar"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "instrumentpanel"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "instrumentpaneler"
 
@@ -12407,7 +12510,7 @@ msgstr "Timeout efter {0} millisekunder."
 msgid "Misfire Instruction"
 msgstr "Felaktig instruktion"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Arkivera detta?"
 
@@ -12425,7 +12528,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "För att använda detta val krävs att angiven värd är en \"FQDN\". Om du ansluter till ett Atlas-kluster kan du behöva använda detta val. Om du inte vet vad det innebär, aktivera inte detta val."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Kör automatiska frågor för enkla summeringar och filter"
 
@@ -12437,7 +12540,7 @@ msgstr "När detta är aktiverat kommer Metabase att automatiskt köra frågor n
 msgid "Learn about this database"
 msgstr "Lär dig om denna databas"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Arkivera denna instrumentpanel?"
 
@@ -12493,11 +12596,11 @@ msgstr "Anpassad fråga"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Använd den anvancerade editorn för att slå ihop data, skapa anpassade kolumner, utföra beräkningar och mycket mer."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Grundläggande mått"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Anpassad..."
 
@@ -12682,15 +12785,15 @@ msgstr "Välj en visualisering"
 msgid "Filter by"
 msgstr "Filtrerat på"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Summerat på"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Grupperat på"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Lägg till ett mått"
 
@@ -12701,15 +12804,15 @@ msgstr "Lägg till ett mått"
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Detta är normalt ganska snabbt, men det ser ut att ta en stund just nu."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Kombination"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Rad"
 
@@ -13130,7 +13233,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Välj kolumnerna du vill ha med"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "När detta är aktiverat kommer Metabase att automatiskt köra frågor när användare utforskar med summering eller filtrering mot en tabell eller karta. Du kan inaktivera detta om frågorna tar lång tid. Denna inställning påverkar inte nedbrytning eller SQL-frågor."
 
@@ -13196,7 +13299,7 @@ msgstr "Logga in med epost"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "För att använda detta val krävs att angiven värd är en FQDN. Om anslutning till ett Atlas-kluster kan du behöva aktivera detta val. Om du inte vet vad detta betyder bör du inte använda detta alternativ."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Som förval användare Metabase en snabb synkning varje timme och en mera omfattande skanning av fältvärden dagligen. Om du har en stor databas rekommenderar vi att du aktiverar detta och tittar på hur ofta skanningen av fältvärden sker."
 
@@ -13264,11 +13367,11 @@ msgstr "Inkludera inte"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Detta fält kommer inte att visas eller kunna väljas i frågor skapade i guiden. Det kommer fortfarande att vara tillgängligt via SQL- eller interna frågor."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Ackumulerad summa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Standardavvikelse"
 
@@ -13284,19 +13387,19 @@ msgstr "Måste vara minst {0} tecken lång"
 msgid "Name (required)"
 msgstr "Namn (obligatoriskt)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Kör vald text"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Kör fråga"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl+enter)"
 
@@ -13644,7 +13747,7 @@ msgstr "Datum och klockslag"
 msgid "Numbers"
 msgstr "Siffror"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Inga grupper som går att mappa"
 
@@ -13684,15 +13787,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "Kom ihåg mig"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Av säkerhetsskäl upphör länkar för återställning av lösenord att gälla efter ett tag. Om du fortfarande behöver återställa ditt lösenord kan du {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Spara nytt lösenord"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Inga matchande resultat"
 
@@ -13718,26 +13821,26 @@ msgid "or"
 msgstr "eller"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "obligatorisk"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Databastyp"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Detta är en snabb process som letar efter uppdateringar till detta databasschema. För det mesta går det utmärkt att låta detta gå varje timme."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase kan skanna värden i varje fält i denna databas för att aktivera val i dialogrutor. Detta kan ta en del resurser, i synnerhet om du har en väldigt stor databas."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Samling"
 
@@ -13784,7 +13887,7 @@ msgstr "Kategorisk"
 msgid "URLs"
 msgstr "URL:er"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Returnerar genomsnittet av värdena i kolumnen."
 
@@ -13793,11 +13896,13 @@ msgstr "Returnerar genomsnittet av värdena i kolumnen."
 msgid "The column whose values to average."
 msgstr "Kolumnerna att ta genomsnitt ifrån"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "start"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "slut"
 
@@ -13809,21 +13914,19 @@ msgstr "Kontrollerar värdet i ett numeriskt fält eller datumfält för att se 
 msgid "Rating"
 msgstr "Betyg"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "villkor"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "utdata"
 
@@ -13831,27 +13934,27 @@ msgstr "utdata"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Testar en lista över villkor och returnerar motsvarande värde för det första uppfyllda villkoret med ett valfritt förvalt värde om inget annat hittas."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Vikt"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Stor"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Medelstor"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Liten"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Något som ska vara sant eller falskt."
 
@@ -13859,33 +13962,33 @@ msgstr "Något som ska vara sant eller falskt."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Värde som returneras om föregående villkor är uppfyllt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "värde1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "värde2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Tittar på värdena i varje argument i tur och ordning, och returnerar det första icke-tomma värdet för varje rad."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Kommentarer"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Anteckningar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Inga kommentarer"
 
@@ -13901,12 +14004,12 @@ msgstr "Om värde1 är tomt returneras värde2 om det inte är tomt, och så vid
 msgid "Combines two or more strings of text together."
 msgstr "Kombinerar två eller flera texter till en."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Efternamn"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Förnamn"
 
@@ -13918,27 +14021,27 @@ msgstr "värde2 kommer att läggas på slutet av detta."
 msgid "This will be added to the end of value1."
 msgstr "Detta kommer att läggas till slutet av värde1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "sträng1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "sträng2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Kontrollerar om sträng1 innehåller sträng2."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Passerat"
 
@@ -13946,7 +14049,7 @@ msgstr "Passerat"
 msgid "The contents of this string will be checked."
 msgstr "Innehållet i denna sträng kommer att kontrolleras."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Sträng eller text att söka efter."
 
@@ -13954,22 +14057,22 @@ msgstr "Sträng eller text att söka efter."
 msgid "Returns the count of rows in the source data."
 msgstr "Returnerar antalet rader i källdatat."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Bara antal rader där villkoret uppfylls."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Delsumma"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Ackumulerat antal rader över en utbrytning."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "Rullande summa av en kolumn över en utbrytning"
 
@@ -13978,53 +14081,57 @@ msgstr "Rullande summa av en kolumn över en utbrytning"
 msgid "The column to sum."
 msgstr "Kolumnen att summera"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Antalet distinkta värden i denna kolumn."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Kolumnen var distinkta värden ska räknas"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "jämförelse"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Returnerar sant om slutet av texten matchar jämförelse-texten"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Aptit"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hungrig"
 
@@ -14033,20 +14140,20 @@ msgstr "hungrig"
 msgid "A column or string of text to check."
 msgstr "En kolumn eller textsträng att kontrollera"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Textsträngen som ursprunglig text ska sluta med."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "regexp"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Plockar ut matchande del-strängar utifrån en regexp."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adress"
 
@@ -14054,7 +14161,7 @@ msgstr "Adress"
 msgid "The column or string of text to search though."
 msgstr "Kolumnen eller textsträngen att genomsöka."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Matchande regexp."
 
@@ -14066,7 +14173,7 @@ msgstr "Returnerar textsträngen med små bokstäver."
 msgid "The column with values to convert to lowercase."
 msgstr "Kolumnen med värden att konvertera till små bokstäver."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Tar bort inledande blanktecken från en textsträng."
 
@@ -14076,15 +14183,16 @@ msgstr "Tar bort inledande blanktecken från en textsträng."
 msgid "The column with values you want to trim."
 msgstr "Kolumnen vars värden du vill beskära."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Returnerar det största värdet från kolumnen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Ålder"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Den numeriska kolumn vars max-värde du vill hitta."
 
@@ -14092,21 +14200,21 @@ msgstr "Den numeriska kolumn vars max-värde du vill hitta."
 msgid "Returns the smallest value found in the column."
 msgstr "Returnerar det minsta värdet i kolumnen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Lön"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Den numeriska kolumnen vars minsta värde du vill hitta"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "position"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "längd"
 
@@ -14115,7 +14223,7 @@ msgstr "längd"
 msgid "new_text"
 msgstr "ny_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Ersätter en del av indata-texten med ny text."
 
@@ -14143,35 +14251,35 @@ msgstr "Antalet tecken att ersätta."
 msgid "The text to use in the replacement."
 msgstr "Text att använda för ersättning."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Tar bort avslutande blanktecken från en textsträng."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Returnerar procenten av rader i datat som matchar villkoret som ett decimaltal."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Returnerar sant om början av texten matchar jämförelsetexten."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Kursnamn"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Datavetenskap"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Textsträngen som ursprunglig text ska börja med"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Räknar ut standardavvikelsen för kolumnen"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Population"
 
@@ -14179,7 +14287,7 @@ msgstr "Population"
 msgid "A numeric column."
 msgstr "En numerisk kolumn."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Returerar en del av den angivna texten."
 
@@ -14187,19 +14295,19 @@ msgstr "Returerar en del av den angivna texten."
 msgid "The text to return a portion of."
 msgstr "Texten att returnera en del av."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Positionen där tecken ska börja kopieras.."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Antalet tecken att returnera."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Adderar alla värden till kolumnen."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Den numeriska kolumnen som ska summeras."
 
@@ -14207,15 +14315,15 @@ msgstr "Den numeriska kolumnen som ska summeras."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Summera värden i en kolumn där rader matchar villkoret."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Orderstatus"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Giltig"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Tar bort inledande och avslutande blanktecken från en textsträng."
 
@@ -14223,47 +14331,47 @@ msgstr "Tar bort inledande och avslutande blanktecken från en textsträng."
 msgid "Returns the string of text in all upper case."
 msgstr "Returnerar en textsträng med stora bokstäver."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Kolumnen med värden som ska konverteras till stora bokstäver."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "måste vara {0} och innehålla {1}."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "måste vara {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "måste innehålla {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "minst {0} tecken lång"
 msgstr[1] "minst {0} tecken lång"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} liten bokstav"
 msgstr[1] "{0} små bokstäver"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} stor bokstav"
 msgstr[1] "{0} stora bokstäver"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} siffra"
 msgstr[1] "{0} siffror"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} speciellt tecken"
@@ -14286,6 +14394,7 @@ msgid "Powered by {0}"
 msgstr "Byggd på {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Till:"
 
@@ -14373,7 +14482,7 @@ msgstr "Formattering av värden"
 msgid "Full"
 msgstr "Hela"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Ingen ändring sedan {0}"
 
@@ -14698,7 +14807,7 @@ msgstr "Fel när inblick skulle genereras för kolumnen:"
 msgid "Sending abandonment email!"
 msgstr "Skickar övergivelse-mejl"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Du kan skapa sparade mått för att lägga till ett namngivet mått-val. Sparade mått innehåller typ av sammanslagning, det sammanslagna fältet och ev. ytterligare filter du vill lägga till. Till exempel kan du använda detta för att skapa något som det officiella sättet att räkna ut snittpris för en order-tabell."
 
@@ -14706,15 +14815,15 @@ msgstr "Du kan skapa sparade mått för att lägga till ett namngivet mått-val.
 msgid "Select and add filters to create your new segment."
 msgstr "Välj och lägg till filter för att skapa ditt nya segment."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alfanumerisk"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Smart"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Sorteringsordning kolumner: {0}"
 
@@ -14766,7 +14875,7 @@ msgstr "lokalisering"
 msgid "Instance language"
 msgstr "Språk i instansen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Val för lokalisering"
 
@@ -14838,19 +14947,20 @@ msgstr "Klistra in en anslutningssträng"
 msgid "Fill out individual fields"
 msgstr "Fyll i enskilda fält"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Ange någon SQL här så att du kan återanvända det senare."
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Ge din snutt ett namn"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Nuvarande kunder"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Lägg till en beskrivning"
 
@@ -14858,46 +14968,47 @@ msgstr "Lägg till en beskrivning"
 msgid "Use site default"
 msgstr "Använd förval från sajten"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "hitta"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "ersätt"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Text att hitta."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Texten som ska användas som ersättning."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Redigerar {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Skapa din egen snutt"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Arkiverade snuttar"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Snuttar är återanvändbara bitar SQL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Skapa en snutt"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Snuttar"
 
@@ -15176,3 +15287,1499 @@ msgstr "värdet måste vara ett nyckelord eller sträng."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Värdet måste vara ett giltigt två-tecken ISO-språk eller språk-land-kod, t.ex 'en' eller 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Rader {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Granska"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Användarens attribut konfiguration (ej obligatorisk)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Använder {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Sätt upp SAML-baserad SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML Autentisering"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Konfigurera din identitetstillhandahållare (idP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Din identitetstillhandahållare kommer begära följande information om Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URLen som din idP skall dirigera tillbaka till"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Detta kallas \"Single Sign On URL\" i Okta, applikationens callback-URL i Auth0, och \"ACS (Consumer) URL\" i OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "För de flesta IdP:er behöver du sätta var och en av dessa i en frågeruta kallad \"Name\" i attribut-delen."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Användarens e-post attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Användarens förnamns attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Användarens efternamns attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Berätta för Metabase om din identitetstillhandahållare."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase kommer behöva följande information om din identitetstillhandahållare."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML identitetstillhandahållarens URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "SAML identitetstillhandahållarens certifikat."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML applikations namn"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Signera SSO anrop (inte obligatoriskt)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML nyckelgenväg."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "SAML nyckellösenord."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Shh..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML nyckel alias"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Syncronizera grupp tillhörigheten med din SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "För att tillhandahålla detta behöver du skapa mappningar för att beskriva för Metabase vilken grupp(er) dina användare skall adderas till baserat på vilken SSO-grupp de befinner sig i."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Gruppnamn"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Gruppens attributnamn"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Notering:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Om du ändrar någon av inställningarna på en existerande och aktiv SAML koppling, så kommer du behöva starta om Metabase för att dom ska användas."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Tillåt användare att logga in via en SAML Identity Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Tillåt användare att logga in via en JWT Identity Provider."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Aktivera lösenordsautentisering"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "När den är aktiverad kan användare också logga in med epost och lösenord."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Informera admin-användare om nya SSO-användare"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "När den är aktiverad kommer administratörer att få epost första gången en användare loggar in med Single Sign-On."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Använd inställningarna nedan för att konfigurera din SSO via SAML. Om du har några frågor, se vår {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "dokumentation"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML Identity Provider URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT-autentisering"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT Identity Provider URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Textsträng som används av JWT signing key"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Inbäddning av hela Metabase-appen"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Om du vill inbädda hela Metabase, ange ursprunget till webbsajterna eller web-apparna där du vill tillåta inbäddning i en iframe separerade av mellanslag. Här är {0} för det som kan anges."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Tillåt sandbox-access till denna tabell"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "När användare i denna grupp tittar på denna tabell kommer de att se en version som filtrerats av deras användarattribut, eller en anpassad vy av den baserad på en sparad fråga."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Hur vill du filtrera denna tabell för användare i denna grupp?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Välj en sparad fråga som returnerar den anpassade vyn för tabellen som användarna ska se."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Du kan också lägga till ytterligare filter här baserade på användar-attributen. Dessa filter kommer att aktiveras ovanpå de ev. filter som redan finns i denna sparade fråga."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "För att detta ska fungera behöver dina användare ha några attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "För att lägga till ytterligare filter behöver dina användare ha några attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Inga användar-attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Välj en användares attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Välj en parameter"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Välj en kolumn"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Användare i {0} kan se"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "rader fråga {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "rader i tabellen {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "där {0} är lika med {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "och {0} är lika med {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Du kan lägga till attribut automatiskt genom att sätta upp en SSO som använder SAML, eller så kan du ange dem manuellt genom att gå till Människor och klicka på menyn ... längst till höger."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Användar-attribut"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Vi kan automatiskt få din användares attribut om du satt upp SSO, eller så kan du ange dem manuellt från menyn \"...\" i avdelningen Människor under Admin."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parameter eller variabel"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "är lika med"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Tillåt sandboxed-access"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Sandboxed-access"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Redigera sandbox-access"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Redigera mappdetaljer"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Ändra rättigheter"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Skapa din nya mapp"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Ny mapp"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Vi har problem med att validera din biljett"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Dubbelkolla att din instans kan ansluta till Metabase servrar"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Få hjälp"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Få ut mera av Metabase med Enterprise-versionen"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Alla de verktyg du behöver för att snabbt och enkelt göra rapporter till dina kunder eller hjälpa dig att köra och övervaka Metabase i en stor organisation"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Aktivera en licens"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Din provperiod är aktiv med dessa funktioner"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Provperioden avslutas {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Behöver du hjälp? Redo att köpa?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Prata med oss"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Din provperiod är slut"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Behöver du mer tid? Redo att köpa?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Dina funktioner är aktiverade!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Din licens är giltig till {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Din licens är ogiltig"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Den gick ut den {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Vill du förnya din licens?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Lär dig hur man använder detta"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Ingår inte i ditt nuvarande upplägg"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Ange den biljett du fick från affären"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Aktivera"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Behöver du hjälp?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Mer information om ditt problem"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Kontakta supporten"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Data-sandboxar"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Säkerställ att du visar rätt personer rätt data med automatiska och säkra filter baserade på användar-attribut."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Vit-listning"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Matcha Metabase till ditt varumärke med anpassade färger, din egen logga mm."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Granskning"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Håll ett öga på prestanda och uppförande med robusta verktyg för granskning."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Single sign-on"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Ger en enkel inloggning som fungerar med din befintliga struktur för autentisering."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Affär"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Applikationsnamn"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Färgkarta"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logga"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favorit-ikon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Slutsida"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Inga grupper"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Rättigheter för {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Rättigheter för denna mapp"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Ge tillåtelse att redigera"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Kan ändra i snuttar i denna mapp"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Ge tillåtelse att se"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Kan lägga in och använda snuttar i denna mapp, men kan inte redigera den SQL de innehåller"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Kan inte visa eller lägga in snuttar i denna mapp"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Också ändra undermappar"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Första dagen i veckan"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Ett problem uppstod vid inloggning med Google. Kontakta en administratör."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "på"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "vid"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Öppna menyn för Metabase-åtgärder"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Gör ingenting"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Gå till en vald destination"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Uppdatera filter för en instrumentpanel"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} uppdatering filter {1}"
+msgstr[1] "{0} uppdateringar filter {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} går till {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Beteende vid klick för varje kolumn"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Gå till förvald destination"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Öppna val-menyn"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Beteende vid klick för {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Välj ett eller flera filter att uppdatera"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Sparad fråga"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Länka till"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Ange en URL att länka till"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Du kan ange värdet på ett filter från en kolumn eller instrumentpanel genom att använda dess namn, så här: {{någon_kolumn}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "t.ex http://minsajt.se/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Välj en instrumentpanel"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Välj en fråga"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Välj en instrumentpanel att länka till"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Välj en fråga att länka till"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Skicka värdena för denna instrumentpanels filter (valfritt)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Skicka värden till denna frågas variabler (valfritt)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Skicka värden till för att filtrera denna fråga (valfritt)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Filter för instrumentpanel"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Användar-attribut"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Anpassa länktext (valfritt)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "T.ex detaljer för {{Column Name}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Värden du kan referera till"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Inga tillgängliga mål"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "variabel"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Andra tillgängliga filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Tillgängliga filter"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Andra tillgängliga variabler"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Tillgängliga variabler"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Andra tillgängliga kolumner"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Tillgängliga kolumner"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "användar-attribut"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Lista med text"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Uppförande vid klick"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Visuella val"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Redigera serier"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Lägg till serier"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Vid klick"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Ändra titel och beskrivning"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Du har uppdaterat inbäddade parametrar och beöhver uppdatera din inbäddade kod."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Lägg till fråga"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Du redigerar denna kontrollpanel"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Kolumn att filtrera"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "samling snuttar"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "samlingar av snuttar"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Ge din mapp ett namn"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Något kort och bra"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Mapp denna ska ligga i"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Öppna val-menyn"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "kolumnen {0} har anpassningar"
+msgstr[1] "kolumnerna {0} har anpassningar"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Gå till..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Gå till instrumentpanel"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Gå till fråga"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Gå till URL"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Filtrera denna instrumentpanel"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Returnerar antalet rader från valt data."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Kolumn eller siffra att summera."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Den numeriska kolumnen att få standardavvikelse från"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Den numeriska kolumnen för genomsnittsvärde"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Returnera det minsta värdet i kolumnen"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Summera de angivna kolumnerna bara för rader där villkoret uppfyllts"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Returnera numerisk varians för en angiven kolumn"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Temperatur"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Kolumn eller siffra att få variansen från"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Returnerar median-värdet för den angivna kolumnen"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Kolumnen eller värdet att få median från"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "percentil-värde"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Returnerar värdet från kolumnen vid percentil-värdet"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Kolumen eller siffra att få percentil från"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Värdet av percentilen"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Returnerar textsträngen med små bokstäver"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Kolumnen med värden att konvertera till gemena."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Returnerar texten med stora bokstäver"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Kolumnen eller texten att returnera den del av"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Kolumnen eller texter att genomsöska"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Slå ihop två eller flera textsträngar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Kolumnen eller texten att börja med."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Detta kommer att läggas på slutet av värde 1 och så vidare."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Enorm"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Gigantisk"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Returnerar antalet tecken i texten."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Kolumnen eller texten du vill få längden av."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Kolumnen eller texten du vill rensa från avslutande blanktecken."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Returnerar det absoluta värdet av angiven kolumn."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Debet"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Kolumnen eller siffran att returnera absoluta värdet av."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Avrundar ett decimaltal neråt."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Kolumnen eller siffran att avrunda neråt."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Avrundar ett decimaltal uppåt."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Kolumnen eller siffran att avrunda uppåt."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Avrundar ett decimaltal upp eller ner till närmaste heltal."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "Kolumnen eller siffran att avrunda till närmaste heltal."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Returnerar kvadratroten ur."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hypotenusa"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Kolumnen eller siffran att returnera kvradratroten ur."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "exponent"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Upphöjer en siffra till exponentvärdet"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Längd"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Kolumnen att upphöja"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Värdet på exponenten"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Returnerar 10-logaritmen för värdet."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Värde"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Kolumnen eller siffra att returnera naturliga logaritmen från"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Returnera Eulers värde e upphöjt med angivet värde"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Räntemånader"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Kolumnen eller siffran att returnera det exponentiella värdet från."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Kolumnen eller texten som ska kontrolleras.."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Kontrollerar en datum- eller sifferkolumns värde för att se om det ligger inom angivet intervall."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Skapad"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Datum- eller sifferkolumn som ska ligga inom start- och slutvärdena"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Start-värde."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Slut-värde."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Kontrollerar en datum-kolumns värden för att se om de ligger inom det relativa intervallet."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Datum-kolumnen att returnera intervall ifrån"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Period för intervall där negativa värden är tillbaka i tiden"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Intern typ som \"dag\", \"månad\", \"år\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Kolumnen eller värdet att returnera."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Om värde 1 är tomt returneras värde 2 om det inte är tomt, och så vidare."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Testar ett uttryck mot en lista av fall och returnerar det motsvarande värdet för den förstas matchningen, eventuellt med ett förvalt värde om matchning saknas."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Värde som kommer att returneras om föregående krav är uppfyllt och så vidare."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Är tomt"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Är inte tomt"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Ökande summa av alla värden i en kolumn, t.ex total intäkt över tid."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Ökande antal av antalet rader, t.ex totalt antal försäljningar över tid."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Länkade filter"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Etikett"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Förvalt värde"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Inget förvalt"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "För att se detta måste {0} vara kopplat till minst ett fält."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Begränsa detta filters val"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Om du har ett annat instrumentpanel-filter kan du begränsa de val som visas för detta filter baserat på det andra filtret."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Så först, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "lägg till ytterligare instrumentpanel-filter"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Om du aktiverar ett av dessa instrumentpanel-filter kommer ett valt värde för detta filter att begränsa tillgängliga val för filter {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Kolumn för filter"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Filtrerad kolumn"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Ange användarnamn eller epost-adresser"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Ny snutt"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 PM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Varje timme"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Dagligen vid {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Veckovis vid {0} på {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Månadsvis den {0} {1} på {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Ta bort denna prenumeration"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Prenumerationer"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Skapa prenumeration på en instrumentpanel"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Skicka  som epost"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Du kan skicka denna instrumentpanel regelbundet till användare eller epost-adresser."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Skicka den till Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Välj kanal och schemaläggning så kommer Metabase att göra resten."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Skicka denna instrumentpanel som epost"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Skicka inte om resultat saknas"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Bifoga resultat"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Bilagor kan innehålla upp till 2000 rader data."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Skicka denna instrumentpanel till Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Instrumentpanelen har ingen parameter med ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Parameter {0} är inte kopplad till några fält"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include måste vara antingen tomt eller värdet 'tables'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "'database' krävs för alla frågor som inte är av typen 'internal'."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Inloggning med lösenord är inaktiverat för denna installation."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Ditt konto är inaktiverat. Kontakta din administratör."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Ditt konto är inaktiverat."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Felaktig Slack-biljett."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "Kommandot \"{0}\" är bara tillgängligt i Enterprise-versionen av Metabase."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Tillägg för Metabase Enterprise-versionen är aktiverade."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Användning av tillägg för Metabase Enterprise-versionen styrs av Metabase Commercial License."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Se {0} för detaljer."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Tillägg för Metabase Enterprise-versionen är INTE AKTIVERADE."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Du är välkommen att gå med i {0}s {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} skapade ett {1}-konto"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} accepterade inbjudan från {1}"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Begäran om återställning lösenord"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "Notifiering [{0}]"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Hjälp till att förbättra [{1}]."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Berätta för oss hur det går"
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Fel uppstod när \"events listener\" skulle startas"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Ska vi synka användar-attributen med någons inloggningar via LDAP?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Komma-separerad lista över användar-attribut för att skippa synkning för LDAP-användare."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Felaktig biljett"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "API-fel i Slack: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Slack-kanalen \"metabase_files\" saknas!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Skapa eller hämta kanalen från arkiv för att fullfölja integrationen med Slack"
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Kanalen som används för att spara grafer som finns med i ögonblicksbilder och MetaBot-svar."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Ladda upp bild"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Fel vid uppladdning till Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Ogiltig session. Förväntade en instans av Session."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "Session-cookies för SameSite är konfigurera som \"None\", men sajten är"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "levereras över en osäker förbindelse. Några webbläsare kommer inte att acceptera "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookies under dessa omständigheter. "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Översta mappen"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":parameters måste vara en följd av kartor med String :id-nycklar"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Felaktigt human-readable-values: värdena måste vara en följd, där varje värde måste vara tomt eller en sträng"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":värden måste finnas för att hämta :human_readable_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Fältvärdens totala längd är > {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "Snutt-namn kan inte innehålla '}' eller börja med blanktecken"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Fel vid körning av fråga med länkade filter"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Fält {0} finns inte."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Kan inte söka i icke-text-fält {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Ger rättigheter för grupp {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Återkallar rättigheter för grupp {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Felaktiga databasrättigheter. Om du har tillåtelse att skriva inbyggda frågor måste du ha full databasrättighet."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Felaktiga databasrättigheter. Om du har tillåtelse att se inbyggda frågor måste du också ha tillgång till data."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Ändrar rättigheter från {0} till {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "attribut-nycklar för login måste vara nyckelord eller sträng"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Förvalt språk för alla användare av Metabase, epostadresser för system, ögonblicksbilder och notifieringar."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Användare kan var och en ändra detta språk i deras egna konto-inställningar"
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Förvald sida att visa en användare"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Tillåt denna källa att bädda in hela Metabase-applikationen"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Värden större än {0} ({1}) tillåts inte"
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Detta kommer att ersätta ordet Metabase där det förekommer."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Detta är de primära färgerna som används i grafer och i hela Metabase. Du man behöva ladda om sidan i webbläsaren för att se ändringarna."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "För bästa resultat, använd en SVG-fil med genomskinlig bakgrund."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "Url:en eller bilden som du vill använda som favorit-ikon."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Tillåt inloggning med epost och lösenord."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Detta kommer att påverka sådant som gruppering på vecka eller filtrering via grafiska frågor. Det kommer inte att påverka SQL-frågor."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Kan inte validera biljetten"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Biljettens format är ogiltigt."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Fel vid validering av biljett"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Fel vid filtrering mot fältet {0}. Kunde inte tolka sträng {1} till en {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Fel vid hämtning av detaljerna för jobb {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Påbörjar synkning för databas {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Kan inte synka databasen {0}. Databasen finns inte."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Uppdatering av fältvärden triggad för databas {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Skippar uppdatering - automatiska uppdateringar av fältvärden är inte aktiverat för databas {0}."

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -28,15 +28,16 @@ msgstr "Bu verilere göz at"
 msgid "Select a database type"
 msgstr "Veritabanı türü seçin"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Kaydet"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Metabase veritabanınızı taramak zorundadır. Metadata'yı güncel tutmak için periyodik olarak yeniden taramaları sürdüreceğiz. Periyodik taramaların ne zaman gerçekleşeceğini kontrol edebilirsiniz."
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Veritabanı senkronize ediliyor"
 
@@ -64,7 +65,7 @@ msgstr "Bu veritabanı şemasını güncelleyen, çok işlemci gücü istemeyen 
 msgid "Scan"
 msgstr "Tara"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Filtre Değerleri Taranıyor"
 
@@ -76,7 +77,7 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase , kontrol panelindeki onay kutu filtrelerini etkinleştirmek için veritabanındaki her alanda bulunan değerleri tarayabilir.\n"
 "Eğer büyük bir veritabanınız varsa bu süreç biraz yoğun olabilir."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase alan değerlerini otomatik olarak taramayı ve önbelleğe almayı ne zaman yapmalıdır?"
 
@@ -134,29 +135,31 @@ msgstr "SİL"
 msgid "in this box:"
 msgstr "Bu kutuda:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -179,9 +182,9 @@ msgstr "Sil"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -201,8 +204,9 @@ msgstr "Bağlantı"
 msgid "Scheduling"
 msgstr "Zamanlama"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -281,10 +285,10 @@ msgstr "Veritabanı ekle"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -319,10 +323,8 @@ msgid "Successfully saved!"
 msgstr "Başarıyla kaydedildi!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Düzenle"
@@ -401,26 +403,29 @@ msgstr "Özel bir tip seçiniz"
 msgid "Select a target"
 msgstr "Bir hedef seç"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Sütunlar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Sütun"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Görünürlük"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Tip"
 
@@ -428,7 +433,7 @@ msgstr "Tip"
 msgid "Current database:"
 msgstr "Güncel veritabanı:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Orjinal şemayı göster"
 
@@ -498,7 +503,7 @@ msgstr "Tablo bul"
 msgid "Schemas"
 msgstr "Şemalar"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -515,7 +520,7 @@ msgstr "Metrik Ekle"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Açıklamalar"
 
@@ -583,35 +588,35 @@ msgstr "Tarihçe"
 msgid "Revision History for"
 msgstr "Revizyon Geçmişi için"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} –Alan Ayarları"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Bu alanın Metabase de nerede görüneceği"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Bu alanda filtreleme"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Bu alan filtrede kullanıldığında, insanların filtrelemek istedikleri değeri girmek için ne kullanmaları gerekir?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Bu alan için henüz açıklama yok"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Orjinal değer"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Eşlenen değer"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Değeri girin"
 
@@ -628,31 +633,31 @@ msgid "Custom mapping"
 msgstr "Özel eşleşme"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Tanınmayan eşleşme türü"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Geçerli alan yabancı anahtar değil veya hedef tablosundaki yabancı anahtar verileri eksik"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Seçilen alan yabancı anahtar değildir"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Ekran değerleri"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Orijinal değeri veritabanından göstermeyi seçin, veya bu alanın ilişkili veya özel bilgileri gösterilmesini sağlayın"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Bir alan seç"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Lütfen ekran için kullanılacak bir sütun seçin."
 
@@ -660,16 +665,16 @@ msgstr "Lütfen ekran için kullanılacak bir sütun seçin."
 msgid "Tip:"
 msgstr "Tavsiye:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Yaptığınız yeni seçimlerin mantıklı olduğundan emin olmak için alan adını güncellemek isteyebilirsiniz."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Önbelleğe alınmış alan değerleri"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase, kontrol paneli filtrelerinde ve sorgularda onay kutu filtrelerini etkinleştirmek için bu alanın değerlerini tarayabilir."
 
@@ -696,35 +701,36 @@ msgstr "Tetik atın!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Şemasını görmek ve meta verileri eklemek veya düzenlemek için herhangi bir tablo seçin."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "İsim gerekli"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Açıklama gerekli"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Revizyon mesajı gerekli"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Toplama gerekli"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Metriğini düzenle"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Metriğini oluştur"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Metriğinizde değişiklikler yapın ve açıklayıcı bir not ekleyin."
 
@@ -732,46 +738,46 @@ msgstr "Metriğinizde değişiklikler yapın ve açıklayıcı bir not ekleyin."
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Bu tabloya adlandırılmış bir metrik seçeneği eklemek için kayıtlı metrikler oluşturabilirsiniz. Kayıtlı metrikler, toplama türünü, toplanmış alanı ve isteğe bağlı olarak eklediğiniz herhangi bir filtreyi içerir. Örnek olarak, bir Siparişler tablosu için \"Ortalama Fiyat\" hesaplamasını oluşturmak için bu oluşturduğunuz metrikleri kullanabilirsiniz."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Sonuç:"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Metriğini adlandır"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Başkalarına yardımcı olmak için metriğinize bir isim verin."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Açıklayıcı bir şey ama çok uzun değil"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Metriğini tanımla"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Metriğinize başkalarının ne ile ilgili olduğunu anlamasına yardımcı olmak için  bir açıklama verin."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Daha az belirgin metrik kuralları hakkında daha spesifik olmak için iyi bir yer"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Değişiklik Nedeni"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Yaptığınız değişiklikleri ve neden gerekli olduklarını açıklamak için bir not bırakın."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Bu, metriklerin revizyon geçmişinde herkesin neden değiştiğini hatırlamasına yardımcı olacak."
 
@@ -824,6 +830,7 @@ msgstr "Neden değiştiğini hatırlamalarını yardımcı olmak için bu segmen
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -838,8 +845,7 @@ msgid "Re-scan this table"
 msgstr "Bu tabloyu yeniden tara"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Ekle"
 
@@ -856,7 +862,7 @@ msgid "Last name"
 msgstr "Soyisim"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "E-posta adresi"
@@ -865,7 +871,7 @@ msgstr "E-posta adresi"
 msgid "Permission Groups"
 msgstr "İzin grupları"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Bu kullanıcıyı yönetici yap"
 
@@ -962,6 +968,8 @@ msgstr "Grubu Kaldır"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -974,11 +982,12 @@ msgstr "Tamam"
 msgid "Group name"
 msgstr "Grup adı"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Gruplar"
@@ -1089,7 +1098,7 @@ msgstr "Sıfırla"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Bunu yapmak istediğine emin misin?"
 
@@ -1202,7 +1211,7 @@ msgstr "İzinlerde değişiklik yapılmayacak."
 msgid "You've made changes to permissions."
 msgstr "İzinlerde değişiklik yaptınız."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Bu koleksiyon için izinler"
 
@@ -1258,6 +1267,7 @@ msgstr "Lİmit erişimi"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Erişimi iptal et"
 
@@ -1321,23 +1331,23 @@ msgstr "Koleksiyonu ayarlayın"
 msgid "View collection"
 msgstr "Koleksiyonu görüntüle"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Veri Erişimi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Tabloları görüntüle"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL Sorguları"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Şemaları görüntüle"
 
@@ -1408,12 +1418,15 @@ msgstr "Gönderildi!"
 msgid "Clear"
 msgstr "Anlaşılır"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Doğrulama"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Sunucu Ayarları"
@@ -1426,6 +1439,7 @@ msgstr "Kullanıcı Şeması"
 msgid "Attributes"
 msgstr "Nitelikler"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Grup Şeması"
@@ -1497,6 +1511,9 @@ msgid "Add a map"
 msgstr "Harita ekle"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1506,19 +1523,19 @@ msgid "Delete custom map"
 msgstr "Özel haritayı sil"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Kaldır"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1616,19 +1633,19 @@ msgstr "Bir token al"
 msgid "Enter a token"
 msgstr "Bir tokene girin"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Eşlemeleri Düzenle"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Grup Eşlemeleri"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Bir eşleştirme oluşturma"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1740,7 +1757,7 @@ msgstr "Yardım İstekleri için E-posta Adresi"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Report Timezone"
-msgstr "Saat Dilimini Bildir"
+msgstr "Raporlama Saat Dilimi"
 
 #: frontend/src/metabase/admin/settings/selectors.js:72
 msgid "Database Default"
@@ -1867,18 +1884,27 @@ msgstr "Kullanıcı filtresi"
 msgid "Check your parentheses"
 msgstr "Parantezlerinizi kontrol edin"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Email özelliği"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "İsim niteliği"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Soyisim niteliği"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Grup üyeliklerini senkronize et"
@@ -1907,59 +1933,59 @@ msgstr "Özel Haritalar"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Farklı bölge haritası görselleştirmelerini etkinleştirmek için kendi GeoJSON dosyalarınızı ekleyin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Genel Paylaşım"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Genel Paylaşımı Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Paylaşılan Panolar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Paylaşılan Sorular"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Diğer Uygulamalarda Yerleştirme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Metabase'i Diğer Uygulamalara Yerleştirme özelliğini Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Gizli anahtarı yerleştirme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Yerleşmiş Panolar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Yerleşmiş Sorular"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Önbellek Ayarları"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Önbelleğe almayı etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Minimum Sorgu Süresi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Önbellek Zaman-Canlı (TTL) çarpanı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Maksimum Önbellek Giriş Boyutu"
 
@@ -2001,27 +2027,27 @@ msgstr "Google'a giriş  yapmadan önce , Metabase hesabı oluşturmak için bir
 msgid "Sign in with {0}"
 msgstr "{0} ile giriş yapın"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Lütfen şifrenizi sıfırlamak için bir yöneticiye başvurun"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Parolamı unuttum"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Metabase hesabınız için kullandığınız e-posta"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Şifre sıfırlama e-postası gönder"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Şifrenizi nasıl sıfırlayacağınızla ilgili talimatlar için e-postanızı kontrol edin."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Metabase oturumu açın"
 
@@ -2042,11 +2068,11 @@ msgstr "Oturum aç"
 msgid "I seem to have forgotten my password"
 msgstr "Galiba şifremi unuttum"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "yeni bir sıfırlama e-postası iste"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Whoops, bağlantı geçerlilik süresi doldu"
 
@@ -2055,11 +2081,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Güvenlik nedeniyle, şifre sıfırlama bağlantıları bir süre sonra sona erer. Hala şifrenizi sıfırlamanız gerekiyorsa, {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Yeni Şifre"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Verilerinizi güvende tutmak için, şifreler {0}"
 
@@ -2082,24 +2108,24 @@ msgstr "Yeni şifreyi onayla"
 msgid "Make sure it matches the one you just entered"
 msgstr "Az önce girdiğiniz şifre ile eşleştiğinden emin olun."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Şifreniz sıfırlandı."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Yeni şifrenizle giriş yapın"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Kayıt başarısız"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2109,25 +2135,26 @@ msgstr "Kaydedildi"
 msgid "Ok"
 msgstr "Tamam"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Bu koleksiyonu arşivlediniz mi?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Bu koleksiyondaki panolar, koleksiyonlar ve bildirimler arşivlenecektir."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Arşiv"
 
@@ -2252,7 +2279,7 @@ msgstr "İğneler"
 msgid "Drag something here to pin it to the top"
 msgstr "Üstüne sabitlemek için buraya bir şey sürükleyin"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2281,6 +2308,7 @@ msgstr "\"{0}\" taşı?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Taşı"
@@ -2318,7 +2346,7 @@ msgstr "Bazı veritabanı kurulumlarına sadece bir SSH bastion ana bilgisayarı
 "Bu seçenek ayrıca bir VPN mevcut olmadığında ekstra bir güvenlik katmanı sağlar.\n"
 "Bunu etkinleştirmek genellikle doğrudan bir bağlantıdan daha yavaştır."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Bu büyük bir veritabanıdır, bu yüzden Metabase senkronize edip tarama yaparken benim seçmeme izin ver"
 
@@ -2357,7 +2385,7 @@ msgstr "Metabase'i  bu verilerle kullanmak için Google Developers Console'da AP
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "Daha önce yapmadıysanız {0} konsoluna gitmek için."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Bu veritabanına nasıl başvurmak istersiniz?"
 
@@ -2473,35 +2501,35 @@ msgstr "Şemaya göre"
 msgid "A look at your"
 msgstr "Ya bir bakiş"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Listeyi ara"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "{0} ile ara"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " veya bir kimlik girin"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Bir kimlik girin"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Bir numara giriniz"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Bir metin girin"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Eşleşen {0} bulunamadı."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Filtrenizdeki her seçeneği eklemek muhtemelen pek bir şey yapmaz…"
 
@@ -2513,7 +2541,6 @@ msgstr "Bir şeyler ters gitti"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Bir hatayla karşılaştık. Sayfayı yenilemeyi deneyebilir veya sadece geri dönebilirsiniz."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2524,12 +2551,12 @@ msgstr "Bir hatayla karşılaştık. Sayfayı yenilemeyi deneyebilir veya sadece
 msgid "No description yet"
 msgstr "Henüz bir açıklama yok"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "Yeni {0}"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "{0} tarafından soruldu"
 
@@ -2550,7 +2577,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Önceki bir revizyona ve {0} ye  geri alındı"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Revizyon Geçmişi"
@@ -2596,7 +2625,7 @@ msgid "Questions"
 msgstr "Sorular"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Bildirimler"
 
@@ -2670,52 +2699,69 @@ msgstr "Şimdi değil"
 msgid "Error:"
 msgstr "Hata:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Pazar"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Pazartesi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Salı"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Çarşamba"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Perşembe"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Cuma"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Cumartesi"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "İlk"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Son"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15nci (Orta)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Takvim Günü"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "Metabase saat diliminiz"
 
@@ -2769,11 +2815,11 @@ msgstr "Oluştur"
 msgid "Create dashboard"
 msgstr "Dashboard oluştur"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Tablo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Veritabanı"
 
@@ -2848,9 +2894,9 @@ msgstr "Kartınızın adı nedir?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2864,15 +2910,16 @@ msgstr "Açıklama"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "O isteğe bağlı ama, çok yararlı"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Bu hangi koleksiyonda olmalı?"
 
@@ -2912,11 +2959,11 @@ msgstr "Arşiv Paneli"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Her seri için seçim yaptığınızdan emin olun, veya filtre bu kartta çalışmaz."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Bu gösterge paneli boş görünüyor."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Kullanmaya başlamak için bir soru ekleyin!"
 
@@ -2936,7 +2983,7 @@ msgstr "Tam ekrandan çık"
 msgid "Enter fullscreen"
 msgstr "Tam ekran yap"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Kaydediliyor..."
@@ -2949,7 +2996,8 @@ msgstr "Bir soru ekle"
 msgid "Add a question to this dashboard"
 msgstr "Bu panele bir soru ekle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Filtre ekle"
 
@@ -2958,7 +3006,7 @@ msgstr "Filtre ekle"
 msgid "Parameters"
 msgstr "Parametreler"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Bir metin kutusu ekle"
 
@@ -2966,7 +3014,7 @@ msgstr "Bir metin kutusu ekle"
 msgid "Move dashboard"
 msgstr "Gösterge tablosunu taşı"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Gösterge tablosunu düzenle"
 
@@ -2990,11 +3038,11 @@ msgstr "Gösterge tablosu taşı .."
 msgid "Dashboard moved to {0}"
 msgstr "Gösterge tablosu {0} konumuna taşındı"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Neyi filtrelemek istiyorsunuz?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Ne tür bir filtre?"
 
@@ -3066,20 +3114,22 @@ msgstr "Bu kartın, bu parametre türüne eşlenebilecek herhangi bir alanı vey
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Bu alandaki değerler, seçtiğiniz diğer alanların değerleriyle örtüşmez."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Geçerli alan yok"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "İsim 100 karakter veya daha az olmalı"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Renk gereklidir"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Gösterge tablonuzun adı nedir?"
 
@@ -3134,7 +3184,7 @@ msgstr "en son veri alındı"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
@@ -3259,9 +3309,10 @@ msgstr "Son zamanlarda hiç gösterge tablosuna veya sorusuna bakmadınız"
 msgid "{0} items selected"
 msgstr "{0} öğe seçildi"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Arşivden Çıkar"
 
@@ -3378,7 +3429,7 @@ msgid "Zip Code"
 msgstr "Posta kodu"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Miktar"
 
@@ -3411,11 +3462,13 @@ msgid "User"
 msgstr "kullanıcı"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Kaynak"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Fiyat"
 
@@ -3448,21 +3501,23 @@ msgid "Subscription"
 msgstr "Abone"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Gol"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Başlık"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Yorum "
 
@@ -3516,22 +3571,22 @@ msgstr "Metabase bu alanı asla alamaz. Hassas veya alakasız bilgiler için bun
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
-msgstr "Adet"
+msgstr "Say"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
 msgstr "Kümülatif Sayım"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3549,19 +3604,19 @@ msgstr "Farklı"
 msgid "StandardDeviation"
 msgstr "Standart Sapma"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Ortalama"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Min"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3572,13 +3627,13 @@ msgstr "Maksimum"
 msgid "sad sad panda, lexing errors detected"
 msgstr "çok üzgün panda, lexing hataları tespit edildi"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} saniye"
 msgstr[1] "{0} saniyeler"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} dakika"
@@ -3619,14 +3674,15 @@ msgstr "Ne öğrenmek istiyorsun?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "İşlenmemiş veri"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Birikimli sayım"
 
@@ -3658,12 +3714,12 @@ msgstr "Kümülatif toplam "
 #: frontend/src/metabase/lib/query/description.js:107
 #: frontend/src/metabase/lib/query/description.js:276
 msgid "Maximum of "
-msgstr "...nın Maksimumu"
+msgstr "Maksimum"
 
 #: frontend/src/metabase/lib/query/description.js:112
 #: frontend/src/metabase/lib/query/description.js:278
 msgid "Minimum of "
-msgstr "...nın Minimumu"
+msgstr "Minimum"
 
 #: frontend/src/metabase/lib/query/description.js:126
 #: frontend/src/metabase/lib/query/description.js:286
@@ -3688,174 +3744,172 @@ msgstr "Doğru"
 msgid "False"
 msgstr "Yanlış"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Boylam alanını seç"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Üstteki enlemi girin"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Sol boylamı giriniz"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Daha düşük enlem girin"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Doğru boylamı giriniz"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "ise"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "boş"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "boş değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Eşittir"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Eşit değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
-msgstr "den daha büyük"
+msgstr "Büyük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
-msgstr "Den daha küçük"
+msgstr "Küçük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Arasında"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
-msgstr "Den daha büyük veya eşit"
+msgstr "Eşit veya büyük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
-msgstr "Den daha az veya eşit"
+msgstr "Eşit veya küçük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "İçerir"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "İçermez"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "İle başlar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "İle biter"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Önce"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Sonra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "içeride"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Sadece cevapta satırları olan bir tablo, ek işlem yok."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Satır sayısı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Yanıttaki toplam satır sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
-msgstr "...nın Toplamı"
+msgstr "Toplam"
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Bir sütunun tüm değerlerinin toplamı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
-msgstr "...nın Ortalaması"
+msgstr "Ortalama"
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Bir sütunun tüm değerlerinin ortalaması"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Farklı değerlerinin sayısı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Yanıttaki tüm satırlar arasında bir sütunun benzersiz değerlerinin sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
-msgstr "...nın Kümülatif Toplamı"
+msgstr "Kümülatif Toplam"
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Bir sütunun tüm değerlerinin toplamı. \\\\ ne.x. Zaman içinde toplam gelir."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Kümülatif satır sayısı"
 
@@ -3863,27 +3917,27 @@ msgstr "Kümülatif satır sayısı"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Satırların sayısının toplam sayısı. \\\\ ne.x. Zaman içinde toplam satış sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
-msgstr "Standart sapma ..."
+msgstr "Standart sapma"
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Bir sütunun değerlerinin ne kadarının cevabın tüm satırları arasında değiştiğini ifade eden sayı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
-msgstr "Minimum ..."
+msgstr "Minimum"
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Bir sütunun minimum değeri"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
-msgstr "Maksimum ..."
+msgstr "Maksimum"
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Bir sütunun maksimum değeri"
 
@@ -3899,6 +3953,8 @@ msgstr "küçük harf"
 msgid "upper case letter"
 msgstr "büyük harf"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "numara"
@@ -4146,7 +4202,7 @@ msgstr "Metrikler nasıl oluşturulur?"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Eğilimleri veya değişiklikleri anlamanıza yardımcı olacak şekilde zaman içindeki verileri bir harita olarak görüntüleyin veya döndürün."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Özel"
 
@@ -4169,7 +4225,7 @@ msgstr "Yerel sorgu"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Daha karmaşık sorular için, kendi SQL veya yerel sorgunuzu yazabilirsiniz."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Bir varsayılan değer seç…"
 
@@ -4260,7 +4316,7 @@ msgstr "Bu Ay"
 msgid "This Year"
 msgstr "Bu Yıl"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Bir değer girin ..."
@@ -4270,7 +4326,7 @@ msgid "Enter a default value..."
 msgstr "Varsayılan bir değer girin ..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Bir hata oluştu"
@@ -4528,22 +4584,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Bu bildirimde göndermek istediğiniz soruları seçin"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "E-postalar"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slack mesajları"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Gönderilen"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} şu saatte gönderilecek"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Mesajlar"
 
@@ -4615,30 +4679,30 @@ msgstr "Ekibinizdeki herkesin verilerinizle senkronize olmasına yardımcı olun
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Bildirimler, Metabase'den istediğiniz e-postaya veya Slack'e veri göndermenizi sağlar."
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "{0} den sonra"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "{0} den önce"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Boş"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Boş değil"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Her zaman"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Uygulamak"
 
@@ -4739,12 +4803,12 @@ msgstr[1] "{0}ları görüntüle"
 msgid "Zoom in"
 msgstr "Yakınlaştır"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Özel ifade"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Genel Metrikler"
 
@@ -4941,7 +5005,7 @@ msgstr "genellikle"
 msgid "Pick a segment or table"
 msgstr "Bir segment veya tablo seçin"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Bir veritabanı seç"
@@ -5002,7 +5066,7 @@ msgstr "Sırala"
 msgid "Row limit"
 msgstr "Satır sınırı"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Bilinmeyen Alan"
 
@@ -5010,7 +5074,7 @@ msgstr "Bilinmeyen Alan"
 msgid "field"
 msgstr "alan"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Maçlar"
 
@@ -5035,11 +5099,11 @@ msgstr "Bir gruplama ekle"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Veri"
 
@@ -5056,11 +5120,12 @@ msgstr "Görünüm"
 msgid "Grouped By"
 msgstr "Tarafından gruplandırılmış"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Yok"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Bu soru {0} ile yazılmıştır."
 
@@ -5072,7 +5137,7 @@ msgstr "Düzenleyiciyi Gizle"
 msgid "Hide Query"
 msgstr "Sorguyu Gizle"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Editör'ü Aç"
 
@@ -5080,7 +5145,7 @@ msgstr "Editör'ü Aç"
 msgid "Show Query"
 msgstr "Sorguyu Göster"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Bu metrik kullanımdan kaldırıldı. Artık kullanıma hazır değil."
 
@@ -5281,7 +5346,7 @@ msgstr "Son koşuya dönüş"
 msgid "Visualization"
 msgstr "Görüntüleme"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Açıklama ayarlanmamış."
 
@@ -5338,7 +5403,7 @@ msgstr "Yeni bir soru oluşturmadan önce tablo meta verileri bulunamadı"
 msgid "See {0}"
 msgstr "{0} adresini gör"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Metrik Tanımı"
 
@@ -5356,11 +5421,11 @@ msgstr "{0} sayısı"
 msgid "See all {0}"
 msgstr "Tüm {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Segment tanımı"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Tablo yüklenirken bir hata oluştu"
 
@@ -5368,7 +5433,7 @@ msgstr "Tablo yüklenirken bir hata oluştu"
 msgid "See the raw data for {0}"
 msgstr "{0} için ham verileri görün"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Daha"
 
@@ -5388,6 +5453,8 @@ msgstr "Alan formülü"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Bunu bir e-tablo programında formül yazmak gibi bir şey olarak düşünün: Sayıları, bu tablodaki alanları, + gibi matematiksel sembolleri ve bazı işlevleri kullanabilirsiniz. Böylece Subtotal - Cost gibi bir şey yazabilirsiniz."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5455,7 +5522,7 @@ msgstr "yanlış"
 msgid "Add filter"
 msgstr "Filtre ekle"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "Madde"
 
@@ -5574,11 +5641,11 @@ msgstr "Eşlenecek alan"
 msgid "Filter widget type"
 msgstr "Filtre aracı türünü filtrele"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Gereklidir?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Varsayılan filtre widget değeri"
 
@@ -5590,7 +5657,7 @@ msgstr "Bu soruyu arşivlediniz mi?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Bu soru, onu kullanan herhangi bir gösterge tablosundan veya bildirimlerden çıkarılacaktır."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Soru"
 
@@ -5637,7 +5704,7 @@ msgstr "Alan türü"
 msgid "Select a Foreign Key"
 msgstr "Yabancı Anahtar Seç"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "{0} formülünü görüntüle"
 
@@ -6121,22 +6188,24 @@ msgstr "Bu segmentle ilgili sorular"
 msgid "X-ray this segment"
 msgstr "Bu segmenti incele"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Oturum aç"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Arama"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Gösterge paneli"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Yeni soru"
 
@@ -6208,36 +6277,36 @@ msgstr "Tüm koleksiyon tamamen anonimdir."
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Koleksiyon, yönetici ayarlarınızdaki herhangi bir noktada kapatılabilir."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Sıkışmış hissediyorsan"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "başlangıç kılavuzumuz"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "sadece bir tık uzakta."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Metabase' e Hoş Geldiniz"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Her şey çalışıyor gibi görünüyor. Şimdi sizi tanıyalım, verilerinize bağlanın ve size bazı cevaplar bulmaya başlayın!\n"
 "Onun şey çalışıyor gibi."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Başlayalım"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Her şey hazır!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Beni Metabase' e götür"
 
@@ -6489,39 +6558,40 @@ msgstr "Filtreyi iptal et"
 msgid "Pin Map"
 msgstr "Pin Haritası"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Ayarını kaldır"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "{0} - {1} - {2} satırda"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Veriler {0} satırına kesildi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Görselleştirme bulunamadı"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Grafik bu verileri görüntülenemedi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Hala bekliyorum ."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Bu genellikle ortalama {0} alır."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Bu bir gösterge paneli için biraz uzun)"
 
@@ -6547,15 +6617,15 @@ msgstr "Aşağıdaki listeden alanlar ekleyin"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "den daha az"
+msgstr "küçük"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "den daha büyük"
+msgstr "büyük"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "den daha az veya eşit"
+msgstr "eşit veya küçük"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
@@ -6631,7 +6701,7 @@ msgid "Highlight the whole row"
 msgstr "Tüm satırı vurgula"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Renkler"
 
@@ -6717,24 +6787,50 @@ msgstr "Hedef"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Doh! Sorgunuzdaki veriler seçilen ekran seçimine uymuyor. Bu görselleştirme en az {0} {1} veri gerektirir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "sütun"
@@ -6766,7 +6862,7 @@ msgid "xValues missing!"
 msgstr "xValues eksik!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X koordinatı"
 
@@ -6775,7 +6871,7 @@ msgid "Add a series breakout..."
 msgstr "Dizi ayırma ekle ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "X koordinatı"
 
@@ -6788,7 +6884,7 @@ msgid "Bubble size"
 msgstr "Kabarcık boyutu"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Çizgi"
 
@@ -6930,20 +7026,20 @@ msgid "Standard Deviation"
 msgstr "Standart sapma"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Alan"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "alan grafik"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Çubuk "
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "sütun grafik"
 
@@ -6957,7 +7053,7 @@ msgid "Funnel"
 msgstr "Huni"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Tedbir"
 
@@ -6969,81 +7065,81 @@ msgstr "Huni tipi"
 msgid "Bar chart"
 msgstr "Sütun grafik"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "Çizgi grafik"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Grafik ayarlarında boylam ve enlem sütunlarını seçiniz."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Lütfen bir bölge haritası seçin."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Grafik ayarlarında lütfen bölge ve metrik sütunları seçin."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Harita"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Harita türü"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Bölge haritası"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "PIN haritası"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Pin tipi"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Fayans"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "İşaretleyiciler"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Latitude alanı"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Boylam alanı"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Metrik alan"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Bölge alanı"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Yarıçap"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Bulanıklık"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Min Opaklık"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Maksimum Zum"
 
@@ -7055,7 +7151,7 @@ msgstr "İlişki bulunamadı."
 msgid "via {0}"
 msgstr "{0} ile"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "Bu {0} şuna bağlı:"
 
@@ -7067,31 +7163,31 @@ msgstr "Nesne detay"
 msgid "object"
 msgstr "nesne"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Toplam"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Hangi sütunları kullanmak istiyorsunuz?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pasta"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Boyut"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Gösteriyi göster"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Grafikte yüzdeleri göster"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minimum dilim yüzdesi"
 
@@ -7116,7 +7212,8 @@ msgid "Progress"
 msgstr "İlerleme"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Renk"
@@ -7125,7 +7222,7 @@ msgstr "Renk"
 msgid "Row Chart"
 msgstr "Çubuk Grafik"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "çubuk Grafik"
 
@@ -7149,15 +7246,15 @@ msgstr "Bir sonek ekle"
 msgid "Multiply by a number"
 msgstr "Bir sayı ile çarpın"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Dağıtma"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "dağılım grafiği"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Tabloyu döndür"
 
@@ -7207,13 +7304,13 @@ msgstr "Sağ"
 msgid "Show background"
 msgstr "Arka planı göster"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} bölme"
 msgstr[1] "{0} bölmeler"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "Otomatik olarak gruplandı"
 
@@ -7449,10 +7546,13 @@ msgstr "{0} de çok fazla kayıtlı soru var mı? Bunları yönetmek ve bağlam 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7642,7 +7742,7 @@ msgstr "kümülatif toplam"
 msgid "{0} and {1}"
 msgstr "{0} ve {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{1}'n {0} "
@@ -8955,11 +9055,11 @@ msgstr "Veri izinleri"
 msgid "Collection permissions"
 msgstr "Koleksiyon izinleri"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Tüm koleksiyon izinlerine bakın"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Alt koleksiyonları da değiştir"
 
@@ -8971,19 +9071,19 @@ msgstr "Bu koleksiyonu ve içeriğini düzenleyebilir"
 msgid "Can view items in this collection"
 msgstr "Bu koleksiyondaki öğeleri görebilir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Koleksiyon Erişimi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Bu grup, bu koleksiyonun en az bir alt koleksiyonunu görüntüleme iznine sahiptir."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Bu grubun bu koleksiyonun en az bir alt koleksiyonunu düzenleme izni var."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Alt koleksiyonları görüntüle"
 
@@ -9039,6 +9139,7 @@ msgstr "İlgili"
 msgid "More X-rays"
 msgstr "Daha fazla X-rays"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9297,10 +9398,10 @@ msgstr "Paylaşım"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9383,7 +9484,7 @@ msgstr "JVM Zaman Dilimini Kullan"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Veri içinde gezebilmeniz için tabloları ve kolonları analiz ediyoruz."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "İpucu:"
 
@@ -9391,7 +9492,7 @@ msgstr "İpucu:"
 msgid "Select a currency type"
 msgstr "Para birimi seçin"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Alan Tipi"
 
@@ -9446,6 +9547,7 @@ msgid "Currency"
 msgstr "Para Birimi"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Kullanıcı veya kanal seçin"
 
@@ -9607,7 +9709,7 @@ msgstr "Hangi eksen?"
 msgid "Line + Bar"
 msgstr "Çizgi + Çubuk"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "çizgi ve çubuk çzigesi"
 
@@ -9627,15 +9729,15 @@ msgstr "Gösterge aralığı"
 msgid "Field to show"
 msgstr "Gösterilecek alan"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "son {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0}, {1} {2} idi."
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Zaman bağlı olarak değişimi görmek için zaman içeren alana göre gruplandırınız"
 
@@ -9643,23 +9745,23 @@ msgstr "Zaman bağlı olarak değişimi görmek için zaman içeren alana göre 
 msgid "Switch positive / negative colors?"
 msgstr "Pozitif / negatif renklere geçilsin mi?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Özet sütunu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Hücre sütunu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Görünen sütunlar"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Koşullu biçimlendirme"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Sütun başlığı"
 
@@ -10097,10 +10199,10 @@ msgstr "Kaynak başına kullanıcı"
 msgid "The top external pages that brought users to your site"
 msgstr "Kullanıcıları sitenize getiren en üstteki harici sayfalar"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "[[this]] nasıl dağıtılması ve daha fazlası."
 
@@ -10198,13 +10300,13 @@ msgstr "Günün saatine göre olaylar"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Üst 5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Alt 5 [[this]]"
 
@@ -10217,10 +10319,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "[[GenericCategoryLarge]] başına"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Sıfır değerler"
 
@@ -10248,8 +10350,8 @@ msgstr "Dönemsel olarak karşılaştırılması"
 msgid "Average income per transaction"
 msgstr "İşlem başına ortalama gelir"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[this]] ülke başına"
 
@@ -10373,10 +10475,10 @@ msgstr "[[this]] genel bir görünümü ve unun zaman, yer ve kategorilere göre
 msgid "Average income per state"
 msgstr "Eyalete göre ortalama gelir"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[GenericCategoryMedium]] göre [[this]]"
 
@@ -10553,13 +10655,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "zaman aralığında [[GenericTable]] nasıl dağıtılması, ve mevsimsel desenleri varsa."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "genel bakış"
 
@@ -10668,8 +10770,8 @@ msgstr "[[this]] ice bir bakış"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "[[this]] daha yakından bakış"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Özet"
 
@@ -10733,10 +10835,10 @@ msgstr "Kaynak başına satış"
 msgid "Average income per country"
 msgstr "Ülke başına ortalama gelir"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "[[this]]'in nasıl dağıtılması"
 
@@ -10757,17 +10859,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "[[this]] göre [[GenericCategoryMedium]] sayımı"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "[[this]] bak"
 
@@ -10833,10 +10935,10 @@ msgid "Transactions per source over time"
 msgstr "Zaman içindeki kaynak başına gerçekleşen işlemler"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "[[this]] nasıl dağıtılması"
 
@@ -10865,9 +10967,9 @@ msgstr "Bu hareketlerin gerçekleştiği yer"
 msgid "Which US states are bringing you the most business."
 msgstr "Hangi ABD eyaletleri size en çok iş getiriyor."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Onların amanla nasıl karşılaştırılması"
 
@@ -10972,8 +11074,8 @@ msgstr "Ülkeye göre oturumlar"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "İlerlemeniz için GA istatistiklerinizle ilgili bazı ilginç metrikler."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "Elayet başına [[this]]"
 
@@ -11054,12 +11156,12 @@ msgstr "Bu metrik'in, farklı sayılar içinde nasıl dağıtılması"
 msgid "Sessions by page where the session began"
 msgstr "Sayfaya göre oturumun başladığı yerdeki oturumlar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Farklı değerler"
 
@@ -11122,10 +11224,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "[[GenericCategoryLarge]] başına hareketler"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Dağıtıma göre nasıl karşılaştırılması"
@@ -11431,6 +11533,7 @@ msgstr "Bu panoyu kopyala"
 msgid "Duplicate \"{0}\""
 msgstr "\"{0}\"ı kopyala"
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11528,9 +11631,9 @@ msgid_plural "Quarters of year"
 msgstr[0] "Yılın çeyreği"
 msgstr[1] "Yılın çeyrekleri"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seçim"
@@ -11553,11 +11656,11 @@ msgstr "Geçersiz"
 msgid "Add a time"
 msgstr "Bir zaman ekleyin"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Önceki {0} ile karşılaştırılacak bir şey yok."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "{0} bazında"
 
@@ -11675,7 +11778,7 @@ msgstr "Olayları izlerken beklenmeyen bir hata oluştu"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "Veritabanı eşleştirme hatası"
+msgstr "Veritabanı {0} için eşleştirme hatası"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
@@ -12045,9 +12148,9 @@ msgstr "[[this]]'inizdeki kişilere genel bakış"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] yılın çeyreğine göre"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Yerlerine göre karşılaştırma"
 
@@ -12076,12 +12179,12 @@ msgstr "[[CreateTimestamp]] haftanın günlerine göre"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "[[this]]'inize Google Analytics verileri bazında genel bakış"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "[[this]]'inize genel bakış"
 
@@ -12159,11 +12262,11 @@ msgstr "derlem"
 msgid "collections"
 msgstr "derlemler"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "bilgi panosu"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "bilgi panoları"
 
@@ -12413,7 +12516,7 @@ msgstr "{0} milisaniyenin ardından zaman aşımı."
 msgid "Misfire Instruction"
 msgstr "Yanlış talimat"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Arşiv"
 
@@ -12433,7 +12536,7 @@ msgstr "Bu seçeneğin kullanılması, sağlanan ana makinenin bir FQDN olmasın
 "bir Atlas kümesine bağlaniyorsa, bu seçeneği etkinleştirmeniz gerekebilir. Bunun ne anlama geldiğini bilmiyorsanız,\n"
 "bunu devre dışı bırakın."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Basit filteleme işlemleri yaparken sörfü sonuçlarını hemen göster "
 
@@ -12445,7 +12548,7 @@ msgstr "(Bu ayar açık ise) Metabase, kullanıcılar bir tabloyu veya grafiği 
 msgid "Learn about this database"
 msgstr "Veritabanı detayları "
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Bu dashboardu arşivle "
 
@@ -12501,11 +12604,11 @@ msgstr "Özel soru"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Verileri birleştirmek, özel sütunlar oluşturmak, matematiksel işlemler yapmak ve daha fazlası için gelişmiş not defteri düzenleyicisini kullanın."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Basit Metrikler"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Özel..."
 
@@ -12625,8 +12728,8 @@ msgstr "Alarmlar"
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "{0} kaçış"
-msgstr[1] "{0} kaçışlar"
+msgstr[0] "{0} alan"
+msgstr[1] "{0} alan"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:41
 msgid "Hide filters"
@@ -12690,15 +12793,15 @@ msgstr "Grafik seçin"
 msgid "Filter by"
 msgstr "Filtrele"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Şuna göre özetle"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Grupla"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Metrik ekle"
 
@@ -12709,15 +12812,15 @@ msgstr "Metrik ekle"
 msgid "Profile"
 msgstr "Profil"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Genellikle hızlıdır ama şu an biraz sürecek gibi duruyor."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Birleşik"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Satır"
 
@@ -13138,7 +13241,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Eklemek istediğiniz sütunları seçin"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Bu açıkken, kullanıcılar bir tabloyu veya grafiği görüntülerken Özetle ve Filtrele düğmeleriyle basit keşifler yaptığında Metabase otomatik olarak sorguları çalıştırır. Bu veritabanını sorgulamak yavaşsa bunu kapatabilirsiniz. Bu ayar detaylandırma veya SQL sorgularını etkilemez."
 
@@ -13204,7 +13307,7 @@ msgstr "E-posta ile oturum açın"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Bu seçeneğin kullanılması, sağlanan ana makinenin bir FQDN olmasını gerektirir. Bir Atlas kümesine bağlanıyorsanız, bu seçeneği etkinleştirmeniz gerekebilir. Bunun ne anlama geldiğini bilmiyorsanız, devre dışı bırakın."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Varsayılan olarak, Metabase sistemi yormadan saatlik senkronizasyonlar yapar ve alan değerlerinin günlük olarak yoğun bir şekilde taranmasını sağlar. Büyük bir veritabanınız varsa, bunu açmanızı ve alan değeri taramalarının ne zaman ve ne sıklıkta gerçekleştiğini gözden geçirmenizi öneririz."
 
@@ -13272,11 +13375,11 @@ msgstr "Dahil etme"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Bu alan, GUI arabirimleriyle oluşturulan sorularda görünmez veya seçilemez. Yine de SQL / yerel sorgularda erişilebilir."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Kümülatif toplam"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Standart sapma"
 
@@ -13292,19 +13395,19 @@ msgstr "En az {0} karakter uzunluğunda olmalı"
 msgid "Name (required)"
 msgstr "İsim (gerekli)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Seçili metni çalıştır"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Sorguyu çalıştır"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13652,7 +13755,7 @@ msgstr "Tarihler ve Saatler"
 msgid "Numbers"
 msgstr "Sayılar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Eşlenebilir grup yok"
 
@@ -13692,15 +13795,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "Beni hatırla"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Güvenlik nedeniyle, parola sıfırlama bağlantılarının süresi bir süre sonra dolar. Hala şifrenizi sıfırlamanız gerekiyorsa {0} yapabilirsiniz."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Yeni parolayı kaydet"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Eşleşen sonuç bulunamadı"
 
@@ -13726,26 +13829,26 @@ msgid "or"
 msgstr "veya"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "zorunlu"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Veritabanı türü"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Bu, bu veritabanının şemasındaki güncellemeleri kontrol eden hafif bir işlemdir. Çoğu durumda, bu seti saatlik olarak senkronize etmek için iyi durumda olmalısınız."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase, gösterge tablolarında ve sorulardaki onay kutusu filtrelerini etkinleştirmek için bu veritabanındaki her alanda bulunan değerleri tarayabilir. Bu, özellikle çok büyük bir veritabanınız varsa, kaynak yoğun bir süreç olabilir."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Koleksiyon"
 
@@ -13792,7 +13895,7 @@ msgstr "Kategorik"
 msgid "URLs"
 msgstr "URL'ler"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Sütundaki değerlerin ortalamasını döndürür."
 
@@ -13801,11 +13904,13 @@ msgstr "Sütundaki değerlerin ortalamasını döndürür."
 msgid "The column whose values to average."
 msgstr "Değerleri ortalama olan sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "Başlat"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "Bitir"
 
@@ -13817,21 +13922,19 @@ msgstr "Belirtilen aralıkta olup olmadıklarını görmek için bir tarih veya 
 msgid "Rating"
 msgstr "Değerlendirme"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "durum"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "çıktı"
 
@@ -13839,27 +13942,27 @@ msgstr "çıktı"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Bir vaka listesini test eder ve başka bir şey karşılanmazsa isteğe bağlı bir varsayılan değerle ilk gerçek vakanın karşılık gelen değerini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Ağırlık"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Büyük"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Orta"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Küçük"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Doğru veya yanlış olarak değerlendirilmesi gereken bir şey."
 
@@ -13867,33 +13970,33 @@ msgstr "Doğru veya yanlış olarak değerlendirilmesi gereken bir şey."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Önceki koşul doğruysa döndürülecek değer."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "değer1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "değer2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Her bir bağımsız değişkendeki değerlere sırayla bakar ve her satır için ilk boş olmayan değeri döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Notlar"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Yorum yok"
 
@@ -13909,12 +14012,12 @@ msgstr "Değer1 boşsa, değer2 boş değilse döndürülür ve bu böyle devam 
 msgid "Combines two or more strings of text together."
 msgstr "İki veya daha fazla metin dizesini bir araya getirir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Soyadı"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Adı"
 
@@ -13926,27 +14029,27 @@ msgstr "Bunun sonuna değer2 eklenecektir."
 msgid "This will be added to the end of value1."
 msgstr "Bu değer1 sonuna eklenir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "dize1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "dize2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Dize1 içinde dize2 içerip içermediğini kontrol eder."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Durum"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Geçiş"
 
@@ -13954,7 +14057,7 @@ msgstr "Geçiş"
 msgid "The contents of this string will be checked."
 msgstr "Bu dizenin içeriği kontrol edilecektir."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Aranacak metin dizesi."
 
@@ -13962,22 +14065,22 @@ msgstr "Aranacak metin dizesi."
 msgid "Returns the count of rows in the source data."
 msgstr "Kaynak verilerdeki satır sayısını döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Yalnızca koşulun doğru olduğu satırları sayar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Ara toplam"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Bir aradaki satırların toplamı."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "Bir koparma boyunca bir sütunun yuvarlanan toplamı."
 
@@ -13986,53 +14089,57 @@ msgstr "Bir koparma boyunca bir sütunun yuvarlanan toplamı."
 msgid "The column to sum."
 msgstr "Toplanacak sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Bu sütundaki farklı değerlerin sayısı."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Farklı değerleri sayılacak sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "metin"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "karşılaştırma"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Metnin sonu karşılaştırma metniyle eşleşirse true değerini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "İştah"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "Aç"
 
@@ -14041,20 +14148,20 @@ msgstr "Aç"
 msgid "A column or string of text to check."
 msgstr "Kontrol edilecek bir sütun veya metin dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Orijinal metnin bitmesi gereken metin dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "regular_expression"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Normal ifadeye göre eşleşen alt dizeleri ayıklar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Adres"
 
@@ -14062,7 +14169,7 @@ msgstr "Adres"
 msgid "The column or string of text to search though."
 msgstr "Yine de aranacak metin sütunu veya dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Eşleşecek normal ifade."
 
@@ -14074,7 +14181,7 @@ msgstr "Tüm küçük harfli metin dizesini döndürür."
 msgid "The column with values to convert to lowercase."
 msgstr "Küçük harfe dönüştürülecek değerlere sahip sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Bir metin dizesinden önde gelen boşlukları kaldırır."
 
@@ -14084,15 +14191,16 @@ msgstr "Bir metin dizesinden önde gelen boşlukları kaldırır."
 msgid "The column with values you want to trim."
 msgstr "Kırpmak istediğiniz değerlerin bulunduğu sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Sütunda bulunan en büyük değeri döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Yaş"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Maksimum değerini bulmak istediğiniz sayısal sütun."
 
@@ -14100,21 +14208,21 @@ msgstr "Maksimum değerini bulmak istediğiniz sayısal sütun."
 msgid "Returns the smallest value found in the column."
 msgstr "Sütunda bulunan en küçük değeri döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Maaş"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Minimum değerini bulmak istediğiniz sayısal sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "durum"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "uzunluk"
 
@@ -14123,7 +14231,7 @@ msgstr "uzunluk"
 msgid "new_text"
 msgstr "yeni_metin"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Giriş metninin bir kısmını yeni metinle değiştirir."
 
@@ -14151,35 +14259,35 @@ msgstr "Değiştirilecek karakter sayısı."
 msgid "The text to use in the replacement."
 msgstr "Değiştirme işleminde kullanılacak metin."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Bir metin dizesinden sonraki boşlukları kaldırır."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Verideki koşulla eşleşen satırların yüzdesini ondalık sayı olarak döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Metnin başı karşılaştırma metniyle eşleşirse true değerini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Ders Adı"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Bilgisayar Bilimi"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Orijinal metnin başlaması gereken metin dizesi."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Sütunun standart sapmasını hesaplar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Nüfus"
 
@@ -14187,7 +14295,7 @@ msgstr "Nüfus"
 msgid "A numeric column."
 msgstr "Sayısal bir sütun."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Sağlanan metnin bir bölümünü döndürür."
 
@@ -14195,19 +14303,19 @@ msgstr "Sağlanan metnin bir bölümünü döndürür."
 msgid "The text to return a portion of."
 msgstr "Bir kısmını döndürecek metin."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Karakterleri kopyalamaya başlama konumu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Döndürülecek karakter sayısı."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Sütunun tüm değerlerini toplar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Toplanacak sayısal sütun."
 
@@ -14215,15 +14323,15 @@ msgstr "Toplanacak sayısal sütun."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Satırların koşulla eşleştiği bir sütundaki değerleri toplar."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Sipariş durumu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Geçerli"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Bir metin dizesinden öndeki ve sondaki boşlukları kaldırır."
 
@@ -14231,47 +14339,47 @@ msgstr "Bir metin dizesinden öndeki ve sondaki boşlukları kaldırır."
 msgid "Returns the string of text in all upper case."
 msgstr "Tüm büyük harfli metin dizesini döndürür."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Büyük harfe dönüştürülecek değerlere sahip sütun."
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "{0} olmalı ve {1} içermelidir."
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "{0} olmalıdır."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "{0} içermelidir."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "en az {0} karakter uzunluğunda"
 msgstr[1] "en az {0} karakter uzunluğunda"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} küçük harf"
 msgstr[1] "{0} küçük harf"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} büyük harf"
 msgstr[1] "{0} büyük harf"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} sayı"
 msgstr[1] "{0} sayı"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} özel karakter"
@@ -14294,6 +14402,7 @@ msgid "Powered by {0}"
 msgstr "{0} tarafından desteklenmektedir"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Kime:"
 
@@ -14381,7 +14490,7 @@ msgstr "Değer biçimlendirme"
 msgid "Full"
 msgstr "Tam"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Son {0} itibariyle değişiklik yok"
 
@@ -14706,7 +14815,7 @@ msgstr "Sütun için içgörü oluşturulurken hata oluştu:"
 msgid "Sending abandonment email!"
 msgstr "Vazgeçme e-postası gönderme!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Adlandırılmış bir metrik seçeneği eklemek için kaydedilmiş metrikler oluşturabilirsiniz. Kaydedilen metrikler, birleştirme türünü, birleştirilmiş alanı ve isteğe bağlı olarak eklediğiniz filtreleri içerir. Örnek olarak, bunu bir Siparişler tablosu için \"Ortalama Fiyat\" hesaplamanın resmi yolu gibi bir şey oluşturmak için kullanabilirsiniz."
 
@@ -14714,15 +14823,15 @@ msgstr "Adlandırılmış bir metrik seçeneği eklemek için kaydedilmiş metri
 msgid "Select and add filters to create your new segment."
 msgstr "Yeni segmentinizi oluşturmak için filtreleri seçin ve ekleyin."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Alfabetik"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Akıllı"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Kolon sırası : {0}"
 
@@ -14774,7 +14883,7 @@ msgstr "Yerelleştirme"
 msgid "Instance language"
 msgstr "Örnek dil"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Yerelleştirme seçenekleri"
 
@@ -14846,19 +14955,20 @@ msgstr "Bir bağlantı dizesi yapıştırma"
 msgid "Fill out individual fields"
 msgstr "Tek tek alanları doldurun"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Daha sonra tekrar kullanabilmek için buraya biraz SQL girin"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Snippet'inize bir ad verin"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Mevcut Müşteriler"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Bir açıklama ekle"
 
@@ -14866,46 +14976,47 @@ msgstr "Bir açıklama ekle"
 msgid "Use site default"
 msgstr "Site varsayılanını kullan"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "bul"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "değiştir"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Bulunacak metin."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Değiştirme olarak kullanılacak metin."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "{0} düzenleniyor"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Yeni snippet'inizi oluşturun"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Arşivlenmiş snippet'ler"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Parçacıklar, SQL'in yeniden kullanılabilir parçalarıdır"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Parçacık oluşturma"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Parçacıklar"
 
@@ -15184,3 +15295,1505 @@ msgstr "değer bir anahtar kelime veya dize olmalıdır."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Dize, geçerli iki harfli ISO dili veya dil-ülke kodu olmalıdır; 'en' veya 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "{0}/{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Denetim"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Kullanıcı özelliği yapılandırması (isteğe bağlı)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "{0} kullanılıyor"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "SAML tabanlı SSO kurma"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML Kimlik Doğrulaması"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Kimlik sağlayıcınızı (IdP) yapılandırın"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Kimlik sağlayıcınız Metabase hakkında aşağıdaki bilgilere ihtiyaç duyacaktır."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "IdP'nin yeniden yönlendirmesi gereken URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Buna Okta'da Tek Oturum Açma URL'si, Auth0'daki Uygulama Geri Arama URL'si denir,\n"
+"ve OneLogin'deki ACS (Tüketici) URL'si."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML özellikleri"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "Çoğu IdP'de, bunların her birini etiketli bir giriş kutusuna koymanız gerekir.\n"
+"Öznitelik ifadeleri bölümünde \"Ad\"."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Kullanıcının e-posta özelliği"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Kullanıcının ad özelliği"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Kullanıcının soyadı özelliği"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Metabase'e kimlik sağlayıcınız hakkında bilgi verin"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase, sağlayıcınız hakkında aşağıdaki bilgilere ihtiyaç duyacaktır."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML Kimlik Sağlayıcı URL'si"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "SAML Kimlik Sağlayıcı Sertifikası"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML Uygulama Adı"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "SSO isteklerini imzala (isteğe bağlı)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML Anahtar Deposu Yolu"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "SAML Anahtar Deposu Şifresi"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Şşş..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML Anahtar Deposu Takma Adı"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Grup üyeliğini SSO'nuzla senkronize edin"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Bunu etkinleştirmek için, Metabase'e kullanıcılarınızın hangi grup (lar) ı kullanması gerektiğini söyleyen eşlemeler oluşturmanız gerekir\n"
+"içinde bulundukları SSO grubuna göre eklenecek."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Grup Adı"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Grup Özellik Adı"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Not:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Mevcut bir SAML etkin kurulumunun herhangi bir ayarını değiştirirseniz, bunların etkili olması için Metabase'i yeniden başlatmanız gerekir."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Kullanıcıların bir SAML Kimlik Sağlayıcı aracılığıyla oturum açmasına izin verir."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Kullanıcıların bir JWT Kimlik Sağlayıcı aracılığıyla oturum açmasına izin verir."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Parola Doğrulamayı Etkinleştir"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Etkinleştirildiğinde, kullanıcılar ayrıca e-posta ve şifre ile giriş yapabilir."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Yeni kullanıcıları yöneticilerei bildir."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Etkinleştirildiğinde, yöneticiler bir kullanıcı Tek Oturum Açma'yı ilk kez kullandığında bir e-posta alır."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "SSO'nuzu SAML aracılığıyla yapılandırmak için aşağıdaki ayarları kullanın. Herhangi bir sorunuz varsa, {0} sayfamıza bakın."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "dokümantasyon"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML Kimlik Sağlayıcı URI'si"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT Kimlik Doğrulaması"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT Kimlik Sağlayıcı URI'si"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "JWT imzalama anahtarı tarafından kullanılan dize"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Metabase uygulamasının tamamını gömme"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Metabase'in tamamını gömmek istiyorsanız, iç çerçeveye yerleştirmeye izin vermek istediğiniz web sitelerinin veya web uygulamalarının kökenlerini boşlukla ayırarak girin. İşte girilebilecekler için {0}."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Bu tabloya korumalı alanda erişim verin"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Bu gruptaki kullanıcılar bu tabloyu görüntülediklerinde, tablonun kullanıcı özelliklerine göre filtrelenmiş bir sürümünü veya kaydedilmiş bir soruya göre özel bir görünümünü görürler."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Bu gruptaki kullanıcılar için bu tabloyu nasıl filtrelemek istersiniz?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Bu kullanıcıların görmesi gereken bu tablonun özel görünümünü döndüren kayıtlı bir soru seçin."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "İsteğe bağlı olarak, kullanıcı özelliklerine göre buraya ek filtreler ekleyebilirsiniz. Bu filtreler, bu kaydedilmiş soruda bulunan tüm filtrelerin üzerine uygulanacaktır."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Bu seçeneğin çalışması için kullanıcılarınızın bazı özelliklere sahip olması gerekir"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Ek filtreler eklemek için kullanıcılarınızın bazı özniteliklere sahip olması gerekir"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Kullanıcı özelliği yok"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Bir kullanıcı özelliği seçin"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Parametre seçin"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Kolon seçin"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "{0} kullanıcıları görebilir"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "satır ({0} sorusunda)"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "satır ({0} tablosunda)"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "{0} eşit {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "ve {0} eşit {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "SAML kullanan bir TOA kurarak öznitelikleri otomatik olarak ekleyebilir veya Kişiler bölümüne gidip en sağdaki… menüsünü tıklayarak bunları manuel olarak girebilirsiniz."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Kullanıcı özelliği"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "TOA'yı kurduysanız, kullanıcılarınızın özelliklerini otomatik olarak alabiliriz veya bunları Yönetici Panelinin Kişiler bölümündeki \"…\" menüsünden manuel olarak ekleyebilirsiniz."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Parametre veya değişken"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "eşittir"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Korumalı alandaki erişim izni verin"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Korumalı alan erişimi"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Korumalı alandaki erişimi düzenleyin"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Klasör ayrıntılarını düzenleyin"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "İzinleri değiştir"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Yeni klasörünüzü oluşturun"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Yeni dosya"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Jetonunuzu doğrulama konusunda sorun yaşıyoruz"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Lütfen örneğinizin Metabase sunucularına bağlanabildiğini iki kez kontrol edin"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Yardım al"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Enterprise Edition ile Metabase'den daha fazla yararlanın"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Müşterilerinize hızlı ve kolay bir şekilde raporlar sağlamak veya büyük bir organizasyonda Metabase'i çalıştırmanıza ve izlemenize yardımcı olmak için ihtiyacınız olan tüm araçlar"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Bir lisansı etkinleştirin"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Denemeniz bu özelliklerle aktif"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Deneme süresi {0} sona eriyor"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Yardıma mı ihtiyacınız var? Satın almaya hazır mısınız?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Bizimle görüşebilirsiniz"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Deneme süresi doldu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Daha fazla zaman gerek? Satın almaya hazır mısınız?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Özellikleriniz aktif!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Lisansınız {0} arasında geçerlidir"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Lisans süreniz doldu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "{0} tarihinde süresi doldu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Lisansı yenilemek ister misiniz?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Nasıl kullanacağınızı öğrenin"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Şuan ki planınız içermiyor"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Store üzerinden aldığınız token bilgisini girin"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Aktive et"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Yardıma mı ihtiyacınız var?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Sorununuz hakkında daha fazla bilgi."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "İletişim desteği"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Kurumsal"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Veri korumalı alanları"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Kullanıcı özelliklerine göre otomatik ve güvenli filtrelerle doğru verileri doğru kişilere gösterdiğinizden emin olun."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Beyaz etiketleme"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Metabase'i özel renkler, kendi logonuz ve daha fazlasıyla markanızla eşleştirin."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Denetleme"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Güçlü denetim araçlarıyla performans ve davranışa dikkat edin."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Tek seferlik"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Mevcut kimlik doğrulama altyapınızla çalışan kolay oturum açma sağlayın."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Store"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Uygulama Adı"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Renk paleti"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "Favicon"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Açılış sayfası"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Grup yok"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "{0} için yetkilendirme"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Bu klasör için yetkilendirme"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Düzenleme yetkisi ver"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Bu klasördeki parçacıkları değiştirebilir"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Görme yetkisi ver."
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Bu klasöre parçacık ekleyip kullanabilir, ancak içerdikleri SQL'i düzenleyemez"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Bu klasörde ön bilgi görüntülenemiyor veya eklenemiyor"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Alt klasörleri de değiştir"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Haftanın ilk günü"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Google ile oturum açarken bir sorun oluştu. Lütfen bir yönetici ile iletişime geçin."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "üzerinde"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "-de"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Metabase eylemleri menüsünü açın"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Hiçbir şey yapma"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Özel bir hedefe git"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Gösterge tablosu filtresi güncelleme"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} güncelleme {1} filtresi"
+msgstr[1] "filtreleri {0} günceller {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0}, {1} konumuna gider"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Her kolon için tıklama davranışı"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Özel hedefe git"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "İşlemler menüsünü açın"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "{0} için tıklama davranışı"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Güncellemek için bir veya daha fazla filtre seçin"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Kaydedilmiş soru"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Link"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Link için adres girin"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Adını kullanarak bir sütun veya gösterge tablosu filtresinin değerini şu şekilde ekleyebilirsiniz: {{bazı_sütun}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "Örneğin. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Gösterge panosu seçin..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Soru seçin..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Bağlanmak için bir gösterge tablosu seçin"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Bağlanmak için bir soru seçin"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Değerleri bu kontrol panelinin filtrelerine geçirin (isteğe bağlı)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Bu sorunun değişkenlerine değer iletin (isteğe bağlı)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Bu soruyu filtrelemek için değerleri iletin (isteğe bağlı)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Gösterge tablosu filtreleri"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Kullanıcı özellikleri"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Bağlantı metnini özelleştirin (isteğe bağlı)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. {{Sütun Adı}} için ayrıntılar"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Referans verebileceğiniz değerler"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Kullanılabilir hedef yok"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "filtre"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "değişken"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Diğer mevcut filtreler"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Mevcut filtreler"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Diğer mevcut değişkenler"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Mevcut değişkenler"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Kullanılabilir diğer sütunlar"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Kullanılabilir sütunlar"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "kullanıcı özelliği"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Metin kartı"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Tıklama davranışı"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Görselleştirme seçenekleri"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Seriyi düzenle"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Seri ekle"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Tıklamada"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Başlığı ve açıklamayı değiştir"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Gömülü parametreleri güncellediniz ve gömme kodunuzu güncellemeniz gerekecek."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Soru ekleyin"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Bu kontrol panelini düzenliyorsunuz."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Filtrelenecek sütun"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "snippet koleksiyonu"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "snippet koleksiyonları"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Klasörünüze bir ad verin"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Kısa ama tatlı bir şey"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Bunun içinde olması gereken klasör"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "İşlem menüsünü açın"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0} sütununun özel davranışı var"
+msgstr[1] "{0} sütununun özel davranışı var"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Git ..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Panoya git"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Soruya git"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Url'ye git"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Bu panoyu filtrele"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Seçili verilerdeki satır sayısını döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Toplanacak sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Standart sapmanın alınacağı sayısal sütun."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Değerleri ortalanacak sayısal sütun."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Sütunda bulunan en küçük değeri verir"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Belirtilen sütunu yalnızca koşulun doğru olduğu satırlar için özetler."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Belirli bir sütun için sayısal varyansı döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Sıcaklık"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Varyansının alınacağı sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Belirtilen sütunun medyan değerini döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Ortanca değeri alınacak sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "yüzdelik değer"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Yüzdelik değerde sütunun değerini döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Yüzdelik dilim alınacak sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Yüzdebirliğin değeri."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Tümü küçük harfli metin dizesini döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Küçük harfe dönüştürülecek değerlere sahip sütun."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Metni tamamen büyük harflerle döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Bir bölümünü döndürülecek sütun veya metin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Aranacak sütun veya metin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "İki veya daha fazla metin dizesini bir araya getirin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Başlamak için sütun veya metin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Bu, değer1'in sonuna eklenecektir ve böyle devam eder."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "Muazzam"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Devasa"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Metindeki karakter sayısını döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Uzunluğunu almak istediğiniz sütun veya metin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Kırpmak istediğiniz sütun veya metin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Belirtilen sütunun mutlak (pozitif) değerini döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Borç"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Mutlak (pozitif) değerini döndürülecek sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Ondalık bir sayıyı aşağı yuvarlar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Aşağı yuvarlanacak sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Ondalık bir sayıyı yukarı yuvarlar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Yuvarlanacak sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Ondalık bir sayıyı en yakın tam sayı değerine yukarı veya aşağı yuvarlar."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "En yakın tam sayıya yuvarlanacak sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Karekökü verir."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Hipotenüs"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Karekök değerini döndürülecek sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "üs"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Bir sayıyı üs değerinin gücüne yükseltir."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Uzunluk"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Üs olan sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Üssün değeri."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Sayının 10 tabanındaki logaritmasını döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Değer"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Doğal logaritma değerini döndürülecek sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Sağlanan sayının üssüne yükseltilmiş Euler sayısını (e) döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Faiz Ayları"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Üstel değerini döndürülecek sütun veya sayı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Kontrol edilecek sütun veya metin."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Belirtilen aralıkta olup olmadıklarını görmek için bir tarih veya sayı sütununun değerlerini kontrol eder."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Oluşturulma Tarihi"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Başlangıç ve bitiş değerleri içinde olması gereken tarih veya sayısal sütun."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Aralığın başlangıcı."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Aralığın sonu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Göreli aralıkta olup olmadıklarını görmek için bir tarih sütununun değerlerini kontrol eder."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Zaman hesaplanacak tarih sütunu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Negatif değerlerin zamanda geri geldiği aralık dönemi."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "\"Gün\", \"ay\", \"yıl\" gibi zaman tipleri."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Döndürülecek sütun veya değer."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Değer1 boşsa, boş değilse değer2 döndürülür ve bu böyle devam eder."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Bir ifade listesine karşı bir ifadeyi test eder ve başka hiçbir şey karşılanmazsa isteğe bağlı bir varsayılan değerle eşleşen ilk büyük / küçük harfin karşılık gelen değerini döndürür."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Önceki koşul doğruysa döndürülecek değer vb."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Boş"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Boş değil"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Bir sütunun tüm değerlerinin toplamsal toplamı.\n"
+"örn; zaman içindeki toplam gelir."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Satır sayısının toplam sayımı.\n"
+"örn; zaman içindeki toplam satış sayısı."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Bağlı filtreler"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Etiket"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Varsayılan değer"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Standart değil"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Bunu görüntülemek için, {0} en az bir alana bağlı olmalıdır."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Bu filtrenin seçeneklerini sınırlandırın"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Başka bir kontrol paneli filtreniz varsa, bu filtre için listelenen seçenekleri diğerinin seçimine göre sınırlayabilirsiniz."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Yani önce {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "başka bir kontrol paneli filtresi ekle"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Bu gösterge tablosu filtrelerinden birini açarsanız, o filtre için bir değer seçmek, {0} filtresi için kullanılabilecek seçenekleri sınırlar."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Filtreleme sütunu"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Filtrelenmiş sütun"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Kullanıcı adlarını veya e-posta adreslerini girin"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Yeni pasaj"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00 Ö.S"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "00:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 Ö.Ö"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Saatlik"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Her gün {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Haftalık {0}, {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Her ay {0} {1}, {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Bu aboneliği silin"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Abonelikler"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Kontrol paneli aboneliği oluşturun"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "E-postayla gönder"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Bu panoyu düzenli olarak kullanıcılara veya e-posta adreslerine gönderebilirsiniz."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Slack'e gönder"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Bir kanal ve program seçin ve Metabase gerisini halleder."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Bu kontrol paneline e-posta gönder"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Sonuç yoksa göndermeyin"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Sonuçları ekleyin"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Ekler, 2.000 satıra kadar veri içerebilir."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Bu kontrol panelini Slack'e gönder"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Gösterge tablosunun {0} kimliğine sahip bir parametresi yok"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "{0} parametresinin kendisiyle ilişkili herhangi bir Alanı yok"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include ya boş olmalı ya da \"tablolar\" değeri olmalıdır"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "Türü \"dahili\" olmayan tüm sorgular için \"veritabanı\" gereklidir."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Bu örnek için şifre girişi devre dışı bırakıldı."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Hesabınız devre dışı bırakıldı. Lütfen yöneticinizle iletişime geçin."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Hesabınız devre dışı bırakıldı."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Geçersiz Slack jetonu."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "'' {0} '' komutu yalnızca Metabase Enterprise Edition'da mevcuttur."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Metabase Enterprise Edition uzantıları MEVCUTTUR."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Metabase Enterprise Edition özelliklerinin kullanımı Metabase Commercial License'a tabidir."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Ayrıntılar için bkz. {0}."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Metabase Enterprise Edition uzantıları MEVCUT DEĞİLDİR."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "{0} adlı kullanıcının {1} grubuna davetlisiniz"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0}, bir {1} hesabı oluşturdu"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0}, {1} davetini kabul etti"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Şifre Sıfırlama İsteği"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Bildirim"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] [{1}] ürününü iyileştirmeye yardımcı olun."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Bize işlerin nasıl gittiğini anlatın."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Etkinlik dinleyicisini başlatırken hata oluştu"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Birisi LDAP aracılığıyla giriş yaptığında kullanıcı özelliklerini senkronize etmeli miyiz?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "LDAP kullanıcıları için senkronizasyonu atlamak için virgülle ayrılmış kullanıcı özellikleri listesi."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Geçersiz belirteç"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Slack API hatası: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "\"Metabase_files\" adlı slack kanal eksik!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Slack entegrasyonunu tamamlamak için lütfen kanalı oluşturun veya arşivden çıkarın."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Kanal, Pulses ve MetaBot cevaplarına dahil edilen grafikleri depolamak için kullanılır."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Yüklenen resim"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Dosya Slack'e yüklenirken hata oluştu:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Geçersiz oturum. Bir Oturum örneği bekleniyordu."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "Oturum tanımlama bilgisinin SameSite'ı \"Yok\" olarak yapılandırılmış, ancak site"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "güvensiz bir bağlantı üzerinden servis edildi. Bazı tarayıcılar reddedecek"
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "bu koşullar altında çerezler."
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Üst klasör"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ": parametreler, String: id anahtarlarına sahip bir harita dizisi olmalıdır"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Geçersiz insan tarafından okunabilen değerler: değerler bir sıra olmalıdır; her öğe sıfır veya bir dizge olmalıdır"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ": insan_readable_values getirmek için değerler mevcut olmalıdır"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Alan değerlerinin toplam uzunluğu> {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "parçacık adları '}' içeremez veya boşlukla başlayamaz"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Zincir filtre sorgusu yürütülürken hata oluştu"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "{0} alanı mevcut değil."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Metin Olmayan Alana göre arama yapılamaz {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "{0} grubu için izinler veriliyor: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "{0} grubu için izinler iptal ediliyor: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Geçersiz DB izinleri: yerel sorgular için yazma erişiminiz varsa, tam veri erişiminiz olmalıdır."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "{0} olan izinler: {1} olarak değiştiriliyor"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "giriş özellik anahtarları bir anahtar kelime veya dize olmalıdır"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Metabase UI, sistem e-postaları, darbeler ve uyarılardaki tüm kullanıcılar için varsayılan dil."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Kullanıcılar bu varsayılan dili kendi hesap ayarlarından bireysel olarak geçersiz kılabilir."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Kullanıcının göreceği ön tanımlı sayfa"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Bu kaynağın tam Metabase uygulamasını yerleştirmesine izin ver"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "{0} ({1}) 'den büyük değerlere izin verilmez."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Bu, göründüğü her yerde \"Metabase\" kelimesinin yerini alacaktır."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Bunlar, grafiklerde ve Metabase'de kullanılan ana renklerdir. Değişikliklerinizin etkili olduğunu görmek için tarayıcınızı yenilemeniz gerekebilir."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Bunlar, grafiklerde ve Metabase'de kullanılan ana renklerdir. Değişikliklerinizin etkili olduğunu görmek için tarayıcınızı yenilemeniz gerekebilir."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "Site simgesi olarak kullanmak istediğiniz url veya resim."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "E-posta ve şifre ile giriş yapmaya izin verin."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Bu, haftaya göre gruplama veya GUI sorgularında filtreleme gibi şeyleri etkileyecektir.\n"
+"   SQL sorgularını etkilemez."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Jeton doğrulanamıyor"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Token biçimi geçersiz."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Jeton doğrulanırken hata oluştu"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "{0} Alanına göre filtreleme hatası: {1} Dizesi bir {2} olarak ayrıştırılamıyor"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "İş için ayrıntılar getirilirken hata oluştu: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Veritabanı {0} için senkronizasyon görevi başlatılıyor."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Veritabanı senkronize edilemiyor {0}: Veritabanı mevcut değil."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "{0} Veritabanı için tetiklenen Alan değerlerini güncelleme görevi."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Güncelleme atlandığında, otomatik Alan değeri güncellemeleri Veritabanı {0} için devre dışı bırakıldı."

--- a/locales/vi.po
+++ b/locales/vi.po
@@ -28,15 +28,16 @@ msgstr "Khám phá dữ liệu này"
 msgid "Select a database type"
 msgstr "Chọn kiểu cơ sở dữ liệu"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "Lưu"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "Để thực hiện một số magic của nó, Metabase cần quét cơ sở dữ liệu của bạn. Chúng tôi cũng sẽ quét lại định kỳ để cập nhật siêu dữ liệu. Bạn có thể kiểm soát khi việc quét lại định kỳ xảy ra dưới đây"
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "Đang đồng bộ cơ sở dữ liệu"
 
@@ -64,7 +65,7 @@ msgstr "thiết lập đồng bộ hóa hàng giờ"
 msgid "Scan"
 msgstr "Quét"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "Quét các giá trị lọc"
 
@@ -76,7 +77,7 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase có thể quét các giá trị hiện tại trong mỗi \n"
 "\" \"có thể là một quá trình tốn nhiều tài nguyên, đặc biệt nếu bạn có \\ n rất lớn\" \"cơ sở dữ liệ"
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Khi nào Metabase sẽ tự động quét và lưu các giá trị trường bộ đệm "
 
@@ -134,29 +135,31 @@ msgstr "XOÁ"
 msgid "in this box:"
 msgstr "trong hộp thoại này:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -179,9 +182,9 @@ msgstr "Xoá"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -201,8 +204,9 @@ msgstr "Kết nối"
 msgid "Scheduling"
 msgstr "Lên lịch"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -281,10 +285,10 @@ msgstr "Thêm cơ sở dữ liệu"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -319,10 +323,8 @@ msgid "Successfully saved!"
 msgstr "Lưu thành công!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "Sửa"
@@ -401,26 +403,29 @@ msgstr "Chọn một kiểu đặc biệt"
 msgid "Select a target"
 msgstr "Chọn một mục tiêu"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "Các cột"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Cột"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "Hiển thị"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "Kiểu"
 
@@ -428,7 +433,7 @@ msgstr "Kiểu"
 msgid "Current database:"
 msgstr "Cơ sở dữ liệu hiện tại:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "Đưa ra schema gốc"
 
@@ -495,7 +500,7 @@ msgstr "Tìm bảng"
 msgid "Schemas"
 msgstr "Các schema"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -512,7 +517,7 @@ msgstr "Thêm một số liệu"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "Định nghĩa"
 
@@ -580,35 +585,35 @@ msgstr " Lịch sử"
 msgid "Revision History for"
 msgstr "Lịch sử thay đổi cho"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - Cài đặt trường"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "Trường này sẽ xuất hiện trên khắp Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Lọc trên trường này"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Khi trường này được sử dụng trong bộ lọc, mọi người nên sử dụng gì để nhập giá trị họ muốn lọc?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Chưa có mô tả cho trường này"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "Giá trị gốc"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "Giá trị đã được ánh xạ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "Nhập giá trị"
 
@@ -625,31 +630,31 @@ msgid "Custom mapping"
 msgstr "Tuỳ chỉnh ánh xạ"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "Không nhận diện được kiểu ảnh xạ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Trường hiện tại không phải khoá ngoài hoặc thiếu bảng đích của khoá ngoài"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "Trường đã chọn không phải khoá ngoài"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "Các giá trị hiển thị"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Chọn hiển thị giá trị gốc từ cơ sở dữ liệu hoặc hiển thị trường này liên quan hoặc thông tin tùy chỉnh."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "Chọn một trường"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "Vui lòng chọn một cột để hiển thị."
 
@@ -657,16 +662,16 @@ msgstr "Vui lòng chọn một cột để hiển thị."
 msgid "Tip:"
 msgstr "Mẹo:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Bạn có thể muốn cập nhật tên trường để đảm bảo nó vẫn có ý nghĩa dựa trên các lựa chọn ánh xạ lại của bạn."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "Giá trị trường lưu trữ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase có thể quét các giá trị cho trường này để bật các bộ lọc hộp kiểm trong bảng điều khiển và câu hỏi."
 
@@ -693,35 +698,36 @@ msgstr "Hủy kích hoạt!"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Chọn bất kỳ bảng nào để xem lược đồ của nó và thêm hoặc chỉnh sửa siêu dữ liệu."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "Tên là bắt buộc"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "Mô tả là bắt buộc"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "Thông điệp sửa đổi là bắt buộc"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "Tổng hợp là cần thiết"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "Chỉnh sửa số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "Tạo số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Thay đổi số liệu của bạn và để lại lời giải thích"
 
@@ -729,46 +735,46 @@ msgstr "Thay đổi số liệu của bạn và để lại lời giải thích"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Bạn có thể tạo số liệu đã lưu để thêm tùy chọn số liệu được đặt tên vào bảng này. Số liệu đã lưu bao gồm loại tổng hợp, trường tổng hợp và tùy chọn bất kỳ bộ lọc nào bạn thêm. Ví dụ: bạn có thể sử dụng điều này để tạo một cái gì đó giống như cách tính chính thức \\ \"Giá trung bình \" cho bảng Đơn hàng."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "Kết quả: "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "Đặt tên số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "Đặt tên số liệu của bạn để giúp người khác tìm thấy nó"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "Một vài mô tả không quá dài"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "Mô tả số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Cho số liệu của bạn một lời mô tả để giúp người khác hiểu nó là gì"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Đây là một nơi tốt để cụ thể hơn về các quy tắc số liệu ít rõ ràng hơn"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "Lý do thay đổi"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Để lại một ghi chú để giải thích những thay đổi bạn đã thực hiện và tại sao chúng được yêu cầu."
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Điều này sẽ hiển thị trong lịch sử sửa đổi cho số liệu này để giúp mọi người nhớ tại sao mọi thứ thay đổi"
 
@@ -821,6 +827,7 @@ msgstr "Điều này sẽ hiển thị trong lịch sử sửa đổi cho phân 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -835,8 +842,7 @@ msgid "Re-scan this table"
 msgstr "Quét lại bảng này"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "Thêm"
 
@@ -853,7 +859,7 @@ msgid "Last name"
 msgstr "Họ"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "Địa chỉ email"
@@ -862,7 +868,7 @@ msgstr "Địa chỉ email"
 msgid "Permission Groups"
 msgstr "Nhóm quyền"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "Cho người dùng này làm quản trị viên"
 
@@ -959,6 +965,8 @@ msgstr "Xoá nhóm"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -971,11 +979,12 @@ msgstr "Xong"
 msgid "Group name"
 msgstr "Tên nhóm"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "Các nhóm"
@@ -1084,7 +1093,7 @@ msgstr "Đặt lại"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "Bạn chắc chắn muốn thực hiện chứ?"
 
@@ -1196,7 +1205,7 @@ msgstr "Không có thay đổi gì về quyền."
 msgid "You've made changes to permissions."
 msgstr "Bạn đã tạo thay đổi về quyền."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "Quyền hạn cho bộ sưu tập này"
 
@@ -1252,6 +1261,7 @@ msgstr "Giới hạn truy cập"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "Thu hồi quyền truy cập"
 
@@ -1315,23 +1325,23 @@ msgstr "Bộ sưu tập"
 msgid "View collection"
 msgstr "Xem bộ sưu tập"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "Truy cập dữ liệu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "Xem bảng"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "Truy vấn SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "Xem schema"
 
@@ -1402,12 +1412,15 @@ msgstr "Đã gửi!"
 msgid "Clear"
 msgstr "Xoá"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "Xác thực"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "Cài đặt máy chủ"
@@ -1420,6 +1433,7 @@ msgstr "Schema người dùng"
 msgid "Attributes"
 msgstr "Các thuộc tính"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "Nhóm Schema"
@@ -1491,6 +1505,9 @@ msgid "Add a map"
 msgstr "Thêm một bản đồ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL"
@@ -1500,19 +1517,19 @@ msgid "Delete custom map"
 msgstr "Xoá bản đồ tuỳ chỉnh"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "Xoá"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1610,19 +1627,19 @@ msgstr "Mua một mã"
 msgid "Enter a token"
 msgstr "Nhập một mã"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "Sửa các ánh xạ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "Nhóm các ánh xạ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "Tạo một ánh xạ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1861,18 +1878,27 @@ msgstr "Lọc người dùng"
 msgid "Check your parentheses"
 msgstr "Kiểm tra dấu ngoặc đơn"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "Thuộc tính email"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "Thuộc tính tên"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "Thuộc tính họ"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "Đồng bộ thành viên nhóm"
@@ -1901,59 +1927,59 @@ msgstr "Tuỳ chỉnh các bản đồ"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Thêm các file GeoJSON của bạn để có thể hiển thị các khu vực bản đồ khác nhau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "Chia sẻ công khai"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "Bật chia sẻ công khai"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "Các trang tổng quan được chi sẻ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "Các câu hỏi được chia sẻ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "Nhung vào các ứng dụng khác"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Cho phép nhúng Metabase vào các ứng dụng khác"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "Mã nhúng khoá bí mật"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "Các trang tổng quan được nhúng"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "Các câu hỏi được nhúng"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "Bộ nhớ đệm"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "Kích hoạt bộ nhớ đệm"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "Thời gian truy vấn tối thiểu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Bộ nhớ đệm hệ số nhân thời gian sống (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "Kích thước mục nhập bộ nhớ cache tối đa"
 
@@ -1995,27 +2021,27 @@ msgstr "Bạn sẽ cần quản trị viên tạo một tài khoản Metabase tr
 msgid "Sign in with {0}"
 msgstr "Đăng nhập với {0}"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "Xin hãy liên hệ với quản trị viên để đặt lại mật khẩu cho bạn"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "Quên mật khẩu"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "Địa chỉ email sử dụng cho tài khoản Metabase"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "Gửi email khôi phục mật khẩu"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Hãy kiểm tra email hướng dẫn cách đặt lại mật khẩu."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "Đăng nhập vào Metabase"
 
@@ -2036,11 +2062,11 @@ msgstr "Đăng nhập"
 msgid "I seem to have forgotten my password"
 msgstr "Có vẻ như tôi đã quên mật khẩu của mình"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "yêu cầu một email đặt lại mật khẩu"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "Ôi, liên kết đó đã hết hạn"
 
@@ -2049,11 +2075,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "Vì lý do bảo mật, liên kết đặt lại mật khẩu sẽ hết hạn trong một khoảng thời gian. Nếu bạn vẫn cần đặt lại mật khẩu, bạn có thể {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "Mật khẩu mới"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "Để giữ cho dữ liệu của bạn được bảo mật, mật khẩu {0}"
 
@@ -2076,24 +2102,24 @@ msgstr "Xác nhận mật khẩu mới"
 msgid "Make sure it matches the one you just entered"
 msgstr "Hãy đảm bảo rằng nó khớp với giá trị bạn vừa nhập"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "Mật khẩu của bạn đã được đặt lại."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "Đăng nhập với mật khẩu mới"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Lưu thất bại"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2103,25 +2129,26 @@ msgstr "Đã lưu"
 msgid "Ok"
 msgstr "Được"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "Lưu trữ bộ sưu tập này?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Bảng điều khiển, bộ sưu tập và xung trong bộ sưu tập này cũng sẽ được lưu trữ."
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "Lưu trữ"
 
@@ -2246,7 +2273,7 @@ msgstr "Các ghim"
 msgid "Drag something here to pin it to the top"
 msgstr "Kéo thứ gì đó vào đây để ghim nó lên đầu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2274,6 +2301,7 @@ msgstr "Di chuyển \"{0}\"?"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "Di chuyển"
@@ -2311,7 +2339,7 @@ msgstr "Một vài cài đặt cơ sở dữ liệu chỉ có thể truy cập b
 "Lựa chọn này cung cấp một tầng bảo mật khi VPN không khả dụng.\n"
 "Bật tính năng này sẽ làm chậm hết nối hơn là kết nối trực tiếp."
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Đây là một cơ sở dữ liệu lớn, vậy nên hãy để tôi chọn khi nào thì Metabase đồng bộ và quét"
 
@@ -2350,7 +2378,7 @@ msgstr "Để sử dụng Metabase với dữ liệu này bạn phải bật tí
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} để đi tới bảng điều khiển nếu bạn chưa làm thế."
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "Bạn muốn tham khảo cơ sở dữ liệu này như thế nào?"
 
@@ -2466,35 +2494,35 @@ msgstr "Dựa vào schema"
 msgid "A look at your"
 msgstr "Nhìn vào cái của bạn"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "Tìm kiếm trong danh sách"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "Tìm kiếm theo {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr " hoặc nhập vào một ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "Nhập vào một ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "Nhập vào một số"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "Nhập vào vài dòng chữ"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "Không có {0} nào khớp."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Bao gồm mọi tùy chọn trong bộ lọc của bạn có thể sẽ không làm được nhiều"
 
@@ -2506,7 +2534,6 @@ msgstr "Có gì đó sai"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "Đã gặp lỗi. Bạn có  thể thử làm mới lại trang, hoặc trở về trang trước."
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2517,12 +2544,12 @@ msgstr "Đã gặp lỗi. Bạn có  thể thử làm mới lại trang, hoặc 
 msgid "No description yet"
 msgstr "Chưa có mô tả"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "{0} mới"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "Được hỏi bởi {0}"
 
@@ -2543,7 +2570,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "Khôi phục về phiên bản trước đó và {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "Lịch sử thay đổi"
@@ -2589,7 +2618,7 @@ msgid "Questions"
 msgstr "Các câu hỏi"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "Xung"
 
@@ -2663,52 +2692,69 @@ msgstr "Không phải bây giờ"
 msgid "Error:"
 msgstr "Lỗi:"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "Chủ nhật"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "Thứ hai"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "Thứ ba"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "Thứ tư"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "Thứ năm"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "Thứ sáu"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "Thứ bảy"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "Đầu tiên"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "Cuối cùng"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "15 (điểm giữa)"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "Lịch ngày"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "Múi giờ Metabase của bạn"
 
@@ -2762,11 +2808,11 @@ msgstr "Tạo"
 msgid "Create dashboard"
 msgstr "Tạo trang tổng quan"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "Bảng"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "Cơ sở dữ liệu"
 
@@ -2841,9 +2887,9 @@ msgstr "Tên thẻ của bạn là gì?"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2857,15 +2903,16 @@ msgstr "Mô tả"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "Nó không bắt buộc, nhưng có ích đó"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "Cái này nên đi vào bộ sưu tập nào?"
 
@@ -2905,11 +2952,11 @@ msgstr "Lưu trữ bảng điều khiển"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Đảm bảo thực hiện lựa chọn cho từng chuỗi hoặc bộ lọc sẽ không hoạt động trên thẻ này."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "Bảng điều khiển này trống"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "Thêm một câu hỏi để bắt đầu khiến nó hữu ích"
 
@@ -2929,7 +2976,7 @@ msgstr "Thoát toàn màn hình"
 msgid "Enter fullscreen"
 msgstr "Vào toàn màn hình"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Đang lưu..."
@@ -2942,7 +2989,8 @@ msgstr "Thêm một câu hỏi"
 msgid "Add a question to this dashboard"
 msgstr "Thêm một câu hỏi vào bảng điều khiển này"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "Thêm một bộ lọc"
 
@@ -2950,7 +2998,7 @@ msgstr "Thêm một bộ lọc"
 msgid "Parameters"
 msgstr "Thông số"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "Thêm một hộp văn bản"
 
@@ -2958,7 +3006,7 @@ msgstr "Thêm một hộp văn bản"
 msgid "Move dashboard"
 msgstr "Di chuyển bảng điều khiển"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "Chỉnh sửa bảng điều khiển"
 
@@ -2982,11 +3030,11 @@ msgstr "Di chuyển bảng điều khiển đến..."
 msgid "Dashboard moved to {0}"
 msgstr "Bảng điều khiển đã di chuyển tới {0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "Bạn muốn lọc cái gì?"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "Kiểu của bộ lọc là gì?"
 
@@ -3058,20 +3106,22 @@ msgstr "Thẻ này không có bất kỳ trường hoặc tham số nào có th�
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Các giá trị trong trường này không trùng với giá trị của bất kỳ trường nào khác bạn đã chọn."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "Trường không khả dụng"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "Tên phải chứa ít hơn 100 kí tự"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "Màu sắc là bắt buộc"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "Tên của bảng điều khiển của bạn là gì?"
 
@@ -3126,7 +3176,7 @@ msgstr "Đã nhận dữ liệu mới nhất từ"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "Không biết"
 
@@ -3251,9 +3301,10 @@ msgstr "Bạn không xem bảng điều khiển hay câu hỏi nào gần đây"
 msgid "{0} items selected"
 msgstr "{0} mục được chọn"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "Bỏ lưu trữ"
 
@@ -3370,7 +3421,7 @@ msgid "Zip Code"
 msgstr "Mã bưu chính"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "Số lượng"
 
@@ -3403,11 +3454,13 @@ msgid "User"
 msgstr "Người dùng"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "Nguồn"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "Giá"
 
@@ -3440,21 +3493,23 @@ msgid "Subscription"
 msgstr "Theo dõi"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "Điểm"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "Tiêu đề"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "Bình luận"
 
@@ -3508,14 +3563,14 @@ msgstr "Cơ sở dữ liệu tích lũy sẽ không bao giờ lấy lại trư�
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "Số đếm"
 
@@ -3523,7 +3578,7 @@ msgstr "Số đếm"
 msgid "CumulativeCount"
 msgstr "Số tích lũy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3541,19 +3596,19 @@ msgstr "Phân biệt"
 msgid "StandardDeviation"
 msgstr "Độ lệch chuẩn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "Trung bình"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "Nhỏ nhất"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3564,12 +3619,12 @@ msgstr "Lớn nhất"
 msgid "sad sad panda, lexing errors detected"
 msgstr "Lỗi lexing được phát hiệ"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} giây"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} phút"
@@ -3609,14 +3664,15 @@ msgstr "Bạn muốn tìm cái gì?"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "Dữ liệu gốc"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "Số tích lũy"
 
@@ -3678,166 +3734,164 @@ msgstr "Đúng"
 msgid "False"
 msgstr "Sai"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "Chọn trường kinh độ"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "Nhập vĩ độ cao hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "Nhập kinh độ trái"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "Nhập vĩ độ thấp hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "Nhập kinh độ phải"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "Là"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "Không là"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "Trống"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "Không trống"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "Bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "Không bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "Lớn hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "Ít hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Giữa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "Lớn hơn hoặc bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "Ít hơn hoặc bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "Bao gồm"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "Không bao gồm"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "Bắt đầu với"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "Kết thúc với"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Trước"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Sau"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "Bên trong"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Chỉ cần một bảng với các hàng trong câu trả lời, không có thao tác bổ sung."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "Đếm số hàng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "Tổng số dòng trong câu trả lời"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "Tổng của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "Tổng tất cả giá trị của một cột"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "Trung bình của..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "Trung bình tất cả giá trị của một cột"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "Số lượng giá trị riêng biệt của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Số giá trị duy nhất của một cột trong số tất cả các hàng trong câu trả lời."
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "Tổng cộng của"
 
@@ -3845,7 +3899,7 @@ msgstr "Tổng cộng của"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Tổng cộng của tất cả các giá trị của một cột. \\\\ ne.x. tổng doanh thu theo thời gian."
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "Số hàng tích lũy"
 
@@ -3853,27 +3907,27 @@ msgstr "Số hàng tích lũy"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Tổng số phụ của số lượng hàng. \\\\ ne.x. tổng số lượng bán hàng theo thời gian."
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "Độ lệch chuẩn của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Số biểu thị số lượng giá trị của một cột khác nhau giữa tất cả các hàng trong câu trả lời."
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "Nhỏ nhất của..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "Giá trị nhỏ nhất của cột"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "Lớn nhất của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "Giá trị cao nhất của cột"
 
@@ -3889,6 +3943,8 @@ msgstr "chữ thường"
 msgid "upper case letter"
 msgstr "chữ hoa"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "số"
@@ -4136,7 +4192,7 @@ msgstr "Cách tạo số liệu"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "Xem dữ liệu theo thời gian, dưới dạng bản đồ hoặc xoay vòng để giúp bạn hiểu xu hướng hoặc thay đổi."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "Tập quán"
 
@@ -4159,7 +4215,7 @@ msgstr "Truy vấn gốc"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Với nhiều câu hỏi phức tạp hơn, bạn có thể viết SQL hoặc truy vấn gốc của bạn."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "Chọn một giá trị mặc định..."
 
@@ -4247,7 +4303,7 @@ msgstr "Tháng này"
 msgid "This Year"
 msgstr "Năm nay"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "Nhập một giá trị..."
@@ -4257,7 +4313,7 @@ msgid "Enter a default value..."
 msgstr "Nhập một giá trị mặc định..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Có lỗi xảy ra"
@@ -4514,22 +4570,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "Chọn câu hỏi bạn muốn gửi trong xung này"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "Email"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Tin nhắn Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "Đã gửi"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0} sẽ được gửi tại"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "Tin nhắn"
 
@@ -4601,30 +4665,30 @@ msgstr "Giúp mọi người trong nhóm của bạn tiếp tục đồng bộ v
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "Các xung cho phép bạn gửi dữ liệu từ Metabase đến email hoặc Slack theo lịch bạn chọn"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "Sau {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "Trước {0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Trống rỗng"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Không trống rỗng"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Tất cả thời gian"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "Áp dụng"
 
@@ -4724,12 +4788,12 @@ msgstr[0] "Xem {0}"
 msgid "Zoom in"
 msgstr "Phóng to"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "Biểu hiện tùy chỉnh"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "Số liệu chung"
 
@@ -4926,7 +4990,7 @@ msgstr "thường"
 msgid "Pick a segment or table"
 msgstr "Chọn một phân đoạn hoặc bảng"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "Chọn một cơ sở dữ liệu"
@@ -4987,7 +5051,7 @@ msgstr "Phân loại"
 msgid "Row limit"
 msgstr "Giới hạn dòng"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "Trường không xác định"
 
@@ -4995,7 +5059,7 @@ msgstr "Trường không xác định"
 msgid "field"
 msgstr "trường"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "Những sự kết hợp"
 
@@ -5020,11 +5084,11 @@ msgstr "Thêm một nhóm"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dữ liệu"
 
@@ -5041,11 +5105,12 @@ msgstr "Xem"
 msgid "Grouped By"
 msgstr "Được nhóm bởi"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "Không"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "Câu hỏi này được viết bằng {0}"
 
@@ -5057,7 +5122,7 @@ msgstr "Ẩn biên tập"
 msgid "Hide Query"
 msgstr "Ẩn truy vấn"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "Mở trình chỉnh sửa"
 
@@ -5065,7 +5130,7 @@ msgstr "Mở trình chỉnh sửa"
 msgid "Show Query"
 msgstr "Hiển thị truy vấn"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "Số liệu này đã được bỏ. Nó không còn có sẵn để sử dụng."
 
@@ -5265,7 +5330,7 @@ msgstr "Quay lại lần chạy trước"
 msgid "Visualization"
 msgstr "Hình ảnh hóa"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "Không có bộ mô tả."
 
@@ -5322,7 +5387,7 @@ msgstr "Không thể tìm thấy siêu dữ liệu bảng trước khi tạo câ
 msgid "See {0}"
 msgstr "Xem {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "Định nghĩa số liệu"
 
@@ -5340,11 +5405,11 @@ msgstr "Số của {0}"
 msgid "See all {0}"
 msgstr "Xem tất cả {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "Định nghĩa phân đoạn"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "Lỗi xảy ra khi tải bảng"
 
@@ -5352,7 +5417,7 @@ msgstr "Lỗi xảy ra khi tải bảng"
 msgid "See the raw data for {0}"
 msgstr "Xem dữ liệu thô cho {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "Nhiều hơn"
 
@@ -5372,6 +5437,8 @@ msgstr "Công thức trường"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Hãy nghĩ về điều này giống như viết một công thức trong chương trình bảng tính: bạn có thể sử dụng các số, các trường trong bảng này, các ký hiệu toán học như + và một số hàm. Vì vậy, bạn có thể gõ một cái gì đó như tổng phụ - Chi phí."
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5439,7 +5506,7 @@ msgstr "sai"
 msgid "Add filter"
 msgstr "Thêm bộ lọc"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "mục"
 
@@ -5558,11 +5625,11 @@ msgstr "Trường để ánh xạ tới"
 msgid "Filter widget type"
 msgstr "Loại bộ lọc"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "Cần thiết?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "Giá trị widget bộ lọc mặc định"
 
@@ -5574,7 +5641,7 @@ msgstr "Lưu trữ câu hỏi này?"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Câu hỏi này sẽ bị xóa khỏi bất kỳ bảng điều khiển hoặc xung sử dụng nó."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "Câu hỏi"
 
@@ -5621,7 +5688,7 @@ msgstr "Kiểu trường"
 msgid "Select a Foreign Key"
 msgstr "Chọn một chìa khóa nước ngoài"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "Xem công thức {0}"
 
@@ -6105,22 +6172,24 @@ msgstr "Câu hỏi về phân khúc này"
 msgid "X-ray this segment"
 msgstr "X-ray phân khúc này"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "Đăng nhập"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "Bảng điều khiển"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "Câu hỏi mới"
 
@@ -6192,35 +6261,35 @@ msgstr "Tất cả bộ sưu tập đều hoàn toàn ẩn danh"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Có thể tắt bộ sưu tập bất cứ lúc nào trong phần cài đặt quản trị của bạn"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "Nếu bạn cảm thấy bế tắc"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "Hướng dẫn khởi động của chúng tôi"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "Chỉ một click nữa"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "Chào mừng đến Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Có vẻ mọi thứ đang hoạt động. Giờ để hiểu về bạn, hãy kết nối dữ liệu của bạn, và bắt đầu tìm kiếm cho bạn vài câu trả lời"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "Cùng bắt đầu"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "Bạn đã được trang bị đầy đủ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "Đưa tôi đến Metabase"
 
@@ -6472,39 +6541,40 @@ msgstr "Hủy lọc"
 msgid "Pin Map"
 msgstr "Gắn bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "Không đặt"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "Hàng {0} - {1} trong số {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "Dữ liệu bị cắt ngắn thành {0} hàng"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "Không thể tìm thấy trực quan"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "Không thể hiển thị biểu đồ này với dữ liệu này"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "Không có kết quả"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "Đang chờ..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "Điều này thường mất trung bình {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Đây là một chút dài cho một bảng điều khiển)"
 
@@ -6614,7 +6684,7 @@ msgid "Highlight the whole row"
 msgstr "Đánh dấu toàn bộ hàng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Màu"
 
@@ -6700,24 +6770,50 @@ msgstr "Mục đích"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "Đừng! Dữ liệu từ truy vấn của bạn không phù hợp với lựa chọn hiển thị đã chọn. Hình dung này yêu cầu ít nhất {0} {1} dữ liệu."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "cột"
@@ -6748,7 +6844,7 @@ msgid "xValues missing!"
 msgstr "Giá trị thiếu"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Trục X"
 
@@ -6757,7 +6853,7 @@ msgid "Add a series breakout..."
 msgstr "Thêm chuỗi"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "trục Y"
 
@@ -6770,7 +6866,7 @@ msgid "Bubble size"
 msgstr "Kích thước bong bóng"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "Dòng"
 
@@ -6912,20 +7008,20 @@ msgid "Standard Deviation"
 msgstr "Độ lệch chuẩn"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "Vùng"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "biểu đồ khu vực"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "Thanh"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "biểu đồ thanh"
 
@@ -6939,7 +7035,7 @@ msgid "Funnel"
 msgstr "Phễu"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Đo lường"
 
@@ -6951,81 +7047,81 @@ msgstr "Loại phễu"
 msgid "Bar chart"
 msgstr "Biểu đồ cột"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "biểu đồ đường"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Vui lòng chọn các cột kinh độ và vĩ độ trong cài đặt biểu đồ."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "Vui lòng chọn một bản đồ khu vực."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Vui lòng chọn các cột khu vực và số liệu trong cài đặt biểu đồ."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "Loại bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "Vùng trên bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "Đánh dấu trên bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "Loại đánh dấu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "Ngói"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "Dấu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "Trường vĩ độ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "Trường kinh độ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "Trường số liệu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "Trường vùng"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "Bán kính"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "Làm nhòe"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "Độ mờ tối thiểu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "Thu phóng tối đa"
 
@@ -7037,7 +7133,7 @@ msgstr "Không tìm thấy quan hệ"
 msgid "via {0}"
 msgstr "thông qua {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr " {0} này được liên kết đến:"
 
@@ -7049,31 +7145,31 @@ msgstr "Chi tiết đối tượng"
 msgid "object"
 msgstr "đối tượng"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "Tổng"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Cột bạn muốn sử dụng"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Bánh"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Kích thước"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Hiển thị huyền thoại"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Hiển thị phần trăm trong huyền thoại"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Tỉ lệ phần trăm tối thiểu"
 
@@ -7098,7 +7194,8 @@ msgid "Progress"
 msgstr "Đang thực hiện"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Màu"
@@ -7107,7 +7204,7 @@ msgstr "Màu"
 msgid "Row Chart"
 msgstr "Biểu đồ hàng"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "biểu đồ hàng"
 
@@ -7131,15 +7228,15 @@ msgstr "Thêm một hậu tố"
 msgid "Multiply by a number"
 msgstr "Nhân với một số"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "Tiêu tan"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "phân tán âm mưu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "Xoay bảng"
 
@@ -7190,12 +7287,12 @@ msgstr "Phải"
 msgid "Show background"
 msgstr "Hiển thị nền"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "ngăn"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "tự động ngăn"
 
@@ -7431,10 +7528,13 @@ msgstr "Có rất nhiều câu hỏi được lưu trong {0}? Tạo các bộ s�
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Cơ sở dữ liệu"
 
@@ -7622,7 +7722,7 @@ msgstr "tổng tích lũy"
 msgid "{0} and {1}"
 msgstr "{0} và {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} của {1}"
@@ -8934,11 +9034,11 @@ msgstr "Quyền dữ liệu"
 msgid "Collection permissions"
 msgstr "Quyền thu thập"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "Xem tất cả các quyền thu thập"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "Đồng thời thay đổi bộ sưu tập phụ"
 
@@ -8950,19 +9050,19 @@ msgstr "Có thể chỉnh sửa bộ sưu tập này và nội dung của nó"
 msgid "Can view items in this collection"
 msgstr "Có thể xem các mục trong bộ sưu tập này"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "Có thể xem các mục trong bộ sưu tập này"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Nhóm này có quyền xem ít nhất một bộ sưu tập của bộ sưu tập này."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Nhóm này có quyền chỉnh sửa ít nhất một bộ sưu tập con của bộ sưu tập này."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "Xem các bộ sưu tập phụ "
 
@@ -9018,6 +9118,7 @@ msgstr "Liên quan"
 msgid "More X-rays"
 msgstr "Thêm tia X"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9276,10 +9377,10 @@ msgstr "Chia sẻ"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9363,7 +9464,7 @@ msgstr "Sử dụng múi giờ JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Chúng tôi hiện đang phân tích các bảng và trường để giúp bạn khám phá dữ liệu của mình. "
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "Mẹo"
 
@@ -9371,7 +9472,7 @@ msgstr "Mẹo"
 msgid "Select a currency type"
 msgstr "Chọn một loại tiền tệ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "Loại lĩnh vực"
 
@@ -9426,6 +9527,7 @@ msgid "Currency"
 msgstr "Tiền tệ"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "Chọn người dùng hoặc kênh ..."
 
@@ -9587,7 +9689,7 @@ msgstr "Trục nào?"
 msgid "Line + Bar"
 msgstr "Dòng + Cột"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "biểu đồ đường và biểu đồ cột"
 
@@ -9607,15 +9709,15 @@ msgstr "Phạm vi đo"
 msgid "Field to show"
 msgstr "Lĩnh vực để hiển thị"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "cuối {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0} là {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Nhóm theo trường thời gian để xem điều này đã thay đổi theo thời gian như thế nào"
 
@@ -9623,23 +9725,23 @@ msgstr "Nhóm theo trường thời gian để xem điều này đã thay đổi
 msgid "Switch positive / negative colors?"
 msgstr "Chuyển màu dương / âm?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "Cột xoay"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "Cột di động"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "Cột có thể nhìn thấy"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "Định dạng có điều kiện"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "Tiêu đề cột"
 
@@ -10077,10 +10179,10 @@ msgstr "Người dùng mỗi nguồn"
 msgid "The top external pages that brought users to your site"
 msgstr "Các trang bên ngoài hàng đầu đã đưa người dùng đến trang web của bạn"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "Cách [[này]] được phân phối và hơn thế nữa"
 
@@ -10178,13 +10280,13 @@ msgstr "Sự kiện mỗi giờ trong ngày"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "Top 5 [[này]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "Dưới 5 [[này]]"
 
@@ -10197,10 +10299,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Mỗi [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "Giá trị không"
 
@@ -10228,8 +10330,8 @@ msgstr "Làm thế nào họ so sánh theo mùa"
 msgid "Average income per transaction"
 msgstr "Thu nhập trung bình trên mỗi giao dịch"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "[[này]] mỗi quốc gia"
 
@@ -10353,10 +10455,10 @@ msgstr "Tổng quan về [[này]] của bạn và cách phân bổ theo thời g
 msgid "Average income per state"
 msgstr "Thu nhập trung bình trên mỗi huyện"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] bởi [[GenericCategoryMedium]"
 
@@ -10533,13 +10635,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "Cách [[GenericTable]] được phân bổ trên trường thời gian này nếu nó có bất kỳ mẫu theo mùa nào."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "Tổng qua"
 
@@ -10648,8 +10750,8 @@ msgstr "Đây là một cái nhìn gần hơn về [[this]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "Đây là một cái nhìn gần hơn về trường [[this]] của bạ"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "Tóm lượ"
 
@@ -10713,10 +10815,10 @@ msgstr "Doanh số theo nguồ"
 msgid "Average income per country"
 msgstr "Thu nhập bình quân theo vùn"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "Cách [[this]] được phân b"
 
@@ -10737,17 +10839,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "Đếm [[GenericCategoryMedium]] theo [[this]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "Xem [[this]]"
 
@@ -10813,10 +10915,10 @@ msgid "Transactions per source over time"
 msgstr "Giao dịch trên mỗi nguồn theo thời gia"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr " Cách [[this]] được phân b"
 
@@ -10845,9 +10947,9 @@ msgstr "Các sự kiện này xảy ra ở đâ"
 msgid "Which US states are bringing you the most business."
 msgstr "Những tiểu bang nào của Hoa Kỳ đang mang lại cho bạn nhiều mối làm ăn nhất."
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "Làm thế nào họ so sánh theo thời gian"
 
@@ -10952,8 +11054,8 @@ msgstr "Phiên theo vùng"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "Một số số liệu thú vị về số liệu thống kê GA của bạn để giúp bạn bắt đầu."
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]] theo vùn"
 
@@ -11034,12 +11136,12 @@ msgstr "Cách số liệu này được phân bổ trên các số khác nhau"
 msgid "Sessions by page where the session began"
 msgstr "Phiên theo trang nơi phiên bắt đầu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "Giá trị riêng biệt"
 
@@ -11102,10 +11204,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "Các sự kiện theo [[GenericCategoryLarge]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "Làm thế nào so sánh bằng phân bổ"
@@ -11411,6 +11513,7 @@ msgstr "Đã tạo bản sao"
 msgid "Duplicate \"{0}\""
 msgstr "Tạo bản sao \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11499,9 +11602,9 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "quý mỗi năm"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "lựa chọn"
@@ -11523,11 +11626,11 @@ msgstr "Không phù hợp"
 msgid "Add a time"
 msgstr "Thêm thời gian"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "Không có gì để so sánh với {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "bởi {0}"
 
@@ -12015,9 +12118,9 @@ msgstr "Dưới đây là tổng quan về những người trong [[this]]"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "[[CreateTimestamp]] theo quý của năm"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "Cách họ so sánh giữa các vị trí"
 
@@ -12046,12 +12149,12 @@ msgstr "[[CreateTimestamp]] theo ngày trong tuần"
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "Đây là tổng quan về dữ liệu [[this]] của bạn từ Google Analytics"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "Đây là tổng quan về [[this]]"
 
@@ -12129,11 +12232,11 @@ msgstr "bộ sưu tập"
 msgid "collections"
 msgstr "bộ sưu tập"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "bảng điều khiển"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "bảng điều khiển"
 
@@ -12383,7 +12486,7 @@ msgstr "Đã hết thời gian sau {0} mili giây."
 msgid "Misfire Instruction"
 msgstr "Hướng dẫn Misfire"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "Lưu trữ cái này?"
 
@@ -12401,7 +12504,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "Sử dụng tùy chọn này yêu cầu máy chủ được cung cấp là FQDN. Nếu kết nối với cụm Atlas, bạn có thể cần bật tùy chọn này. Nếu bạn không biết điều này có nghĩa là gì, hãy để điều này bị vô hiệu hóa."
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "Tự động chạy truy vấn khi thực hiện lọc và tóm tắt đơn giản"
 
@@ -12413,7 +12516,7 @@ msgstr "Khi cái này trên Metabase sẽ tự động chạy các truy vấn kh
 msgid "Learn about this database"
 msgstr "Tìm hiểu về cơ sở dữ liệu này"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "Lưu trữ bảng điều khiển này?"
 
@@ -12469,11 +12572,11 @@ msgstr "Câu hỏi tuỳ chỉnh"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "Sử dụng trình chỉnh sửa sổ ghi chép nâng cao để nối dữ liệu, tạo cột tùy chỉnh, làm toán và hơn thế nữa."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "Các số liệu cơ bản"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "Tuỳ chỉnh..."
 
@@ -12656,15 +12759,15 @@ msgstr "Chọn một hiển thị"
 msgid "Filter by"
 msgstr "Lọc theo"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "Tóm tắt bằng"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "Nhóm theo"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "Thêm một số liệu"
 
@@ -12675,15 +12778,15 @@ msgstr "Thêm một số liệu"
 msgid "Profile"
 msgstr "Hồ sơ"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "Điều này thường khá nhanh nhưng bây giờ dường như sẽ mất một lúc."
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "Combo"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "Hàng"
 
@@ -13105,7 +13208,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Chọn các cột bạn muốn bao gồm"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "Khi điều này được bật, Metabase sẽ tự động chạy các truy vấn khi người dùng thực hiện các khám phá đơn giản với các nút Tóm tắt và Lọc khi xem bảng hoặc biểu đồ. Bạn có thể tắt cái này nếu truy vấn cơ sở dữ liệu này chậm. Cài đặt này không ảnh hưởng truy vấn khoan sâu hoặc truy vấn SQL."
 
@@ -13171,7 +13274,7 @@ msgstr "Đăng ký bằng email"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "Sử dụng tùy chọn này yêu cầu máy chủ được cung cấp là FQDN. Nếu kết nối với cụm Atlas, bạn có thể cần bật tùy chọn này. Nếu bạn không biết điều này có nghĩa là gì, hãy để điều này bị vô hiệu hóa."
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Theo mặc định, Metabase thực hiện đồng bộ hóa hàng giờ và quét kỹ các giá trị trường hàng ngày. Nếu bạn có cơ sở dữ liệu lớn, chúng tôi khuyên bạn nên bật tính năng này và xem xét thời điểm và tần suất quét giá trị trường xảy ra."
 
@@ -13239,11 +13342,11 @@ msgstr "Không bao gồm"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "Trường này sẽ không hiển thị hoặc có thể lựa chọn trong các câu hỏi được tạo bằng giao diện GUI. Nó vẫn sẽ có thể truy cập được trong SQL / truy vấn gốc."
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "Tổng tích lũy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "Độ lệch chuẩn"
 
@@ -13259,19 +13362,19 @@ msgstr "Phải dài ít nhất {0} ký tự"
 msgid "Name (required)"
 msgstr "Tên (bắt buộc)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "Chạy văn bản đã chọn"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "Thực hiện truy vấn"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "(⌘ + enter)"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "(Ctrl + enter)"
 
@@ -13619,7 +13722,7 @@ msgstr "Ngày và giờ"
 msgid "Numbers"
 msgstr "Số"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "Không có nhóm bản đồ"
 
@@ -13659,15 +13762,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "Ghi nhớ tôi"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "Vì lý do bảo mật, liên kết đặt lại mật khẩu sẽ hết hạn sau một thời gian. Nếu bạn vẫn cần đặt lại mật khẩu, bạn có thể {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "Lưu mật khẩu mới"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "Không có kết quả phù hợp"
 
@@ -13693,26 +13796,26 @@ msgid "or"
 msgstr "hoặc"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "bắt buộc"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "Kiểu cơ sở dữ liệu"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "Đây là một quy trình nhẹ kiểm tra các bản cập nhật cho lược đồ cơ sở dữ liệu này. Trong hầu hết các trường hợp, bạn sẽ ổn khi để bộ này đồng bộ hóa hàng giờ."
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase có thể quét các giá trị hiện diện trong từng trường trong cơ sở dữ liệu này để bật các bộ lọc hộp kiểm trong bảng điều khiển và câu hỏi. Đây có thể là một quá trình hơi tốn tài nguyên, đặc biệt nếu bạn có một cơ sở dữ liệu rất lớn."
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Bộ sư tập"
 
@@ -13759,7 +13862,7 @@ msgstr "Phân minh"
 msgid "URLs"
 msgstr "Đường dẫn"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "Trả về giá trị trung bình của các giá trị trong cột."
 
@@ -13768,11 +13871,13 @@ msgstr "Trả về giá trị trung bình của các giá trị trong cột."
 msgid "The column whose values to average."
 msgstr "Cột có giá trị trung bình."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "bắt đầu"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "kết thúc"
 
@@ -13784,21 +13889,19 @@ msgstr "Kiểm tra giá trị của một ngày hoặc cột số để xem chú
 msgid "Rating"
 msgstr "Xếp hạng"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "điều kiện"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "đầu ra"
 
@@ -13806,27 +13909,27 @@ msgstr "đầu ra"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "Kiểm tra danh sách các trường hợp và trả về giá trị tương ứng của trường hợp đúng đầu tiên, với giá trị mặc định tùy chọn nếu không có gì khác được đáp ứng."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "Trọng lượng"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "Lớn"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "Medium"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "Nhỏ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "Một cái gì đó nên đánh giá là đúng hay sai."
 
@@ -13834,33 +13937,33 @@ msgstr "Một cái gì đó nên đánh giá là đúng hay sai."
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "Giá trị sẽ được trả về nếu điều kiện trước là đúng."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "value1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "value2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "Xem xét các giá trị trong mỗi đối số theo thứ tự và trả về giá trị không null đầu tiên cho mỗi hàng."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "Bình luận"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "Ghi chú"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "Không có bình luận nào"
 
@@ -13876,12 +13979,12 @@ msgstr "Nếu value1 trống, value2 được trả về nếu nó không trốn
 msgid "Combines two or more strings of text together."
 msgstr "Kết hợp hai hoặc nhiều chuỗi văn bản với nhau."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "Họ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "Tên"
 
@@ -13893,27 +13996,27 @@ msgstr "value2 sẽ được thêm vào cuối"
 msgid "This will be added to the end of value1."
 msgstr "Điều này sẽ được thêm vào cuối giá trị1."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "Kiểm tra xem chuỗi1 có chứa chuỗi2 trong đó không."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "Trạng thái"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "Vượt qua"
 
@@ -13921,7 +14024,7 @@ msgstr "Vượt qua"
 msgid "The contents of this string will be checked."
 msgstr "Nội dung của chuỗi này sẽ được kiểm tra."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "Chuỗi văn bản cần tìm."
 
@@ -13929,22 +14032,22 @@ msgstr "Chuỗi văn bản cần tìm."
 msgid "Returns the count of rows in the source data."
 msgstr "Trả về số lượng hàng trong dữ liệu nguồn."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "Chỉ tính các hàng trong đó điều kiện là đúng."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Tổng phụ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "Tổng số phụ gia của các hàng trên một đột phá."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "Tổng số của một cột trên một đột phá."
 
@@ -13953,53 +14056,57 @@ msgstr "Tổng số của một cột trên một đột phá."
 msgid "The column to sum."
 msgstr "Các cột để tổng hợp."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "Số lượng các giá trị riêng biệt trong cột này."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "Cột có giá trị riêng biệt để tính."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "so sánh"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "Trả về true nếu phần cuối của văn bản khớp với văn bản so sánh."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Khao khát"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "đói"
 
@@ -14008,20 +14115,20 @@ msgstr "đói"
 msgid "A column or string of text to check."
 msgstr "Một cột hoặc chuỗi văn bản để kiểm tra."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "Chuỗi văn bản mà văn bản gốc nên kết thúc bằng."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "biểu hiện thông thường"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "Chiết xuất phù hợp với chất nền theo một biểu thức thông thường."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Địa chỉ"
 
@@ -14029,7 +14136,7 @@ msgstr "Địa chỉ"
 msgid "The column or string of text to search though."
 msgstr "Cột hoặc chuỗi văn bản để tìm kiếm thông qua."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "Các biểu thức chính quy để phù hợp."
 
@@ -14041,7 +14148,7 @@ msgstr "Trả về chuỗi văn bản trong tất cả các chữ thường."
 msgid "The column with values to convert to lowercase."
 msgstr "Cột có giá trị để chuyển đổi thành chữ thường."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "Loại bỏ khoảng trắng hàng đầu khỏi một chuỗi văn bản."
 
@@ -14051,15 +14158,16 @@ msgstr "Loại bỏ khoảng trắng hàng đầu khỏi một chuỗi văn bả
 msgid "The column with values you want to trim."
 msgstr "Cột với các giá trị bạn muốn cắt."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "Trả về giá trị lớn nhất được tìm thấy trong cột."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "Tuổi"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "Cột số có tối đa bạn muốn tìm."
 
@@ -14067,21 +14175,21 @@ msgstr "Cột số có tối đa bạn muốn tìm."
 msgid "Returns the smallest value found in the column."
 msgstr "Trả về giá trị nhỏ nhất được tìm thấy trong cột."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "Lương"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "Cột số có tối thiểu bạn muốn tìm."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "vị trí"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "length"
 
@@ -14090,7 +14198,7 @@ msgstr "length"
 msgid "new_text"
 msgstr "văn bản mới"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "Thay thế một phần của văn bản đầu vào bằng văn bản mới."
 
@@ -14118,35 +14226,35 @@ msgstr "Số lượng ký tự để thay thế."
 msgid "The text to use in the replacement."
 msgstr "Các văn bản để sử dụng trong thay thế."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "Xóa khoảng trắng theo sau khỏi một chuỗi văn bản."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "Trả về phần trăm của các hàng trong dữ liệu khớp với điều kiện, dưới dạng thập phân."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "Trả về true nếu phần đầu của văn bản khớp với văn bản so sánh."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "Tên khoá học"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "Khoa học máy tính"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "Chuỗi văn bản mà văn bản gốc nên bắt đầu bằng."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "Tính độ lệch chuẩn của cột."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "Dân số"
 
@@ -14154,7 +14262,7 @@ msgstr "Dân số"
 msgid "A numeric column."
 msgstr "Một cột số"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "Trả về một phần của văn bản được cung cấp."
 
@@ -14162,19 +14270,19 @@ msgstr "Trả về một phần của văn bản được cung cấp."
 msgid "The text to return a portion of."
 msgstr "Các văn bản để trả lại một phần của."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "Vị trí để bắt đầu sao chép ký tự."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "Số lượng ký tự trở lại."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "Thêm tất cả các giá trị của cột."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "Các cột số để tổng hợp."
 
@@ -14182,15 +14290,15 @@ msgstr "Các cột số để tổng hợp."
 msgid "Sums up values in a column where rows match the condition."
 msgstr "Tổng các giá trị trong một cột trong đó các hàng khớp với điều kiện."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "Tình trạng đặt hàng"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "Hợp lệ"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "Loại bỏ khoảng trắng hàng đầu và dấu kiểm khỏi một chuỗi văn bản."
 
@@ -14198,43 +14306,43 @@ msgstr "Loại bỏ khoảng trắng hàng đầu và dấu kiểm khỏi một 
 msgid "Returns the string of text in all upper case."
 msgstr "Trả về chuỗi văn bản trong tất cả các chữ hoa"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "Cột có giá trị để chuyển đổi sang chữ hoa"
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "phải là {0} và bao gồm {1}"
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "phải là {0}."
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "phải bao gồm {0}."
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "ít nhất {0} ký tự"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} chữ thường"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} chữ in hoa"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} số"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0} ký tự đặc biệt"
@@ -14256,6 +14364,7 @@ msgid "Powered by {0}"
 msgstr "Được cung cấp bởi {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "Đến:"
 
@@ -14343,7 +14452,7 @@ msgstr "Định dạng dữ liệu"
 msgid "Full"
 msgstr "Đầy"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "Không thay đổi so với trước {0}"
 
@@ -14668,7 +14777,7 @@ msgstr "Lỗi tạo thông tin chi tiết cho cột:"
 msgid "Sending abandonment email!"
 msgstr "Gửi email từ bỏ!"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Bạn có thể tạo số liệu đã lưu để thêm tùy chọn số liệu được đặt tên. Số liệu đã lưu bao gồm loại tổng hợp, trường tổng hợp và tùy chọn bất kỳ bộ lọc nào bạn thêm. Ví dụ: bạn có thể sử dụng điều này để tạo ra thứ gì đó giống như cách tính chính thức \"Giá trung bình\" cho bảng Đơn hàng."
 
@@ -14676,15 +14785,15 @@ msgstr "Bạn có thể tạo số liệu đã lưu để thêm tùy chọn số
 msgid "Select and add filters to create your new segment."
 msgstr "Chọn và thêm bộ lọc để tạo phân khúc mới của bạn."
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "Bảng chữ cái"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "Thông minh"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "Thứ tự cột: {0}"
 
@@ -14736,7 +14845,7 @@ msgstr "Localization"
 msgid "Instance language"
 msgstr "Ngôn ngữ sơ thẩm"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "Tùy chọn nội địa hóa"
 
@@ -14808,19 +14917,20 @@ msgstr "Dán chuỗi kết nối"
 msgid "Fill out individual fields"
 msgstr "Điền vào các trường riêng lẻ"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "Nhập một số SQL ở đây để bạn có thể sử dụng lại sau"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "Đặt tên cho đoạn trích của bạn"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "Khách hàng hiện tại"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "Thêm một mô tả"
 
@@ -14828,46 +14938,47 @@ msgstr "Thêm một mô tả"
 msgid "Use site default"
 msgstr "Sử dụng trang mặc định"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "tìm"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "thay thế"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "Văn bản để tìm."
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "Các văn bản để sử dụng như là sự thay thế."
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "Chỉnh sửa {0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "Tạo đoạn mã mới của bạn"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "Đoạn trích lưu trữ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "Đoạn mã là các bit có thể tái sử dụng của SQL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "Tạo một đoạn"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "Đoạn mã"
 
@@ -15146,4 +15257,1501 @@ msgstr "giá trị phải là một từ khóa hoặc chuỗi."
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "Chuỗi phải là ngôn ngữ ISO hai chữ cái hợp lệ hoặc mã quốc gia ngôn ngữ, ví dụ: 'en' hoặc 'en_US'."
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "Hàng {0} - {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "Kiểm tra"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "Cấu hình thuộc tính người dùng (tùy chọn)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "Sử dụng {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "Thiết lập SSO dựa trên SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "Xác thực SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "Cấu hình nhà cung cấp danh tính của bạn (IdP)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "Nhà cung cấp danh tính của bạn sẽ cần thông tin sau về Metabase."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "URL mà IdP phải chuyển hướng trở lại"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "Đây được gọi là URL đăng nhập một lần ở Okta, URL gọi lại ứng dụng trong Auth0, và URL ACS (Người dùng) trong OneLogin."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "Thuộc tính SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "Trong hầu hết các IdP, bạn sẽ cần đặt từng IdP này vào hộp nhập có nhãn \"Tên\" trong phần câu lệnh thuộc tính."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "Thuộc tính email của người dùng"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "Thuộc tính tên của người dùng"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "Thuộc tính họ của người dùng"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "Cho Metabase biết về nhà cung cấp danh tính của bạn"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase sẽ cần thông tin sau về nhà cung cấp của bạn."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "URL nhà cung cấp danh tính SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "Chứng chỉ nhà cung cấp danh tính SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "Tên ứng dụng SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "Ký yêu cầu SSO (tùy chọn)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "Đường dẫn kho khóa SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "Mật khẩu kho khóa SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "Suỵt ..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "Bí danh kho khóa SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "Đồng bộ hóa tư cách thành viên nhóm với SSO của bạn"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "Để kích hoạt điều này, bạn sẽ cần tạo ánh xạ để cho Metabase biết (các) nhóm người dùng của bạn nên được thêm vào dựa trên nhóm SSO mà họ đang ở trong đó."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "Tên nhóm"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "Tên thuộc tính nhóm"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "Ghi chú:"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "Nếu bạn thay đổi bất kỳ cài đặt nào của thiết lập SAML đang hoạt động hiện có, thì bạn sẽ cần khởi động lại Metabase để chúng có hiệu lực."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "Cho phép người dùng đăng nhập qua Nhà cung cấp danh tính SAML."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "Cho phép người dùng đăng nhập thông qua Nhà cung cấp danh tính JWT."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "Bật xác thực mật khẩu"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "Khi được bật, người dùng có thể đăng nhập thêm bằng email và mật khẩu."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "Thông báo cho quản trị viên về những người dùng SSO mới"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "Khi được bật, quản trị viên sẽ nhận được email lần đầu tiên người dùng sử dụng Đăng nhập một lần."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "Sử dụng cài đặt bên dưới để định cấu hình SSO của bạn qua SAML. Nếu bạn có bất kỳ câu hỏi nào, hãy xem {0} của chúng tôi."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "tài liệu"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "URI của nhà cung cấp danh tính SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "Xác thực JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "URI của nhà cung cấp danh tính JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "Chuỗi được sử dụng bởi khóa ký JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "Nhúng toàn bộ ứng dụng Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "Nếu bạn muốn nhúng tất cả Metabase, hãy nhập nguồn gốc của các trang web hoặc ứng dụng web mà bạn muốn cho phép nhúng vào iframe, được phân tách bằng dấu cách. Đây là {0} cho những gì có thể được nhập."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "Cấp quyền truy cập sandboxed vào bảng này"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "Khi người dùng trong nhóm này xem bảng này, họ sẽ thấy phiên bản của bảng được lọc theo thuộc tính người dùng của họ hoặc chế độ xem tùy chỉnh của bảng dựa trên một câu hỏi đã lưu."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "Bạn muốn lọc bảng này cho những người dùng trong nhóm này như thế nào?"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "Chọn một câu hỏi đã lưu trả về chế độ xem tùy chỉnh của bảng này mà những người dùng này sẽ thấy."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "Bạn có thể tùy chọn thêm các bộ lọc bổ sung tại đây dựa trên các thuộc tính của người dùng. Các bộ lọc này sẽ được áp dụng trên bất kỳ bộ lọc nào đã có trong câu hỏi đã lưu này."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "Để tùy chọn này hoạt động, người dùng của bạn cần có một số thuộc tính"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "Để thêm các bộ lọc bổ sung, người dùng của bạn cần có một số thuộc tính"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "Không có thuộc tính người dùng"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "Chọn một thuộc tính người dùng"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "Chọn một thông số"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "Chọn một cột"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "Người dùng trong {0} có thể xem"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "các hàng trong câu hỏi {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "các hàng trong bảng {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "trong đó {0} bằng {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "và {0} bằng {1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "Bạn có thể thêm thuộc tính tự động bằng cách thiết lập SSO sử dụng SAML hoặc bạn có thể nhập chúng theo cách thủ công bằng cách chuyển đến phần Mọi người và nhấp vào menu… ở ngoài cùng bên phải."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "Thuộc tính người dùng"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "Chúng tôi có thể tự động lấy thuộc tính người dùng của bạn nếu bạn đã thiết lập SSO hoặc bạn có thể thêm chúng theo cách thủ công từ menu \"…\" trong phần Mọi người của Bảng điều khiển quản trị."
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "Tham số hoặc biến"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "bằng"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "Cấp quyền truy cập sandboxed"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "Truy cập sandboxed"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "Sửa truy cập sandboxed"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "Chỉnh sửa chi tiết thư mục"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "Thay đổi quyền"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "Tạo thư mục mới của bạn"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "Thư mục mới"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "Chúng tôi đang gặp sự cố khi xác thực mã thông báo của bạn"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "Vui lòng kiểm tra kỹ để đảm bảo phiên bản của bạn có thể kết nối với máy chủ của Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "Được giúp đỡ"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "Khai thác nhiều hơn nữa Metabase với phiên bản Enterprise"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "Tất cả các công cụ bạn cần để nhanh chóng và dễ dàng cung cấp báo cáo cho khách hàng của mình hoặc để giúp bạn chạy và giám sát Metabase trong một tổ chức lớn"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "Kích hoạt giấy phép"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "Bản dùng thử của bạn đang hoạt động với các tính năng này"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "Thời gian dùng thử hết hạn {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "Cần giúp đỡ? Sẵn sàng để mua?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "Nói với chúng tôi"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "Dùng thử của bạn đã hết hạn"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "Cần thêm thời gian? Sẵn sàng để mua?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "Các tính năng của bạn đang hoạt động!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "Giấy phép của bạn hợp lệ thông qua {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "Giấy phép của bạn đã hết hạn"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "Nó đã hết hạn vào {0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "Muốn gia hạn giấy phép của bạn?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "Tìm hiểu cách sử dụng cái này"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "Không có trong gói hiện tại của bạn"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "Nhập mã thông báo bạn nhận được từ cửa hàng"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "Kích hoạt"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "Cần giúp đỡ?"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "Thông tin thêm về vấn đề của bạn."
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "Liên hệ hỗ trợ"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "Doanh nghiệp"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "Hộp cát dữ liệu"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "Đảm bảo rằng bạn đang hiển thị cho đúng người đúng dữ liệu bằng các bộ lọc tự động và an toàn dựa trên các thuộc tính của người dùng."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "Nhãn trắng"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "Kết hợp Metabase với thương hiệu của bạn bằng màu sắc tùy chỉnh, biểu trưng của riêng bạn và hơn thế nữa."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "Kiểm toán"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "Theo dõi hiệu suất và hành vi bằng các công cụ kiểm toán mạnh mẽ."
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "Đăng nhập một lần"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "Cung cấp thông tin đăng nhập dễ dàng hoạt động với cơ sở hạ tầng xác thực hiện có của bạn."
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "Tích trữ"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "Tên ứng dụng"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "Bảng màu"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "Logo"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "yêu thích"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "Trang đích"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "Không có nhóm"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "Quyền cho {0}"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "Quyền cho thư mục này"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "Cấp quyền truy cập Chỉnh sửa"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "Có thể sửa đổi các đoạn mã trong thư mục này"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "Cấp quyền truy cập Chế độ xem"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "Có thể chèn và sử dụng các đoạn mã trong thư mục này, nhưng không thể chỉnh sửa SQL mà chúng chứa"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "Không thể xem hoặc chèn các đoạn mã trong thư mục này"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "Đồng thời thay đổi các thư mục con"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "Ngày đầu tiên trong tuần"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "Đã xảy ra sự cố khi đăng nhập với Google. Vui lòng liên hệ với quản trị viên."
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "trên"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "tại"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "Mở menu hành động Metabase"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "Không làm gì cả"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "Đi đến một điểm đến tùy chỉnh"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "Cập nhật bộ lọc trang tổng quan"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0} cập nhật {1} bộ lọc"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0} chuyển đến {1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "Hành vi khi nhấp cho mỗi cột"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "Đi đến điểm đến tùy chỉnh"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "Mở menu tác vụ"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "Hành vi nhấp cho {0}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "Chọn một hoặc nhiều bộ lọc để cập nhật"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "Câu hỏi đã lưu"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "Liên kết đến"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "Nhập một URL để liên kết đến"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "Bạn có thể chèn giá trị của bộ lọc cột hoặc trang tổng quan bằng cách sử dụng tên của nó, như sau: {{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "ví dụ. http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "Chọn một trang tổng quan ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "Chọn một câu hỏi ..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "Chọn một trang tổng quan để liên kết đến"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "Chọn một câu hỏi để liên kết với"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "Chuyển các giá trị đến các bộ lọc của trang tổng quan này (tùy chọn)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "Chuyển giá trị cho các biến của câu hỏi này (tùy chọn)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "Chuyển các giá trị để lọc câu hỏi này (tùy chọn)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "Bộ lọc trang tổng quan"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "Thuộc tính người dùng"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "Tùy chỉnh văn bản liên kết (tùy chọn)"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "Ví dụ. Chi tiết cho {{Column Name}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "Giá trị bạn có thể tham khảo"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "Không có mục tiêu khả dụng"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "bộ lọc"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "biến số"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "Các bộ lọc có sẵn khác"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "Bộ lọc có sẵn"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "Các biến khả dụng khác"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "Các biến có sẵn"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "Các cột có sẵn khác"
+
+#. english typo
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "Các cột có sẵn"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "thuộc tính người dùng"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "Thẻ văn bản"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "Hành vi nhấp chuột"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "Tùy chọn hiển thị"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "Chỉnh sửa chuỗi"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "Thêm chuỗi"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "Trong một cái nhấp chuột"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "Thay đổi tiêu đề và mô tả"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "Bạn đã cập nhật các thông số nhúng và sẽ cần cập nhật mã nhúng của mình."
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "Thêm câu hỏi"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "Bạn đang chỉnh sửa bảng điều khiển này."
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "Cột để lọc"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "bộ sưu tập đoạn mã"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "các bộ sưu tập đoạn mã"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "Đặt tên cho thư mục của bạn"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "Một cái gì đó ngắn nhưng ngọt ngào"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "Thư mục này phải có trong"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "Mở menu hành động"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "Cột {0} có hành vi tùy chỉnh"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "Đi đến..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "Đi đến bảng điều khiển"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "Đi đến câu hỏi"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "Đi tới url"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "Lọc trang tổng quan này"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "Trả về số hàng trong dữ liệu đã chọn."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "Cột hoặc số để tính tổng."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "Cột số để nhận độ lệch chuẩn."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "Cột số có giá trị trung bình."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "Trả về giá trị nhỏ nhất được tìm thấy trong cột"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "Google"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "Tính tổng cột được chỉ định chỉ cho các hàng có điều kiện là đúng."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "Trả về phương sai số cho một cột nhất định."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "Nhiệt độ"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "Cột hoặc số để lấy phương sai."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "Trả về giá trị trung bình của cột được chỉ định."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "Cột hoặc số để lấy giá trị trung bình."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "phần trăm giá trị"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "Trả về giá trị của cột theo giá trị phân vị."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "Cột hoặc số để lấy phần trăm."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "Giá trị của phân vị."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "Trả về chuỗi văn bản trong tất cả các chữ thường."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "Cột có các giá trị cần chuyển đổi thành chữ thường."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "Trả về văn bản trong tất cả các chữ hoa."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "Cột hoặc văn bản để trả về một phần."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "Cột hoặc văn bản để tìm kiếm."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "Kết hợp hai hoặc nhiều chuỗi văn bản với nhau."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "Cột hoặc văn bản để bắt đầu."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "Điều này sẽ được thêm vào cuối giá trị1, v.v."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "To lớn"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "Khổng lồ"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "Trả về số ký tự trong văn bản."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "Cột hoặc văn bản bạn muốn lấy độ dài."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "Cột hoặc văn bản bạn muốn cắt."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "Trả về giá trị tuyệt đối (dương) của cột được chỉ định."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "Nợ"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "Cột hoặc số trả về giá trị tuyệt đối (dương)."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "Làm tròn một số thập phân xuống."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "Cột hoặc số để làm tròn xuống."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "Làm tròn một số thập phân lên."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "Cột hoặc số để làm tròn."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "Làm tròn một số thập phân lên hoặc xuống đến giá trị số nguyên gần nhất."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "Cột hoặc số để làm tròn đến số nguyên gần nhất."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "Trả về căn bậc hai."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "Cạnh huyền"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "Cột hoặc số để trả về giá trị căn bậc hai."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "số mũ"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "Nâng một số thành lũy thừa của giá trị số mũ."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "Chiều dài"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "Cột hoặc số được nâng lên thành số mũ."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "Giá trị của số mũ."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "Trả về nhật ký cơ số 10 của số."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "Giá trị"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "Cột hoặc số để trả về giá trị lôgarit tự nhiên."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "Trả về số của Euler, e, được nâng lên thành lũy thừa của số được cung cấp."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "Tháng lãi"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "Cột hoặc số để trả về giá trị theo cấp số nhân."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "Cột hoặc văn bản để kiểm tra."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "Kiểm tra giá trị của cột ngày hoặc số để xem chúng có nằm trong phạm vi được chỉ định hay không."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "Được tạo lúc"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "Cột ngày hoặc số phải nằm trong giá trị bắt đầu và giá trị kết thúc."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "Sự bắt đầu của phạm vi."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "Khoảng cuối của dãy."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "Kiểm tra các giá trị của cột ngày để xem chúng có nằm trong phạm vi tương đối hay không."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "Cột ngày để trả về khoảng thời gian."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "Khoảng thời gian, trong đó các giá trị âm quay ngược thời gian."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "Loại nội bộ như \"ngày\", \"tháng\", \"năm\"."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "Cột hoặc giá trị cần trả về."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "Nếu giá trị1 trống, giá trị2 được trả về nếu giá trị đó không trống, v.v."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "Kiểm tra một biểu thức với danh sách các trường hợp và trả về giá trị tương ứng của trường hợp khớp đầu tiên, với giá trị mặc định tùy chọn nếu không có gì khác được đáp ứng."
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "Giá trị sẽ được trả về nếu điều kiện trước là đúng, v.v."
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "Là rỗng"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "Có giá trị"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "Tổng cộng của tất cả các giá trị của một cột.\n"
+"Ví dụ. tổng doanh thu theo thời gian."
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "Tính cộng số lượng hàng.\n"
+"Ví dụ. tổng số lần bán hàng theo thời gian."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "Bộ lọc được liên kết"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "Nhãn"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "Giá trị mặc định"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "Không có mặc định"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "Để xem phần này, {0} phải được kết nối với ít nhất một trường."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "Giới hạn các lựa chọn của bộ lọc này"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "Nếu bạn có bộ lọc trang tổng quan khác, bạn có thể giới hạn các lựa chọn được liệt kê cho bộ lọc này dựa trên lựa chọn của bộ lọc kia."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "Vì vậy, trước tiên, {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "thêm một bộ lọc bảng điều khiển"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "Nếu bạn bật một trong các bộ lọc trang tổng quan này, việc chọn một giá trị cho bộ lọc đó sẽ giới hạn các lựa chọn có sẵn cho bộ lọc {0}."
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "Cột lọc"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "Cột đã lọc"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "Nhập tên người dùng hoặc địa chỉ email"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "Đoạn mã mới"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}: 00 giờ tối"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}: 00 giờ sáng"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "Hàng giờ"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "Hàng ngày lúc {0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "Hàng tuần lúc {0} vào {1}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "Hàng tháng vào {0} {1} lúc {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "Xóa đăng ký này"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "Đăng ký"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "Tạo một thuê bao dashboard"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "Gửi nó qua email"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "Bạn có thể gửi trang tổng quan này thường xuyên cho người dùng hoặc địa chỉ email."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "Gửi nó đến Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "Chọn một kênh và một lịch trình và Metabase sẽ thực hiện phần còn lại."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "Gửi trang tổng quan này qua email"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "Đừng gửi nếu không có kết quả"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "Đính kèm kết quả"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "Tệp đính kèm có thể chứa tới 2.000 hàng dữ liệu."
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "Gửi trang tổng quan này tới Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "Bảng điều khiển không có tham số với ID {0}"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "Tham số {0} không có bất kỳ Trường nào được liên kết với nó"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "bao gồm phải trống hoặc giá trị 'bảng'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "`cơ sở dữ liệu` là bắt buộc đối với tất cả các truy vấn có kiểu không phải là ʻinternal`."
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "Đăng nhập bằng mật khẩu bị tắt cho trường hợp này."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "Tài khoản của bạn bị vô hiệu hóa. Vui lòng liên hệ với quản trị viên của bạn."
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "Tài khoản của bạn bị vô hiệu hóa."
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "Mã thông báo Slack không hợp lệ."
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "Lệnh '' {0} '' chỉ có trong Metabase Enterprise Edition."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Các phần mở rộng Metabase Enterprise Edition CÓ SẴN."
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Việc sử dụng các tính năng của Metabase Enterprise Edition phải tuân theo Giấy phép Thương mại Metabase."
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "Xem {0} để biết chi tiết."
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Phần mở rộng Metabase Enterprise Edition KHÔNG TỒN TẠI."
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "Bạn được mời tham gia {0} của {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0} đã tạo một tài khoản {1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0} đã chấp nhận lời mời {1} của họ"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] Yêu cầu đặt lại mật khẩu"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] Thông báo"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}] Giúp cải thiện [{1}]."
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] Cho chúng tôi biết mọi thứ đang diễn ra như thế nào."
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "Lỗi khi bắt đầu trình nghe sự kiện"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "Chúng ta có nên đồng bộ hóa các thuộc tính người dùng khi ai đó đăng nhập qua LDAP không?"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "Danh sách các thuộc tính người dùng được phân tách bằng dấu phẩy để bỏ qua đồng bộ hóa cho người dùng LDAP."
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "Mã không hợp lệ"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Lỗi API Slack: {0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "Kênh Slack có tên `metabase_files` bị thiếu!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "Vui lòng tạo hoặc hủy lưu trữ kênh để hoàn tất quá trình tích hợp Slack."
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "Kênh được sử dụng để lưu trữ các biểu đồ được bao gồm trong các câu trả lời Pulses và MetaBot."
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "Hình ảnh đã tải lên"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "Lỗi khi tải tệp lên Slack:"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "Phiên không hợp lệ. Dự kiến một thể hiện của phiên."
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "SameSite của cookie phiên được định cấu hình thành \"Không có\", nhưng trang web thì"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "được phân phát qua một kết nối không an toàn. Một số trình duyệt sẽ từ chối."
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "cookie trong các điều kiện này."
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "Thư mục trên cùng"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":tham số phải là một chuỗi bản đồ với các khóa String: id"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "Giá trị con người có thể đọc được không hợp lệ: giá trị phải là một chuỗi; mỗi mục phải là nil hoặc một chuỗi"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ": giá trị phải có để tìm nạp: giá trị con người có thể đọc được"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "Tổng độ dài các giá trị trường là> {0}."
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "tên đoạn mã không được bao gồm '}' hoặc bắt đầu bằng dấu cách"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "Lỗi khi thực hiện truy vấn bộ lọc chuỗi"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "Trường {0} không tồn tại."
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "Không thể tìm kiếm đối với Trường không phải Văn bản {0} {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "Cấp quyền cho nhóm {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "Thu hồi quyền cho nhóm {0}: {1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "Quyền DB không hợp lệ: nếu bạn có quyền ghi cho các truy vấn gốc, bạn phải có toàn quyền truy cập dữ liệu."
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "Quyền DB không hợp lệ: nếu bạn có quyền truy cập truy vấn gốc chỉ đọc, bạn cũng phải có quyền truy cập dữ liệu."
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "Thay đổi quyền từ: {0} thành: {1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "khóa thuộc tính đăng nhập phải là một từ khóa hoặc chuỗi"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Ngôn ngữ mặc định cho tất cả người dùng trên Metabase UI, email hệ thống, xung và cảnh báo."
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "Người dùng có thể ghi đè riêng ngôn ngữ mặc định này từ cài đặt tài khoản của riêng họ."
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "Trang mặc định để hiển thị cho người dùng"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "Cho phép nguồn gốc này nhúng ứng dụng Metabase đầy đủ"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "Giá trị lớn hơn {0} ({1}) không được phép."
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "Từ này sẽ thay thế từ \"Metabase\" ở bất kỳ nơi nào nó xuất hiện."
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "Đây là những màu cơ bản được sử dụng trong biểu đồ và trên toàn bộ Metabase. Bạn có thể cần phải làm mới trình duyệt của mình để xem các thay đổi của bạn có hiệu lực."
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "Để có kết quả tốt nhất, hãy sử dụng tệp SVG có nền trong suốt."
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "Url hoặc hình ảnh mà bạn muốn sử dụng làm biểu tượng yêu thích."
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "Cho phép đăng nhập bằng email và mật khẩu."
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "Điều này sẽ ảnh hưởng đến những thứ như nhóm theo tuần hoặc lọc trong các truy vấn GUI. Nó sẽ không ảnh hưởng đến các truy vấn SQL."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "Không thể xác thực mã thông báo"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "Định dạng mã thông báo không hợp lệ."
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "Lỗi khi xác thực mã thông báo"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "Lỗi khi lọc theo {0} Trường: không thể phân tích cú pháp Chuỗi {1} thành {2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "Lỗi khi tìm nạp chi tiết cho Công việc: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "Bắt đầu tác vụ đồng bộ hóa cho Cơ sở dữ liệu {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "Không thể đồng bộ hóa Cơ sở dữ liệu {0}: Cơ sở dữ liệu không tồn tại."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "Tác vụ Cập nhật giá trị Trường được kích hoạt cho Cơ sở dữ liệu {0}."
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "Bỏ qua cập nhật, cập nhật giá trị Trường tự động bị tắt cho Cơ sở dữ liệu {0}."
 

--- a/locales/zh-HK.po
+++ b/locales/zh-HK.po
@@ -28,15 +28,16 @@ msgstr "探索資料"
 msgid "Select a database type"
 msgstr "選擇資料庫類型"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "儲存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "為了做一些預設分析的事情，Metabase需要掃描您的資料庫。我們將會定期自動掃描您的資料庫，確保資料庫欄位的資訊在 Metabase 是最新的狀態。您可以在下方更改分析的時間。"
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "資料庫同步中"
 
@@ -64,7 +65,7 @@ msgstr "這個程序僅僅檢查資料庫欄位的更新，並不會耗費太多
 msgid "Scan"
 msgstr "掃描"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "根據篩選值進行掃描"
 
@@ -75,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase 可以掃描資料庫中每個欄位的值，用來壤使用者啟用查詢或資訊看板中的篩選器。當您的資料庫較大時，這個功能同時會耗費更多的系統資源。"
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase應該在什麼時候自動掃描快取的欄位值"
 
@@ -133,29 +134,31 @@ msgstr "刪除"
 msgid "in this box:"
 msgstr "在這個框裡:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -178,9 +181,9 @@ msgstr "刪除"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -200,8 +203,9 @@ msgstr "連線"
 msgid "Scheduling"
 msgstr "排程"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -280,10 +284,10 @@ msgstr "新增資料庫"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -318,10 +322,8 @@ msgid "Successfully saved!"
 msgstr "儲存成功！"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "編輯"
@@ -400,26 +402,29 @@ msgstr "請選擇一個指定類型"
 msgid "Select a target"
 msgstr "選擇目標"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "可見性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "類型"
 
@@ -427,7 +432,7 @@ msgstr "類型"
 msgid "Current database:"
 msgstr "當前資料庫"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "顯示原始資料綱要結構"
 
@@ -494,7 +499,7 @@ msgstr "搜尋資料表"
 msgid "Schemas"
 msgstr "資料表結構"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -511,7 +516,7 @@ msgstr "新增量值"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "定義"
 
@@ -579,35 +584,35 @@ msgstr "歷史"
 msgid "Revision History for"
 msgstr "歷史版本"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - 欄位設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "這些欄位將在哪裡顯示？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "欄位過濾"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "當在篩選器中使用此欄位時，人們應該使用什麼形式輸入他們想要過濾的值?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "暫無篩選欄位敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "對映值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "輸入值"
 
@@ -624,31 +629,31 @@ msgid "Custom mapping"
 msgstr "自訂映射"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "無法識別對應類型"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "當前欄位不是外鍵或者缺少外鍵關聯表後設資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "選中的欄位不是外鍵"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "顯示值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "選擇顯示資料庫中的原始值，或者顯示此欄位的關聯或自訂訊息。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "選擇欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "請選擇顯示欄位"
 
@@ -656,16 +661,16 @@ msgstr "請選擇顯示欄位"
 msgid "Tip:"
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "您可能想要更新這個欄位的名稱來確保它基於您的重新映射選擇時仍然有意義"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "快取欄位值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase 通過掃描該欄位，以啟用資訊看板和問題的多選框篩選。"
 
@@ -692,35 +697,36 @@ msgstr "丟棄處理已經觸發！"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "選擇任意資料表來顯示它的結構並且新增或編輯後設資料"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "名稱必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "敘述必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "調整訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "聚集訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "編輯量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "建立量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "修改量值並留下簡要說明。"
 
@@ -728,46 +734,46 @@ msgstr "修改量值並留下簡要說明。"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "您能夠建立已存儲的量值來新增一個已經命名的量值選項到這個表單。儲存的量值包括您新增的聚合類型，聚合欄位和可選的任何篩選項。舉個例子，您可能使用這個來為一個訂單表單創造一些像是“平均價”的官方計算方法，"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "結果："
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "命名量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "為量值命名，方便其他人搜尋。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "簡短的敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "敘述量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "敘述量值，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "在這裡詳細敘述量值，比如不太明顯的規則"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "更改原因"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "留言以說明您所做的更改以及為何需要這些更改。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "這將顯示在此量值的修訂歷史記錄中，以幫助每個人記住事情發生變化的原因"
 
@@ -820,6 +826,7 @@ msgstr "這將顯示在篩選器的修訂歷史記錄中，以幫助每個人記
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -834,8 +841,7 @@ msgid "Re-scan this table"
 msgstr "刷新表格"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "新增"
 
@@ -852,7 +858,7 @@ msgid "Last name"
 msgstr "姓"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "信箱地址"
@@ -861,7 +867,7 @@ msgstr "信箱地址"
 msgid "Permission Groups"
 msgstr "群組權限"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "設為管理員"
 
@@ -957,6 +963,8 @@ msgstr "移除群組"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -969,11 +977,12 @@ msgstr "完成"
 msgid "Group name"
 msgstr "群組名稱"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "群組"
@@ -1082,7 +1091,7 @@ msgstr "重設"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "是否確認執行此操作？"
 
@@ -1194,7 +1203,7 @@ msgstr "權限無更改。"
 msgid "You've made changes to permissions."
 msgstr "權限被更改。"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "這個集合(collection)的權限"
 
@@ -1250,6 +1259,7 @@ msgstr "部分權限"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "取消權限"
 
@@ -1313,23 +1323,23 @@ msgstr "修改集合(collection)"
 msgid "View collection"
 msgstr "檢視集合(collection)"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "允許訪問資料"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "檢視表格"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL查詢"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "檢視綱要結構"
 
@@ -1400,12 +1410,15 @@ msgstr "已發送"
 msgid "Clear"
 msgstr "完成"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "認證"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "伺服器設定"
@@ -1418,6 +1431,7 @@ msgstr "使用者結構"
 msgid "Attributes"
 msgstr "屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "群組結構"
@@ -1489,6 +1503,9 @@ msgid "Add a map"
 msgstr "新增一個地圖"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL連結"
@@ -1498,19 +1515,19 @@ msgid "Delete custom map"
 msgstr "刪除自訂地圖"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "刪除"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1608,19 +1625,19 @@ msgstr "購買 token"
 msgid "Enter a token"
 msgstr "輸入 token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "編輯映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "分組映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "建立映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1859,18 +1876,27 @@ msgstr "使用者篩選"
 msgid "Check your parentheses"
 msgstr "檢查括號"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "電子郵件屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "名字屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "姓氏屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "同步組成員"
@@ -1899,59 +1925,59 @@ msgstr "自訂地圖"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "新增您自己的GeoJSON檔案以啟用不同的區域地圖可視化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "公開分享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "開啟公開共享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "已共享資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "已共享提問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "嵌入在其他的應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "啟用將Metabase嵌入到其他應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "嵌入密鑰"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "嵌入的資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "嵌入的問題"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "快取中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "啟用快取"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "最小查詢週期"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "快取生存時間（TTL）乘數"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "最大快取允許大小"
 
@@ -1993,27 +2019,27 @@ msgstr "在您能夠使用Google帳戶登入之前，需要一個管理員來建
 msgid "Sign in with {0}"
 msgstr "用{0}登入"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "請聯絡管理員來重設您的密碼"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "忘記密碼"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "您作為Metabase帳戶的Email地址"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "發送帳號重設郵件"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "檢查您的郵件來獲取重設密碼說明"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "登入Metabase"
 
@@ -2034,11 +2060,11 @@ msgstr "登入"
 msgid "I seem to have forgotten my password"
 msgstr "我似乎忘記了我的密碼"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "發送一個新的重設email郵件"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "噢，那是個過期的連結"
 
@@ -2047,11 +2073,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "於安全原因，密碼重設連結會在一段時間後過期。如果您仍需要重設密碼，可以{0}。"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "新密碼"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "為了確保您的資料安全，密碼{0}"
 
@@ -2074,24 +2100,24 @@ msgstr "確認新密碼"
 msgid "Make sure it matches the one you just entered"
 msgstr "確認它和您剛剛輸入的一致"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "您的密碼已經被重設"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "用您的新密碼登入"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "儲存失敗"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2101,25 +2127,26 @@ msgstr "已儲存"
 msgid "Ok"
 msgstr "好"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "歸檔集合"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "此集合中的資訊看板，集合和定時通知也將被歸檔。"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "歸檔"
 
@@ -2244,7 +2271,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "把東西拖到這裡將它固定在頂部"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2272,6 +2299,7 @@ msgstr "移動''{0}''？"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "移動"
@@ -2309,7 +2337,7 @@ msgstr "一些資料庫安裝只有通過SSH通道訪問的伺服器有權訪問
 "當VPN不可用時，這個選項也提供了一個額外的安全層。\n"
 "啟用這個選項，通常比直接連接速度更慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "這是一個大型資料庫，讓我選擇Metabase同步和掃描的時間"
 
@@ -2349,7 +2377,7 @@ msgstr "要將Metabase用於此資料，您必須在Google Developers Console中
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "如果您還沒有這樣做，請轉到控制台{0}。"
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "您想如何使用這個資料庫？"
 
@@ -2465,35 +2493,35 @@ msgstr "基於這個綱要結構"
 msgid "A look at your"
 msgstr "看看您的"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "搜尋欄位表"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "用{0}搜索"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr "或者輸入一個ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "輸入一個ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "輸入一個數字"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "輸入一些文字"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "沒有找到符合的{0} "
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "包括每個選項在您的篩選器中很可能將不會起很大作用……"
 
@@ -2505,7 +2533,6 @@ msgstr "有些問題發生了"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "我們執行中出現了一個錯誤，您可以嘗試刷新這個頁面，或者直接返回"
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2516,12 +2543,12 @@ msgstr "我們執行中出現了一個錯誤，您可以嘗試刷新這個頁面
 msgid "No description yet"
 msgstr "暫無敘述"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "新的"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "被{0}發起的提問"
 
@@ -2542,7 +2569,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "回滾到一個更早的調整並且{0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "調整記錄"
@@ -2588,7 +2617,7 @@ msgid "Questions"
 msgstr "問題"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "定時任務"
 
@@ -2662,52 +2691,69 @@ msgstr "先不用"
 msgid "Error:"
 msgstr "錯誤："
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "星期日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "星期一"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "星期二"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "星期三"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "星期四"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "星期五"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "星期六"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "第一個"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "過往"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "第十五個（中位數）"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "日曆日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "您的Metabase時區"
 
@@ -2761,11 +2807,11 @@ msgstr "建立"
 msgid "Create dashboard"
 msgstr "建立資訊看板"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "資料庫"
 
@@ -2840,9 +2886,9 @@ msgstr "這個卡片叫什麼名字？"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2856,15 +2902,16 @@ msgstr "敘述"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "這是可選的，但非常有幫助"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "將這個放到哪個集合中？"
 
@@ -2904,11 +2951,11 @@ msgstr "歸檔資訊看板"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "確保為每個欄位都做出了選擇，不然篩選將不會在這個卡片上起作用"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "這個資訊看板看起來是空的"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "新增一個提問來讓它變得有用"
 
@@ -2928,7 +2975,7 @@ msgstr "退出全螢幕"
 msgid "Enter fullscreen"
 msgstr "進入全螢幕"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "儲存中"
@@ -2941,7 +2988,8 @@ msgstr "新增一個問題"
 msgid "Add a question to this dashboard"
 msgstr "新增報表到資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "新增篩選"
 
@@ -2949,7 +2997,7 @@ msgstr "新增篩選"
 msgid "Parameters"
 msgstr "參數"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "新增文本框"
 
@@ -2957,7 +3005,7 @@ msgstr "新增文本框"
 msgid "Move dashboard"
 msgstr "移動資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "編輯資訊看板"
 
@@ -2981,11 +3029,11 @@ msgstr "移動資訊看板到……"
 msgid "Dashboard moved to {0}"
 msgstr "資訊看板移動到{0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "您想要篩選什麼"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "什麼類型的篩選"
 
@@ -3057,20 +3105,22 @@ msgstr "此卡沒有可以映射到此參數類型的任何欄位或參數。"
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "此欄位中的值不會與您選擇的任何其他欄位的值重疊。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "無可用欄位"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "名稱不能超過100個字元"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "顏色是必需的"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "您的資訊看板叫什麼名字？"
 
@@ -3125,7 +3175,7 @@ msgstr "接收最新的資料來自"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "未知"
 
@@ -3250,9 +3300,10 @@ msgstr "最近沒有檢視的資訊看板或者圖表"
 msgid "{0} items selected"
 msgstr "{0}項已選擇"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "取消歸檔"
 
@@ -3369,7 +3420,7 @@ msgid "Zip Code"
 msgstr "郵遞區號"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "數量"
 
@@ -3402,11 +3453,13 @@ msgid "User"
 msgstr "使用者"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "來源"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "價格"
 
@@ -3439,21 +3492,23 @@ msgid "Subscription"
 msgstr "訂閱"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "分數"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "標題"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "評論"
 
@@ -3507,14 +3562,14 @@ msgstr "Metabase永遠不會獲取此欄位。將此用於敏感或不相關的�
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "計數"
 
@@ -3522,7 +3577,7 @@ msgstr "計數"
 msgid "CumulativeCount"
 msgstr "累積計數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3540,19 +3595,19 @@ msgstr "不重複"
 msgid "StandardDeviation"
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3563,12 +3618,12 @@ msgstr "最大值"
 msgid "sad sad panda, lexing errors detected"
 msgstr "哎呀，出錯了"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0}秒"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0}分鐘"
@@ -3608,14 +3663,15 @@ msgstr "您想找出什麼？"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "原始資料"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "累積計數"
 
@@ -3677,166 +3733,164 @@ msgstr "真"
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "選擇經度欄位"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "輸入緯度上邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "輸入經度左邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "輸入緯度下邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "輸入經度右邊界"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "不是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "為空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "不為空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "不等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "大於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "小於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "介於之間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "以…開始"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "以…結束"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "早於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "晚於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "介於中間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "只是一個包含資料行的表格，沒有其他操作。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "總行數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "答案的總資料行數。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "總和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "一個欄位所有數值的總和。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "一個欄位所有數值的平均值。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "不重複值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "一個欄位所有互不重複的值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "累積求和"
 
@@ -3844,7 +3898,7 @@ msgstr "累積求和"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "一個欄位所有數值的累積加總。\\\\n比如：隨著時間推移的總收入。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "累積行數"
 
@@ -3852,27 +3906,27 @@ msgstr "累積行數"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "累積的資料行數。\\\\ n比如：隨著時間的推移銷售數量。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "一個欄位所有數值的標準差。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "一個欄位的最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "一個欄位的最大值"
 
@@ -3888,6 +3942,8 @@ msgstr "小寫字母"
 msgid "upper case letter"
 msgstr "大寫字母"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "個數"
@@ -4135,7 +4191,7 @@ msgstr "如何建立量值"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "按地圖、趨勢檢視時間維度的資料，方便了解趨勢變化"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "自訂"
 
@@ -4158,7 +4214,7 @@ msgstr "原生查詢"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "為了回答更多複雜的提問，您可以寫下您自己的SQL語句或者原生查詢。"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "選擇一個預設值"
 
@@ -4246,7 +4302,7 @@ msgstr "這個月"
 msgid "This Year"
 msgstr "今年"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "輸入一個值……"
@@ -4256,7 +4312,7 @@ msgid "Enter a default value..."
 msgstr "輸入一個預設值……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "發生了一個錯誤"
@@ -4513,22 +4569,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "挑選您想在這個定時任務裡發送的圖表。"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "電子信箱"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slack消息"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "發送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0}將會在……被發送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "訊息"
 
@@ -4600,30 +4664,30 @@ msgstr "幫助每個在您們團隊的人和您們的資料保持聯結"
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "定時通知允許您根據您選擇的時間表從Metabase發送資料到電子郵件或Slack。"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "{0}之後"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "{0}之前"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "是空的"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "不是空的"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "所有時間"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "應用"
 
@@ -4723,12 +4787,12 @@ msgstr[0] "查看此{0}"
 msgid "Zoom in"
 msgstr "放大"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "自訂表達方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "共同量值"
 
@@ -4925,7 +4989,7 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "選擇一個區間或者表單"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "選擇一個資料庫"
@@ -4986,7 +5050,7 @@ msgstr "排序"
 msgid "Row limit"
 msgstr "行限制"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "未知欄位"
 
@@ -4994,7 +5058,7 @@ msgstr "未知欄位"
 msgid "field"
 msgstr "欄位"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "匹配"
 
@@ -5019,11 +5083,11 @@ msgstr "新增一個聚合"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "資料"
 
@@ -5040,11 +5104,12 @@ msgstr "檢視"
 msgid "Grouped By"
 msgstr "分組條件"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "沒有"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "這個提問已經被寫入{0}"
 
@@ -5056,7 +5121,7 @@ msgstr "隱藏編輯器"
 msgid "Hide Query"
 msgstr "隱藏查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "打開編輯器"
 
@@ -5064,7 +5129,7 @@ msgstr "打開編輯器"
 msgid "Show Query"
 msgstr "顯示查詢"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "這個量值已經被淘汰，它將不再可用了"
 
@@ -5264,7 +5329,7 @@ msgstr "返回上一次執行"
 msgid "Visualization"
 msgstr "可視化"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "沒有設定敘述"
 
@@ -5321,7 +5386,7 @@ msgstr "在建立一個新的提問之前不能找到表單後設資料"
 msgid "See {0}"
 msgstr "檢視{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "量值定義"
 
@@ -5339,11 +5404,11 @@ msgstr "{0}的數字"
 msgid "See all {0}"
 msgstr "檢視所有的{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "劃分定義"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "在載入表時發生了一個錯誤"
 
@@ -5351,7 +5416,7 @@ msgstr "在載入表時發生了一個錯誤"
 msgid "See the raw data for {0}"
 msgstr "檢視{0}的所有原始資料"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "更多"
 
@@ -5371,6 +5436,8 @@ msgstr "欄位公式"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "這有點像在EXCEL表中編寫公式，您可以使用數字，欄位，數學符號和一些函數，例如 Subtotal - Cost。"
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5438,7 +5505,7 @@ msgstr "錯誤"
 msgid "Add filter"
 msgstr "新增篩選器"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "項"
 
@@ -5557,11 +5624,11 @@ msgstr "欄位映射到"
 msgid "Filter widget type"
 msgstr "篩選器樣式"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "必填項？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "篩選器預設值"
 
@@ -5573,7 +5640,7 @@ msgstr "歸檔提問？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "這個提問會從已引用的資訊看板或定時任務中移除"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "提問"
 
@@ -5620,7 +5687,7 @@ msgstr "欄位類型"
 msgid "Select a Foreign Key"
 msgstr "選擇一個外鍵"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "檢視{0}的公式"
 
@@ -6104,22 +6171,24 @@ msgstr "有關這個劃分的提問"
 msgid "X-ray this segment"
 msgstr "透視這個劃分"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "登入"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "查詢"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "資訊看板"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "新提問"
 
@@ -6191,35 +6260,35 @@ msgstr "所有的收集都是匿名的。"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "您隨時可以在管理設定中關閉訊息收集。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "如果您不知從何下手"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "初始化檔案"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "點擊一下"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "歡迎來到Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "看起來一切都在正常工作，現在讓我們了解您吧，連接到您的資料，並且開始尋找一些屬於您的答案！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "讓我們開始吧"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "您已經設定完畢了！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "帶我去Metabase"
 
@@ -6471,39 +6540,40 @@ msgstr "取消篩選器"
 msgid "Pin Map"
 msgstr "固定地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "撤銷設定"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "{2}的{0}~{1}行"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "資料被截斷為{0}行。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "找不到可視化"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "無法顯示這個圖表顯示這些資料"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "沒有結果！"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "仍然在等待……"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "這將通常取一個{0}的平均數。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "（這對於資訊看板來說有點太長了）"
 
@@ -6613,7 +6683,7 @@ msgid "Highlight the whole row"
 msgstr "高亮整行"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "顏色"
 
@@ -6699,24 +6769,50 @@ msgstr "目標"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "正在……噢！從您的查詢中獲得的數去並不適合所選的展示選項，這個可視化需要最少資料中的{0}{1}。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "欄位"
@@ -6747,7 +6843,7 @@ msgid "xValues missing!"
 msgstr "x值遺失！"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X軸"
 
@@ -6756,7 +6852,7 @@ msgid "Add a series breakout..."
 msgstr "新增一系欄位斷點......"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y軸"
 
@@ -6769,7 +6865,7 @@ msgid "Bubble size"
 msgstr "氣泡大小"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "線段"
 
@@ -6911,20 +7007,20 @@ msgid "Standard Deviation"
 msgstr "標準差"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "區域"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "區域圖表"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "柱"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "柱形圖"
 
@@ -6938,7 +7034,7 @@ msgid "Funnel"
 msgstr "漏斗"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "測量"
 
@@ -6950,81 +7046,81 @@ msgstr "漏斗類型"
 msgid "Bar chart"
 msgstr "柱形圖"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "線段圖表"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "請在圖表設定中選擇經度和維度的欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "請選擇一個區域地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "請在圖表設定中選擇一個區域和量值欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "地圖類型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "區域地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "固定地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "固定類型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "標題"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "標記"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "維度欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "經度欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "量值欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "區域欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "半徑"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "模糊"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "最小不透明度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "放到最大"
 
@@ -7036,7 +7132,7 @@ msgstr "沒有發現關聯。"
 msgid "via {0}"
 msgstr "通過{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "這個{0}連接到"
 
@@ -7048,31 +7144,31 @@ msgstr "對象細節"
 msgid "object"
 msgstr "對象"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "總計"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "需要用哪些欄位？"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "餅圖"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "維度"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "顯示說明"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "在說明中顯示百分比"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "最小切片百分比"
 
@@ -7097,7 +7193,8 @@ msgid "Progress"
 msgstr "處理"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "顏色"
@@ -7106,7 +7203,7 @@ msgstr "顏色"
 msgid "Row Chart"
 msgstr "原始圖表"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "原始圖表"
 
@@ -7130,15 +7227,15 @@ msgstr "新增一個後綴"
 msgid "Multiply by a number"
 msgstr "乘以數字"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "分散"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "散點圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "透視表"
 
@@ -7188,12 +7285,12 @@ msgstr "右邊"
 msgid "Show background"
 msgstr "顯示背景"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0}箱"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "自動分組"
 
@@ -7429,10 +7526,13 @@ msgstr "在{0}中有很多已儲存的問題？建立集合以幫助管理它們
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7618,7 +7718,7 @@ msgstr "累積總和"
 msgid "{0} and {1}"
 msgstr "{0} 和 {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} 的 {1}"
@@ -8930,11 +9030,11 @@ msgstr "資料權限"
 msgid "Collection permissions"
 msgstr "檔案夾權限"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "檢視所有檔案夾權限"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "同時更改子集合"
 
@@ -8946,19 +9046,19 @@ msgstr "允許修改集合及其內容"
 msgid "Can view items in this collection"
 msgstr "允許檢視該集合的內容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "集合的權限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "該組有權檢視此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "該組有權編輯此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "檢視子集合"
 
@@ -9014,6 +9114,7 @@ msgstr "相關"
 msgid "More X-rays"
 msgstr "更多透視方法"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9272,10 +9373,10 @@ msgstr "分享"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9358,7 +9459,7 @@ msgstr "使用Java虛擬機時區"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "我們現在正在分析資料表和欄位來幫助您探索資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "提示："
 
@@ -9366,7 +9467,7 @@ msgstr "提示："
 msgid "Select a currency type"
 msgstr "選擇一個統用的類型"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "欄位類型"
 
@@ -9421,6 +9522,7 @@ msgid "Currency"
 msgstr "貨幣"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "選擇一個使用者或頻道"
 
@@ -9582,7 +9684,7 @@ msgstr "哪個軸？"
 msgid "Line + Bar"
 msgstr "線狀圖+條行圖"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "線狀圖和條型圖"
 
@@ -9602,15 +9704,15 @@ msgstr "標尺範圍"
 msgid "Field to show"
 msgstr "顯示的欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "上一{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0}{2} {1}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "聚一個時間欄位來看量值隨著時間的變化情況"
 
@@ -9618,23 +9720,23 @@ msgstr "聚一個時間欄位來看量值隨著時間的變化情況"
 msgid "Switch positive / negative colors?"
 msgstr "切換正、負顏色"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "透視欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "欄位單元"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "可見欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "條件格式化"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "欄位抬頭"
 
@@ -10072,10 +10174,10 @@ msgstr "每來源使用者"
 msgid "The top external pages that brought users to your site"
 msgstr "將使用者帶到您網站的外部熱門網頁"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "[[這個]]如何分發等等。"
 
@@ -10173,13 +10275,13 @@ msgstr "當日每小時事件"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "前5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "後5 [[this]]"
 
@@ -10192,10 +10294,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "空值"
 
@@ -10223,8 +10325,8 @@ msgstr "How they compare by seasonality"
 msgid "Average income per transaction"
 msgstr "每次交易的平均收入"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "每個國家"
 
@@ -10348,10 +10450,10 @@ msgstr "An overview of your [[this]] and how its distributed across time, place,
 msgid "Average income per state"
 msgstr "Average income per state"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] by [[GenericCategoryMedium]]"
 
@@ -10528,13 +10630,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "[[GenericTable]]如何在此時間欄位中分布，以及是否有任何季節性模式。"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "總覽"
 
@@ -10643,8 +10745,8 @@ msgstr "繼續仔細看看[[這個]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "繼續仔細看看[[這個]]欄位"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "概覽"
 
@@ -10708,10 +10810,10 @@ msgstr "每個來源的銷售量"
 msgid "Average income per country"
 msgstr "每個國家平均收入"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "如何[[this]]分發"
 
@@ -10732,17 +10834,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "由[[this]]計算[[GenericCategoryMedium]]的數量"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "檢視您的 [[this]]"
 
@@ -10808,10 +10910,10 @@ msgid "Transactions per source over time"
 msgstr "每個來源的交易"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "[[this]]每天的每小時"
 
@@ -10840,9 +10942,9 @@ msgstr "這些事件發生的地方"
 msgid "Which US states are bringing you the most business."
 msgstr "美國哪些州為您帶來最大的業務？"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "他們如何比較時間？"
 
@@ -10947,8 +11049,8 @@ msgstr "總計[[this.short-name]]"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "有關GA統計資料的一些有趣量值可幫助您入門。"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]]每個區域"
 
@@ -11029,12 +11131,12 @@ msgstr "該量值如何分布在不同的數字上"
 msgid "Sessions by page where the session began"
 msgstr "會話開始時的頁面會話"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "不重複的值"
 
@@ -11097,10 +11199,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "[[GenericTable]] [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "他們如何通過分布進行比較"
@@ -11406,6 +11508,7 @@ msgstr "複製資訊看板"
 msgid "Duplicate \"{0}\""
 msgstr "複製 \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11494,9 +11597,9 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "季度季度"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0}選擇"
@@ -11518,11 +11621,11 @@ msgstr "無效"
 msgid "Add a time"
 msgstr "新增時間"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "無法與前{0}比較"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "[[時間戳]]按小時計算"
 
@@ -12010,9 +12113,9 @@ msgstr "由於所需的依賴性，Metabase無法初始化插件{0}。"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "找不到類：{0}"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "他們如何比較不同的位置"
 
@@ -12041,12 +12144,12 @@ msgstr "取消註冊原始JDBC驅動程序{0} ..."
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "預設連接屬性{0}不存在。"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "無效的連接屬性{0}：不是字串或映射。"
 
@@ -12124,11 +12227,11 @@ msgstr "收藏"
 msgid "collections"
 msgstr "收藏"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "資訊看板"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "資訊看板"
 
@@ -12378,7 +12481,7 @@ msgstr "{0} ms 後逾時."
 msgid "Misfire Instruction"
 msgstr "失火指令"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "將這個歸檔?"
 
@@ -12396,7 +12499,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "使用此選項要求提供的主機是一個FQDN。 如果連接到一個Atlas集群，您可能需要啟用此選項。 如果您不知道這意味著什麼，請取消使用該選項。"
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "在進行簡單的過濾和匯總時自動執行查詢"
 
@@ -12408,7 +12511,7 @@ msgstr "這個選項開啟時，當使用者在檢視表格或圖表時使用“
 msgid "Learn about this database"
 msgstr "了解這個資料庫"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "是否歸檔該資訊看板?"
 
@@ -12463,11 +12566,11 @@ msgstr "自訂問題查詢"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "使用高級查詢編輯器完成關聯, 建立自訂欄位, 實現數學計算等更多進階功能."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "基礎量值"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "自訂"
 
@@ -12650,15 +12753,15 @@ msgstr "選擇可視化方法"
 msgid "Filter by"
 msgstr "篩選條件(Filter by)"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "聚合條件(Summarize by)"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "分組條件(Group by)"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "新增量值"
 
@@ -12669,15 +12772,15 @@ msgstr "新增量值"
 msgid "Profile"
 msgstr "首頁"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "這通常很快，但現在似乎需要一段時間。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "組合(Combo)"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "行(Row)"
 
@@ -13098,7 +13201,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "選擇需要包含的欄位"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "這個選項開啟時，當使用者在檢視表格或圖表時使用“匯總”和“過濾”按鈕進行簡單資料探索時，Metabase將自動執行查詢。 如果查詢此資料庫的速度很慢，可以將該選項關閉。 此設定不會影響資料鑽探或SQL查詢。"
 
@@ -13164,7 +13267,7 @@ msgstr "使用EMail登入"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "使用此選項要求提供的主機是FQDN。 如果連接到Atlas群集，則可能需要啟用此選項。 如果您不知道這意味著什麼，請取消此功能。"
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "預設情況下，Metabase每小時執行一次輕量級同步，每天執行一次密集掃描。 如果您有一個大型資料庫，我們建議啟用此功能並檢視欄位值掃描的發生時間和頻率。"
 
@@ -13232,11 +13335,11 @@ msgstr "不包含"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "在使用GUI界面建立的問題中，該欄位將不可見或不可選擇。 在SQL/原生查詢中仍然可以使用。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "累積和(Cumulative sum)"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "標準差(Standard deviation)"
 
@@ -13252,19 +13355,19 @@ msgstr "必須至少為{0}個字元"
 msgid "Name (required)"
 msgstr "名稱（必填）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "執行SQL陳述句"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "執行查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "（command + enter）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "（Ctrl + enter）"
 
@@ -13612,7 +13715,7 @@ msgstr "Dates and Times"
 msgid "Numbers"
 msgstr "Numbers"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "No mappable groups"
 
@@ -13652,15 +13755,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "記住我"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "為安全起見，密碼重置連結將會失效。假如欲重新設定密碼，可以 {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "儲存新密碼"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "無結果相符"
 
@@ -13686,26 +13789,26 @@ msgid "or"
 msgstr "or"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "必須"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "資料庫類型"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "檢核或更新資料庫 schema 是一個輕量級的動作，大部分情況下，可以設定為每小時同步一次。"
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase 會掃描資料庫中每個欄位的資料值，方便在展示板與提問(查詢)點擊篩選核取方塊。這個動作會有一點耗費系統資源，尤其是資料內容非常大的時候。"
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Collection"
 
@@ -13719,18 +13822,18 @@ msgstr "密碼不符合"
 
 #: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
-msgstr "Department of Awesome"
+msgstr "真棒系"
 
 #: frontend/src/metabase/lib/core.js:88 frontend/src/metabase/lib/core.js:93
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "Financial"
+msgstr "金融"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
 msgid "Numeric"
-msgstr "Numeric"
+msgstr "數字"
 
 #: frontend/src/metabase/lib/core.js:169 frontend/src/metabase/lib/core.js:174
 #: frontend/src/metabase/lib/core.js:179 frontend/src/metabase/lib/core.js:184
@@ -13740,19 +13843,19 @@ msgstr "Numeric"
 #: frontend/src/metabase/lib/core.js:219 frontend/src/metabase/lib/core.js:224
 #: frontend/src/metabase/lib/core.js:229 frontend/src/metabase/lib/core.js:234
 msgid "Date and Time"
-msgstr "Date and Time"
+msgstr "日期和時間"
 
 #: frontend/src/metabase/lib/core.js:241 frontend/src/metabase/lib/core.js:246
 #: frontend/src/metabase/lib/core.js:251
 msgid "Categorical"
-msgstr "Categorical"
+msgstr "分類的"
 
 #: frontend/src/metabase/lib/core.js:258 frontend/src/metabase/lib/core.js:263
 #: frontend/src/metabase/lib/core.js:268
 msgid "URLs"
-msgstr "URLs"
+msgstr "網址"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "返回欄位資料的平均值"
 
@@ -13761,11 +13864,13 @@ msgstr "返回欄位資料的平均值"
 msgid "The column whose values to average."
 msgstr "此欄位的值要計算平均"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "開始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "結束"
 
@@ -13777,49 +13882,47 @@ msgstr "檢查欄位資料看看數值是否符合特定範圍"
 msgid "Rating"
 msgstr "評分"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "健康）狀況"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "輸出"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
-msgstr "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met"
+msgstr "測試案例列表並返回第一個真實案例的對應值，如果不滿足其他條件，則返回一個可選的默認值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "重量"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "中"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "某些情況將被評估為真或假"
 
@@ -13827,33 +13930,33 @@ msgstr "某些情況將被評估為真或假"
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "假如進行的條件為真則返回的資料數值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "value1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "value2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
-msgstr "Looks at the values in each argument in order and returns the first non-null value for each row"
+msgstr "按順序查看每個參數中的值，並為每行返回第一個非空值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "評論"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "筆記"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "沒有評論"
 
@@ -13869,12 +13972,12 @@ msgstr "假如 value1 是空的，則返回非空值的 value2"
 msgid "Combines two or more strings of text together."
 msgstr "合併兩個或兩個以上的文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "名字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "姓氏"
 
@@ -13886,35 +13989,35 @@ msgstr "value2將會加在這個的後面"
 msgid "This will be added to the end of value1."
 msgstr "這將會加在 value1的後面"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "檢查 string1 是否含 string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
-msgstr "Status"
+msgstr "狀態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
-msgstr "Pass"
+msgstr "通過"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "字串內容將被檢核"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "欲尋找的文字字串"
 
@@ -13922,22 +14025,22 @@ msgstr "欲尋找的文字字串"
 msgid "Returns the count of rows in the source data."
 msgstr "返回原始資料的行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "只計算符合條件為真的資料行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "The additive total of rows across a breakout"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "The rolling sum of a column across a breakout"
 
@@ -13946,53 +14049,57 @@ msgstr "The rolling sum of a column across a breakout"
 msgid "The column to sum."
 msgstr "欲加總之欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "此欄位中相異資料的個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "計算欄位相異資料個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "比較"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "假如文字結尾符合對比文字則返回真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Appetite"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hungry"
 
@@ -14001,20 +14108,20 @@ msgstr "hungry"
 msgid "A column or string of text to check."
 msgstr "欲檢核的欄位或字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "原始文字結尾的文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "正則表達式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "擷取符合正則表達式的文字或數字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Address"
 
@@ -14022,7 +14129,7 @@ msgstr "Address"
 msgid "The column or string of text to search though."
 msgstr "欲搜尋的欄位或文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "符合的正則表達式"
 
@@ -14034,7 +14141,7 @@ msgstr "返回小寫字串"
 msgid "The column with values to convert to lowercase."
 msgstr "欄位資料將轉換為小寫"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "刪除字串開頭空白"
 
@@ -14044,15 +14151,16 @@ msgstr "刪除字串開頭空白"
 msgid "The column with values you want to trim."
 msgstr "欲截除的欄位資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "返回此欄位的最大值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "年齡"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "數值欄位中欲尋找的最大值"
 
@@ -14060,21 +14168,21 @@ msgstr "數值欄位中欲尋找的最大值"
 msgid "Returns the smallest value found in the column."
 msgstr "返回此欄位的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "薪水"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "數值欄位中欲尋找的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "長度"
 
@@ -14083,13 +14191,13 @@ msgstr "長度"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "以新文字替換部分輸入文字"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "訂購ID"
+msgstr "訂單編號"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
@@ -14111,35 +14219,35 @@ msgstr "欲置換的字元數目"
 msgid "The text to use in the replacement."
 msgstr "欲置換的文字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "刪除文字結尾空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "以數字表示返回符合條件的資料行數百分比"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "假如文字開頭符合比較的文字則返回結果為真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "課程名"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "計算機科學"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "原始文字開頭的字元"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "計算此欄位的標準差"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "人口"
 
@@ -14147,7 +14255,7 @@ msgstr "人口"
 msgid "A numeric column."
 msgstr "數字欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "返回部分提供的文字"
 
@@ -14155,35 +14263,35 @@ msgstr "返回部分提供的文字"
 msgid "The text to return a portion of."
 msgstr "此文字返回某部分的"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "開始複製字元的位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "欲返回字元的數目"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
-msgstr "將列的所有值相加"
+msgstr "Adds up all the values of the column"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "數字欄位加總"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
-msgstr "匯總行匹配條件的列中的值"
+msgstr "Sums up values in a column where rows match the condition"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
-msgstr "訂單狀態"
+msgstr "Order Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
-msgstr "有效"
+msgstr "Valid"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "刪除文字開頭及結尾空白"
 
@@ -14191,43 +14299,43 @@ msgstr "刪除文字開頭及結尾空白"
 msgid "Returns the string of text in all upper case."
 msgstr "返回大寫文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "欄位資料轉換成大寫"
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "必須是 {0} 及包含 {1}"
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "必須是 {0} "
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "必須包含 {0}"
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "至少{0}個字符長"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0}小寫字母"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0}大寫字母"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0}號"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0}特殊字符"
@@ -14246,11 +14354,12 @@ msgstr "感謝使用 Metabase ！"
 
 #: frontend/src/metabase/public/components/LogoBadge.jsx:20
 msgid "Powered by {0}"
-msgstr "供電 {0}"
+msgstr "Powered by {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
-msgstr "至:"
+msgstr "至："
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
@@ -14290,8 +14399,7 @@ msgstr "{0} 在查詢範本建立一個變數名稱為\"variable_name\"。可以
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:261
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "設定過濾篩選變數來連結到展示板上的相關SQL提問(查詢)的篩選元件。\n"
-"當加入欲篩選欄位時，欄位篩選變數會插入一段SQL語法到視覺查詢建構器所產生的查詢語句"
+msgstr "設定過濾篩選變數來連結到展示板上的相關SQL提問(查詢)的篩選元件。當加入欲篩選欄位時，欄位篩選變數會插入一段SQL語法到視覺查詢建構器所產生的查詢語句"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
@@ -14337,7 +14445,7 @@ msgstr "資料格式"
 msgid "Full"
 msgstr "充分"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "從上沒有變化 {0}"
 
@@ -14351,7 +14459,7 @@ msgstr "連線至主機 \"{0}\" 成功，但是 port {1} 是無效的"
 
 #: src/metabase/api/database.clj
 msgid "Host ''{0}'' is not reachable"
-msgstr "主辦 ''{0}'' 無法到達"
+msgstr "Host ''{0}'' is not reachable"
 
 #: src/metabase/api/database.clj
 msgid "Unable to connect to database."
@@ -14399,7 +14507,7 @@ msgstr "其他一切"
 
 #: src/metabase/core.clj
 msgid "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."
-msgstr "警告：You have enabled namespace tracing, which could log sensitive information like db passwords"
+msgstr "警告：您已啟用名稱空間跟踪，它可以記錄敏感信息，例如數據庫密碼"
 
 #: src/metabase/db.clj
 msgid "Database Upgrade Required"
@@ -14424,7 +14532,7 @@ msgstr "資料庫需要手動更新"
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "將交易設置為自動回滾..."
+msgstr "Set transaction to automatically roll back..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
@@ -14526,11 +14634,11 @@ msgstr "設定 {0} 是內部的"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "正在加載本地插件清單{0}"
+msgstr "加載本地插件清單 {0}"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Google Analytics（分析）跟踪代碼。"
+msgstr "Google Analytics tracking code."
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
@@ -14547,7 +14655,7 @@ msgstr "Rendering pulse card with chart-type {0} and render-type {1}"
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
+msgstr "修復我：這些不是有效的時間文字：{0} {1}。我們為什麼要嘗試格式化它們？"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
@@ -14662,7 +14770,7 @@ msgstr "從欄位產生 insights 錯誤"
 msgid "Sending abandonment email!"
 msgstr "送出 abandonment email ！"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "您可以創建保存的指標以添加命名指標選項。保存的指標包括聚合類型，聚合字段以及您添加的任何過濾器（可選）。例如，您可以使用它來創建類似於為Orders表計算“平均價格”的官方方法。"
 
@@ -14670,15 +14778,15 @@ msgstr "您可以創建保存的指標以添加命名指標選項。保存的指
 msgid "Select and add filters to create your new segment."
 msgstr "選擇並添加過濾器以創建新的細分。"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "按字母順序"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "聰明"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "列順序：{0}"
 
@@ -14730,7 +14838,7 @@ msgstr "本土化"
 msgid "Instance language"
 msgstr "實例語言"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "本地化選項"
 
@@ -14802,19 +14910,20 @@ msgstr "粘貼連接字符串"
 msgid "Fill out individual fields"
 msgstr "填寫各個字段"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "在此處輸入一些SQL，以便稍後使用"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "給您的代碼片段起個名字"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "現有客戶"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "增加一個說明"
 
@@ -14822,46 +14931,47 @@ msgstr "增加一個說明"
 msgid "Use site default"
 msgstr "使用網站默認"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "找"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "更換"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "要查找的文字。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "用作替代的文本。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "編輯{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "創建您的新片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "存檔片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "片段是SQL的可重用位"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "創建一個片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "片段"
 
@@ -15140,3 +15250,1503 @@ msgstr "值必須是關鍵字或字符串。"
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "字符串必須是有效的兩個字母的ISO語言或語言國家/地區代碼，例如“ en”或“ en_US”。"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "第{0}-{1}行"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "審計"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "智威湯遜"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "用戶屬性配置（可選）"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "使用{0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "設置基於SAML的SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML身份驗證"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "配置您的身份提供商（IdP）"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "您的身份提供者將需要以下有關元數據庫的信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "IdP應該重定向回的URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "這在Okta中稱為單一登錄URL，在Auth0中稱為應用程序回調URL，\n"
+"以及OneLogin中的ACS（消費者）URL。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "在大多數IdP中，您需要將每個IdP放入標有\n"
+"屬性語句部分中的“名稱”。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "用戶的電子郵件屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "用戶的名字屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "用戶的姓氏屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "告訴Metabase您的身份提供者"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "配置數據庫將需要有關您的提供程序的以下信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML身份提供者URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "SAML身份提供商證書"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML應用程序名稱"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "簽署SSO請求（可選）"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML密鑰庫路徑"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "SAML密鑰庫密碼"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "噓..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML密鑰庫別名"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "將組成員身份與您的SSO同步"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "為此，您需要創建映射以告訴Metabase您的用戶應該使用哪個組。\n"
+"根據他們所在的SSO組添加到。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "組的名字"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "組屬性名稱"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "注意："
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "如果更改現有SAML活動設置的任何設置，則將需要重新啟動Metabase才能使它們生效。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "允許用戶通過SAML身份提供程序登錄。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "允許用戶通過JWT身份提供程序登錄。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "啟用密碼驗證"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "啟用後，用戶還可以使用電子郵件和密碼登錄。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "通知管理員新的SSO用戶"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "啟用後，管理員將在用戶首次使用單一登錄時收到一封電子郵件。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "使用以下設置通過SAML配置SSO。如有任何疑問，請查看我們的{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "文件資料"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML身份提供者URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT認證"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT身份提供者URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "JWT簽名密鑰使用的字符串"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "嵌入整個Metabase應用"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "如果要嵌入所有元數據庫，請輸入要允許嵌入iframe的網站或Web應用程序的來源，以空格分隔。這是可以輸入的內容{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "授予沙盒訪問此表的權限"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "當該組中的用戶查看此表時，他們將看到按其用戶屬性過濾的該表的版本，或基於已保存問題的自定義視圖。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "您要如何為該組中的用戶過濾該表？"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "選擇一個保存的問題，該問題將返回這些用戶應看到的該表的自定義視圖。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "您可以根據用戶屬性在此處添加其他過濾器。這些過濾器將應用於此已保存問題中已存在的所有過濾器之上。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "為了使此選項起作用，您的用戶需要具有一些屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "要添加其他過濾器，您的用戶需要具有一些屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "沒有用戶屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "選擇一個用戶屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "選擇一個參數"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "選擇專欄"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "{0}中的用戶可以查看"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "{0}問題中的行"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "{0}表中的行"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "其中{0}等於{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "並且{0}等於{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "您可以通過設置使用SAML的SSO來自動添加屬性，也可以通過轉到人員部分並單擊最右邊的…菜單來手動輸入屬性。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "用戶屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "如果您已設置SSO，我們可以自動獲取用戶的屬性，也可以從管理面板的“人員”部分的“ ...”菜單中手動添加它們。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "參數或變量"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "等於"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "授予沙盒訪問權限"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "沙盒訪問"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "編輯沙盒訪問"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "編輯文件夾詳細信息"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "變更權限"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "創建您的新文件夾"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "新建文件夾"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "我們無法驗證您的令牌"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "請仔細檢查您的實例可以連接到Metabase的服務器"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "得到幫助"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "通過企業版充分利用Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "快速，輕鬆地為客戶提供報告，或幫助您在大型組織中運行和監視Metabase所需的所有工具"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "激活許可證"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "您的試用版具有這些功能"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "試用到期{0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "需要幫忙？準備買？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "與我們交談"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "您的試用期已過期"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "需要更多時間？準備買？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "您的功能已啟用！"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "您的許可證通過{0}有效"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "您的許可證已過期"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "它於{0}到期"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "要續簽您的許可證嗎？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "了解如何使用"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "當前計劃中未包括"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "輸入您從商店收到的令牌"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "啟用"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "需要幫忙？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "有關您的問題的更多信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "聯繫支持"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "企業"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "數據沙箱"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "確保根據用戶屬性使用自動和安全的篩選器向正確的人顯示正確的數據。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "白色標籤"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "使用自定義顏色，您自己的徽標等將Metabase與您的品牌匹配。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "稽核"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "借助強大的審核工具來關注性能和行為。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "單點登錄"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "提供與您現有的身份驗證基礎結構配合使用的簡單登錄名。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "商店"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "應用名稱"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "調色板"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "商標"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "網站圖標"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "登陸頁面"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "沒有團體"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "{0}的權限"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "此文件夾的權限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "授予編輯權限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "可以修改此文件夾中的片段"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "授予查看權限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "可以在此文件夾中插入和使用摘要，但不能編輯其中包含的SQL"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "無法查看或在此文件夾中插入片段"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "同時更改子文件夾"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "一周的第一天"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "使用Google登錄時出現問題。請與管理員聯繫。"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "在"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "在"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "打開配置數據庫操作菜單"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "沒做什麼"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "轉到自定義目的地"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "更新儀表板過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0}更新{1}過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0}轉到{1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "每列的點擊行為"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "前往自訂目的地"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "打開動作菜單"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "{0}的點擊行為"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "選擇一個或多個過濾器進行更新"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "保存的問題"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "鏈接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "輸入要鏈接的URL"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "您可以使用其名稱插入列或儀表板過濾器的值，如下所示：{{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "例如http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "選擇儀表板..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "選擇一個問題..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "選擇一個儀表板以鏈接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "選擇一個問題鏈接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "將值傳遞到此儀表板的過濾器（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "將值傳遞給該問題的變量（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "傳遞值以過濾此問題（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "儀表板過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "用戶屬性"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "自定義鏈接文本（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. {{Column Name}}的詳細信息"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "您可以參考的值"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "沒有可用的目標"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "過濾"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "變量"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "其他可用的過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "可用的過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "其他可用變量"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "可用變量"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "其他可用列"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "可用列"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "用戶屬性"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "文字卡"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "點擊行為"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "可視化選項"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "編輯系列"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "添加系列"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "點擊時"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "更改標題和描述"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "您已經更新了嵌入式參數，將需要更新嵌入代碼。"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "添加問題"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "您正在編輯此儀表板。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "要過濾的列"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "摘要集"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "摘要集"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "給你的文件夾起個名字"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "矮而甜的東西"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "文件夾應該在"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "打開動作菜單"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0}列具有自定義行為"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "去..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "前往資訊主頁"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "去提問"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "前往網址"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "篩選此儀表板"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "返回所選數據中的行數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "要累加的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "要獲取其標準偏差的數字列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "要取其平均值的數字列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "返回列中找到的最小值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "谷歌"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "僅對條件為真的行匯總指定的列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "返回給定列的數值方差。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "溫度"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "要獲取其方差的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "返回指定列的中間值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "要獲取中位數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "百分數值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "以百分比值返回列的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "要獲取其百分位數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "百分位數的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "以小寫形式返回文本字符串。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "具有要轉換為小寫字母的值的列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "以大寫形式返回文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "要返回其一部分的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "要搜索的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "將兩個或多個文本字符串組合在一起。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "開頭的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "這將被添加到value1的末尾，依此類推。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "巨大"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "巨大"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "返回文本中的字符數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "您要獲取長度的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "您要修剪的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "返回指定列的絕對（正）值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "債務"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "要返回其絕對（正）值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "向下舍入十進制數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "要捨入的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "向上舍入十進制數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "要向上舍入的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "將十進制數字向上或向下舍入為最接近的整數值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "要捨入到最接近整數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "返回平方根。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "斜邊"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "要返回其平方根值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "指數"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "將數字提高到指數值的冪。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "長度"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "升至指數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "指數的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "返回該數字的以10為底的對數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "要返回其自然對數值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "返回歐拉數e，提高到所提供數字的冪。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "利息月"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "要返回其指數值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "要檢查的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "檢查日期或數字列的值以查看它們是否在指定範圍內。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "創建於"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "日期或數字列應在開始和結束值之內。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "範圍的開始。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "範圍的結尾。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "檢查日期列的值以查看它們是否在相對范圍內。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "返回間隔的日期列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "間隔時間，其中負值會及時返回。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "內部類型，例如“天”，“月”，“年”。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "要返回的列或值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "如果value1為空，則value2不為空則返回，依此類推。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "針對案例列表測試表達式，並返回第一個匹配案例的相應值，如果不滿足其他條件，則返回可選的默認值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "如果前面的條件為true，將返回的值，依此類推。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "一片空白"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "不為空"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "列的所有值的累加總和。\n"
+"e.x.總收入。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "行數的累加計數。\n"
+"e.x.一段時間內的銷售總數。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "鏈接的過濾器"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "標籤"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "默認值"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "沒有預設"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "要查看此內容，必須將{0}連接到至少一個字段。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "限制此過濾器的選擇"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "如果您有另一個儀表板過濾器，則可以基於另一個過濾器的選擇來限制為此過濾器列出的選擇。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "所以首先，{0}。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "添加另一個儀表板過濾器"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "如果啟用這些儀表板過濾器之一，則為該過濾器選擇一個值將限制{0}過濾器的可用選項。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "過濾柱"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "過濾列"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "輸入用戶名或電子郵件地址"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "新片段"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}：下午00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}：00上午"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "每小時一次"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "每天{0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "{1}的每週{0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "每月{0} {1} {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "刪除此訂閱"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "訂閱內容"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "創建儀表板訂閱"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "用電子郵件發送"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "您可以定期將此儀表板發送給用戶或電子郵件地址。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "發送給Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "選擇一個頻道和時間表，其餘的工作由Metabase完成。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "通過電子郵件發送此信息中心"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "如果沒有結果就不要發送"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "附加結果"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "附件最多可以包含2,000行數據。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "將此儀表板發送到Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "儀表板沒有ID為{0}的參數"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "參數{0}沒有與之關聯的任何字段"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include必須為空或值'tables'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "所有非內部類型的查詢都必須使用“數據庫”。"
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "該實例的密碼登錄已禁用。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "您的帳戶已被禁用。請與您的管理員聯繫。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "您的帳戶已被禁用。"
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "無效的Slack令牌。"
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "“ {0}”命令僅在Metabase Enterprise Edition中可用。"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Metabase Enterprise Edition擴展是當前的。"
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Metabase Enterprise Edition功能的使用須遵守Metabase商業許可。"
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "有關詳細信息，請參見{0}。"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "不存在Metabase Enterprise Edition擴展。"
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "邀請您加入{0}的{1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0}創建了一個{1}帳戶"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0}接受了他們的{1}邀請"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}]密碼重置請求"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}]通知"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}]幫助改善[{1}]。"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}]告訴我們情況如何。"
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "啟動事件偵聽器時出錯"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "當有人通過LDAP登錄時，我們應該同步用戶屬性嗎？"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "用戶屬性的逗號分隔列表，以跳過LDAP用戶的同步。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "令牌無效"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "鬆弛API錯誤：{0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "缺少名為“ metabase_files”的鬆弛通道！"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "請創建或取消歸檔通道，以完成Slack集成。"
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "該通道用於存儲包含在Pulses和MetaBot答案中的圖形。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "上傳的圖片"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "將文件上傳到Slack時出錯："
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "無效會話。預期為Session的實例。"
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "會話Cookie的SameSite配置為“無”，但站點"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "通過不安全的連接提供服務。一些瀏覽器會拒絕 "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "這些條件下的Cookie。 "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "頂級文件夾"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr "：parameters必須是具有String：id鍵的映射序列"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "無效的人類可讀值：值必須是序列；每個項目必須為nil或字符串"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr "：values必須存在才能獲取：human_read_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "字段值的總長度> {0}。"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "摘要名稱不能包含'}'或以空格開頭"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "執行鍊式過濾器查詢時出錯"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "字段{0}不存在。"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "無法針對非文本字段{0} {1}搜索"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "授予組{0}的權限：{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "撤銷組{0}的權限：{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "無效的數據庫權限：如果您具有本地查詢的寫訪問權限，則必須具有完整的數據訪問權限。"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "無效的數據庫權限：如果您具有隻讀的本機查詢訪問權限，則還必須具有數據訪問權限。"
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "將權限從{0}更改為：{1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "登錄屬性鍵必須是關鍵字或字符串"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Metabase UI，系統電子郵件，脈沖和警報中所有用戶的默認語言。"
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "用戶可以從自己的帳戶設置中單獨覆蓋此默認語言。"
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "顯示用戶的默認頁面"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "允許此來源嵌入完整的Metabase應用程序"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "不允許大於{0}（{1}）的值。"
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "無論出現在何處，它將替換單詞“ Metabase”。"
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "這些是圖表和整個Metabase中使用的原色。您可能需要刷新瀏覽器才能看到更改生效。"
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "為了獲得最佳效果，請使用透明背景的SVG文件。"
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "您要用作網站圖標的URL或圖像。"
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "允許通過電子郵件和密碼登錄。"
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "這將影響諸如按週分組或在GUI查詢中過濾之類的事情。\n"
+"  它不會影響SQL查詢。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "無法驗證令牌"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "令牌格式無效。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "驗證令牌時出錯"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "針對{0}字段的過濾錯誤：無法將字符串{1}解析為{2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "提取作業{0}的詳細信息時出錯"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "正在啟動數據庫{0}的同步任務。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "無法同步數據庫{0}：數據庫不存在。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "已為數據庫{0}觸發了“更新字段值”任務。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "跳過更新，數據庫{0}的自動字段值更新被禁用。"

--- a/locales/zh-TW.po
+++ b/locales/zh-TW.po
@@ -28,15 +28,16 @@ msgstr "探索資料"
 msgid "Select a database type"
 msgstr "選擇資料庫類型"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -49,7 +50,7 @@ msgstr "儲存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "為了做一些預設分析的事情，Metabase需要掃描您的資料庫。我們將會定期自動掃描您的資料庫，確保資料庫欄位的後設資料在 Metabase 是最新的狀態。您可以在下方更改更新掃描時間。"
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "資料庫同步中"
 
@@ -64,7 +65,7 @@ msgstr "這個程序僅僅檢查資料庫欄位後設資料的更新，並不會
 msgid "Scan"
 msgstr "掃描"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "根據篩選值進行掃描"
 
@@ -75,9 +76,9 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase 可以掃描資料庫中每個欄位的值，用來讓使用者啟用查詢或資訊看板中的篩選器。當您的資料庫較大時，這個功能同時會耗費更多的系統資源。"
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "Metabase應該在什麼時候自動掃描快取的欄位值？"
+msgstr "Metabase應該在什麼時候自動掃描及快取欄位值？"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:25
 msgid "Regularly, on a schedule"
@@ -85,7 +86,7 @@ msgstr "根據排程，週期性地啟動"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:50
 msgid "Only when adding a new filter widget"
-msgstr "只有當您在新增一個新的篩選控制項時"
+msgstr "只在新增篩選控制項時"
 
 #: frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx:54
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
@@ -133,29 +134,31 @@ msgstr "DELETE"
 msgid "in this box:"
 msgstr "在輸入框裡："
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -178,9 +181,9 @@ msgstr "刪除"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -200,8 +203,9 @@ msgstr "連線"
 msgid "Scheduling"
 msgstr "排程"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -280,10 +284,10 @@ msgstr "新增資料庫"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -318,10 +322,8 @@ msgid "Successfully saved!"
 msgstr "儲存成功！"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "編輯"
@@ -400,36 +402,39 @@ msgstr "請選擇一個指定類型"
 msgid "Select a target"
 msgstr "選擇目標"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "可見性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
-msgstr "類型"
+msgstr "後設資料(Metadata)欄位類型"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "當前資料庫"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
-msgstr "顯示原始資料綱要結構"
+msgstr "顯示原始資料庫綱要(Schema)"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
@@ -494,7 +499,7 @@ msgstr "搜尋資料表"
 msgid "Schemas"
 msgstr "資料表結構"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -511,7 +516,7 @@ msgstr "新增量值"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "定義"
 
@@ -579,35 +584,35 @@ msgstr "歷史"
 msgid "Revision History for"
 msgstr "歷史版本"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - 欄位設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "這些欄位將在哪裡顯示？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "欄位過濾"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "當在篩選器中使用此欄位時，使用者應該用什麼形式輸入他們想要過濾的值?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "暫無篩選欄位敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "對應值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "輸入值"
 
@@ -624,31 +629,31 @@ msgid "Custom mapping"
 msgstr "自訂對應"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "無法識別對應類型"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "當前欄位不是外鍵或者缺少外鍵關聯表後設資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "選中的欄位不是外鍵"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "顯示值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "選擇顯示資料庫中的原始值，或者顯示此欄位的相關或自訂訊息。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "選擇欄位"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "請選擇欄位來做展示"
 
@@ -656,16 +661,16 @@ msgstr "請選擇欄位來做展示"
 msgid "Tip:"
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "您可能想要更新這個欄位的名稱來確保它基於您的重新對應選擇時仍然有意義"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "快取欄位值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase 會掃描該欄位，來啟用資訊看板和提問的多選框篩選。"
 
@@ -692,35 +697,36 @@ msgstr "丟棄處理已經觸發！"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "選擇任意資料表來顯示它的結構並且新增或編輯後設資料"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "名稱必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "敘述必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "版本訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "聚集訊息必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "編輯量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "建立量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "修改量值並留下簡要說明。"
 
@@ -728,46 +734,46 @@ msgstr "修改量值並留下簡要說明。"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "您能夠建立已存儲的量值來新增一個已經命名的量值選項到這個表單。儲存的量值包括您新增的聚合類型，聚合欄位和可選的任何篩選項。舉個例子，您可能使用這個來為一個訂單表單創造一些像是“平均價”的官方計算方法，"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "結果："
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "命名量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "為量值命名，方便其他人搜尋。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "簡短的敘述"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "敘述量值"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "敘述量值，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "在這裡詳細敘述量值，比如不太明顯的規則"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "更改原因"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "留言以說明您所做的更改以及為何需要這些更改。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "這將顯示在此量值的修訂歷史記錄中，以幫助每個人記住事情發生變化的原因"
 
@@ -820,6 +826,7 @@ msgstr "這將顯示在篩選器的修訂歷史記錄中，以幫助每個人記
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -834,8 +841,7 @@ msgid "Re-scan this table"
 msgstr "刷新表格"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "新增"
 
@@ -852,7 +858,7 @@ msgid "Last name"
 msgstr "姓"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "電子郵件地址"
@@ -861,7 +867,7 @@ msgstr "電子郵件地址"
 msgid "Permission Groups"
 msgstr "群組權限"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "設為系統管理員"
 
@@ -957,6 +963,8 @@ msgstr "移除群組"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -969,11 +977,12 @@ msgstr "完成"
 msgid "Group name"
 msgstr "群組名稱"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "所屬群組"
@@ -1082,7 +1091,7 @@ msgstr "重設"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "是否確認執行此操作？"
 
@@ -1194,7 +1203,7 @@ msgstr "權限無更改。"
 msgid "You've made changes to permissions."
 msgstr "權限被更改。"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "這個集合(collection)的權限"
 
@@ -1250,6 +1259,7 @@ msgstr "部分權限"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "取消權限"
 
@@ -1313,30 +1323,30 @@ msgstr "修改集合(collection)"
 msgid "View collection"
 msgstr "檢視集合(collection)"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "允許資料存取權限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "檢視資料表權限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL查詢"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "檢視綱要結構"
 
 #: frontend/src/metabase/admin/routes.jsx:66
 #: frontend/src/metabase/nav/containers/Navbar.jsx:241
 msgid "Data Model"
-msgstr "資料模型"
+msgstr "後設資料設定"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 #: frontend/src/metabase/plugins/builtin/auth/google.js:31
@@ -1400,12 +1410,15 @@ msgstr "已發送"
 msgid "Clear"
 msgstr "完成"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "授權認證"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "伺服器設定"
@@ -1418,6 +1431,7 @@ msgstr "使用者結構"
 msgid "Attributes"
 msgstr "屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "群組結構"
@@ -1489,6 +1503,9 @@ msgid "Add a map"
 msgstr "新增一個地圖"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "URL連結"
@@ -1498,19 +1515,19 @@ msgid "Delete custom map"
 msgstr "刪除自訂地圖"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "刪除"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1608,19 +1625,19 @@ msgstr "購買 token"
 msgid "Enter a token"
 msgstr "輸入 token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "編輯映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "分組映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "建立映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1859,18 +1876,27 @@ msgstr "使用者篩選"
 msgid "Check your parentheses"
 msgstr "檢查括號"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "電子郵件屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "名字屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "姓氏屬性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "同步群組成員"
@@ -1899,59 +1925,59 @@ msgstr "自訂地圖"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "新增您自己的GeoJSON檔案以啟用不同的區域地圖可視化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "公開分享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "開啟公開共享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "已共享資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "已共享提問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "嵌入在其他的應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "啟用將Metabase嵌入到其他應用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "嵌入密鑰"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "嵌入的資訊看板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "嵌入的問題"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "快取中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "啟用快取"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "最小查詢週期"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "快取生存時間（TTL）乘數"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "最大快取允許大小"
 
@@ -1993,27 +2019,27 @@ msgstr "在您能夠使用Google帳戶登入之前，需要一個系統管理員
 msgid "Sign in with {0}"
 msgstr "用{0}登入"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "請聯絡系統管理員來重設您的密碼"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "忘記密碼"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "您作為Metabase帳戶的Email地址"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "發送帳號重設郵件"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "檢查您的郵件來獲取重設密碼說明"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "登入Metabase"
 
@@ -2034,11 +2060,11 @@ msgstr "登入"
 msgid "I seem to have forgotten my password"
 msgstr "我似乎忘記了我的密碼"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "發送一個新的重設密碼郵件"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "噢，那是個過期的連結"
 
@@ -2047,11 +2073,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "基於安全原因，密碼重設連結會在一段時間後過期。如果您仍需要重設密碼，可以{0}。"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "新密碼"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "為了確保您的資料安全，密碼{0}"
 
@@ -2074,24 +2100,24 @@ msgstr "確認新密碼"
 msgid "Make sure it matches the one you just entered"
 msgstr "確認它和您剛剛輸入的一致"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "您的密碼已經被重設"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "用您的新密碼登入"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "儲存失敗"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2101,25 +2127,26 @@ msgstr "已儲存"
 msgid "Ok"
 msgstr "好"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "歸檔集合"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "此集合中的資訊看板，集合和定時通知也將被歸檔。"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "歸檔"
 
@@ -2142,7 +2169,7 @@ msgstr "取消歸檔此{0}"
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:48
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Our data"
-msgstr "我們的資料"
+msgstr "目前資料集"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:156
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:53
@@ -2244,7 +2271,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "把東西拖到這裡將它固定在頂部"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2272,6 +2299,7 @@ msgstr "移動''{0}''？"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "移動"
@@ -2309,7 +2337,7 @@ msgstr "一些資料庫安裝只有通過SSH通道訪問的伺服器有權訪問
 "當VPN不可用時，這個選項也提供了一個額外的安全層。\n"
 "啟用這個選項，通常比直接連接速度更慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "這是一個大型資料庫，讓我選擇Metabase同步和掃描的時間"
 
@@ -2349,7 +2377,7 @@ msgstr "要將Metabase用於此資料，您必須在Google Developers Console中
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "如果您還沒有這樣做，請轉到控制台{0}。"
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "您想如何使用這個資料庫？"
 
@@ -2465,35 +2493,35 @@ msgstr "基於這個綱要結構"
 msgid "A look at your"
 msgstr "看看您的"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "搜尋欄位表"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "用{0}搜索"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr "或者輸入一個ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "輸入一個ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "輸入一個數字"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "輸入一些文字"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "沒有找到符合的{0} "
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "包括每個選項在您的篩選器中很可能將不會起很大作用……"
 
@@ -2505,7 +2533,6 @@ msgstr "有些問題發生了"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "我們執行中出現了一個錯誤，您可以嘗試刷新這個頁面，或者直接返回"
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2516,12 +2543,12 @@ msgstr "我們執行中出現了一個錯誤，您可以嘗試刷新這個頁面
 msgid "No description yet"
 msgstr "暫無敘述"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "新的"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "被{0}的發問"
 
@@ -2542,7 +2569,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "回溯到一個更早的版本並且{0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "版本記錄"
@@ -2588,7 +2617,7 @@ msgid "Questions"
 msgstr "問題"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "定時任務"
 
@@ -2662,52 +2691,69 @@ msgstr "先不用"
 msgid "Error:"
 msgstr "錯誤："
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "星期日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "星期一"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "星期二"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "星期三"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "星期四"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "星期五"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "星期六"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "第一個"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "最後一個"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "第十五個（中位數）"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "日曆日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "您的Metabase時區"
 
@@ -2761,13 +2807,13 @@ msgstr "建立"
 msgid "Create dashboard"
 msgstr "建立資訊看板"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
-msgstr "資料庫"
+msgstr "資料庫來源設定"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
@@ -2840,9 +2886,9 @@ msgstr "這個卡片叫什麼名字？"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2856,15 +2902,16 @@ msgstr "敘述"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "這是可選的，但非常有幫助"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "將這個放到哪個集合中？"
 
@@ -2904,11 +2951,11 @@ msgstr "歸檔資訊看板"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "確保為每個欄位都做出了選擇，不然篩選將不會在這個卡片上起作用"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "這個資訊看板看起來是空的"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "新增一個提問來讓它變得有用"
 
@@ -2928,7 +2975,7 @@ msgstr "退出全螢幕"
 msgid "Enter fullscreen"
 msgstr "進入全螢幕"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "儲存中"
@@ -2941,7 +2988,8 @@ msgstr "新增一個問題"
 msgid "Add a question to this dashboard"
 msgstr "新增報表到資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "新增篩選"
 
@@ -2949,7 +2997,7 @@ msgstr "新增篩選"
 msgid "Parameters"
 msgstr "參數"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "新增文本框"
 
@@ -2957,7 +3005,7 @@ msgstr "新增文本框"
 msgid "Move dashboard"
 msgstr "移動資訊看板"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "編輯資訊看板"
 
@@ -2981,11 +3029,11 @@ msgstr "移動資訊看板到……"
 msgid "Dashboard moved to {0}"
 msgstr "資訊看板移動到{0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "您想要篩選什麼"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "什麼類型的篩選"
 
@@ -3057,20 +3105,22 @@ msgstr "此卡沒有可以映射到此參數類型的任何欄位或參數。"
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "此欄位中的值不會與您選擇的任何其他欄位的值重疊。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "無可用欄位"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "名稱不能超過100個字元"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "顏色是必需的"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "您的資訊看板叫什麼名字？"
 
@@ -3125,7 +3175,7 @@ msgstr "接收最新的資料來自"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "未知"
 
@@ -3250,9 +3300,10 @@ msgstr "最近沒有檢視的資訊看板或者圖表"
 msgid "{0} items selected"
 msgstr "{0}項已選擇"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "取消歸檔"
 
@@ -3369,7 +3420,7 @@ msgid "Zip Code"
 msgstr "郵遞區號"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "數量"
 
@@ -3402,11 +3453,13 @@ msgid "User"
 msgstr "使用者"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "來源"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "價格"
 
@@ -3439,21 +3492,23 @@ msgid "Subscription"
 msgstr "訂閱"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "分數"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "標題"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "評論"
 
@@ -3507,14 +3562,14 @@ msgstr "Metabase永遠不會獲取此欄位。將此用於敏感或不相關的�
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "計數"
 
@@ -3522,7 +3577,7 @@ msgstr "計數"
 msgid "CumulativeCount"
 msgstr "累積計數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3540,19 +3595,19 @@ msgstr "不重複"
 msgid "StandardDeviation"
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3563,12 +3618,12 @@ msgstr "最大值"
 msgid "sad sad panda, lexing errors detected"
 msgstr "哎呀，出錯了"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0}秒"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0}分鐘"
@@ -3580,7 +3635,7 @@ msgstr "您好"
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "它工作的怎麼樣"
+msgstr "如何開始資料分析"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
@@ -3608,14 +3663,15 @@ msgstr "您想找出什麼？"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "原始資料"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "累積計數"
 
@@ -3677,166 +3733,164 @@ msgstr "真"
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "選擇經度欄位"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "輸入緯度上邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "輸入經度左邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "輸入緯度下邊界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "輸入經度右邊界"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "不是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "為空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "不為空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "不等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "大於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "小於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "介於之間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "以…開始"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "以…結束"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "早於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "晚於"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "介於中間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "只是一個包含資料行的表格，沒有其他操作。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "總行數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "答案的總資料行數。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "總和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "一個欄位所有數值的總和。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "一個欄位所有數值的平均值。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "不重複值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "一個欄位所有互不重複的值的總數"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "累積求和"
 
@@ -3844,7 +3898,7 @@ msgstr "累積求和"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "一個欄位所有數值的累積加總。\\\\n比如：隨著時間推移的總收入。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "累積行數"
 
@@ -3852,27 +3906,27 @@ msgstr "累積行數"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "累積的資料行數。\\\\ n比如：隨著時間的推移銷售數量。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "標準差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "一個欄位所有數值的標準差。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "一個欄位的最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "一個欄位的最大值"
 
@@ -3888,6 +3942,8 @@ msgstr "小寫字母"
 msgid "upper case letter"
 msgstr "大寫字母"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "個數"
@@ -4135,7 +4191,7 @@ msgstr "如何建立量值"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "按地圖、趨勢檢視時間維度的資料，方便了解趨勢變化"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "自訂"
 
@@ -4158,7 +4214,7 @@ msgstr "原生查詢"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "為了回答更多複雜的提問，您可以寫下您自己的SQL語句或者原生查詢。"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "選擇一個預設值"
 
@@ -4246,7 +4302,7 @@ msgstr "這個月"
 msgid "This Year"
 msgstr "今年"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "輸入一個值……"
@@ -4256,7 +4312,7 @@ msgid "Enter a default value..."
 msgstr "輸入一個預設值……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "發生了一個錯誤"
@@ -4513,22 +4569,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "挑選您想在這個定時任務裡發送的圖表。"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "電子郵件"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slack消息"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "發送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0}將會在……被發送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "訊息"
 
@@ -4600,30 +4664,30 @@ msgstr "幫助每個在您們團隊的人和您們的資料保持聯結"
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "定時通知允許您根據您選擇的時間表從Metabase發送資料到電子郵件或Slack。"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "{0}之後"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "{0}之前"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "是空的"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "不是空的"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "所有時間"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "應用"
 
@@ -4724,12 +4788,12 @@ msgstr[0] "檢視這個{0}\n"
 msgid "Zoom in"
 msgstr "放大"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "自訂表達方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "共同量值"
 
@@ -4926,7 +4990,7 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "選擇一個區間或者表單"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "選擇一個資料庫"
@@ -4987,7 +5051,7 @@ msgstr "排序"
 msgid "Row limit"
 msgstr "行限制"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "未知欄位"
 
@@ -4995,7 +5059,7 @@ msgstr "未知欄位"
 msgid "field"
 msgstr "欄位"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "匹配"
 
@@ -5020,11 +5084,11 @@ msgstr "新增一個聚合"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "資料"
 
@@ -5041,11 +5105,12 @@ msgstr "檢視"
 msgid "Grouped By"
 msgstr "分組條件"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "沒有"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "這個提問已經被寫入{0}"
 
@@ -5057,7 +5122,7 @@ msgstr "隱藏編輯器"
 msgid "Hide Query"
 msgstr "隱藏查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "打開編輯器"
 
@@ -5065,7 +5130,7 @@ msgstr "打開編輯器"
 msgid "Show Query"
 msgstr "顯示查詢"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "這個量值已經被棄用，它將不再可用了"
 
@@ -5265,7 +5330,7 @@ msgstr "返回上一次執行"
 msgid "Visualization"
 msgstr "可視化"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "沒有設定敘述"
 
@@ -5322,7 +5387,7 @@ msgstr "在建立一個新的提問之前不能找到表單後設資料"
 msgid "See {0}"
 msgstr "檢視{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "量值定義"
 
@@ -5340,11 +5405,11 @@ msgstr "{0}的數字"
 msgid "See all {0}"
 msgstr "檢視所有的{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "劃分定義"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "在載入表時發生了一個錯誤"
 
@@ -5352,7 +5417,7 @@ msgstr "在載入表時發生了一個錯誤"
 msgid "See the raw data for {0}"
 msgstr "檢視{0}的所有原始資料"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "更多"
 
@@ -5372,6 +5437,8 @@ msgstr "欄位公式"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "這有點像在EXCEL表中編寫公式，您可以使用數字，欄位，數學符號和一些函數，例如 Subtotal - Cost。"
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5439,7 +5506,7 @@ msgstr "錯誤"
 msgid "Add filter"
 msgstr "新增篩選器"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "項"
 
@@ -5558,11 +5625,11 @@ msgstr "欄位對應到"
 msgid "Filter widget type"
 msgstr "篩選器樣式"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "必填項？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "篩選器預設值"
 
@@ -5574,7 +5641,7 @@ msgstr "歸檔提問？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "這個提問會從已引用的資訊看板或定時任務中移除"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "提問"
 
@@ -5621,7 +5688,7 @@ msgstr "欄位類型"
 msgid "Select a Foreign Key"
 msgstr "選擇一個外鍵"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "檢視{0}的公式"
 
@@ -5741,12 +5808,12 @@ msgstr "資料庫和資料表"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:31
 msgid "Details"
-msgstr "相關資訊"
+msgstr "資料集相關資訊"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:34
 #: frontend/src/metabase/reference/databases/TableList.jsx:114
 msgid "Tables in {0}"
-msgstr "{0}中的資料表"
+msgstr "{0} 資料集中的資料表"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:226
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:204
@@ -6105,22 +6172,24 @@ msgstr "有關這個劃分的提問"
 msgid "X-ray this segment"
 msgstr "透視這個劃分"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "登入"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "查詢"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "資訊看板"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "新提問"
 
@@ -6192,35 +6261,35 @@ msgstr "所有的收集都是匿名的。"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "您隨時可以在管理設定中關閉訊息收集。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "如果您不知從何下手"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "初級上手教學"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "點擊一下"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "歡迎來到Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "看起來一切都在正常工作，現在讓我們了解您吧，連接到您的資料，並且開始尋找一些屬於您的答案！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "讓我們開始吧"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "您已經設定完畢了！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "開始使用Metabase"
 
@@ -6472,39 +6541,40 @@ msgstr "取消篩選器"
 msgid "Pin Map"
 msgstr "固定地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "撤銷設定"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "{2}的{0}~{1}行"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "資料被截斷為{0}行。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "找不到可視化"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "無法顯示這個圖表顯示這些資料"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "沒有結果！"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "仍然在等待……"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "這將通常取一個{0}的平均數。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "（這對於資訊看板來說有點太長了）"
 
@@ -6614,7 +6684,7 @@ msgid "Highlight the whole row"
 msgstr "高亮整行"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "顏色"
 
@@ -6700,24 +6770,50 @@ msgstr "目標"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "正在……噢！從您的查詢中獲得的數去並不適合所選的展示選項，這個可視化需要最少資料中的{0}{1}。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "欄位"
@@ -6748,7 +6844,7 @@ msgid "xValues missing!"
 msgstr "x值遺失！"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X軸"
 
@@ -6757,7 +6853,7 @@ msgid "Add a series breakout..."
 msgstr "新增一序列欄位斷點......"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y軸"
 
@@ -6770,7 +6866,7 @@ msgid "Bubble size"
 msgstr "氣泡大小"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "線段"
 
@@ -6912,20 +7008,20 @@ msgid "Standard Deviation"
 msgstr "標準差"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "區域"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "區域圖"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "柱"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "柱狀圖"
 
@@ -6939,7 +7035,7 @@ msgid "Funnel"
 msgstr "漏斗"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "測量"
 
@@ -6951,81 +7047,81 @@ msgstr "漏斗類型"
 msgid "Bar chart"
 msgstr "柱狀圖"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "線段圖表"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "請在圖表設定中選擇經度和維度的欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "請選擇一個區域地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "請在圖表設定中選擇一個區域和量值欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "地圖類型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "區域地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "固定地圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "固定類型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "標題"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "標記"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "維度欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "經度欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "量值欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "區域欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "半徑"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "模糊程度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "最小不透明度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "放到最大"
 
@@ -7037,7 +7133,7 @@ msgstr "沒有發現關聯。"
 msgid "via {0}"
 msgstr "通過{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "這個{0}連接到"
 
@@ -7049,31 +7145,31 @@ msgstr "對象細節"
 msgid "object"
 msgstr "對象"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "總計"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "需要用哪些欄位？"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "圓餅圖"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "維度"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "顯示說明"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "在說明中顯示百分比"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "最小切片百分比"
 
@@ -7098,7 +7194,8 @@ msgid "Progress"
 msgstr "處理"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "顏色"
@@ -7107,7 +7204,7 @@ msgstr "顏色"
 msgid "Row Chart"
 msgstr "原始圖表"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "原始圖表"
 
@@ -7131,15 +7228,15 @@ msgstr "新增一個後綴"
 msgid "Multiply by a number"
 msgstr "乘以數字"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "分散"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "散佈圖"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "透視表"
 
@@ -7189,12 +7286,12 @@ msgstr "右邊"
 msgid "Show background"
 msgstr "顯示背景"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} 刻度間隔"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "自動分組"
 
@@ -7430,10 +7527,13 @@ msgstr "在{0}中有很多已儲存的問題？建立集合以幫助管理它們
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7619,7 +7719,7 @@ msgstr "累積總和"
 msgid "{0} and {1}"
 msgstr "{0} 和 {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} 的 {1}"
@@ -8932,11 +9032,11 @@ msgstr "資料權限"
 msgid "Collection permissions"
 msgstr "檔案夾權限"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "檢視所有檔案夾權限"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "同時更改子集合"
 
@@ -8948,19 +9048,19 @@ msgstr "允許修改集合及其內容"
 msgid "Can view items in this collection"
 msgstr "允許檢視該集合的內容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "集合的權限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "該組有權檢視此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "該組有權編輯此集合的至少一個子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "檢視子集合"
 
@@ -9016,6 +9116,7 @@ msgstr "相關"
 msgid "More X-rays"
 msgstr "更多透視方法"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9274,10 +9375,10 @@ msgstr "分享"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9360,7 +9461,7 @@ msgstr "使用Java虛擬機時區"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "我們現在正在分析資料表和欄位來幫助您探索資料"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "提示："
 
@@ -9368,7 +9469,7 @@ msgstr "提示："
 msgid "Select a currency type"
 msgstr "選擇一個統用的類型"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "欄位類型"
 
@@ -9423,6 +9524,7 @@ msgid "Currency"
 msgstr "貨幣"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "選擇一個使用者或頻道"
 
@@ -9584,7 +9686,7 @@ msgstr "哪個軸？"
 msgid "Line + Bar"
 msgstr "線狀圖+條行圖"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "線狀圖和條型圖"
 
@@ -9604,15 +9706,15 @@ msgstr "標尺範圍"
 msgid "Field to show"
 msgstr "顯示的欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "上一{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0}{2} {1}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "聚一個時間欄位來看量值隨著時間的變化情況"
 
@@ -9620,23 +9722,23 @@ msgstr "聚一個時間欄位來看量值隨著時間的變化情況"
 msgid "Switch positive / negative colors?"
 msgstr "切換正、負顏色"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "透視欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "欄位單元"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "可見欄位"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "條件格式化"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "欄位抬頭"
 
@@ -10074,10 +10176,10 @@ msgstr "每來源使用者"
 msgid "The top external pages that brought users to your site"
 msgstr "將使用者帶到您網站的外部熱門網頁"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "[[這個]]如何分發等等。"
 
@@ -10175,13 +10277,13 @@ msgstr "當日每小時事件"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "前5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "後5 [[this]]"
 
@@ -10194,10 +10296,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "空值"
 
@@ -10225,8 +10327,8 @@ msgstr "How they compare by seasonality"
 msgid "Average income per transaction"
 msgstr "每次交易的平均收入"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "每個國家"
 
@@ -10350,10 +10452,10 @@ msgstr "An overview of your [[this]] and how its distributed across time, place,
 msgid "Average income per state"
 msgstr "Average income per state"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] by [[GenericCategoryMedium]]"
 
@@ -10530,13 +10632,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "[[GenericTable]]如何在此時間欄位中分布，以及是否有任何季節性模式。"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "總覽"
 
@@ -10645,8 +10747,8 @@ msgstr "繼續仔細看看[[這個]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "繼續仔細看看[[這個]]欄位"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "概覽"
 
@@ -10710,10 +10812,10 @@ msgstr "每個來源的銷售量"
 msgid "Average income per country"
 msgstr "每個國家平均收入"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "如何[[this]]分發"
 
@@ -10734,17 +10836,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "由[[this]]計算[[GenericCategoryMedium]]的數量"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "檢視您的 [[this]]"
 
@@ -10810,10 +10912,10 @@ msgid "Transactions per source over time"
 msgstr "每個來源的交易"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "[[this]]每天的每小時"
 
@@ -10842,9 +10944,9 @@ msgstr "這些事件發生的地方"
 msgid "Which US states are bringing you the most business."
 msgstr "美國哪些州為您帶來最大的業務？"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "他們如何比較時間？"
 
@@ -10949,8 +11051,8 @@ msgstr "總計[[this.short-name]]"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "有關GA統計資料的一些有趣量值可幫助您入門。"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]]每個區域"
 
@@ -11031,12 +11133,12 @@ msgstr "該量值如何分布在不同的數字上"
 msgid "Sessions by page where the session began"
 msgstr "會話開始時的頁面會話"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "不重複的值"
 
@@ -11099,10 +11201,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "[[GenericTable]] [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "他們如何通過分布進行比較"
@@ -11408,6 +11510,7 @@ msgstr "複製資訊看板"
 msgid "Duplicate \"{0}\""
 msgstr "複製 \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11496,9 +11599,9 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "季度"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} 選擇"
@@ -11520,11 +11623,11 @@ msgstr "無效"
 msgid "Add a time"
 msgstr "新增時間"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "無法與前{0}比較"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "[[時間戳]]按小時計算"
 
@@ -12012,9 +12115,9 @@ msgstr "由於所需的依賴性，Metabase無法初始化插件{0}。"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "找不到類：{0}"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "他們如何比較不同的位置"
 
@@ -12043,12 +12146,12 @@ msgstr "取消註冊原始JDBC驅動程序{0} ..."
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "預設連接屬性{0}不存在。"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "無效的連接屬性{0}：不是字串或映射。"
 
@@ -12126,11 +12229,11 @@ msgstr "收藏"
 msgid "collections"
 msgstr "收藏"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "資訊看板"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "資訊看板"
 
@@ -12380,13 +12483,13 @@ msgstr "{0} ms 後逾時."
 msgid "Misfire Instruction"
 msgstr "失火指令"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "將這個歸檔?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:253
 msgid "Learn about our data"
-msgstr "了解我們的資料"
+msgstr "了解資料集"
 
 #: frontend/src/metabase/entities/databases/forms.js:22
 msgid "Use DNS SRV when connecting"
@@ -12398,7 +12501,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "使用此選項要求提供的主機是一個FQDN。 如果連接到一個Atlas集群，您可能需要啟用此選項。 如果您不知道這意味著什麼，請取消使用該選項。"
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "在進行簡單的過濾和匯總時自動執行查詢"
 
@@ -12408,9 +12511,9 @@ msgstr "這個選項開啟時，當使用者在檢視表格或圖表時使用“
 
 #: frontend/src/metabase/containers/Overworld.jsx:329
 msgid "Learn about this database"
-msgstr "了解這個資料庫"
+msgstr "了解這個資料集"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "是否歸檔該資訊看板?"
 
@@ -12465,11 +12568,11 @@ msgstr "自訂問題查詢"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "使用高級查詢編輯器完成關聯, 建立自訂欄位, 實現數學計算等更多進階功能."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "基礎量值"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "自訂"
 
@@ -12652,15 +12755,15 @@ msgstr "選擇可視化方法"
 msgid "Filter by"
 msgstr "篩選條件(Filter by)"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "聚合條件(Summarize by)"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "分組條件(Group by)"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "新增量值"
 
@@ -12671,15 +12774,15 @@ msgstr "新增量值"
 msgid "Profile"
 msgstr "基本資料"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "這通常很快，但現在似乎需要一段時間。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "組合(Combo)"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "行(Row)"
 
@@ -13100,7 +13203,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "選擇需要包含的欄位"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "這個選項開啟時，當使用者在檢視表格或圖表時使用“匯總”和“過濾”按鈕進行簡單資料探索時，Metabase將自動執行查詢。 如果查詢此資料庫的速度很慢，可以將該選項關閉。 此設定不會影響資料鑽探或SQL查詢。"
 
@@ -13166,7 +13269,7 @@ msgstr "使用EMail登入"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "使用此選項要求提供的主機是FQDN。 如果連接到Atlas群集，則可能需要啟用此選項。 如果您不知道這意味著什麼，請取消此功能。"
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "預設情況下，Metabase每小時執行一次輕量級同步，每天執行一次密集掃描。 如果您有一個大型資料庫，我們建議啟用此功能並檢視欄位值掃描的發生時間和頻率。"
 
@@ -13234,11 +13337,11 @@ msgstr "不包含"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "在使用GUI界面建立的問題中，該欄位將不可見或不可選擇。 在SQL/原生查詢中仍然可以使用。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "累積和(Cumulative sum)"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "標準差(Standard deviation)"
 
@@ -13254,19 +13357,19 @@ msgstr "必須至少為{0}個字元"
 msgid "Name (required)"
 msgstr "名稱（必填）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "執行SQL陳述句"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "執行查詢"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "（command + enter）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "（Ctrl + enter）"
 
@@ -13614,7 +13717,7 @@ msgstr "Dates and Times"
 msgid "Numbers"
 msgstr "Numbers"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "No mappable groups"
 
@@ -13654,15 +13757,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "記住我"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "為安全起見，密碼重置連結將會失效。假如欲重新設定密碼，可以 {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "儲存新密碼"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "無結果相符"
 
@@ -13688,26 +13791,26 @@ msgid "or"
 msgstr "or"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "必須"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "資料庫類型"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "檢核或更新資料庫 schema 是一個輕量級的動作，大部分情況下，可以設定為每小時同步一次。"
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase 會掃描資料庫中每個欄位的資料值，方便在展示板與提問(查詢)點擊篩選核取方塊。這個動作會有一點耗費系統資源，尤其是資料內容非常大的時候。"
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "Collection"
 
@@ -13721,13 +13824,13 @@ msgstr "密碼不符合"
 
 #: frontend/src/metabase/entities/users/forms.js:86
 msgid "Department of Awesome"
-msgstr "Department of Awesome"
+msgstr "真棒系"
 
 #: frontend/src/metabase/lib/core.js:88 frontend/src/metabase/lib/core.js:93
 #: frontend/src/metabase/lib/core.js:98 frontend/src/metabase/lib/core.js:103
 #: frontend/src/metabase/lib/core.js:108 frontend/src/metabase/lib/core.js:113
 msgid "Financial"
-msgstr "Financial"
+msgstr "金融"
 
 #: frontend/src/metabase/lib/core.js:120 frontend/src/metabase/lib/core.js:125
 #: frontend/src/metabase/lib/core.js:130
@@ -13754,7 +13857,7 @@ msgstr "分類的"
 msgid "URLs"
 msgstr "網址"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "返回欄位資料的平均值"
 
@@ -13763,11 +13866,13 @@ msgstr "返回欄位資料的平均值"
 msgid "The column whose values to average."
 msgstr "此欄位的值要計算平均"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "開始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "結束"
 
@@ -13779,21 +13884,20 @@ msgstr "檢查欄位資料看看數值是否符合特定範圍"
 msgid "Rating"
 msgstr "評分"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "健康）狀況"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "輸出"
 
@@ -13801,27 +13905,27 @@ msgstr "輸出"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "測試案例列表並返回第一個真實案例的對應值，如果不滿足其他條件，則返回一個可選的默認值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "重量"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "中"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "某些情況將被評估為真或假"
 
@@ -13829,33 +13933,33 @@ msgstr "某些情況將被評估為真或假"
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "假如進行的條件為真則返回的資料數值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "value1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "value2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
-msgstr "Looks at the values in each argument in order and returns the first non-null value for each row"
+msgstr "按順序查看每個參數中的值，並為每行返回第一個非空值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "評論"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "筆記"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "沒有評論"
 
@@ -13871,12 +13975,12 @@ msgstr "假如 value1 是空的，則返回非空值的 value2"
 msgid "Combines two or more strings of text together."
 msgstr "合併兩個或兩個以上的文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "名字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "姓氏"
 
@@ -13888,35 +13992,35 @@ msgstr "value2將會加在這個的後面"
 msgid "This will be added to the end of value1."
 msgstr "這將會加在 value1的後面"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "string1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "檢查 string1 是否含 string2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
-msgstr "Status"
+msgstr "狀態"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
-msgstr "Pass"
+msgstr "通過"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:105
 msgid "The contents of this string will be checked."
 msgstr "字串內容將被檢核"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "欲尋找的文字字串"
 
@@ -13924,22 +14028,22 @@ msgstr "欲尋找的文字字串"
 msgid "Returns the count of rows in the source data."
 msgstr "返回原始資料的行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "只計算符合條件為真的資料行數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "The additive total of rows across a breakout"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "The rolling sum of a column across a breakout"
 
@@ -13948,53 +14052,57 @@ msgstr "The rolling sum of a column across a breakout"
 msgid "The column to sum."
 msgstr "欲加總之欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "此欄位中相異資料的個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "計算欄位相異資料個數"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "比較"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "假如文字結尾符合對比文字則返回真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "Appetite"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "hungry"
 
@@ -14003,20 +14111,20 @@ msgstr "hungry"
 msgid "A column or string of text to check."
 msgstr "欲檢核的欄位或字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "原始文字結尾的文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "正則表達式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "擷取符合正則表達式的文字或數字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "Address"
 
@@ -14024,7 +14132,7 @@ msgstr "Address"
 msgid "The column or string of text to search though."
 msgstr "欲搜尋的欄位或文字字串"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "符合的正則表達式"
 
@@ -14036,7 +14144,7 @@ msgstr "返回小寫字串"
 msgid "The column with values to convert to lowercase."
 msgstr "欄位資料將轉換為小寫"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "刪除字串開頭空白"
 
@@ -14046,15 +14154,16 @@ msgstr "刪除字串開頭空白"
 msgid "The column with values you want to trim."
 msgstr "欲截除的欄位資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "返回此欄位的最大值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "年齡"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "數值欄位中欲尋找的最大值"
 
@@ -14062,36 +14171,36 @@ msgstr "數值欄位中欲尋找的最大值"
 msgid "Returns the smallest value found in the column."
 msgstr "返回此欄位的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "薪水"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "數值欄位中欲尋找的最小值"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "長度"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:185
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "new_text"
-msgstr "新文字"
+msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "以新文字替換部分輸入文字"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Order ID"
-msgstr "訂購ID"
+msgstr "訂單編號"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:189
 msgid "Updated Part of ID"
@@ -14113,35 +14222,35 @@ msgstr "欲置換的字元數目"
 msgid "The text to use in the replacement."
 msgstr "欲置換的文字資料"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "刪除文字結尾空白"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "以數字表示返回符合條件的資料行數百分比"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "假如文字開頭符合比較的文字則返回結果為真"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "課程名"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "計算機科學"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "原始文字開頭的字元"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "計算此欄位的標準差"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "人口"
 
@@ -14149,7 +14258,7 @@ msgstr "人口"
 msgid "A numeric column."
 msgstr "數字欄位"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "返回部分提供的文字"
 
@@ -14157,35 +14266,35 @@ msgstr "返回部分提供的文字"
 msgid "The text to return a portion of."
 msgstr "此文字返回某部分的"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "開始複製字元的位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "欲返回字元的數目"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
-msgstr "將列的所有值相加。"
+msgstr "Adds up all the values of the column"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "數字欄位加總"
 
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
 msgid "Sums up values in a column where rows match the condition."
-msgstr "匯總行匹配條件的列中的值"
+msgstr "Sums up values in a column where rows match the condition"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
-msgstr "訂單狀態"
+msgstr "Order Status"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
-msgstr "有效"
+msgstr "Valid"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "刪除文字開頭及結尾空白"
 
@@ -14193,46 +14302,46 @@ msgstr "刪除文字開頭及結尾空白"
 msgid "Returns the string of text in all upper case."
 msgstr "返回大寫文字"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "欄位資料轉換成大寫"
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "必須是 {0} 及包含 {1}"
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "必須是 {0} "
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "必須包含 {0}"
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "至少 {0} 字元長度"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0} 小寫字母"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0} 大寫字母"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0} 數字umbe"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
-msgstr[0] "{0} 特殊的角色"
+msgstr[0] "{0} special character"
 
 #: frontend/src/metabase/lib/validate.js:8
 msgid "must be a valid email address"
@@ -14251,8 +14360,9 @@ msgid "Powered by {0}"
 msgstr "Powered by {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
-msgstr "至:"
+msgstr "至："
 
 #: frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx:39
 msgid "This question can't be used because it's based on a different database."
@@ -14292,8 +14402,7 @@ msgstr "{0} 在查詢範本建立一個變數名稱為\"variable_name\"。可以
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:261
 msgid "Giving a variable the \"Field Filter\" type allows you to link questions to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "設定過濾篩選變數來連結到展示板上的相關SQL提問(查詢)的篩選元件。\n"
-"當加入欲篩選欄位時，欄位篩選變數會插入一段SQL語法到視覺查詢建構器所產生的查詢語句"
+msgstr "設定過濾篩選變數來連結到展示板上的相關SQL提問(查詢)的篩選元件。當加入欲篩選欄位時，欄位篩選變數會插入一段SQL語法到視覺查詢建構器所產生的查詢語句"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Variable name"
@@ -14339,7 +14448,7 @@ msgstr "資料格式"
 msgid "Full"
 msgstr "充分"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "從上沒有變化 {0}"
 
@@ -14401,7 +14510,7 @@ msgstr "其他一切"
 
 #: src/metabase/core.clj
 msgid "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."
-msgstr "警告：You have enabled namespace tracing, which could log sensitive information like db passwords"
+msgstr "警告：您已啟用名稱空間跟踪，它可以記錄敏感信息，例如數據庫密碼"
 
 #: src/metabase/db.clj
 msgid "Database Upgrade Required"
@@ -14426,7 +14535,7 @@ msgstr "資料庫需要手動更新"
 #. Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
 #: src/metabase/db.clj
 msgid "Set transaction to automatically roll back..."
-msgstr "將交易設置為自動回滾..."
+msgstr "Set transaction to automatically roll back..."
 
 #. Disable auto-commit. This should already be off but set it just to be safe
 #: src/metabase/db.clj
@@ -14439,16 +14548,16 @@ msgstr "以 connection pool 設定預設資料庫連線"
 
 #: src/metabase/db.clj
 msgid "Successfully verified {0} {1} application database connection."
-msgstr "成功驗證 {0} {1} 應用程序數據庫連接"
+msgstr "Successfully verified {0} {1} application database connection"
 
 #. if both of the decoders above fail, then the date string is invalid
 #: src/metabase/driver/common/parameters/dates.clj
 msgid "Don''t know how to parse date param ''{0}'' — invalid format"
-msgstr "不知道如何解析日期參數 ''{0}'' — 無效的格式"
+msgstr "Don''t know how to parse date param ''{0}'' — invalid format"
 
 #: src/metabase/driver/common/parameters/values.clj
 msgid "The sub-query from referenced question #{0} failed with the following error: {1}"
-msgstr "引用問題的子查詢 #{0} 失敗，出現以下錯誤： {1}"
+msgstr "The sub-query from referenced question #{0} failed with the following error: {1}"
 
 #: src/metabase/driver/mysql.clj
 msgid "WARNING: Metabase only officially supports MySQL {0}/MariaDB {1} and above."
@@ -14528,28 +14637,28 @@ msgstr "設定 {0} 是內部的"
 
 #: src/metabase/plugins.clj
 msgid "Loading local plugin manifest at {0}"
-msgstr "正在加載本地插件清單 {0}"
+msgstr "加載本地插件清單"
 
 #: src/metabase/public_settings.clj
 msgid "Google Analytics tracking code."
-msgstr "Google Analytics（分析）跟踪代碼."
+msgstr "Google Analytics tracking code."
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via email"
-msgstr "發送脈衝 ({0}: {1}) 與 {2} 通過電子郵件卡"
+msgstr "Sending Pulse ({0}: {1}) with {2} Cards via email"
 
 #: src/metabase/pulse.clj
 msgid "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
-msgstr "發送脈衝 ({0}: {1}) 與 {2} 通過鬆弛卡"
+msgstr "Sending Pulse ({0}: {1}) with {2} Cards via Slack"
 
 #: src/metabase/pulse/render.clj
 msgid "Rendering pulse card with chart-type {0} and render-type {1}"
-msgstr "圖表類型的渲染脈衝卡 {0} 和渲染類型 {1}"
+msgstr "Rendering pulse card with chart-type {0} and render-type {1}"
 
 #. TODO  - there is code that calls this in `render.body` regardless of the types of values
 #: src/metabase/pulse/render/datetime.clj
 msgid "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
-msgstr "FIXME: These aren''t valid temporal literals: {0} {1}. Why are we attempting to format them as such?"
+msgstr "修復我：這些不是有效的時間文字：{0} {1}。我們為什麼要嘗試格式化它們？"
 
 #: src/metabase/query_processor/context/default.clj
 msgid "Error reducing result rows"
@@ -14581,7 +14690,7 @@ msgstr "清除舊查詢結果快取錯誤"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Caching results for next time for query with hash {0}."
-msgstr "下次緩存結果以進行哈希查詢 {0}."
+msgstr "Caching results for next time for query with hash {0}."
 
 #: src/metabase/query_processor/middleware/cache.clj
 #: src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -14664,7 +14773,7 @@ msgstr "從欄位產生 insights 錯誤"
 msgid "Sending abandonment email!"
 msgstr "送出 abandonment email ！"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "您可以創建保存的指標以添加命名指標選項。保存的指標包括聚合類型，聚合字段以及您添加的任何過濾器（可選）。例如，您可以使用它來創建類似於為Orders表計算“平均價格”的官方方法。"
 
@@ -14672,17 +14781,17 @@ msgstr "您可以創建保存的指標以添加命名指標選項。保存的指
 msgid "Select and add filters to create your new segment."
 msgstr "選擇並添加過濾器以創建新的細分。"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "按字母順序"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "聰明"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
-msgstr "列順序：{0}"
+msgstr "欄位排列順序：{0}"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:203
 msgid "Unhide all"
@@ -14732,17 +14841,17 @@ msgstr "本土化"
 msgid "Instance language"
 msgstr "實例語言"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "本地化選項"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:51
 msgid "This database doesn't have any tables."
-msgstr "該數據庫沒有任何表。"
+msgstr "該資料庫沒有任何資料表。"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:125
 msgid "This field only accepts a single value because it's used in a SQL query."
-msgstr "該字段僅接受一個值，因為它在SQL查詢中使用。"
+msgstr "該欄位僅接受一個值，因為它在SQL查詢中使用。"
 
 #: frontend/src/metabase/entities/databases/big-query-fields.js:17
 msgid "Service Accounts"
@@ -14804,19 +14913,20 @@ msgstr "粘貼連接字符串"
 msgid "Fill out individual fields"
 msgstr "填寫各個字段"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "在此處輸入一些SQL，以便稍後使用"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "給您的代碼片段起個名字"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "現有客戶"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "增加一個說明"
 
@@ -14824,46 +14934,47 @@ msgstr "增加一個說明"
 msgid "Use site default"
 msgstr "使用網站默認"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "找"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "更換"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "要查找的文字。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "用作替代的文本。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "編輯{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "創建您的新片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "存檔片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "片段是SQL的可重用位"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "創建一個片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "片段"
 
@@ -15021,7 +15132,7 @@ msgstr "{0}只能進入{1}名稱空間的Collections中。"
 
 #: src/metabase/models/database.clj
 msgid "Error sending database deletion notification"
-msgstr "發送數據庫刪除通知時出錯"
+msgstr "送出資料庫刪除通知時錯誤"
 
 #: src/metabase/models/native_query_snippet.clj
 msgid "You cannot update the creator_id of a NativeQuerySnippet."
@@ -15029,19 +15140,19 @@ msgstr "您無法更新NativeQuerySnippet的creator_id。"
 
 #: src/metabase/models/setting.clj
 msgid "Error fetching value of Setting"
-msgstr "獲取設置值時出錯"
+msgstr "撈取設置值時錯誤"
 
 #: src/metabase/public_settings.clj
 msgid "The language that should be used for Metabase's UI, system emails, pulses, and alerts."
-msgstr "Metabase的UI，系統電子郵件，脈沖和警報應使用的語言。"
+msgstr "語系會使用在Metabase的UI，系統電子郵件，pulses和alerts。"
 
 #: src/metabase/public_settings.clj
 msgid "This is also the default language for all users, which they can change from their own account settings."
-msgstr "這也是所有用戶的默認語言，他們可以從自己的帳戶設置中更改。"
+msgstr "這也是所有用戶的預設語系，他們可以從自己的帳戶設置中更改。"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid locale {0}"
-msgstr "無效的語言環境{0}"
+msgstr "無效的語系環境{0}"
 
 #: src/metabase/public_settings.clj
 msgid "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS"
@@ -15057,7 +15168,7 @@ msgstr "註冊字體時出錯：Metabase無法發送Pulse。"
 
 #: src/metabase/pulse/render/png.clj
 msgid "This is a known issue with certain JVMs. See {0} and for more details."
-msgstr "這是某些JVM的已知問題。有關更多詳細信息，請參見{0}。"
+msgstr "這是某些JVM的已知問題。有關更多詳細資訊，請參考{0}。"
 
 #: src/metabase/pulse/render/png.clj
 msgid "Error rendering Pulse"
@@ -15069,7 +15180,7 @@ msgstr "查詢在{0}之後超時，引發超時異常。"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "No fields found for table {0}."
-msgstr "找不到表{0}的字段。"
+msgstr "找不到資料表{0}的欄位。"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Case"
@@ -15077,7 +15188,7 @@ msgstr "案件"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Variance of {0}"
-msgstr "{0}的方差"
+msgstr "{0}的變異數"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Median of {0}"
@@ -15085,11 +15196,11 @@ msgstr "{0}的中位數"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "{0}th percentile of {1}"
-msgstr "{1}的第{0}個百分點"
+msgstr "{1}的第{0}個百分位數"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Not caching results: results are larger than {0} KB"
-msgstr "不緩存結果：結果大於{0} KB"
+msgstr "不緩存結果集：結果集大於{0} KB"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Cannot cache results: expected byte array, got {0}"
@@ -15129,16 +15240,1516 @@ msgstr "生成時間序列洞察力時出錯，輸入鍵為：{0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database position of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "{0}的數據庫位置已從“ {1}”更改為“ {2}”。"
+msgstr "資料庫{0}位置已從“ {1}”更改為“ {2}”。"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Unscheduling task for Database {0}: trigger: {1}"
-msgstr "數據庫{0}的未調度任務：觸發器：{1}"
+msgstr "資料庫{0}的未排程任務：觸發器：{1}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a keyword or string."
-msgstr "值必須是關鍵字或字符串。"
+msgstr "值必須是關鍵字或字串。"
 
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
-msgstr "字符串必須是有效的兩個字母的ISO語言或語言國家/地區代碼，例如“ en”或“ en_US”。"
+msgstr "語系字串必須是有效的兩個字母的ISO語系或國家/地區語系代碼，例如“ en”或“ en_US”。"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "第{0}-{1}行"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "審計"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "智威湯遜"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "用戶屬性配置（可選）"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "使用{0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "設置基於SAML的SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML身份驗證"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "配置您的身份提供商（IdP）"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "您的身份提供者將需要以下有關元數據庫的信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "IdP應該重定向回的URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "這在Okta中稱為單一登錄URL，在Auth0中稱為應用程序回調URL，\n"
+"以及OneLogin中的ACS（消費者）URL。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "在大多數IdP中，您需要將每個IdP放入標有\n"
+"屬性語句部分中的“名稱”。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "用戶的電子郵件屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "用戶的名字屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "用戶的姓氏屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "告訴Metabase您的身份提供者"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "配置數據庫將需要有關您的提供程序的以下信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML身份提供者URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "SAML身份提供商證書"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML應用程序名稱"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "簽署SSO請求（可選）"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML密鑰庫路徑"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "SAML密鑰庫密碼"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "噓..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML密鑰庫別名"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "將組成員身份與您的SSO同步"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "為此，您需要創建映射以告訴Metabase您的用戶應該使用哪個組。\n"
+"根據他們所在的SSO組添加到。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "組的名字"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "組屬性名稱"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "注意："
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "如果更改現有SAML活動設置的任何設置，則將需要重新啟動Metabase才能使它們生效。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "允許用戶通過SAML身份提供程序登錄。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "允許用戶通過JWT身份提供程序登錄。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "啟用密碼驗證"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "啟用後，用戶還可以使用電子郵件和密碼登錄。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "通知管理員新的SSO用戶"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "啟用後，管理員將在用戶首次使用單一登錄時收到一封電子郵件。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "使用以下設置通過SAML配置SSO。如有任何疑問，請查看我們的{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "文件資料"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML身份提供者URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT認證"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT身份提供者URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "JWT簽名密鑰使用的字符串"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "嵌入整個Metabase應用"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "如果要嵌入所有元數據庫，請輸入要允許嵌入iframe的網站或Web應用程序的來源，以空格分隔。這是可以輸入的內容{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "授予沙盒訪問此表的權限"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "當該組中的用戶查看此表時，他們將看到按其用戶屬性過濾的該表的版本，或基於已保存問題的自定義視圖。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "您要如何為該組中的用戶過濾該表？"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "選擇一個保存的問題，該問題將返回這些用戶應看到的該表的自定義視圖。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "您可以根據用戶屬性在此處添加其他過濾器。這些過濾器將應用於此已保存問題中已存在的所有過濾器之上。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "為了使此選項起作用，您的用戶需要具有一些屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "要添加其他過濾器，您的用戶需要具有一些屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "沒有用戶屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "選擇一個用戶屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "選擇一個參數"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "選擇專欄"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "{0}中的用戶可以查看"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "{0}問題中的行"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "{0}表中的行"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "其中{0}等於{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "並且{0}等於{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "您可以通過設置使用SAML的SSO來自動添加屬性，也可以通過轉到人員部分並單擊最右邊的…菜單來手動輸入屬性。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "用戶屬性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "如果您已設置SSO，我們可以自動獲取用戶的屬性，也可以從管理面板的“人員”部分的“ ...”菜單中手動添加它們。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "參數或變量"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "等於"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "授予沙盒訪問權限"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "沙盒訪問"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "編輯沙盒訪問"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "編輯文件夾詳細信息"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "變更權限"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "創建您的新文件夾"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "新建文件夾"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "我們無法驗證您的令牌"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "請仔細檢查您的實例可以連接到Metabase的服務器"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "得到幫助"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "通過企業版充分利用Metabase"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "快速，輕鬆地為客戶提供報告，或幫助您在大型組織中運行和監視Metabase所需的所有工具"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "激活許可證"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "您的試用版具有這些功能"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "試用到期{0}"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "需要幫忙？準備買？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "與我們交談"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "您的試用期已過期"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "需要更多時間？準備買？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "您的功能已啟用！"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "您的許可證通過{0}有效"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "您的許可證已過期"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "它於{0}到期"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "要續簽您的許可證嗎？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "了解如何使用"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "當前計劃中未包括"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "輸入您從商店收到的令牌"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "啟用"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "需要幫忙？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "有關您的問題的更多信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "聯繫支持"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "企業"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "數據沙箱"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "確保根據用戶屬性使用自動和安全的篩選器向正確的人顯示正確的數據。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "白色標籤"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "使用自定義顏色，您自己的徽標等將Metabase與您的品牌匹配。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "稽核"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "借助強大的審核工具來關注性能和行為。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "單點登錄"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "提供與您現有的身份驗證基礎結構配合使用的簡單登錄名。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "商店"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "應用名稱"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "調色板"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "商標"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "網站圖標"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "登陸頁面"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "沒有團體"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "{0}的權限"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "此文件夾的權限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "授予編輯權限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "可以修改此文件夾中的片段"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "授予查看權限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "可以在此文件夾中插入和使用摘要，但不能編輯其中包含的SQL"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "無法查看或在此文件夾中插入片段"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "同時更改子文件夾"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "一周的第一天"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "使用Google登錄時出現問題。請與管理員聯繫。"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "在"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "在"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "打開配置數據庫操作菜單"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "沒做什麼"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "轉到自定義目的地"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "更新儀表板過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0}更新{1}過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0}轉到{1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "每列的點擊行為"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "前往自訂目的地"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "打開動作菜單"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "{0}的點擊行為"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "選擇一個或多個過濾器進行更新"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "保存的問題"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "鏈接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "輸入要鏈接的URL"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "您可以使用其名稱插入列或儀表板過濾器的值，如下所示：{{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "例如http://acme.com/id/{{user_id}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "選擇儀表板..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "選擇一個問題..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "選擇一個儀表板以鏈接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "選擇一個問題鏈接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "將值傳遞到此儀表板的過濾器（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "將值傳遞給該問題的變量（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "傳遞值以過濾此問題（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "儀表板過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "用戶屬性"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "自定義鏈接文本（可選）"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. {{Column Name}}的詳細信息"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "您可以參考的值"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "沒有可用的目標"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "過濾"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "變量"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "其他可用的過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "可用的過濾器"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "其他可用變量"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "可用變量"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "其他可用列"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "可用列"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "用戶屬性"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "文字卡"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "點擊行為"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "可視化選項"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "編輯系列"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "添加系列"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "點擊時"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "更改標題和描述"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "您已經更新了嵌入式參數，將需要更新嵌入代碼。"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "添加問題"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "您正在編輯此儀表板。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "要過濾的列"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "摘要集"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "摘要集"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "給你的文件夾起個名字"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "矮而甜的東西"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "文件夾應該在"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "打開動作菜單"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0}列具有自定義行為"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "去..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "前往資訊主頁"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "去提問"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "前往網址"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "篩選此儀表板"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "返回所選數據中的行數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "要累加的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "要獲取其標準偏差的數字列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "要取其平均值的數字列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "返回列中找到的最小值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "谷歌"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "僅對條件為真的行匯總指定的列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "返回給定列的數值方差。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "溫度"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "要獲取其方差的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "返回指定列的中間值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "要獲取中位數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "百分數值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "以百分比值返回列的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "要獲取其百分位數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "百分位數的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "以小寫形式返回文本字符串。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "具有要轉換為小寫字母的值的列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "以大寫形式返回文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "要返回其一部分的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "要搜索的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "將兩個或多個文本字符串組合在一起。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "開頭的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "這將被添加到value1的末尾，依此類推。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "巨大"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "巨大"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "返回文本中的字符數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "您要獲取長度的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "您要修剪的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "返回指定列的絕對（正）值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "債務"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "要返回其絕對（正）值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "向下舍入十進制數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "要捨入的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "向上舍入十進制數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "要向上舍入的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "將十進制數字向上或向下舍入為最接近的整數值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "要捨入到最接近整數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "返回平方根。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "斜邊"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "要返回其平方根值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "指數"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "將數字提高到指數值的冪。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "長度"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "升至指數的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "指數的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "返回該數字的以10為底的對數。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "要返回其自然對數值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "返回歐拉數e，提高到所提供數字的冪。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "利息月"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "要返回其指數值的列或數字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "要檢查的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "檢查日期或數字列的值以查看它們是否在指定範圍內。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "創建於"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "日期或數字列應在開始和結束值之內。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "範圍的開始。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "範圍的結尾。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "檢查日期列的值以查看它們是否在相對范圍內。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "返回間隔的日期列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "間隔時間，其中負值會及時返回。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "內部類型，例如“天”，“月”，“年”。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "要返回的列或值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "如果value1為空，則value2不為空則返回，依此類推。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "針對案例列表測試表達式，並返回第一個匹配案例的相應值，如果不滿足其他條件，則返回可選的默認值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "如果前面的條件為true，將返回的值，依此類推。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "一片空白"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "不為空"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "列的所有值的累加總和。\n"
+"e.x.總收入。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "行數的累加計數。\n"
+"e.x.一段時間內的銷售總數。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "鏈接的過濾器"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "標籤"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "默認值"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "沒有預設"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "要查看此內容，必須將{0}連接到至少一個字段。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "限制此過濾器的選擇"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "如果您有另一個儀表板過濾器，則可以基於另一個過濾器的選擇來限制為此過濾器列出的選擇。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "所以首先，{0}。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "添加另一個儀表板過濾器"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "如果啟用這些儀表板過濾器之一，則為該過濾器選擇一個值將限制{0}過濾器的可用選項。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "過濾柱"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "過濾列"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "輸入用戶名或電子郵件地址"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "新片段"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}：下午00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "12:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}：00上午"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "每小時一次"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "每天{0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "{1}的每週{0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "每月{0} {1} {2}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "刪除此訂閱"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "訂閱內容"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "創建儀表板訂閱"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "用電子郵件發送"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "您可以定期將此儀表板發送給用戶或電子郵件地址。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "發送給Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "選擇一個頻道和時間表，其餘的工作由Metabase完成。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "通過電子郵件發送此信息中心"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "如果沒有結果就不要發送"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "附加結果"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "附件最多可以包含2,000行數據。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "將此儀表板發送到Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "儀表板沒有ID為{0}的參數"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "參數{0}沒有與之關聯的任何字段"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include必須為空或值'tables'"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "所有非內部類型的查詢都必須使用“數據庫”。"
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "該實例的密碼登錄已禁用。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "您的帳戶已被禁用。請與您的管理員聯繫。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "您的帳戶已被禁用。"
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "無效的Slack令牌。"
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "“ {0}”命令僅在Metabase Enterprise Edition中可用。"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Metabase Enterprise Edition擴展是當前的。"
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Metabase Enterprise Edition功能的使用須遵守Metabase商業許可。"
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "有關詳細信息，請參見{0}。"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "不存在Metabase Enterprise Edition擴展。"
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "邀請您加入{0}的{1}"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0}創建了一個{1}帳戶"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0}接受了他們的{1}邀請"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}]密碼重置請求"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}]通知"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}]幫助改善[{1}]。"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}]告訴我們情況如何。"
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "啟動事件偵聽器時出錯"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "當有人通過LDAP登錄時，我們應該同步用戶屬性嗎？"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "用戶屬性的逗號分隔列表，以跳過LDAP用戶的同步。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "令牌無效"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "鬆弛API錯誤：{0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "缺少名為“ metabase_files”的鬆弛通道！"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "請創建或取消歸檔通道，以完成Slack集成。"
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "該通道用於存儲包含在Pulses和MetaBot答案中的圖形。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "上傳的圖片"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "將文件上傳到Slack時出錯："
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "無效會話。預期為Session的實例。"
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "會話Cookie的SameSite配置為“無”，但站點"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "通過不安全的連接提供服務。一些瀏覽器會拒絕 "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "這些條件下的Cookie。 "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "頂級文件夾"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr "：parameters必須是具有String：id鍵的映射序列"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "無效的人類可讀值：值必須是序列；每個項目必須為nil或字符串"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr "：values必須存在才能獲取：human_read_values"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "字段值的總長度> {0}。"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "摘要名稱不能包含'}'或以空格開頭"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "執行鍊式過濾器查詢時出錯"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "字段{0}不存在。"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "無法針對非文本字段{0} {1}搜索"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "授予組{0}的權限：{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "撤銷組{0}的權限：{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "無效的數據庫權限：如果您具有本地查詢的寫訪問權限，則必須具有完整的數據訪問權限。"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "無效的數據庫權限：如果您具有隻讀的本機查詢訪問權限，則還必須具有數據訪問權限。"
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "將權限從{0}更改為：{1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "登錄屬性鍵必須是關鍵字或字符串"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Metabase UI，系統電子郵件，脈沖和警報中所有用戶的默認語言。"
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "用戶可以從自己的帳戶設置中單獨覆蓋此默認語言。"
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "顯示用戶的默認頁面"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "允許此來源嵌入完整的Metabase應用程序"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "不允許大於{0}（{1}）的值。"
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "無論出現在何處，它將替換單詞“ Metabase”。"
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "這些是圖表和整個Metabase中使用的原色。您可能需要刷新瀏覽器才能看到更改生效。"
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "為了獲得最佳效果，請使用透明背景的SVG文件。"
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "您要用作網站圖標的URL或圖像。"
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "允許通過電子郵件和密碼登錄。"
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "這將影響諸如按週分組或在GUI查詢中過濾之類的事情。\n"
+"  它不會影響SQL查詢。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "無法驗證令牌"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "令牌格式無效。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "驗證令牌時出錯"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "針對{0}字段的過濾錯誤：無法將字符串{1}解析為{2}"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "提取作業{0}的詳細信息時出錯"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "正在啟動數據庫{0}的同步任務。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "無法同步數據庫{0}：數據庫不存在。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "已為數據庫{0}觸發了“更新字段值”任務。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "跳過更新，數據庫{0}的自動字段值更新被禁用。"

--- a/locales/zh.po
+++ b/locales/zh.po
@@ -9,12 +9,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
-#, fuzzy
 msgid "Your database has been added!"
 msgstr "数据库添加成功！"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
-#, fuzzy
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
 msgstr "我们查看了你的数据，有一些自动化的探索，我们可以告诉你！"
 
@@ -30,15 +28,16 @@ msgstr "探索数据"
 msgid "Select a database type"
 msgstr "选择数据库类型"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:254
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:415
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:72
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:212
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:428
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:106
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:209
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:153
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:184
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:169
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:46
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:213
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
@@ -51,7 +50,7 @@ msgstr "保存"
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
 msgstr "为了做一些神奇的事情，Metabase 需要扫描你的数据库。我们将会定期扫描，来保持源数据是最新的。你也可以在周期的扫描之前，手工来控制扫描。"
 
-#: frontend/src/metabase/entities/databases/forms.js:290
+#: frontend/src/metabase/entities/databases/forms.js:291
 msgid "Database syncing"
 msgstr "数据库同步中"
 
@@ -66,7 +65,7 @@ msgstr "这是一个检查数据库模式变化的轻量级的过程，大部分
 msgid "Scan"
 msgstr "扫描"
 
-#: frontend/src/metabase/entities/databases/forms.js:297
+#: frontend/src/metabase/entities/databases/forms.js:298
 msgid "Scanning for Filter Values"
 msgstr "扫描过滤器值"
 
@@ -77,7 +76,7 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase 可以扫描数据库中每个字段的值, 用以启用查询或仪表板中的选择框过滤器. 当您的数据库较大时, 这可能是一个资源密集型的过程."
 
-#: frontend/src/metabase/entities/databases/forms.js:301
+#: frontend/src/metabase/entities/databases/forms.js:302
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase 应该在什么时候自动扫描缓存的字段值"
 
@@ -135,29 +134,31 @@ msgstr "删除"
 msgid "in this box:"
 msgstr "在这个框里:"
 
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:247
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:65
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:66
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:84
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:93
 #: frontend/src/metabase/admin/permissions/selectors.js:163
 #: frontend/src/metabase/admin/permissions/selectors.js:173
 #: frontend/src/metabase/admin/permissions/selectors.js:188
 #: frontend/src/metabase/admin/permissions/selectors.js:227
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:211
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:278
-#: frontend/src/metabase/components/ArchiveModal.jsx:35
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:208
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:275
+#: frontend/src/metabase/components/ArchiveModal.jsx:37
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
 #: frontend/src/metabase/components/form/CustomForm.jsx:260
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:288
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:167
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:163
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:32
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:28
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
@@ -180,9 +181,9 @@ msgstr "删除"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:147
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
-#: frontend/src/metabase/admin/permissions/selectors.js:323
-#: frontend/src/metabase/admin/permissions/selectors.js:330
-#: frontend/src/metabase/admin/permissions/selectors.js:441
+#: frontend/src/metabase/admin/permissions/selectors.js:341
+#: frontend/src/metabase/admin/permissions/selectors.js:348
+#: frontend/src/metabase/admin/permissions/selectors.js:459
 #: frontend/src/metabase/admin/routes.jsx:60
 #: frontend/src/metabase/nav/containers/Navbar.jsx:247
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
@@ -202,8 +203,9 @@ msgstr "连接"
 msgid "Scheduling"
 msgstr "调度"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:193
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:175
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:62
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:80
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:228
@@ -282,10 +284,10 @@ msgstr "添加数据库"
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:131
 #: frontend/src/metabase/entities/collections.js:94
-#: frontend/src/metabase/entities/dashboards.js:142
-#: frontend/src/metabase/entities/databases/forms.js:264
-#: frontend/src/metabase/entities/questions.js:86
-#: frontend/src/metabase/entities/questions.js:102
+#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/questions.js:87
+#: frontend/src/metabase/entities/questions.js:103
 #: frontend/src/metabase/visualizations/lib/settings/column.js:349
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:91
 msgid "Name"
@@ -320,10 +322,8 @@ msgid "Successfully saved!"
 msgstr "保存成功！"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:90
 msgid "Edit"
 msgstr "编辑"
@@ -402,26 +402,29 @@ msgstr "选择指定类型"
 msgid "Select a target"
 msgstr "选择目标"
 
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:807
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:155
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:23
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Columns"
 msgstr "字段"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:104
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:109
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "字段"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:106
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:111
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:140
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:295
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:297
 msgid "Visibility"
 msgstr "可见性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:107
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:112
 msgid "Type"
 msgstr "类型"
 
@@ -429,7 +432,7 @@ msgstr "类型"
 msgid "Current database:"
 msgstr "当前数据库"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:79
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:84
 msgid "Show original schema"
 msgstr "查看原始格式"
 
@@ -496,7 +499,7 @@ msgstr "查找表格"
 msgid "Schemas"
 msgstr "表结构"
 
-#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:852
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:830
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:40
 #: frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx:39
 #: frontend/src/metabase/home/containers/SearchApp.jsx:67
@@ -513,7 +516,7 @@ msgstr "添加指标"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx:29
 #: frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx:29
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "Definition"
 msgstr "定义"
 
@@ -581,35 +584,35 @@ msgstr " 历史"
 msgid "Revision History for"
 msgstr "历史版本"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:235
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:236
 msgid "{0} – Field Settings"
 msgstr "{0} - 字段设置"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:296
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Where this field will appear throughout Metabase"
 msgstr "这些字段将在哪里显示？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "字段过滤"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:320
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "当在过滤器中使用此字段时，人们应该使用什么形式输入他们想要过滤的值?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:445
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "暂无筛选条件描述"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:393
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:406
 msgid "Original value"
 msgstr "原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:394
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:407
 msgid "Mapped value"
 msgstr "映射值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:437
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:450
 msgid "Enter value"
 msgstr "输入值"
 
@@ -626,31 +629,31 @@ msgid "Custom mapping"
 msgstr "自定义映射"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:56
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:162
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:164
 msgid "Unrecognized mapping type"
 msgstr "无法识别的映射类型"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:92
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "当前字段不是外键或者缺少外键关联表元数据"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:197
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:199
 msgid "The selected field isn't a foreign key"
 msgstr "选中的字段不是外键"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:335
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:338
 msgid "Display values"
 msgstr "显示值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:336
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "选择显示数据库中的原始值，或者显示此字段的关联或自定义信息。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:281
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:283
 msgid "Choose a field"
 msgstr "选择字段"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:302
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:304
 msgid "Please select a column to use for display."
 msgstr "请选择显示字段"
 
@@ -658,16 +661,16 @@ msgstr "请选择显示字段"
 msgid "Tip:"
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:447
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:460
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "你可能想要更新这个字段的名称来确保它基于你的重新映射选择时仍然有意义"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:352
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:355
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:83
 msgid "Cached field values"
 msgstr "缓存字段值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:353
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase 通过扫描该字段，以启用仪表盘和问题的多选框筛选。"
 
@@ -694,35 +697,36 @@ msgstr "丢弃处理已经触发！"
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "选择任意表单来显示它的所有模式并且添加或删除元数据"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:31
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:30
 #: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/snippet-collections.js:75
 msgid "Name is required"
 msgstr "名称必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:33
 msgid "Description is required"
 msgstr "描述必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:37
 msgid "Revision message is required"
 msgstr "调整信息必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:44
 msgid "Aggregation is required"
 msgstr "聚合信息必填"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Edit Your Metric"
 msgstr "编辑指标"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:85
 msgid "Create Your Metric"
 msgstr "创建指标"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:89
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "修改指标并留下简要说明。"
 
@@ -730,46 +734,46 @@ msgstr "修改指标并留下简要说明。"
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "你能够创造已存储的指标来添加一个已经命名的指标选项到这个表单。存储刻度包括你添加的聚合类型，聚合字段和可选的任何筛选项。举个例子，你可能使用这个来为一个订单表单创造一些像是“平均价”的官方计算方法，"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:100
 msgid "Result: "
 msgstr "结果： "
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:108
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
 msgid "Name Your Metric"
 msgstr "命名你的指标"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:109
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:110
 msgid "Give your metric a name to help others find it."
 msgstr "为指标命名，方便其他人查找。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:114
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:130
 msgid "Something descriptive but not too long"
 msgstr "简短的描述"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
 msgid "Describe Your Metric"
 msgstr "描述你的指标"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:119
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "描述指标，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:123
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "在这里详细描述指标，比如不太明显的规则"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:127
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:143
 msgid "Reason For Changes"
 msgstr "变更的原因"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:128
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:129
 #: frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx:145
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "留言以说明您所做的更改以及为何需要这些更改。"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:132
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:133
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "这将显示在此指标的修订历史记录中，以帮助每个人记住事情发生变化的原因"
 
@@ -822,6 +826,7 @@ msgstr "这将显示在过滤器的修订历史记录中，以帮助每个人记
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:216
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:94
 #: frontend/src/metabase/nav/containers/Navbar.jsx:229
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:18
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:94
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:201
 msgid "Settings"
@@ -836,8 +841,7 @@ msgid "Re-scan this table"
 msgstr "刷新表格"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:284
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:281
 msgid "Add"
 msgstr "添加"
 
@@ -854,7 +858,7 @@ msgid "Last name"
 msgstr "姓"
 
 #: frontend/src/metabase/auth/components/LdapAndEmailForm.jsx:35
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:53
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:46
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
 msgid "Email address"
 msgstr "邮箱地址"
@@ -863,7 +867,7 @@ msgstr "邮箱地址"
 msgid "Permission Groups"
 msgstr "权限组"
 
-#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
+#: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:61
 msgid "Make this user an admin"
 msgstr "设为管理员"
 
@@ -959,6 +963,8 @@ msgstr "移除分组"
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:41
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:281
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:642
+#: frontend/src/metabase/dashboard/components/Sidebar.jsx:36
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
 #: frontend/src/metabase/query_builder/components/ExpressionPopover.jsx:86
 #: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
@@ -971,11 +977,12 @@ msgstr "完成"
 msgid "Group name"
 msgstr "分组名称"
 
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:67
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:22
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:97
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:178
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:175
 #: frontend/src/metabase/entities/users/forms.js:70
 msgid "Groups"
 msgstr "分组"
@@ -1084,7 +1091,7 @@ msgstr "重置"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:54
 msgid "Are you sure you want to do this?"
 msgstr "是否确认执行此操作？"
 
@@ -1196,7 +1203,7 @@ msgstr "权限无更改。"
 msgid "You've made changes to permissions."
 msgstr "权限被更改。"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:82
 msgid "Permissions for this collection"
 msgstr "这个集合的权限"
 
@@ -1252,6 +1259,7 @@ msgstr "部分权限"
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
+#: frontend/src/metabase/admin/permissions/selectors.js:309
 msgid "Revoke access"
 msgstr "吊销权限"
 
@@ -1315,23 +1323,23 @@ msgstr "修改集合"
 msgid "View collection"
 msgstr "查看集合"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:334
-#: frontend/src/metabase/admin/permissions/selectors.js:445
-#: frontend/src/metabase/admin/permissions/selectors.js:558
+#: frontend/src/metabase/admin/permissions/selectors.js:352
+#: frontend/src/metabase/admin/permissions/selectors.js:463
+#: frontend/src/metabase/admin/permissions/selectors.js:576
 msgid "Data Access"
 msgstr "允许访问数据"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:510
-#: frontend/src/metabase/admin/permissions/selectors.js:665
-#: frontend/src/metabase/admin/permissions/selectors.js:670
+#: frontend/src/metabase/admin/permissions/selectors.js:528
+#: frontend/src/metabase/admin/permissions/selectors.js:683
+#: frontend/src/metabase/admin/permissions/selectors.js:688
 msgid "View tables"
 msgstr "查看表格"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:606
+#: frontend/src/metabase/admin/permissions/selectors.js:624
 msgid "SQL Queries"
 msgstr "SQL查询"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:676
+#: frontend/src/metabase/admin/permissions/selectors.js:694
 msgid "View schemas"
 msgstr "查看架构"
 
@@ -1400,14 +1408,17 @@ msgstr "已发送"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:93
 msgid "Clear"
-msgstr "完成"
+msgstr "清除"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:12
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:68
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:19
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:197
 msgid "Authentication"
 msgstr "认证"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:18
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:25
 msgid "Server Settings"
 msgstr "服务器设置"
@@ -1420,6 +1431,7 @@ msgstr "用户结构"
 msgid "Attributes"
 msgstr "属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:35
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:49
 msgid "Group Schema"
 msgstr "用户组结构"
@@ -1491,6 +1503,9 @@ msgid "Add a map"
 msgstr "添加一个地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:123
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:550
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:587
 #: frontend/src/metabase/lib/core.js:267
 msgid "URL"
 msgstr "链接"
@@ -1500,19 +1515,19 @@ msgid "Delete custom map"
 msgstr "删除自定义地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:362
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:337
 #: frontend/src/metabase/containers/Overworld.jsx:146
 #: frontend/src/metabase/containers/Overworld.jsx:293
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:287
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:34
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:124
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:160
 msgid "Remove"
 msgstr "删除"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:176
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:243
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:177
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:248
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:140
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:188
 msgid "Select…"
@@ -1610,19 +1625,19 @@ msgstr "购买 token"
 msgid "Enter a token"
 msgstr "输入 token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:158
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:155
 msgid "Edit Mappings"
 msgstr "编辑映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:164
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:161
 msgid "Group Mappings"
 msgstr "分组映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:171
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:168
 msgid "Create a mapping"
 msgstr "创建映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:170
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1861,18 +1876,27 @@ msgstr "用户筛选"
 msgid "Check your parentheses"
 msgstr "检查括号"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:125
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:205
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:87
 msgid "Email attribute"
 msgstr "电子邮件属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:130
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:210
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:92
 msgid "First name attribute"
 msgstr "名字属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:135
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:215
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:97
 msgid "Last name attribute"
 msgstr "姓氏属性"
 
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:162
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:140
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:220
 #: frontend/src/metabase/plugins/builtin/auth/ldap.js:102
 msgid "Synchronize group memberships"
 msgstr "同步组成员"
@@ -1901,59 +1925,59 @@ msgstr "自定义地图"
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "添加您自己的GeoJSON文件以启用不同的区域地图可视化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/admin/settings/selectors.js:260
 msgid "Public Sharing"
 msgstr "公开分享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:249
+#: frontend/src/metabase/admin/settings/selectors.js:264
 msgid "Enable Public Sharing"
 msgstr "开启公开共享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:254
+#: frontend/src/metabase/admin/settings/selectors.js:269
 msgid "Shared Dashboards"
 msgstr "已共享仪表盘"
 
-#: frontend/src/metabase/admin/settings/selectors.js:260
+#: frontend/src/metabase/admin/settings/selectors.js:275
 msgid "Shared Questions"
 msgstr "已共享提问"
 
-#: frontend/src/metabase/admin/settings/selectors.js:267
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Embedding in other Applications"
 msgstr "嵌入在其他的应用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:293
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "启用将Metabase嵌入到其他应用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:303
+#: frontend/src/metabase/admin/settings/selectors.js:318
 msgid "Embedding secret key"
 msgstr "嵌入秘钥"
 
-#: frontend/src/metabase/admin/settings/selectors.js:309
+#: frontend/src/metabase/admin/settings/selectors.js:324
 msgid "Embedded Dashboards"
 msgstr "嵌入的仪表板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:315
+#: frontend/src/metabase/admin/settings/selectors.js:330
 msgid "Embedded Questions"
 msgstr "嵌入的问题"
 
-#: frontend/src/metabase/admin/settings/selectors.js:322
+#: frontend/src/metabase/admin/settings/selectors.js:337
 msgid "Caching"
 msgstr "缓存中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:326
+#: frontend/src/metabase/admin/settings/selectors.js:341
 msgid "Enable Caching"
 msgstr "启用缓存"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:346
 msgid "Minimum Query Duration"
 msgstr "最小查询周期"
 
-#: frontend/src/metabase/admin/settings/selectors.js:338
+#: frontend/src/metabase/admin/settings/selectors.js:353
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "缓存生存时间（TTL）乘数"
 
-#: frontend/src/metabase/admin/settings/selectors.js:345
+#: frontend/src/metabase/admin/settings/selectors.js:360
 msgid "Max Cache Entry Size"
 msgstr "最大缓存允许大小"
 
@@ -1995,27 +2019,27 @@ msgstr "在你能够使用Google账户登录之前，需要一个管理员来创
 msgid "Sign in with {0}"
 msgstr "用{0}登录"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:39
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:33
 msgid "Please contact an administrator to have them reset your password"
 msgstr "请联系管理员来重置你的密码"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:40
 msgid "Forgot password"
 msgstr "忘记密码"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:47
 msgid "The email you use for your Metabase account"
 msgstr "你作为Metabase账户的Email地址"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:61
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:54
 msgid "Send password reset email"
 msgstr "发送账号重置邮件"
 
-#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:70
+#: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:63
 msgid "Check your email for instructions on how to reset your password."
 msgstr "检查你的邮件来获取重置密码说明"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:44
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:27
 msgid "Sign in to Metabase"
 msgstr "登录Metabase"
 
@@ -2036,11 +2060,11 @@ msgstr "登录"
 msgid "I seem to have forgotten my password"
 msgstr "我似乎忘记了我的密码"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:66
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:65
 msgid "request a new reset email"
 msgstr "发送一个新的重置email邮件"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:80
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:73
 msgid "Whoops, that's an expired link"
 msgstr "噢，那是个过期的链接"
 
@@ -2049,11 +2073,11 @@ msgid "For security reasons, password reset links expire after a little while. I
 "to reset your password, you can {0}."
 msgstr "于安全原因，密码重置链接会在一段时间后过期。如果您仍需要重置密码，可以{0}。"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:100
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
 msgid "New password"
 msgstr "新密码"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:84
 msgid "To keep your data secure, passwords {0}"
 msgstr "为了确保您的数据安全，密码{0}"
 
@@ -2076,24 +2100,24 @@ msgstr "确认新密码"
 msgid "Make sure it matches the one you just entered"
 msgstr "确认它和你刚刚输入的一致"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:115
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:96
 msgid "Your password has been reset."
 msgstr "你的密码已经被重置"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:121
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:126
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:107
 msgid "Sign in with your new password"
 msgstr "用你的新密码登录"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:186
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "保存失败"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:187
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
@@ -2103,25 +2127,26 @@ msgstr "已保存"
 msgid "Ok"
 msgstr "好"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:46
 msgid "Archive this collection?"
 msgstr "归档集合"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "此集合中的仪表板，集合和定时通知也将被归档。"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:85
+#: frontend/src/metabase/components/ArchiveModal.jsx:40
 #: frontend/src/metabase/components/CollectionLanding.jsx:616
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:339
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:43
-#: frontend/src/metabase/routes.jsx:196
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:58
+#: frontend/src/metabase/routes.jsx:198
 msgid "Archive"
 msgstr "归档"
 
@@ -2246,7 +2271,7 @@ msgstr "固定"
 msgid "Drag something here to pin it to the top"
 msgstr "把东西拖到这里将它固定在顶部"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:753
+#: frontend/src/metabase/admin/permissions/selectors.js:782
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:77
 msgid "Collections"
@@ -2274,6 +2299,7 @@ msgstr "移动“{0}”？"
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:329
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:36
 msgid "Move"
 msgstr "移动"
@@ -2311,7 +2337,7 @@ msgstr "一些数据库安装只有通过SSH通道访问的服务器有权访问
 "当VPN不可用时，这个选项也提供了一个额外的安全层。\n"
 "启用这个选项，通常比直接连接速度更慢。"
 
-#: frontend/src/metabase/entities/databases/forms.js:281
+#: frontend/src/metabase/entities/databases/forms.js:282
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "这是一个大型数据库，让我选择Metabase同步和扫描的时间"
 
@@ -2351,7 +2377,7 @@ msgstr "要将Metabase用于此数据，您必须在Google Developers Console中
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "如果您还没有这样做，请转到控制台{0}。"
 
-#: frontend/src/metabase/entities/databases/forms.js:265
+#: frontend/src/metabase/entities/databases/forms.js:266
 msgid "How would you like to refer to this database?"
 msgstr "您想如何使用这个数据库？"
 
@@ -2467,35 +2493,35 @@ msgstr "基于这个模式"
 msgid "A look at your"
 msgstr "看看您的"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:296
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:383
 msgid "Search the list"
 msgstr "查找列表"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:307
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:394
 msgid "Search by {0}"
 msgstr "用{0}搜索"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:309
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:396
 msgid " or enter an ID"
 msgstr "或者输入一个ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:314
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:401
 msgid "Enter an ID"
 msgstr "输入一个ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:316
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:403
 msgid "Enter a number"
 msgstr "输入一个数字"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:318
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:405
 msgid "Enter some text"
 msgstr "输入一些文本"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:429
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:519
 msgid "No matching {0} found."
 msgstr "没有找到匹配的{0} "
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:438
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:528
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "包括每个选项在你的过滤器中很可能将不会起很大作用……"
 
@@ -2507,7 +2533,6 @@ msgstr "有些问题发生了"
 msgid "We've run into an error. You can try refreshing the page, or just go back."
 msgstr "我们运行中出现了一个错误，你可以尝试刷新这个页面，或者直接返回"
 
-#: frontend/src/metabase/components/Header.jsx:104
 #: frontend/src/metabase/reference/components/Detail.jsx:45
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:162
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:217
@@ -2518,12 +2543,12 @@ msgstr "我们运行中出现了一个错误，你可以尝试刷新这个页面
 msgid "No description yet"
 msgstr "暂无描述"
 
-#: frontend/src/metabase/components/Header.jsx:119
+#: frontend/src/metabase/components/Header.jsx:99
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:53
 msgid "New {0}"
 msgstr "新的"
 
-#: frontend/src/metabase/components/Header.jsx:130
+#: frontend/src/metabase/components/Header.jsx:109
 msgid "Asked by {0}"
 msgstr "被{0}发起的提问"
 
@@ -2544,7 +2569,9 @@ msgid "Reverted to an earlier revision and {0}"
 msgstr "回滚到一个更早的调整并且{0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:285
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:266
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:271
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:310
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
 msgid "Revision history"
 msgstr "调整记录"
@@ -2590,7 +2617,7 @@ msgid "Questions"
 msgstr "问题"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:311
+#: frontend/src/metabase/routes.jsx:315
 msgid "Pulses"
 msgstr "定时任务"
 
@@ -2664,52 +2691,69 @@ msgstr "先不用"
 msgid "Error:"
 msgstr "错误："
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:23
+#: frontend/src/metabase/admin/settings/selectors.js:241
+#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:340
 msgid "Sunday"
 msgstr "星期日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:24
+#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:328
 msgid "Monday"
 msgstr "星期一"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:25
+#: frontend/src/metabase/admin/settings/selectors.js:243
+#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:330
 msgid "Tuesday"
 msgstr "星期二"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:26
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:332
 msgid "Wednesday"
 msgstr "星期三"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:27
+#: frontend/src/metabase/admin/settings/selectors.js:245
+#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:334
 msgid "Thursday"
 msgstr "星期四"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:28
+#: frontend/src/metabase/admin/settings/selectors.js:246
+#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:336
 msgid "Friday"
 msgstr "星期五"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:29
+#: frontend/src/metabase/admin/settings/selectors.js:247
+#: frontend/src/metabase/components/SchedulePicker.jsx:30
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:338
 msgid "Saturday"
 msgstr "星期六"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:33
+#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:349
 msgid "First"
 msgstr "第一个"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:34
+#: frontend/src/metabase/components/SchedulePicker.jsx:35
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:351
 msgid "Last"
 msgstr "过往"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:35
+#: frontend/src/metabase/components/SchedulePicker.jsx:36
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:353
 msgid "15th (Midpoint)"
 msgstr "第十五个（中位数）"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:125
+#: frontend/src/metabase/components/SchedulePicker.jsx:126
 msgid "Calendar Day"
 msgstr "日历日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:205
+#: frontend/src/metabase/components/SchedulePicker.jsx:211
 msgid "your Metabase timezone"
 msgstr "你的Metabase时区"
 
@@ -2763,11 +2807,11 @@ msgstr "创建"
 msgid "Create dashboard"
 msgstr "创建仪表盘"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:59
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:58
 msgid "Table"
 msgstr "表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:144
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:150
 msgid "Database"
 msgstr "数据库"
 
@@ -2842,9 +2886,9 @@ msgstr "这个卡片叫什么名字？"
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:142
 #: frontend/src/metabase/entities/collections.js:102
-#: frontend/src/metabase/entities/dashboards.js:148
-#: frontend/src/metabase/entities/questions.js:89
-#: frontend/src/metabase/entities/questions.js:105
+#: frontend/src/metabase/entities/dashboards.js:149
+#: frontend/src/metabase/entities/questions.js:90
+#: frontend/src/metabase/entities/questions.js:106
 #: frontend/src/metabase/lib/core.js:38
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:160
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:215
@@ -2858,15 +2902,16 @@ msgstr "描述"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:143
 #: frontend/src/metabase/entities/collections.js:104
-#: frontend/src/metabase/entities/dashboards.js:150
-#: frontend/src/metabase/entities/questions.js:91
-#: frontend/src/metabase/entities/questions.js:107
-#: frontend/src/metabase/entities/snippets.js:31
+#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/entities/questions.js:92
+#: frontend/src/metabase/entities/questions.js:108
+#: frontend/src/metabase/entities/snippet-collections.js:82
+#: frontend/src/metabase/entities/snippets.js:27
 msgid "It's optional but oh, so helpful"
 msgstr "这是可选的，但非常有帮助"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:147
-#: frontend/src/metabase/entities/dashboards.js:154
+#: frontend/src/metabase/entities/dashboards.js:155
 msgid "Which collection should this go in?"
 msgstr "将这个放到哪个集合中？"
 
@@ -2906,11 +2951,11 @@ msgstr "文档仪表盘"
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "确保为每个系列都做出了选择，不然筛选将不会在这个卡片上起作用"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:281
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:305
 msgid "This dashboard is looking empty."
 msgstr "这个仪表盘看起来是空的"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:282
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:306
 msgid "Add a question to start making it useful!"
 msgstr "添加一个疑问来让它变得有用"
 
@@ -2930,7 +2975,7 @@ msgstr "退出全屏"
 msgid "Enter fullscreen"
 msgstr "进入全屏"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:185
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "保存中"
@@ -2943,7 +2988,8 @@ msgstr "添加一个问题"
 msgid "Add a question to this dashboard"
 msgstr "添加报表到仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:247
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:498
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:242
 msgid "Add a filter"
 msgstr "添加筛选"
 
@@ -2951,7 +2997,7 @@ msgstr "添加筛选"
 msgid "Parameters"
 msgstr "参数"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:272
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:221
 msgid "Add a text box"
 msgstr "添加文本框"
 
@@ -2959,7 +3005,7 @@ msgstr "添加文本框"
 msgid "Move dashboard"
 msgstr "移动仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:298
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
 msgid "Edit dashboard"
 msgstr "编辑仪表盘"
 
@@ -2983,11 +3029,11 @@ msgstr "移动仪表盘到……"
 msgid "Dashboard moved to {0}"
 msgstr "仪表盘移动到{0}"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:87
 msgid "What do you want to filter?"
 msgstr "你想要筛选什么"
 
-#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
+#: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:122
 msgid "What kind of filter?"
 msgstr "什么类型的筛选"
 
@@ -3059,20 +3105,22 @@ msgstr "此卡没有可以映射到此参数类型的任何字段或参数。"
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "此字段中的值不会与您选择的任何其他字段的值重叠。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:173
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:174
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:38
 msgid "No valid fields"
 msgstr "无可用字段"
 
 #: frontend/src/metabase/entities/collections.js:98
+#: frontend/src/metabase/entities/snippet-collections.js:76
 msgid "Name must be 100 characters or less"
 msgstr "名称不能超过100个字符"
 
 #: frontend/src/metabase/entities/collections.js:112
+#: frontend/src/metabase/entities/snippet-collections.js:90
 msgid "Color is required"
 msgstr "颜色是必需的"
 
-#: frontend/src/metabase/entities/dashboards.js:143
+#: frontend/src/metabase/entities/dashboards.js:144
 msgid "What is the name of your dashboard?"
 msgstr "你的仪表盘叫什么名字？"
 
@@ -3127,7 +3175,7 @@ msgstr "接收最新的数据来自"
 
 #: frontend/src/metabase/home/components/Activity.jsx:247
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:332
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:331
 msgid "Unknown"
 msgstr "未知"
 
@@ -3252,9 +3300,10 @@ msgstr "最近没有查看的仪表盘或者图表"
 msgid "{0} items selected"
 msgstr "{0}项已选择"
 
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:59
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:299
+#: frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx:89
 msgid "Unarchive"
 msgstr "取消归档"
 
@@ -3371,7 +3420,7 @@ msgid "Zip Code"
 msgstr "邮编"
 
 #: frontend/src/metabase/lib/core.js:119
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:8
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
 msgid "Quantity"
 msgstr "数量"
 
@@ -3404,11 +3453,13 @@ msgid "User"
 msgstr "用户"
 
 #: frontend/src/metabase/lib/core.js:250
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:272
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
 msgid "Source"
 msgstr "来源"
 
 #: frontend/src/metabase/lib/core.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:326
 msgid "Price"
 msgstr "价格"
 
@@ -3441,21 +3492,23 @@ msgid "Subscription"
 msgstr "订阅"
 
 #: frontend/src/metabase/lib/core.js:124
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:164
 msgid "Score"
 msgstr "分数"
 
 #: frontend/src/metabase/lib/core.js:48
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:205
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:250
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:19
 msgid "Title"
 msgstr "标题"
 
 #: frontend/src/metabase/lib/core.js:33
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:260
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:266
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:278
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:287
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:296
 msgid "Comment"
 msgstr "评论"
 
@@ -3509,14 +3562,14 @@ msgstr "Metabase永远不会获取此字段。将此用于敏感或不相关的�
 
 #: frontend/src/metabase/lib/query/description.js:77
 #: frontend/src/metabase/lib/query/description.js:262
-#: frontend/src/metabase/lib/schema_metadata.js:476
+#: frontend/src/metabase/lib/schema_metadata.js:507
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 #: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Count"
 msgstr "计数"
 
@@ -3524,7 +3577,7 @@ msgstr "计数"
 msgid "CumulativeCount"
 msgstr "累积计数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:516
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:18
 #: frontend/src/metabase/visualizations/lib/utils.js:130
 msgid "Sum"
@@ -3542,19 +3595,19 @@ msgstr "不重复"
 msgid "StandardDeviation"
 msgstr "标准差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:494
+#: frontend/src/metabase/lib/schema_metadata.js:525
 #: frontend/src/metabase/visualizations/lib/utils.js:128
 msgid "Average"
 msgstr "平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:539
+#: frontend/src/metabase/lib/schema_metadata.js:570
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:26
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 msgid "Min"
 msgstr "最小"
 
-#: frontend/src/metabase/lib/schema_metadata.js:548
+#: frontend/src/metabase/lib/schema_metadata.js:579
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:492
@@ -3565,12 +3618,12 @@ msgstr "最大"
 msgid "sad sad panda, lexing errors detected"
 msgstr "哎呀，出错了"
 
-#: frontend/src/metabase/lib/formatting.js:832
+#: frontend/src/metabase/lib/formatting.js:855
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0}秒"
 
-#: frontend/src/metabase/lib/formatting.js:835
+#: frontend/src/metabase/lib/formatting.js:858
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0}分钟"
@@ -3610,14 +3663,15 @@ msgstr "你想找出什么？"
 
 #: frontend/src/metabase/lib/query/description.js:75
 #: frontend/src/metabase/lib/query/description.js:260
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:498
+#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:71
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:239
 msgid "Raw data"
 msgstr "原始数据"
 
 #: frontend/src/metabase/lib/query/description.js:79
 #: frontend/src/metabase/lib/query/description.js:264
-#: frontend/src/metabase/lib/schema_metadata.js:521
+#: frontend/src/metabase/lib/schema_metadata.js:552
 msgid "Cumulative count"
 msgstr "累积计数"
 
@@ -3679,166 +3733,164 @@ msgstr "真"
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase/lib/schema_metadata.js:322
+#: frontend/src/metabase/lib/schema_metadata.js:328
 msgid "Select longitude field"
 msgstr "选择经度字段"
 
-#: frontend/src/metabase/lib/schema_metadata.js:323
+#: frontend/src/metabase/lib/schema_metadata.js:329
 msgid "Enter upper latitude"
 msgstr "输入纬度上边届"
 
-#: frontend/src/metabase/lib/schema_metadata.js:324
+#: frontend/src/metabase/lib/schema_metadata.js:330
 msgid "Enter left longitude"
 msgstr "输入经度左边界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:325
+#: frontend/src/metabase/lib/schema_metadata.js:331
 msgid "Enter lower latitude"
 msgstr "输入纬度下边界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:326
+#: frontend/src/metabase/lib/schema_metadata.js:332
 msgid "Enter right longitude"
 msgstr "输入经度右边界"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:539
-#: frontend/src/metabase-lib/lib/Dimension.js:541
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:398
-#: frontend/src/metabase/lib/schema_metadata.js:406
-#: frontend/src/metabase/lib/schema_metadata.js:412
-#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:416
+#: frontend/src/metabase/lib/schema_metadata.js:422
+#: frontend/src/metabase/lib/schema_metadata.js:427
 msgid "Is"
 msgstr "是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:363
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/lib/schema_metadata.js:393
-#: frontend/src/metabase/lib/schema_metadata.js:407
-#: frontend/src/metabase/lib/schema_metadata.js:413
+#: frontend/src/metabase/lib/schema_metadata.js:369
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:417
+#: frontend/src/metabase/lib/schema_metadata.js:423
 msgid "Is not"
 msgstr "不是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:364
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:370
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:394
-#: frontend/src/metabase/lib/schema_metadata.js:402
-#: frontend/src/metabase/lib/schema_metadata.js:408
+#: frontend/src/metabase/lib/schema_metadata.js:404
+#: frontend/src/metabase/lib/schema_metadata.js:412
 #: frontend/src/metabase/lib/schema_metadata.js:418
+#: frontend/src/metabase/lib/schema_metadata.js:428
 msgid "Is empty"
 msgstr "为空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:379
-#: frontend/src/metabase/lib/schema_metadata.js:387
+#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:385
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:403
-#: frontend/src/metabase/lib/schema_metadata.js:409
+#: frontend/src/metabase/lib/schema_metadata.js:405
+#: frontend/src/metabase/lib/schema_metadata.js:413
 #: frontend/src/metabase/lib/schema_metadata.js:419
+#: frontend/src/metabase/lib/schema_metadata.js:429
 msgid "Not empty"
 msgstr "不为空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Equal to"
 msgstr "等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Not equal to"
 msgstr "不等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:373
+#: frontend/src/metabase/lib/schema_metadata.js:379
 msgid "Greater than"
 msgstr "大于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:374
+#: frontend/src/metabase/lib/schema_metadata.js:380
 msgid "Less than"
 msgstr "小于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:375
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:381
+#: frontend/src/metabase/lib/schema_metadata.js:411
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "介于之间"
 
-#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:382
 msgid "Greater than or equal to"
 msgstr "大于或等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:377
+#: frontend/src/metabase/lib/schema_metadata.js:383
 msgid "Less than or equal to"
 msgstr "小于或等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:384
+#: frontend/src/metabase/lib/schema_metadata.js:390
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:391
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/lib/schema_metadata.js:396
 msgid "Starts with"
 msgstr "以…开始"
 
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:397
 msgid "Ends with"
 msgstr "以…结束"
 
-#: frontend/src/metabase/lib/schema_metadata.js:399
+#: frontend/src/metabase/lib/schema_metadata.js:409
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "早于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:410
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "晚于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:414
+#: frontend/src/metabase/lib/schema_metadata.js:424
 msgid "Inside"
 msgstr "介于中间"
 
-#: frontend/src/metabase/lib/schema_metadata.js:468
+#: frontend/src/metabase/lib/schema_metadata.js:499
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "只是一个包含数据行的表格，没有其他操作。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Count of rows"
 msgstr "总行数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Total number of rows in the answer."
 msgstr "总的数据行数。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:484
+#: frontend/src/metabase/lib/schema_metadata.js:515
 msgid "Sum of ..."
 msgstr "总和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:486
+#: frontend/src/metabase/lib/schema_metadata.js:517
 msgid "Sum of all the values of a column."
 msgstr "一个字段所有数值的总和。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:493
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Average of ..."
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:495
+#: frontend/src/metabase/lib/schema_metadata.js:526
 msgid "Average of all the values of a column"
 msgstr "一个字段所有数值的平均值。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:502
+#: frontend/src/metabase/lib/schema_metadata.js:533
 msgid "Number of distinct values of ..."
 msgstr "不重复值的总数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:504
+#: frontend/src/metabase/lib/schema_metadata.js:535
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "一个字段所有互不重复的值的总数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:511
+#: frontend/src/metabase/lib/schema_metadata.js:542
 msgid "Cumulative sum of ..."
 msgstr "累积求和"
 
@@ -3846,7 +3898,7 @@ msgstr "累积求和"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "一个字段所有数值的累积加和。\\\\n比如：随着时间推移的总收入。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:520
+#: frontend/src/metabase/lib/schema_metadata.js:551
 msgid "Cumulative count of rows"
 msgstr "累积行数"
 
@@ -3854,27 +3906,27 @@ msgstr "累积行数"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "累积的数据行数。\\\\ n比如：随着时间的推移销售数量。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:529
+#: frontend/src/metabase/lib/schema_metadata.js:560
 msgid "Standard deviation of ..."
 msgstr "标准差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:531
+#: frontend/src/metabase/lib/schema_metadata.js:562
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "一个字段所有数值的标准差。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:538
+#: frontend/src/metabase/lib/schema_metadata.js:569
 msgid "Minimum of ..."
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:540
+#: frontend/src/metabase/lib/schema_metadata.js:571
 msgid "Minimum value of a column"
 msgstr "一个字段的最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:547
+#: frontend/src/metabase/lib/schema_metadata.js:578
 msgid "Maximum of ..."
 msgstr "最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:549
+#: frontend/src/metabase/lib/schema_metadata.js:580
 msgid "Maximum value of a column"
 msgstr "一个字段的最大值"
 
@@ -3890,6 +3942,8 @@ msgstr "小写字母"
 msgid "upper case letter"
 msgstr "大写字母"
 
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:455
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "个数"
@@ -4137,7 +4191,7 @@ msgstr "如何创建指标"
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
 msgstr "按地图、趋势查看时间维度的数据，方便了解趋势变化"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:146
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:152
 msgid "Custom"
 msgstr "自定义"
 
@@ -4160,7 +4214,7 @@ msgstr "原生查询"
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "为了回答更多复杂的疑问，你可以写下你自己的SQL语句或者原生查询。"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:242
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:247
 msgid "Select a default value…"
 msgstr "选择一个默认值"
 
@@ -4248,7 +4302,7 @@ msgstr "这个月"
 msgid "This Year"
 msgstr "今年"
 
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:97
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:104
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
 msgstr "输入一个值……"
@@ -4258,7 +4312,7 @@ msgid "Enter a default value..."
 msgstr "输入一个默认值……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:49
-#: frontend/src/metabase/containers/Form.jsx:307
+#: frontend/src/metabase/containers/Form.jsx:308
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "发生了一个错误"
@@ -4515,22 +4569,30 @@ msgid "Choose questions you'd like to send in this pulse"
 msgstr "挑选你想在这个定时任务里发送的图表。"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:60
 msgid "Emails"
 msgstr "电子邮箱"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:61
 msgid "Slack messages"
 msgstr "Slack消息"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:598
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:679
 msgid "Sent"
 msgstr "发送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:599
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:680
 msgid "{0} will be sent at"
 msgstr "{0}将会在……被发送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:601
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:682
 msgid "Messages"
 msgstr "信息"
 
@@ -4602,30 +4664,30 @@ msgstr "帮助每个在你们团队的人和你们的数据保持联结"
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
 msgstr "定时通知允许您根据您选择的时间表从Metabase发送数据到电子邮件或Slack。"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:98
 msgid "After {0}"
 msgstr "之后{0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "Before {0}"
 msgstr "之前{0}"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "是空的"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "不是空的"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:107
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "所有时间"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:152
 msgid "Apply"
 msgstr "应用"
 
@@ -4726,12 +4788,12 @@ msgstr[0] "查看这个{0}\n"
 msgid "Zoom in"
 msgstr "放大"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:52
 msgid "Custom Expression"
 msgstr "自定义表达方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
 msgid "Common Metrics"
 msgstr "共同指标"
 
@@ -4928,7 +4990,7 @@ msgstr "通常"
 msgid "Pick a segment or table"
 msgstr "选择一个区间或者表单"
 
-#: frontend/src/metabase/entities/databases/forms.js:260
+#: frontend/src/metabase/entities/databases/forms.js:261
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:70
 msgid "Select a database"
 msgstr "选择一个数据库"
@@ -4989,7 +5051,7 @@ msgstr "排序"
 msgid "Row limit"
 msgstr "行限制"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldWidget.jsx:76
 msgid "Unknown Field"
 msgstr "未知字段"
 
@@ -4997,7 +5059,7 @@ msgstr "未知字段"
 msgid "field"
 msgstr "字段"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:117
+#: frontend/src/metabase/query_builder/components/Filter.jsx:116
 msgid "Matches"
 msgstr "匹配"
 
@@ -5022,11 +5084,11 @@ msgstr "添加一个聚合"
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:319
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:305
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:311
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:317
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "数据"
 
@@ -5043,11 +5105,12 @@ msgstr "查看"
 msgid "Grouped By"
 msgstr "分组条件"
 
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:161
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
 msgstr "没有"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:538
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:552
 msgid "This question is written in {0}."
 msgstr "这个疑问已经被写入{0}"
 
@@ -5059,7 +5122,7 @@ msgstr "隐藏编辑器"
 msgid "Hide Query"
 msgstr "隐藏查询"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:547
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:561
 msgid "Open Editor"
 msgstr "打开编辑器"
 
@@ -5067,7 +5130,7 @@ msgstr "打开编辑器"
 msgid "Show Query"
 msgstr "显示查询"
 
-#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
+#: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:20
 msgid "This metric has been retired.  It's no longer available for use."
 msgstr "这个指标已经被淘汰，它将不再可用了"
 
@@ -5267,7 +5330,7 @@ msgstr "返回上一次运行"
 msgid "Visualization"
 msgstr "可视化"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:94
 msgid "No description set."
 msgstr "没有设置描述"
 
@@ -5324,7 +5387,7 @@ msgstr "在创建一个新的疑问之前不能找到表单元数据"
 msgid "See {0}"
 msgstr "查看{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:100
 msgid "Metric Definition"
 msgstr "指标定义"
 
@@ -5342,11 +5405,11 @@ msgstr "{0}的数字"
 msgid "See all {0}"
 msgstr "查看所有的{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:154
 msgid "Segment Definition"
 msgstr "区段定义"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:58
 msgid "An error occurred loading the table"
 msgstr "在加载表时发生了一个错误"
 
@@ -5354,7 +5417,7 @@ msgstr "在加载表时发生了一个错误"
 msgid "See the raw data for {0}"
 msgstr "查看{0}的所有原始数据"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:177
 msgid "More"
 msgstr "更多"
 
@@ -5374,6 +5437,8 @@ msgstr "字段公式"
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "这有点像在EXCEL表中编写公式，你可以使用数字，字段，数学符号和一些函数，例如 Subtotal - Cost。"
 
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:111
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:281
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:353
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:73
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:209
@@ -5441,7 +5506,7 @@ msgstr "错误"
 msgid "Add filter"
 msgstr "添加过滤器"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
+#: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:60
 msgid "Item"
 msgstr "项"
 
@@ -5560,11 +5625,11 @@ msgstr "字段映射到"
 msgid "Filter widget type"
 msgstr "过滤器样式"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:231
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:232
 msgid "Required?"
 msgstr "必填项？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:241
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:242
 msgid "Default filter widget value"
 msgstr "过滤器默认值"
 
@@ -5576,7 +5641,7 @@ msgstr "归档图表？"
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "这个图表会从已引用的仪表盘或定时任务中移除"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:164
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:163
 msgid "Question"
 msgstr "疑问"
 
@@ -5623,7 +5688,7 @@ msgstr "字段类型"
 msgid "Select a Foreign Key"
 msgstr "选择一个外键"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:56
+#: frontend/src/metabase/reference/components/Formula.jsx:47
 msgid "View the {0} formula"
 msgstr "查看{0}的公式"
 
@@ -6107,22 +6172,24 @@ msgstr "有关这个区段的疑问"
 msgid "X-ray this segment"
 msgstr "透视这个区段"
 
-#: frontend/src/metabase/routes.jsx:169 frontend/src/metabase/routes.jsx:170
+#: frontend/src/metabase/routes.jsx:171 frontend/src/metabase/routes.jsx:172
 msgid "Login"
 msgstr "登录"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:303
-#: frontend/src/metabase/containers/ItemPicker.jsx:115
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx:20
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:390
+#: frontend/src/metabase/containers/ItemPicker.jsx:129
 #: frontend/src/metabase/nav/containers/Navbar.jsx:157
-#: frontend/src/metabase/routes.jsx:195
+#: frontend/src/metabase/routes.jsx:197
 msgid "Search"
 msgstr "查询"
 
-#: frontend/src/metabase/routes.jsx:214
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:548
+#: frontend/src/metabase/routes.jsx:216
 msgid "Dashboard"
 msgstr "仪表盘"
 
-#: frontend/src/metabase/routes.jsx:227
+#: frontend/src/metabase/routes.jsx:231
 msgid "New Question"
 msgstr "新疑问"
 
@@ -6194,35 +6261,35 @@ msgstr "所有的收集都是匿名的。"
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "您随时可以在管理设置中关闭信息收集。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:59
+#: frontend/src/metabase/setup/components/Setup.jsx:61
 msgid "If you feel stuck"
 msgstr "如果你不知从何下手"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:64
+#: frontend/src/metabase/setup/components/Setup.jsx:66
 msgid "our getting started guide"
 msgstr "初始化文档"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:65
+#: frontend/src/metabase/setup/components/Setup.jsx:67
 msgid "is just a click away."
 msgstr "点击一下"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:111
+#: frontend/src/metabase/setup/components/Setup.jsx:113
 msgid "Welcome to Metabase"
 msgstr "欢迎来到Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:112
+#: frontend/src/metabase/setup/components/Setup.jsx:114
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "看起来一切都在正常工作，现在让我们了解你吧，连接到你的数据，并且开始寻找一些属于你的答案！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:116
+#: frontend/src/metabase/setup/components/Setup.jsx:118
 msgid "Let's get started"
 msgstr "让我们开始吧"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:166
+#: frontend/src/metabase/setup/components/Setup.jsx:168
 msgid "You're all set up!"
 msgstr "你已经设置完毕了！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:177
+#: frontend/src/metabase/setup/components/Setup.jsx:179
 msgid "Take me to Metabase"
 msgstr "带我去Metabase"
 
@@ -6399,7 +6466,7 @@ msgstr "保存你的疑问"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "环比，你可以存储你的疑问，你以后可以引用他们。已存储的疑问统一能够被放进仪表盘或者波动中。"
+msgstr "顺便说一句，你可以存储你的疑问，你以后可以引用他们。已存储的疑问统一能够被放进仪表盘或者波动中。"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
@@ -6474,39 +6541,40 @@ msgstr "取消过滤器"
 msgid "Pin Map"
 msgstr "固定地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:377
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:373
 msgid "Unset"
 msgstr "撤销设置"
 
-#: frontend/src/metabase/visualizations/components/TableSimple.jsx:277
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:116
+#: frontend/src/metabase/visualizations/components/TableSimple.jsx:284
 msgid "Rows {0}-{1} of {2}"
 msgstr "{2}的{0}~{1}行"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:206
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:208
 msgid "Data truncated to {0} rows."
 msgstr "数据被截断为{0}行。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:403
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:415
 msgid "Could not find visualization"
 msgstr "找不到可视化"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:410
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:422
 msgid "Could not display this chart with this data."
 msgstr "无法显示这个图表显示这些数据"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:533
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:541
 msgid "No results!"
 msgstr "没有结果！"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:554
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:562
 msgid "Still Waiting..."
 msgstr "仍然在等待……"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:557
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:565
 msgid "This usually takes an average of {0}."
 msgstr "这将通常取一个{0}的平均数。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:563
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:571
 msgid "(This is a bit long for a dashboard)"
 msgstr "（这对于仪表盘来说有点太长了）"
 
@@ -6616,7 +6684,7 @@ msgid "Highlight the whole row"
 msgstr "高亮整行"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "颜色"
 
@@ -6702,24 +6770,50 @@ msgstr "目标"
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
 msgstr "正在……噢！从你的查询中获得的数去并不适合所选的展示选项，这个可视化需要最少数据中的{0}{1}。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:6
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:10
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:19
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:142
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:146
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:214
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:219
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:231
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:299
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:302
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:327
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:219
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:20
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:27
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:34
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:46
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:51
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:58
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:63
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:70
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:75
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:82
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:87
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:138
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:143
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:150
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:155
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:303
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:315
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:324
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:333
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:345
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:370
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:382
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:387
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:436
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:451
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgstr "列"
@@ -6750,7 +6844,7 @@ msgid "xValues missing!"
 msgstr "x值丢失！"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:33
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X轴"
 
@@ -6759,7 +6853,7 @@ msgid "Add a series breakout..."
 msgstr "添加一系列断点......"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:37
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y轴"
 
@@ -6772,7 +6866,7 @@ msgid "Bubble size"
 msgstr "气泡大小"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:17
 msgid "Line"
 msgstr "线段"
 
@@ -6914,20 +7008,20 @@ msgid "Standard Deviation"
 msgstr "标准差"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:19
 msgid "Area"
 msgstr "区域"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:23
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:22
 msgid "area chart"
 msgstr "区域图表"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:18
 msgid "Bar"
 msgstr "柱"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:21
 msgid "bar chart"
 msgstr "柱形图"
 
@@ -6941,7 +7035,7 @@ msgid "Funnel"
 msgstr "漏斗"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "测量"
 
@@ -6953,81 +7047,81 @@ msgstr "漏斗类型"
 msgid "Bar chart"
 msgstr "柱形图"
 
-#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:20
 msgid "line chart"
 msgstr "线段图表"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:306
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:304
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "请在图表设置中选择经度和维度的列"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:310
 msgid "Please select a region map."
 msgstr "请选择一个区域地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:318
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:316
 msgid "Please select region and metric columns in the chart settings."
 msgstr "请在图表设置中选择一个区域和指标列"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:40
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:132
 msgid "Map type"
 msgstr "地图类型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:136
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:229
 msgid "Region map"
 msgstr "区域地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:138
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:137
 msgid "Pin map"
 msgstr "固定地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:184
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:183
 msgid "Pin type"
 msgstr "固定类型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:188
 msgid "Tiles"
 msgstr "标题"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:189
 msgid "Markers"
 msgstr "标记"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:208
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:207
 msgid "Latitude field"
 msgstr "维度字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:214
 msgid "Longitude field"
 msgstr "经度字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:222
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:221
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:248
 msgid "Metric field"
 msgstr "指标字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:252
 msgid "Region field"
 msgstr "区域字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:272
 msgid "Radius"
 msgstr "半径"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:279
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:278
 msgid "Blur"
 msgstr "模糊"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:285
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:284
 msgid "Min Opacity"
 msgstr "最小不透明度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:291
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:290
 msgid "Max Zoom"
 msgstr "放到最大"
 
@@ -7039,7 +7133,7 @@ msgstr "没有发现关联。"
 msgid "via {0}"
 msgstr "通过{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:350
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:349
 msgid "This {0} is connected to:"
 msgstr "这个{0}连接到"
 
@@ -7051,31 +7145,31 @@ msgstr "对象细节"
 msgid "object"
 msgstr "对象"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:375
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:374
 msgid "Total"
 msgstr "总计"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:74
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "需要用哪些列？"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "饼图"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:106
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "维度"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:116
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "显示说明"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "在说明中显示百分比"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:127
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "最小切片百分比"
 
@@ -7100,7 +7194,8 @@ msgid "Progress"
 msgstr "处理"
 
 #: frontend/src/metabase/entities/collections.js:109
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:257
+#: frontend/src/metabase/entities/snippet-collections.js:87
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:256
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "颜色"
@@ -7109,7 +7204,7 @@ msgstr "颜色"
 msgid "Row Chart"
 msgstr "原始图表"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
 msgstr "原始图表"
 
@@ -7133,15 +7228,15 @@ msgstr "添加一个后缀"
 msgid "Multiply by a number"
 msgstr "乘以数字"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:17
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
 msgstr "分散"
 
-#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
 msgstr "散点图"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:85
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:84
 msgid "Pivot the table"
 msgstr "透视表"
 
@@ -7191,12 +7286,12 @@ msgstr "右边"
 msgid "Show background"
 msgstr "显示背景"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:760
+#: frontend/src/metabase-lib/lib/Dimension.js:756
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} 刻度间隔"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:766
+#: frontend/src/metabase-lib/lib/Dimension.js:762
 msgid "Auto binned"
 msgstr "自动分组"
 
@@ -7432,10 +7527,13 @@ msgstr "在{0}中有很多已保存的问题？创建集合以帮助管理它们
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
 #. It shows up a solid 10-15 seconds before the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
+#: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:240
 #: frontend/src/metabase/home/components/Activity.jsx:87
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:90
 #: frontend/src/metabase/public/components/LogoBadge.jsx:22
-#: frontend/src/metabase/routes.jsx:140 src/metabase/api/setup.clj
+#: frontend/src/metabase/routes-public.jsx:15
+#: frontend/src/metabase/routes.jsx:142 src/metabase/api/setup.clj
+#: src/metabase/email/messages.clj
 msgid "Metabase"
 msgstr "Metabase"
 
@@ -7621,7 +7719,7 @@ msgstr "累积总和"
 msgid "{0} and {1}"
 msgstr "{0} 和 {1}"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:76
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:78
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} 的 {1}"
@@ -8933,11 +9031,11 @@ msgstr "数据权限"
 msgid "Collection permissions"
 msgstr "文件夹权限"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:57
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:90
 msgid "See all collection permissions"
 msgstr "查看所有文件夹权限"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
+#: frontend/src/metabase/admin/permissions/selectors.js:815
 msgid "Also change sub-collections"
 msgstr "同时更改子集合"
 
@@ -8949,19 +9047,19 @@ msgstr "允许修改集合及其内容"
 msgid "Can view items in this collection"
 msgstr "允许查看该集合的内容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:765
+#: frontend/src/metabase/admin/permissions/selectors.js:794
 msgid "Collection Access"
 msgstr "集合的权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:841
+#: frontend/src/metabase/admin/permissions/selectors.js:880
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "该组有权查看此集合的至少一个子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:846
+#: frontend/src/metabase/admin/permissions/selectors.js:885
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "该组有权编辑此集合的至少一个子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:859
+#: frontend/src/metabase/admin/permissions/selectors.js:898
 msgid "View sub-collections"
 msgstr "查看子集合"
 
@@ -9017,6 +9115,7 @@ msgstr "相关"
 msgid "More X-rays"
 msgstr "更多透视方法"
 
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx:49
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
@@ -9275,10 +9374,10 @@ msgstr "分享"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:340
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
@@ -9361,7 +9460,7 @@ msgstr "使用Java虚拟机时区"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "我们现在正在分析数据表和字段来帮助你探索数据"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:446
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:459
 msgid "Tip: "
 msgstr "提示："
 
@@ -9369,7 +9468,7 @@ msgstr "提示："
 msgid "Select a currency type"
 msgstr "选择一个统用的类型"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:309
 msgid "Field Type"
 msgstr "字段类型"
 
@@ -9424,6 +9523,7 @@ msgid "Currency"
 msgstr "货币"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:218
 msgid "Pick a user or channel..."
 msgstr "选择一个用户或频道"
 
@@ -9585,7 +9685,7 @@ msgstr "哪个轴？"
 msgid "Line + Bar"
 msgstr "线状图+条行图"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:21
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:20
 msgid "line and bar chart"
 msgstr "线状图和条型图"
 
@@ -9605,15 +9705,15 @@ msgstr "标尺范围"
 msgid "Field to show"
 msgstr "显示的字段"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:141
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:142
 msgid "last {0}"
 msgstr "上一{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:211
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:217
 msgid "{0} was {1} {2}"
 msgstr "{0}{2} {1}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:72
 msgid "Group by a time field to see how this has changed over time"
 msgstr "聚一个时间字段来看指标随着时间的变化情况"
 
@@ -9621,23 +9721,23 @@ msgstr "聚一个时间字段来看指标随着时间的变化情况"
 msgid "Switch positive / negative colors?"
 msgstr "切换正、负颜色"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:97
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:96
 msgid "Pivot column"
 msgstr "透视列"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:128
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:127
 msgid "Cell column"
 msgstr "列单元"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:164
 msgid "Visible columns"
 msgstr "可见列"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:194
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:193
 msgid "Conditional Formatting"
 msgstr "条件格式化"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:235
 msgid "Column title"
 msgstr "列抬头"
 
@@ -10075,10 +10175,10 @@ msgstr "每来源用户"
 msgid "The top external pages that brought users to your site"
 msgstr "将用户带到您网站的外部热门网页"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
 msgstr "[[这个]]如何分发等等。"
 
@@ -10176,13 +10276,13 @@ msgstr "当日每小时事件"
 msgid "[[Singleton]]"
 msgstr "[[Singleton]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Top 5 [[this]]"
 msgstr "前5 [[this]]"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Bottom 5 [[this]]"
 msgstr "后5 [[this]]"
 
@@ -10195,10 +10295,10 @@ msgid "Per [[GenericCategoryLarge]]"
 msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Null values"
 msgstr "空值"
 
@@ -10226,8 +10326,8 @@ msgstr "How they compare by seasonality"
 msgid "Average income per transaction"
 msgstr "每次交易的平均收入"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "[[this]] per country"
 msgstr "每个国家"
 
@@ -10351,10 +10451,10 @@ msgstr "An overview of your [[this]] and how its distributed across time, place,
 msgid "Average income per state"
 msgstr "Average income per state"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
 msgstr "[[this]] by [[GenericCategoryMedium]]"
 
@@ -10531,13 +10631,13 @@ msgid "How [[GenericTable]] are distributed across this time field, and if it ha
 msgstr "[[GenericTable]]如何在此时间字段中分布，以及是否有任何季节性模式。"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Overview"
 msgstr "总览"
 
@@ -10581,9 +10681,10 @@ msgstr "过去30天内每个国家/地区的新用户"
 msgid "Transactions over time"
 msgstr "随着时间的推移"
 
+#. 按[[this]]统计[[GenericCategorySmall]]
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "每[[GenericCategorySmall]] [[this]]"
+msgstr "按照[[GenericCategorySmall]]统计[[this]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
@@ -10646,8 +10747,8 @@ msgstr "继续仔细看看[[这个]]"
 msgid "Heres a closer look at your [[this]] field"
 msgstr "继续仔细看看[[这个]]字段"
 
-#: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Summary"
 msgstr "概览"
 
@@ -10711,10 +10812,10 @@ msgstr "每个来源的销售量"
 msgid "Average income per country"
 msgstr "每个国家平均收入"
 
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
 msgstr "如何[[this]]分发"
 
@@ -10735,17 +10836,17 @@ msgid "Count of [[GenericCategoryMedium]] by [[this]]"
 msgstr "由[[this]]计算[[GenericCategoryMedium]]的数量"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
-#: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/table/TransactionTable.yaml
-#: resources/automagic_dashboards/table/UserTable.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/table/TransactionTable.yaml
+#: resources/automagic_dashboards/table/GenericTable.yaml
+#: resources/automagic_dashboards/table/UserTable.yaml
 msgid "A look at your [[this]]"
 msgstr "查看你的 [[this]]"
 
@@ -10811,10 +10912,10 @@ msgid "Transactions per source over time"
 msgstr "每个来源的交易"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "How the [[this]] is distributed"
 msgstr "[[this]]每天的每小时"
 
@@ -10822,10 +10923,11 @@ msgstr "[[this]]每天的每小时"
 msgid "Total income per source"
 msgstr "每个来源的总收入"
 
+#. [[this.short-name]]的行数
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "您[[this.short-name]]的位置"
+msgstr "总计 [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Some metrics we found about your transactions."
@@ -10843,9 +10945,9 @@ msgstr "这些事件发生的地方"
 msgid "Which US states are bringing you the most business."
 msgstr "美国哪些州为您带来最大的业务？"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
 msgstr "他们如何比较时间？"
 
@@ -10889,10 +10991,11 @@ msgstr "你的所有[[this.short-name]]都是一样的"
 msgid "Average discount per month"
 msgstr "每月的平均折扣"
 
+#. 按月统计[[Timestamp]]
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "这些[[this.short-name]]的位置"
+msgstr "按月统计[[Timestamp]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
@@ -10914,9 +11017,10 @@ msgstr "每产品分类销售"
 msgid "A closer look at the metrics and dimensions used in this saved question."
 msgstr "仔细查看此已保存问题中使用的指标和维度。"
 
+#. 按[[this.short-name]]统计[[GenericCategoryMedium]]
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr "每[[GenericCategoryMedium]] [[this.short-name]]"
+msgstr "按照[[GenericCategoryMedium]]统计[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
@@ -10926,9 +11030,10 @@ msgstr "每件产品的销售[[ProductCategoryLarge]]"
 msgid "Average quantity per country"
 msgstr "每个国家的平均数量"
 
+#. 按[[this.short-name]]统计[[GenericCategoryLarge]]
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr "每[[GenericCategoryLarge]] [[this.short-name]]"
+msgstr "按照[[GenericCategoryLarge]]统计[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
@@ -10950,15 +11055,16 @@ msgstr "总计[[this.short-name]]"
 msgid "Some interesting metrics about your GA stats to get you started."
 msgstr "有关GA统计数据的一些有趣指标可帮助您入门。"
 
-#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "[[this]] per state"
 msgstr "[[this]]每个区域"
 
+#. 按季度统计[[Timestamp]]
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "看起来你[[this]]有交易，所以看看他们"
+msgstr "按季度统计[[Timestamp]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
@@ -10996,13 +11102,15 @@ msgstr "表现最佳者"
 msgid "Transactions in the last 30 days"
 msgstr "过去30天的交易量"
 
+#. 按[[this]]统计[[GenericTable]]
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr "[[this]]每[[GenericCategorySmall]]随着时间的推移"
+msgstr "按[[this]]统计[[GenericTable]]"
 
+#. 来自Google Analytics关于[[this]]的数据概览
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "每[[GenericCategoryMedium]] [[this.short-name]]"
+msgstr "来自Google Analytics关于你的[[this]]数据概览"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
@@ -11016,9 +11124,10 @@ msgstr "按月销售"
 msgid "How the [[this]] is distributed across categories"
 msgstr "每件产品的销售[[ProductCategoryLarge]]"
 
+#. 按月份统计[[Timestamp]]
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "每[[GenericCategoryLarge]] [[this.short-name]]"
+msgstr "按月份统计[[Timestamp]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
@@ -11032,12 +11141,12 @@ msgstr "该指标如何分布在不同的数字上"
 msgid "Sessions by page where the session began"
 msgstr "会话开始时的页面会话"
 
-#: frontend/src/metabase/lib/schema_metadata.js:503
+#: frontend/src/metabase/lib/schema_metadata.js:534
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 msgid "Distinct values"
 msgstr "不重复的值"
 
@@ -11045,10 +11154,11 @@ msgstr "不重复的值"
 msgid "Hours when [[this.short-name]] were added"
 msgstr "下面仔细看看你的[[this]]每个来源"
 
+#. 按星期几统计[[Timestamp]]
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "国家会议"
+msgstr "按星期几统计[[Timestamp]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
@@ -11079,9 +11189,10 @@ msgstr "按照每月的某天创建"
 msgid "Sales by coordinates"
 msgstr "销售的坐标"
 
+#. [[this.short-name]]随着时间的变化
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "[[GenericTable]]每[[this]]"
+msgstr "[[this.short-name]]随着时间的变化"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
@@ -11100,10 +11211,10 @@ msgid "Events per [[GenericCategoryLarge]]"
 msgstr "[[GenericTable]] [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
-#: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/Country.yaml
+#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
 msgstr "他们如何通过分布进行比较"
@@ -11124,9 +11235,10 @@ msgstr "[[this]]如何跨类别分布"
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
 msgstr "[[时间戳]]按年份计算"
 
+#. 依据[[this.short-name]], 在最近30天里添加的数据
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "添加[[this.short-name]]的小时数"
+msgstr "在最近30天里添加的[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
@@ -11409,6 +11521,7 @@ msgstr "复制仪表板"
 msgid "Duplicate \"{0}\""
 msgstr "复制 \"{0}\""
 
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
@@ -11497,9 +11610,9 @@ msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "季度"
 
-#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:286
-#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:285
+#: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:65
+#: frontend/src/metabase/query_builder/components/Filter.jsx:81
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} 选择"
@@ -11521,11 +11634,11 @@ msgstr "无效"
 msgid "Add a time"
 msgstr "添加时间"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:190
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:196
 msgid "Nothing to compare for the previous {0}."
 msgstr "无法与前{0}比较"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:712
+#: frontend/src/metabase-lib/lib/Dimension.js:708
 msgid "by {0}"
 msgstr "[[时间戳]]按小时计算"
 
@@ -11597,9 +11710,10 @@ msgstr "继续仔细看看每个国家的[[this]]"
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
 msgstr "按产品销售[[ProductCategory]]"
 
+#. 已注册的抽象数据库驱动{0}
 #: src/metabase/driver/impl.clj
 msgid "Registered abstract driver {0}"
-msgstr "[[this]]每[[GenericCategoryLarge]]，底部5"
+msgstr "已注册的抽象数据库驱动{0}"
 
 #: src/metabase/driver/impl.clj
 msgid "Registered driver {0}"
@@ -11641,9 +11755,10 @@ msgstr "开始监听事件"
 msgid "Unexpected error listening on events"
 msgstr "监听事件时出现意外错误"
 
+#. 同步数据库{0}失败
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "[[this]]每周的每一天"
+msgstr "同步数据库{0}失败"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
@@ -12013,9 +12128,9 @@ msgstr "由于所需的依赖性，Metabase 无法初始化插件{0}。"
 msgid "[[CreateTimestamp]] by quarter of the year"
 msgstr "找不到类：{0}"
 
+#: resources/automagic_dashboards/metric/GenericMetric.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
-#: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
 msgstr "他们如何比较不同的位置"
 
@@ -12044,12 +12159,12 @@ msgstr "取消注册原始JDBC驱动程序{0} ..."
 msgid "Here's an overview of your [[this]] data from Google Analytics"
 msgstr "默认连接属性{0}不存在。"
 
-#: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#: resources/automagic_dashboards/field/State.yaml
+#: resources/automagic_dashboards/comparison/GenericField.yaml
+#: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
-#: resources/automagic_dashboards/comparison/Country.yaml
-#: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
 msgstr "无效的连接属性{0}：不是字符串或映射。"
 
@@ -12127,11 +12242,11 @@ msgstr "收藏"
 msgid "collections"
 msgstr "收藏"
 
-#: frontend/src/metabase/entities/dashboards.js:32
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboard"
 msgstr "仪表板"
 
-#: frontend/src/metabase/entities/dashboards.js:33
+#: frontend/src/metabase/entities/dashboards.js:34
 msgid "dashboards"
 msgstr "仪表板"
 
@@ -12381,7 +12496,7 @@ msgstr "{0} ms 后超时."
 msgid "Misfire Instruction"
 msgstr "失火指令"
 
-#: frontend/src/metabase/components/ArchiveModal.jsx:31
+#: frontend/src/metabase/components/ArchiveModal.jsx:33
 msgid "Archive this?"
 msgstr "将这个归档?"
 
@@ -12399,7 +12514,7 @@ msgid "Using this option requires that provided host is a FQDN.  If connecting t
 "leave this disabled."
 msgstr "使用此选项要求提供的主机是一个FQDN。 如果连接到一个Atlas集群，您可能需要启用此选项。 如果你不知道这意味着什么，请保持禁用该选项。"
 
-#: frontend/src/metabase/entities/databases/forms.js:273
+#: frontend/src/metabase/entities/databases/forms.js:274
 msgid "Automatically run queries when doing simple filtering and summarizing"
 msgstr "在进行简单的过滤和汇总时自动运行查询"
 
@@ -12411,7 +12526,7 @@ msgstr "这个选项开启时，当用户在查看表格或图表时使用“汇
 msgid "Learn about this database"
 msgstr "了解这个数据库"
 
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+#: frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx:53
 msgid "Archive this dashboard?"
 msgstr "是否归档该仪表板?"
 
@@ -12466,11 +12581,11 @@ msgstr "自定义查询"
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
 msgstr "使用高级查询编辑器完成关联, 创建自定义列, 实现数学计算等更多高级功能."
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:21
 msgid "Basic Metrics"
 msgstr "基础指标"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:311
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:287
 msgid "Custom…"
 msgstr "自定义"
 
@@ -12653,15 +12768,15 @@ msgstr "选择可视化方法"
 msgid "Filter by"
 msgstr "筛选条件"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:56
 msgid "Summarize by"
 msgstr "聚合条件"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:82
 msgid "Group by"
 msgstr "分组条件"
 
-#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:166
 msgid "Add a metric"
 msgstr "添加指标"
 
@@ -12672,15 +12787,15 @@ msgstr "添加指标"
 msgid "Profile"
 msgstr "主页"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:567
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:575
 msgid "This is usually pretty fast but seems to be taking a while right now."
 msgstr "这通常很快，但现在似乎需要一段时间。"
 
-#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:18
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:17
 msgid "Combo"
 msgstr "组合"
 
-#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:14
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
 msgstr "行"
 
@@ -12903,13 +13018,15 @@ msgstr "在没有数据源元数据的情况下，无法使用本机数据源查
 msgid "Query processor error: number of columns returned by driver does not match results."
 msgstr "查询处理器错误：驱动程序返回的列数与结果不匹配。"
 
+#. 要求{0}列, 但是结果的第一行有{1}列.
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "看起来你的[[this]]有交易，所以这里看看它们"
+msgstr "要求{0}列, 但是结果的第一行有{1}列."
 
+#. 没有发现名为{0}的表达式, 已发现的是{1}
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "这里仔细看看你的[[this]]每个州"
+msgstr "没有发现名为{0}的表达式, 已发现的是{1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
@@ -13101,7 +13218,7 @@ msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "选择需要包含的列"
 
-#: frontend/src/metabase/entities/databases/forms.js:274
+#: frontend/src/metabase/entities/databases/forms.js:275
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
 msgstr "这个选项开启时，当用户在查看表格或图表时使用“汇总”和“过滤”按钮进行简单数据探索时，Metabase将自动运行查询。 如果查询此数据库的速度很慢，可以将该选项关闭。 此设置不会影响数据钻探或SQL查询。"
 
@@ -13167,7 +13284,7 @@ msgstr "邮箱登录"
 msgid "Using this option requires that provided host is a FQDN.  If connecting to an Atlas cluster, you might need to enable this option.  If you don't know what this means, leave this disabled."
 msgstr "使用此选项要求提供的主机是FQDN。 如果连接到Atlas群集，则可能需要启用此选项。 如果您不知道这意味着什么，请禁用此功能。"
 
-#: frontend/src/metabase/entities/databases/forms.js:282
+#: frontend/src/metabase/entities/databases/forms.js:283
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "默认情况下，Metabase每小时执行一次轻量级同步，每天执行一次密集扫描。 如果您有一个大型数据库，我们建议启用此功能并查看字段值扫描的发生时间和频率。"
 
@@ -13235,11 +13352,11 @@ msgstr "不包含"
 msgid "This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries."
 msgstr "在使用GUI界面创建的问题中，该字段将不可见或不可选择。 在SQL /本地查询中仍然可以访问。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:512
+#: frontend/src/metabase/lib/schema_metadata.js:543
 msgid "Cumulative sum"
 msgstr "累积和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:530
+#: frontend/src/metabase/lib/schema_metadata.js:561
 msgid "Standard deviation"
 msgstr "标准偏差"
 
@@ -13255,19 +13372,19 @@ msgstr "必须至少为{0}个字符"
 msgid "Name (required)"
 msgstr "名称（必填）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:668
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:684
 msgid "Run selected text"
 msgstr "运行选中文本"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:669
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:685
 msgid "Run query"
 msgstr "运行查询"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(⌘ + enter)"
 msgstr "（command + 回车）"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:671
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:687
 msgid "(Ctrl + enter)"
 msgstr "（Ctrl + 回车）"
 
@@ -13615,7 +13732,7 @@ msgstr "日期和时间"
 msgid "Numbers"
 msgstr "数字"
 
-#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:332
+#: frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx:308
 msgid "No mappable groups"
 msgstr "无匹配集合"
 
@@ -13655,15 +13772,15 @@ msgstr "youlooknicetoday@email.com"
 msgid "Remember me"
 msgstr "记住我"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:82
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:75
 msgid "For security reasons, password reset links expire after a little while. If you still need to reset your password, you can {0}."
 msgstr "出于安全原因，密码重置链接会在一段时间后失效。如果仍然需要重设密码，则可以{0}。"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:106
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:88
 msgid "Save new password"
 msgstr "存储新密码"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:424
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:514
 msgid "No matching result"
 msgstr "无匹配结果"
 
@@ -13689,26 +13806,26 @@ msgid "or"
 msgstr "或"
 
 #: frontend/src/metabase/entities/databases/forms.js:39
-#: frontend/src/metabase/entities/databases/forms.js:226
-#: frontend/src/metabase/entities/databases/forms.js:266
+#: frontend/src/metabase/entities/databases/forms.js:227
+#: frontend/src/metabase/entities/databases/forms.js:267
 #: frontend/src/metabase/entities/users/forms.js:59
 #: frontend/src/metabase/lib/validate.js:6
 msgid "required"
 msgstr "需要"
 
-#: frontend/src/metabase/entities/databases/forms.js:257
+#: frontend/src/metabase/entities/databases/forms.js:258
 msgid "Database type"
 msgstr "数据库类型"
 
-#: frontend/src/metabase/entities/databases/forms.js:291
+#: frontend/src/metabase/entities/databases/forms.js:292
 msgid "This is a lightweight process that checks for updates to this database’s schema. In most cases, you should be fine leaving this set to sync hourly."
 msgstr "这是一个轻量级的过程，用于检查对该数据库架构的更新。在大多数情况下，最好将此设置保持为每小时同步。"
 
-#: frontend/src/metabase/entities/databases/forms.js:299
+#: frontend/src/metabase/entities/databases/forms.js:300
 msgid "Metabase can scan the values present in each field in this database to enable checkbox filters in dashboards and questions. This can be a somewhat resource-intensive process, particularly if you have a very large database."
 msgstr "Metabase可以扫描此数据库中每个字段中存在的值，以启用仪表板和问题中的复选框过滤器。这可能会占用一些资源，特别是如果您的数据库很大。"
 
-#: frontend/src/metabase/entities/questions.js:95
+#: frontend/src/metabase/entities/questions.js:96
 msgid "Collection"
 msgstr "集合"
 
@@ -13755,7 +13872,7 @@ msgstr "分类的"
 msgid "URLs"
 msgstr "网址"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:59
 msgid "Returns the average of the values in the column."
 msgstr "返回列中值的平均值。"
 
@@ -13764,11 +13881,13 @@ msgstr "返回列中值的平均值。"
 msgid "The column whose values to average."
 msgstr "要取其平均值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
 msgid "start"
 msgstr "开始"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:15
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:431
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
 msgid "end"
 msgstr "结束"
 
@@ -13780,21 +13899,19 @@ msgstr "通过检查数字列的值来看它们是否在特定范围内"
 msgid "Rating"
 msgstr "评价"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:26
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:49
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:121
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:275
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:350
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:94
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:106
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:111
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:118
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:131
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:502
 msgid "condition"
 msgstr "状况"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:32
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:53
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:486
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:506
 msgid "output"
 msgstr "输出"
 
@@ -13802,27 +13919,27 @@ msgstr "输出"
 msgid "Tests a list of cases and returns the corresponding value of the first true case, with an optional default value if nothing else is met."
 msgstr "测试案例列表，并返回第一个真实案例的对应值，如果不满足其他条件，则返回可选的默认值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:37
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:41
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:490
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:494
 msgid "Weight"
 msgstr "重量"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:39
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:492
 msgid "Large"
 msgstr "大"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:43
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:496
 msgid "Medium"
 msgstr "中"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:45
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:498
 msgid "Small"
 msgstr "小"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:50
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:127
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:112
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:132
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:503
 msgid "Something that should evaluate to true or false."
 msgstr "应该评估为真或假的东西。"
 
@@ -13830,33 +13947,33 @@ msgstr "应该评估为真或假的东西。"
 msgid "The value that will be returned if the preceeding condition is true."
 msgstr "如果前面的条件为true，则将返回的值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
 msgid "value1"
 msgstr "值1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:60
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:92
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:233
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:466
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:479
 msgid "value2"
 msgstr "值2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:61
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:467
 msgid "Looks at the values in each argument in order and returns the first non-null value for each row."
 msgstr "按顺序查看每个参数中的值，并为每行返回第一个非空值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:470
 msgid "Comments"
 msgstr "评论"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:66
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:472
 msgid "Notes"
 msgstr "笔记"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:68
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:474
 msgid "No comments"
 msgstr "无评论"
 
@@ -13872,12 +13989,12 @@ msgstr "如果value1为空，则如果value2不为空，则返回value2，依此
 msgid "Combines two or more strings of text together."
 msgstr "将两个或多个文本字符串组合在一起。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:148
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:36
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "Last Name"
 msgstr "姓"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:85
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:235
 msgid "First Name"
 msgstr "名"
 
@@ -13889,27 +14006,27 @@ msgstr "将value2添加到此末尾。"
 msgid "This will be added to the end of value1."
 msgstr "这将被添加到value1的末尾。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:104
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
 msgid "string1"
 msgstr "字符串1"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:99
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:394
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "string2"
 msgstr "字符串2"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:100
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:395
 msgid "Checks to see if string1 contains string2 within it."
 msgstr "检查string1中是否包含string2。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:180
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:192
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Status"
 msgstr "状态"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:101
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:396
 msgid "Pass"
 msgstr "通过"
 
@@ -13917,7 +14034,7 @@ msgstr "通过"
 msgid "The contents of this string will be checked."
 msgstr "该字符串的内容将被检查。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:109
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:399
 msgid "The string of text to look for."
 msgstr "要查找的文本字符串。"
 
@@ -13925,22 +14042,22 @@ msgstr "要查找的文本字符串。"
 msgid "Returns the count of rows in the source data."
 msgstr "返回源数据中的行数。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:107
 msgid "Only counts rows where the condition is true."
 msgstr "仅计算条件为真的行。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:123
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:141
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:329
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:338
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:22
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:29
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:108
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:122
 msgid "Subtotal"
 msgstr "小计"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:134
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:14
 msgid "The additive total of rows across a breakout."
 msgstr "突破中行的总和。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:28
 msgid "The rolling sum of a column across a breakout."
 msgstr "突破中列的滚动总和。"
 
@@ -13949,53 +14066,57 @@ msgstr "突破中列的滚动总和。"
 msgid "The column to sum."
 msgstr "要汇总的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:147
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:35
 msgid "The number of distinct values in this column."
 msgstr "此列中不同值的数量。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:40
 msgid "The column whose distinct values to count."
 msgstr "要计数其不同值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:178
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:190
 #: frontend/src/metabase/lib/expressions/helper_text_strings.js:195
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:202
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:207
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:243
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:263
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:288
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:312
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:362
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:369
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:374
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:208
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:264
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:269
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:276
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:294
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:446
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:459
 msgid "text"
 msgstr "文本"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:158
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:167
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:282
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:292
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:404
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:411
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:418
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:424
 msgid "comparison"
 msgstr "比较"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:159
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:419
 msgid "Returns true if the end of the text matches the comparison text."
 msgstr "如果文本的结尾与比较文本匹配，则返回真正。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "Appetite"
 msgstr "食欲"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:160
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:420
 msgid "hungry"
 msgstr "饥饿"
 
@@ -14004,20 +14125,20 @@ msgstr "饥饿"
 msgid "A column or string of text to check."
 msgstr "要检查的一列或一串文本。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:425
 msgid "The string of text that the original text should end with."
 msgstr "原始文本应以其结尾的文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:174
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:183
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:226
 msgid "regular_expression"
 msgstr "正则表达式"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:175
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:221
 msgid "Extracts matching substrings according to a regular expression."
 msgstr "根据正则表达式提取匹配的子字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:176
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:222
 msgid "Address"
 msgstr "地址"
 
@@ -14025,7 +14146,7 @@ msgstr "地址"
 msgid "The column or string of text to search though."
 msgstr "但是，要搜索的文本列或字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:227
 msgid "The regular expression to match."
 msgstr "要匹配的正则表达式。"
 
@@ -14037,7 +14158,7 @@ msgstr "返回所有小写字母的文本字符串。"
 msgid "The column with values to convert to lowercase."
 msgstr "具有要转换为小写字母的值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:295
 msgid "Removes leading whitespace from a string of text."
 msgstr "从文本字符串中删除前导空格。"
 
@@ -14047,15 +14168,16 @@ msgstr "从文本字符串中删除前导空格。"
 msgid "The column with values you want to trim."
 msgstr "具有要修剪的值的列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:83
 msgid "Returns the largest value found in the column."
 msgstr "返回在该列中找到的最大值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:216
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:84
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:152
 msgid "Age"
 msgstr "年龄"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:220
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:88
 msgid "The numeric column whose maximum you want to find."
 msgstr "要查找其最大值的数字列。"
 
@@ -14063,21 +14185,21 @@ msgstr "要查找其最大值的数字列。"
 msgid "Returns the smallest value found in the column."
 msgstr "返回在列中找到的最小值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:228
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:72
 msgid "Salary"
 msgstr "薪水"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:232
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:76
 msgid "The numeric column whose minimum you want to find."
 msgstr "要查找其最小值的数字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:212
 msgid "position"
 msgstr "位置"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:307
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:320
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:203
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "length"
 msgstr "长度"
 
@@ -14086,7 +14208,7 @@ msgstr "长度"
 msgid "new_text"
 msgstr "new_text"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:239
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
 msgid "Replaces a part of the input text with new text."
 msgstr "用新文本替换输入文本的一部分。"
 
@@ -14114,35 +14236,35 @@ msgstr "要替换的字符数。"
 msgid "The text to use in the replacement."
 msgstr "用于替换的文本。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:286
 msgid "Removes trailing whitespace from a string of text."
 msgstr "从文本字符串中删除结尾的空格。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:271
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:95
 msgid "Returns the percent of rows in the data that match the condition, as a decimal."
 msgstr "以十进制形式返回数据中符合条件的行的百分比。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:283
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:405
 msgid "Returns true if the beginning of the text matches the comparison text."
 msgstr "如果文本的开头与比较文本匹配，则返回true。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Course Name"
 msgstr "课程名称"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:285
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:407
 msgid "Computer Science"
 msgstr "计算机科学"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:293
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:412
 msgid "The string of text that the original text should start with."
 msgstr "原始文本应以其开头的文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:300
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:47
 msgid "Calculates the standard deviation of the column."
 msgstr "计算列的标准偏差。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:301
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:48
 msgid "Population"
 msgstr "人口"
 
@@ -14150,7 +14272,7 @@ msgstr "人口"
 msgid "A numeric column."
 msgstr "一个数字列。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:308
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:204
 msgid "Returns a portion of the supplied text."
 msgstr "返回提供的文本的一部分。"
 
@@ -14158,19 +14280,19 @@ msgstr "返回提供的文本的一部分。"
 msgid "The text to return a portion of."
 msgstr "要返回的文本的一部分。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:317
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:213
 msgid "The position to start copying characters."
 msgstr "开始复制字符的位置。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:321
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:215
 msgid "The number of characters to return."
 msgstr "要返回的字符数。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:21
 msgid "Adds up all the values of the column."
 msgstr "将列的所有值相加。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:330
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:129
 msgid "The numeric column to sum."
 msgstr "要求和的数字列。"
 
@@ -14178,15 +14300,15 @@ msgstr "要求和的数字列。"
 msgid "Sums up values in a column where rows match the condition."
 msgstr "汇总行匹配条件的列中的值。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:340
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:124
 msgid "Order Status"
 msgstr "订单状态"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:342
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:126
 msgid "Valid"
 msgstr "有效的"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:277
 msgid "Removes leading and trailing whitespace from a string of text."
 msgstr "从文本字符串中删除开头和结尾的空格。"
 
@@ -14194,43 +14316,43 @@ msgstr "从文本字符串中删除开头和结尾的空格。"
 msgid "Returns the string of text in all upper case."
 msgstr "以大写形式返回文本字符串。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:375
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:196
 msgid "The column with values to convert to upper case."
 msgstr "具有要转换为大写字母的值的列。"
 
-#: frontend/src/metabase/lib/settings.js:190
+#: frontend/src/metabase/lib/settings.js:195
 msgid "must be {0} and include {1}."
 msgstr "必须是 {0} 并且包含 {1}。"
 
-#: frontend/src/metabase/lib/settings.js:192
+#: frontend/src/metabase/lib/settings.js:197
 msgid "must be {0}."
 msgstr "必须是 {0}。"
 
-#: frontend/src/metabase/lib/settings.js:194
+#: frontend/src/metabase/lib/settings.js:199
 msgid "must include {0}."
 msgstr "必须包含 {0}。"
 
-#: frontend/src/metabase/lib/settings.js:207
+#: frontend/src/metabase/lib/settings.js:212
 msgid "at least {0} character long"
 msgid_plural "at least {0} characters long"
 msgstr[0] "至少{0}个字符"
 
-#: frontend/src/metabase/lib/settings.js:216
+#: frontend/src/metabase/lib/settings.js:221
 msgid "{0} lower case letter"
 msgid_plural "{0} lower case letters"
 msgstr[0] "{0}小写字母"
 
-#: frontend/src/metabase/lib/settings.js:225
+#: frontend/src/metabase/lib/settings.js:230
 msgid "{0} upper case letter"
 msgid_plural "{0} upper case letters"
 msgstr[0] "{0}大写字母"
 
-#: frontend/src/metabase/lib/settings.js:234
+#: frontend/src/metabase/lib/settings.js:239
 msgid "{0} number"
 msgid_plural "{0} numbers"
 msgstr[0] "{0}号"
 
-#: frontend/src/metabase/lib/settings.js:239
+#: frontend/src/metabase/lib/settings.js:244
 msgid "{0} special character"
 msgid_plural "{0} special characters"
 msgstr[0] "{0}特殊字符"
@@ -14252,6 +14374,7 @@ msgid "Powered by {0}"
 msgstr "由{0}提供支持"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:195
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:574
 msgid "To:"
 msgstr "至："
 
@@ -14339,7 +14462,7 @@ msgstr "值格式"
 msgid "Full"
 msgstr "充分"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:198
 msgid "No change from last {0}"
 msgstr "与上一个{0}相比没有变化"
 
@@ -14664,7 +14787,7 @@ msgstr "生成列的见解时出错："
 msgid "Sending abandonment email!"
 msgstr "发送遗弃电子邮件！"
 
-#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/MetricForm.jsx:88
 msgid "You can create saved metrics to add a named metric option. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "您可以创建保存的指标以添加命名指标选项。保存的指标包括聚合类型，聚合字段以及您添加的任何过滤器（可选）。例如，您可以使用它来创建类似于为Orders表计算“平均价格”的官方方法。"
 
@@ -14672,15 +14795,15 @@ msgstr "您可以创建保存的指标以添加命名指标选项。保存的指
 msgid "Select and add filters to create your new segment."
 msgstr "选择并添加过滤器以创建新的细分。"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:145
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:151
 msgid "Alphabetical"
 msgstr "按字母顺序"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:147
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:153
 msgid "Smart"
 msgstr "聪明"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:170
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:176
 msgid "Column order: {0}"
 msgstr "列顺序：{0}"
 
@@ -14732,7 +14855,7 @@ msgstr "本土化"
 msgid "Instance language"
 msgstr "实例语言"
 
-#: frontend/src/metabase/admin/settings/selectors.js:237
+#: frontend/src/metabase/admin/settings/selectors.js:252
 msgid "Localization options"
 msgstr "本地化选项"
 
@@ -14804,19 +14927,20 @@ msgstr "粘贴连接字符串"
 msgid "Fill out individual fields"
 msgstr "填写各个字段"
 
-#: frontend/src/metabase/entities/snippets.js:14
+#: frontend/src/metabase/entities/snippets.js:10
 msgid "Enter some SQL here so you can reuse it later"
 msgstr "在此处输入一些SQL，以便稍后使用"
 
-#: frontend/src/metabase/entities/snippets.js:24
+#: frontend/src/metabase/entities/snippets.js:20
 msgid "Give your snippet a name"
 msgstr "给您的代码片段起个名字"
 
-#: frontend/src/metabase/entities/snippets.js:25
+#: frontend/src/metabase/entities/snippets.js:21
 msgid "Current Customers"
 msgstr "现有客户"
 
-#: frontend/src/metabase/entities/snippets.js:30
+#: frontend/src/metabase/entities/snippet-collections.js:80
+#: frontend/src/metabase/entities/snippets.js:26
 msgid "Add a description"
 msgstr "增加一个说明"
 
@@ -14824,46 +14948,47 @@ msgstr "增加一个说明"
 msgid "Use site default"
 msgstr "使用网站默认"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:247
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "find"
 msgstr "找"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:238
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:251
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:246
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "replace"
 msgstr "更换"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:248
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:258
 msgid "The text to find."
 msgstr "要查找的文字。"
 
-#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:259
 msgid "The text to use as the replacement."
 msgstr "用作替代的文本。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:19
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:24
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:33
 msgid "Editing {0}"
 msgstr "编辑{0}"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:20
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx:34
 msgid "Create your new snippet"
 msgstr "创建您的新片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:77
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:207
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:325
 msgid "Archived snippets"
 msgstr "存档片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
 msgid "Snippets are reusable bits of SQL"
 msgstr "片段是SQL的可重用位"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:117
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:153
 msgid "Create a snippet"
 msgstr "创建一个片段"
 
-#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:184
 msgid "Snippets"
 msgstr "片段"
 
@@ -15142,4 +15267,1504 @@ msgstr "值必须是关键字或字符串。"
 #: src/metabase/util/schema.clj
 msgid "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."
 msgstr "字符串必须是有效的两个字母的ISO语言或语言国家/地区代码，例如“ en”或“ en_US”。"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx:117
+msgid "Rows {0}-{1}"
+msgstr "行 {0}-{1}"
+
+#: enterprise/frontend/src/metabase-enterprise/audit_app/index.js:9
+#: enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx:77
+msgid "Audit"
+msgstr "审计"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:13
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:36
+msgid "JWT"
+msgstr "JWT"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm.jsx:26
+msgid "User attribute configuration (optional)"
+msgstr "用户属性配置(可选)"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:27
+msgid "Using {0}"
+msgstr "使用{0}"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:69
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:28
+msgid "SAML"
+msgstr "SAML"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:72
+msgid "Set up SAML-based SSO"
+msgstr "设置基于SAML的SSO"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:76
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:76
+msgid "SAML Authentication"
+msgstr "SAML认证"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:81
+msgid "Configure your identity provider (IdP)"
+msgstr "配置您的身份提供者（IdP）。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:82
+msgid "Your identity provider will need the following info about Metabase."
+msgstr "你的身份提供者将需要以下关于Metabase的信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:85
+msgid "URL the IdP should redirect back to"
+msgstr "IdP应该重定向到的URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:86
+msgid "This is called the Single Sign On URL in Okta, the Application Callback URL in Auth0,\n"
+"and the ACS (Consumer) URL in OneLogin."
+msgstr "这在Okta中称为单点登录URL，在Auth0中称为应用回调URL。\n"
+"和OneLogin中的ACS（消费者）URL。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:91
+msgid "SAML attributes"
+msgstr "SAML属性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:92
+msgid "In most IdPs, you'll need to put each of these in an input box labeled\n"
+"\"Name\" in the attribute statements section."
+msgstr "在大多数的IdP中，你需要把这些内容都放在一个标有以下字样的输入框中。\n"
+"属性语句部分的 \"名称\"。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:97
+msgid "User's email attribute"
+msgstr "用户的电子邮件属性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:102
+msgid "User's first name attribute"
+msgstr "用户的名字属性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:107
+msgid "User's last name attribute"
+msgstr "用户的姓氏属性"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:113
+msgid "Tell Metabase about your identity provider"
+msgstr "告诉Metabase您的身份供应商"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:114
+msgid "Metabase will need the following info about your provider."
+msgstr "Metabase将需要以下关于您的供应商的信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:117
+msgid "SAML Identity Provider URL"
+msgstr "SAML身份提供者URL"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:124
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:98
+msgid "SAML Identity Provider Certificate"
+msgstr "SAML身份提供者证书"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:131
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:104
+msgid "SAML Application Name"
+msgstr "SAML应用名称"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:136
+msgid "Sign SSO requests (optional)"
+msgstr "签署SSO请求（可选"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:139
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:109
+msgid "SAML Keystore Path"
+msgstr "SAML密钥店路径"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:143
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:114
+msgid "SAML Keystore Password"
+msgstr "SAML密钥库密码"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:145
+msgid "Shh..."
+msgstr "嘘..."
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:149
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:120
+msgid "SAML Keystore Alias"
+msgstr "SAML Keystore 别名"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:155
+msgid "Synchronize group membership with your SSO"
+msgstr "将群组成员与您的SSO同步"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:157
+msgid "To enable this, you'll need to create mappings to tell Metabase which group(s) your users should\n"
+"be added to based on the SSO group they're in."
+msgstr "要启用这个功能，您需要创建映射来告诉Metabase您的用户应该加入哪些组。\n"
+"根据他们所在的SSO组添加到。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:173
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:174
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:145
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:225
+msgid "Group Name"
+msgstr "集团名称"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:180
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:151
+msgid "Group attribute name"
+msgstr "集团属性名称"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:185
+msgid "Note:"
+msgstr "注："
+
+#: enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx:186
+msgid "If you change any of the settings of an existing SAML active setup, then you will need to restart Metabase for them to take effect."
+msgstr "如果您更改了现有SAML活动设置的任何设置，那么您需要重新启动Metabase才能生效。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:29
+msgid "Allows users to login via a SAML Identity Provider."
+msgstr "允许用户通过SAML身份提供者登录。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:37
+msgid "Allows users to login via a JWT Identity Provider."
+msgstr "允许用户通过JWT身份提供者登录。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:45
+msgid "Enable Password Authentication"
+msgstr "启用密码验证"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:46
+msgid "When enabled, users can additionally log in with email and password."
+msgstr "启用后，用户可以额外使用电子邮件和密码登录。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:56
+msgid "Notify admins of new SSO users"
+msgstr "通知管理员新的SSO用户"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:57
+msgid "When enabled, administrators will receive an email the first time a user uses Single Sign-On."
+msgstr "启用后，管理员将在用户首次使用单点登录时收到一封邮件。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:77
+msgid "Use the settings below to configure your SSO via SAML. If you have any questions, check out our {0}."
+msgstr "使用下面的设置，通过SAML配置你的SSO。如果您有任何问题，请查看我们的{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:83
+msgid "documentation"
+msgstr "文件"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:90
+msgid "SAML Identity Provider URI"
+msgstr "SAML身份提供者URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:182
+msgid "JWT Authentication"
+msgstr "JWT认证"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:188
+msgid "JWT Identity Provider URI"
+msgstr "JWT身份提供者URI"
+
+#: enterprise/frontend/src/metabase-enterprise/auth/index.js:197
+msgid "String used by the JWT signing key"
+msgstr "JWT签名密钥使用的字符串"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:17
+msgid "Embedding the entire Metabase app"
+msgstr "嵌入整个Metabase应用"
+
+#: enterprise/frontend/src/metabase-enterprise/embedding/index.js:18
+msgid "If you want to embed all of Metabase, enter the origins of the websites or web apps where you want to allow embedding in an iframe, separated by a space. Here are the {0} for what can be entered."
+msgstr "如果你想嵌入Metabase的所有内容，请在iframe中输入你想允许嵌入的网站或Web应用程序的来源，用空格隔开。下面是可以输入的{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:163
+msgid "Grant sandboxed access to this table"
+msgstr "授予对该表的沙箱访问权"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:170
+msgid "When users in this group view this table they'll see a version of it that's filtered by their user attributes, or a custom view of it based on a saved question."
+msgstr "当这个组中的用户查看这个表格时，他们会看到一个由他们的用户属性过滤的版本，或者是基于保存的问题的自定义视图。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:173
+msgid "How do you want to filter this table for users in this group?"
+msgstr "你想如何过滤此表中的用户？"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:192
+msgid "Pick a saved question that returns the custom view of this table that these users should see."
+msgstr "选择一个保存的问题，返回这些用户应该看到的这个表的自定义视图。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:210
+msgid "You can optionally add additional filters here based on user attributes. These filters will be applied on top of any filters that are already in this saved question."
+msgstr "您可以根据用户属性在这里选择添加额外的过滤器。这些过滤器将被应用在这个保存的问题中的任何过滤器之上。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:230
+msgid "For this option to work, your users need to have some attributes"
+msgstr "为了使这个选项有效，你的用户需要有一些属性。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:231
+msgid "To add additional filters, your users need to have some attributes"
+msgstr "要添加额外的过滤器，你的用户需要有一些属性。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:270
+msgid "No user attributes"
+msgstr "无用户属性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:271
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:457
+msgid "Pick a user attribute"
+msgstr "选择一个用户属性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:290
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a parameter"
+msgstr "选择一个参数"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:308
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:476
+msgid "Pick a column"
+msgstr "选择一列"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:328
+msgid "Users in {0} can view"
+msgstr "在{0}的用户可以查看"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:334
+msgid "rows in the {0} question"
+msgstr "行"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:337
+msgid "rows in the {0} table"
+msgstr "行数"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:347
+msgid "where {0} equals {1}"
+msgstr "其中，{0}等于{1}。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:350
+msgid "and {0} equals {1}"
+msgstr "而{0}等于{1}。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:441
+msgid "You can add attributes automatically by setting up an SSO that uses SAML, or you can enter them manually by going to the People section and clicking on the … menu on the far right."
+msgstr "您可以通过设置使用SAML的SSO自动添加属性，也可以通过进入 \"人员 \"部分并点击最右边的...菜单手动输入。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:460
+msgid "User attribute"
+msgstr "用户属性"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:462
+msgid "We can automatically get your users’ attributes if you’ve set up SSO, or you can add them manually from the \"…\" menu in the People section of the Admin Panel."
+msgstr "如果你已经设置了SSO，我们可以自动获取你的用户属性，或者你可以从管理面板的 \"人 \"部分的\"... \"菜单中手动添加他们。"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:479
+msgid "Parameter or variable"
+msgstr "参数或变量"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx:497
+msgid "equals"
+msgstr "等于"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:29
+msgid "Grant sandboxed access"
+msgstr "授予沙箱访问权"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:30
+msgid "Sandboxed access"
+msgstr "沙盒式访问"
+
+#: enterprise/frontend/src/metabase-enterprise/sandboxes/index.js:45
+msgid "Edit sandboxed access"
+msgstr "编辑沙盒访问"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:73
+msgid "Edit folder details"
+msgstr "编辑文件夹详情"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx:79
+msgid "Change permissions"
+msgstr "更改权限"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx:23
+msgid "Create your new folder"
+msgstr "创建你的新文件夹"
+
+#: enterprise/frontend/src/metabase-enterprise/snippets/index.js:22
+msgid "New folder"
+msgstr "新文件夹"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:87
+msgid "We're having trouble validating your token"
+msgstr "我们在验证您的令牌时遇到了麻烦。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:88
+msgid "Please double-check that your instance can connect to Metabase's servers"
+msgstr "请仔细检查您的实例是否可以连接到Metabase的服务器。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:93
+msgid "Get help"
+msgstr "获取帮助"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:100
+msgid "Get even more out of Metabase with the Enterprise Edition"
+msgstr "使用企业版从Metabase中获得更多的好处。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:102
+msgid "All the tools you need to quickly and easily provide reports for your customers, or to help you run and monitor Metabase in a large organization"
+msgstr "所有您需要的工具都能快速、轻松地为您的客户提供报告，或帮助您在大型组织中运行和监控Metabase。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:114
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:136
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:152
+msgid "Activate a license"
+msgstr "激活许可证"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:122
+msgid "Your trial is active with these features"
+msgstr "您的试用版在这些功能上是有效的"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:123
+msgid "Trial expires {0}"
+msgstr "试用期满{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:127
+msgid "Need help? Ready to buy?"
+msgstr "需要帮助吗？准备购买？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:128
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:144
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:181
+msgid "Talk to us"
+msgstr "与我们交流"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:141
+msgid "Your trial has expired"
+msgstr "您的试用期已过"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:143
+msgid "Need more time? Ready to buy?"
+msgstr "需要更多时间吗？准备好购买了吗？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:158
+msgid "Your features are active!"
+msgstr "你的功能是活跃的!"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:161
+msgid "Your licence is valid through {0}"
+msgstr "您的许可证有效期至{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:172
+msgid "Your license has expired"
+msgstr "你的执照已经过期"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:174
+msgid "It expired on {0}"
+msgstr "它的有效期为{0}。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:180
+msgid "Want to renew your license?"
+msgstr "想更新你的执照？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:278
+msgid "Learn how to use this"
+msgstr "学习如何使用这个"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx:285
+msgid "Not included in your current plan"
+msgstr "不包括在您目前的计划中"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:19
+msgid "Enter the token you recieved from the store"
+msgstr "输入你从商店收到的代币。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:65
+msgid "Activate"
+msgstr "激活"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:75
+msgid "Need help?"
+msgstr "需要帮助吗？"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:79
+msgid "More info about your problem."
+msgstr "更多关于您的问题的信息。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx:88
+msgid "Contact support"
+msgstr "联系支持"
+
+#: enterprise/frontend/src/metabase-enterprise/store/index.js:7
+msgid "Enterprise"
+msgstr "企业级"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:6
+msgid "Data sandboxes"
+msgstr "数据沙箱"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:7
+msgid "Make sure you're showing the right people the right data with automatic and secure filters based on user attributes."
+msgstr "通过基于用户属性的自动和安全的过滤器，确保向正确的人展示正确的数据。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:16
+msgid "White labeling"
+msgstr "白标"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:17
+msgid "Match Metabase to your brand with custom colors, your own logo and more."
+msgstr "使用自定义颜色、您自己的徽标等，使Metabase与您的品牌相匹配。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:26
+msgid "Auditing"
+msgstr "审计"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:27
+msgid "Keep an eye on performance and behavior with robust auditing tools."
+msgstr "通过强大的审计工具来关注性能和行为。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:32
+msgid "Single sign-on"
+msgstr "单点登录"
+
+#: enterprise/frontend/src/metabase-enterprise/store/lib/features.js:33
+msgid "Provide easy login that works with your exisiting authentication infrastructure."
+msgstr "提供可与您现有的身份验证基础设施配合使用的简易登录。"
+
+#: enterprise/frontend/src/metabase-enterprise/store/routes.jsx:12
+msgid "Store"
+msgstr "商店"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:34
+msgid "Application Name"
+msgstr "申请名称"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:39
+msgid "Color Palette"
+msgstr "色彩调色板"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:44
+msgid "Logo"
+msgstr "徽标"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:50
+msgid "Favicon"
+msgstr "收藏夹"
+
+#: enterprise/frontend/src/metabase-enterprise/whitelabel/index.js:55
+msgid "Landing Page"
+msgstr "登陆页"
+
+#: frontend/src/metabase/admin/people/components/GroupSelect.jsx:23
+msgid "No groups"
+msgstr "没有团体"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:79
+msgid "Permissions for {0}"
+msgstr "{0}的权限"
+
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:81
+msgid "Permissions for this folder"
+msgstr "此文件夹的权限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:297
+msgid "Grant Edit access"
+msgstr "授予编辑权限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:298
+msgid "Can modify snippets in this folder"
+msgstr "可以修改此文件夹中的片段"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:303
+msgid "Grant View access"
+msgstr "授予查看权限"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:304
+msgid "Can insert and use snippets in this folder, but can't edit the SQL they contain"
+msgstr "可以在此文件夹中插入和使用代码段，但不能编辑它们所包含的SQL。"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:310
+msgid "Can't view or insert snippets in this folder"
+msgstr "无法在此文件夹中查看或插入片段。"
+
+#: frontend/src/metabase/admin/permissions/selectors.js:814
+msgid "Also change sub-folders"
+msgstr "也可更换子文件夹"
+
+#: frontend/src/metabase/admin/settings/selectors.js:238
+msgid "First day of the week"
+msgstr "一周的第一天"
+
+#: frontend/src/metabase/auth/components/GoogleButton.jsx:74
+msgid "There was an issue signing in with Google. Please contact an administrator."
+msgstr "用谷歌登录时出现了问题。请联系管理员。"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:133
+msgid "on the"
+msgstr "在...上"
+
+#: frontend/src/metabase/components/SchedulePicker.jsx:191
+msgid "at"
+msgstr "在"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:44
+msgid "Open the Metabase actions menu"
+msgstr "打开Metabase操作菜单"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:45
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:364
+#: frontend/src/metabase/lib/click-behavior.js:151
+msgid "Do nothing"
+msgstr "什么都不做"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:48
+msgid "Go to a custom destination"
+msgstr "前往自定义目的地"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:50
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:361
+msgid "Update a dashboard filter"
+msgstr "更新仪表板过滤器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:151
+msgid "{0} updates {1} filter"
+msgid_plural "{0} updates {1} filters"
+msgstr[0] "{0}更新 {1}过滤"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:157
+msgid "{0} goes to {1}"
+msgstr "{0}到{1}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:336
+msgid "On-click behavior for each column"
+msgstr "每列的点击行为"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:360
+msgid "Go to custom destination"
+msgstr "前往自定义目的地"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:363
+msgid "Open the actions menu"
+msgstr "打开动作菜单"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:392
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:414
+msgid "Click behavior for {0}"
+msgstr "点击行为为{0}。"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:530
+msgid "Pick one or more filters to update"
+msgstr "选择一个或多个过滤器进行更新"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:549
+msgid "Saved question"
+msgstr "已保存的问题"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:555
+msgid "Link to"
+msgstr "链接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:613
+msgid "Enter a URL to link to"
+msgstr "输入链接到的URL"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:616
+msgid "You can insert the value of a column or dashboard filter using its name, like this: {{some_column}}"
+msgstr "你可以使用列或仪表板过滤器的名称插入其值，就像这样。{{some_column}}"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:620
+msgid "e.g. http://acme.com/id/{{user_id}}"
+msgstr "如：http://acme.com/id/{{用户ID}}。"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:707
+msgid "Pick a dashboard..."
+msgstr "选择一个仪表盘..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:709
+msgid "Pick a question..."
+msgstr "选一个问题..."
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:740
+msgid "Pick a dashboard to link to"
+msgstr "选择一个仪表盘链接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:741
+msgid "Pick a question to link to"
+msgstr "选择一个问题链接到"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:769
+msgid "Pass values to this dashboard's filters (optional)"
+msgstr "传递值到这个仪表板的过滤器（可选）。"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:770
+msgid "Pass values to this question's variables (optional)"
+msgstr "向本题的变量传递数值（可选）。"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:771
+msgid "Pass values to filter this question (optional)"
+msgstr "通过数值来过滤这个问题（可选）。"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:814
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:154
+msgid "Dashboard filters"
+msgstr "仪表板过滤器"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:821
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:156
+msgid "User attributes"
+msgstr "用户属性"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:826
+msgid "Customize link text (optional)"
+msgstr "自定义链接文本（可选"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:829
+msgid "E.x. Details for {{Column Name}}"
+msgstr "E.x. {{栏目名称}}的详情"
+
+#: frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx:841
+msgid "Values you can reference"
+msgstr "您可以参考的值"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:63
+msgid "No available targets"
+msgstr "没有可用的目标"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:220
+msgid "filter"
+msgstr "过滤"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:103
+msgid "variable"
+msgstr "可变的"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:112
+msgid "Other available filters"
+msgstr "其他可用的过滤器"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:113
+msgid "Avaliable filters"
+msgstr "可用的过滤器"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:117
+msgid "Other available variables"
+msgstr "其他可用变量"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:118
+msgid "Avaliable variables"
+msgstr "可变数"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:122
+msgid "Other available columns"
+msgstr "其他可用栏目"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:123
+msgid "Avaliable columns"
+msgstr "可用列数"
+
+#: frontend/src/metabase/dashboard/components/ClickMappings.jsx:221
+msgid "user attribute"
+msgstr "用户属性"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:214
+msgid "Text card"
+msgstr "文本卡"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:271
+msgid "Click behavior"
+msgstr "点击行为"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:298
+msgid "Visualization options"
+msgstr "可视化选项"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Edit series"
+msgstr "编辑系列"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:335
+msgid "Add series"
+msgstr "添加系列"
+
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:383
+msgid "On click"
+msgstr "点击后"
+
+#: frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx:25
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:301
+msgid "Change title and description"
+msgstr "更改标题和说明"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:150
+msgid "You've updated embedded params and will need to update your embed code."
+msgstr "你已经更新了嵌入参数，需要更新你的嵌入代码。"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:205
+msgid "Add question"
+msgstr "添加问题"
+
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:388
+msgid "You're editing this dashboard."
+msgstr "你正在编辑这个仪表板。"
+
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:144
+msgid "Column to filter on"
+msgstr "要过滤的列"
+
+#: frontend/src/metabase/entities/snippet-collections.js:22
+msgid "snippet collection"
+msgstr "片段集"
+
+#: frontend/src/metabase/entities/snippet-collections.js:23
+msgid "snippet collections"
+msgstr "片段集"
+
+#: frontend/src/metabase/entities/snippet-collections.js:72
+msgid "Give your folder a name"
+msgstr "给你的文件夹起个名字"
+
+#: frontend/src/metabase/entities/snippet-collections.js:73
+msgid "Something short but sweet"
+msgstr "短而甜的东西"
+
+#: frontend/src/metabase/entities/snippet-collections.js:94
+#: frontend/src/metabase/entities/snippets.js:55
+msgid "Folder this should be in"
+msgstr "这应该在文件夹中"
+
+#: frontend/src/metabase/lib/click-behavior.js:150
+msgid "Open the action menu"
+msgstr "打开操作菜单"
+
+#: frontend/src/metabase/lib/click-behavior.js:159
+msgid "{0} column has custom behavior"
+msgid_plural "{0} columns have custom behavior"
+msgstr[0] "{0}列有自定义行为"
+
+#: frontend/src/metabase/lib/click-behavior.js:172
+msgid "Go to..."
+msgstr "去..."
+
+#: frontend/src/metabase/lib/click-behavior.js:174
+msgid "Go to dashboard"
+msgstr "进入仪表盘"
+
+#: frontend/src/metabase/lib/click-behavior.js:176
+msgid "Go to question"
+msgstr "转到问题"
+
+#: frontend/src/metabase/lib/click-behavior.js:177
+msgid "Go to url"
+msgstr "转到网址"
+
+#: frontend/src/metabase/lib/click-behavior.js:180
+msgid "Filter this dashboard"
+msgstr "过滤这个仪表盘"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:7
+msgid "Returns the count of rows in the selected data."
+msgstr "返回所选数据中的行数。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:23
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:30
+msgid "The column or number to sum."
+msgstr "栏目或数字的总和。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:52
+msgid "The numeric column to get standard deviation of."
+msgstr "获取标准差的数字列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:64
+msgid "The numeric column whose values to average."
+msgstr "平均值的数值列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:71
+msgid "Returns the smallest value found in the column"
+msgstr "返回在列中找到的最小值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:96
+msgid "Google"
+msgstr "谷歌"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:119
+msgid "Sums up the specified column only for rows where the condition is true."
+msgstr "只对条件为真的行进行求和。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:139
+msgid "Returns the numeric variance for a given column."
+msgstr "返回给定列的数字方差。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:140
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:335
+msgid "Temperature"
+msgstr "溫度"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:144
+msgid "The column or number to get the variance of."
+msgstr "要获取方差的列或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:151
+msgid "Returns the median value of the specified column."
+msgstr "返回指定列的中值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:156
+msgid "The column or number to get the median of."
+msgstr "获取中位数的列或数。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:162
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:171
+msgid "percentile-value"
+msgstr "百分位值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:163
+msgid "Returns the value of the column at the percentile value."
+msgstr "返回列的百分位值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:168
+msgid "The column or number to get the percentile of."
+msgstr "得到百分位数的列或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:172
+msgid "The value of the percentile."
+msgstr "百分位数的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:179
+msgid "Returns the string of text in all lower case."
+msgstr "返回全部为小写的文本字符串。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:184
+msgid "The column with values to convert to lower case."
+msgstr "含有要转换为小写的值的列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:191
+msgid "Returns the text in all upper case."
+msgstr "返回全部大写的文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:209
+msgid "The column or text to return a portion of."
+msgstr "要返回一部分的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:224
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:257
+msgid "The column or text to search through."
+msgstr "要搜索的栏目或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:234
+msgid "Combine two or more strings of text together."
+msgstr "将两串或多串文字组合在一起。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:237
+msgid "The column or text to begin with."
+msgstr "栏目或文字开始。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:240
+msgid "This will be added to the end of value1, and so on."
+msgstr "这将被添加到value1的末尾，以此类推。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:252
+msgid "Enormous"
+msgstr "巨大的"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:254
+msgid "Gigantic"
+msgstr "巨大的"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:265
+msgid "Returns the number of characters in text."
+msgstr "返回文本中的字符数。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:270
+msgid "The column or text you want to get the length of."
+msgstr "你想得到的列或文本的长度。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:280
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:289
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:298
+msgid "The column or text you want to trim."
+msgstr "你要修剪的列或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:304
+msgid "Returns the absolute (positive) value of the specified column."
+msgstr "返回指定列的绝对值（正值）。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:305
+msgid "Debt"
+msgstr "债务"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:309
+msgid "The column or number to return absolute (positive) value of."
+msgstr "返回绝对值（正值）的列或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:316
+msgid "Rounds a decimal number down."
+msgstr "将一个小数点向下舍入。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:319
+msgid "The column or number to round down."
+msgstr "要四舍五入的栏目或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:325
+msgid "Rounds a decimal number up."
+msgstr "将小数点向上舍入。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:328
+msgid "The column or number to round up."
+msgstr "要四舍五入的栏目或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:334
+msgid "Rounds a decimal number either up or down to the nearest integer value."
+msgstr "将小数点向上或向下舍入到最接近的整数值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:339
+msgid "The column or number to round to nearest integer."
+msgstr "要四舍五入到最接近的整数的列或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:346
+msgid "Returns the square root."
+msgstr "返回平方根。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:347
+msgid "Hypotenuse"
+msgstr "下端"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:351
+msgid "The column or number to return square root value of."
+msgstr "返回列或数字的平方根值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:357
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "exponent"
+msgstr "指数"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:358
+msgid "Raises a number to the power of the exponent value."
+msgstr "将一个数字提高到指数值的幂。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:359
+msgid "Length"
+msgstr "长度"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:363
+msgid "The column or number raised to the exponent."
+msgstr "列或数字提高到指数。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:365
+msgid "The value of the exponent."
+msgstr "指数的值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:371
+msgid "Returns the base 10 log of the number."
+msgstr "返回数字的基数为10的对数。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:372
+msgid "Value"
+msgstr "价值"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:376
+msgid "The column or number to return the natural logarithm value of."
+msgstr "要返回自然对数值的列或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:383
+msgid "Returns Euler's number, e, raised to the power of the supplied number."
+msgstr "返回欧拉数e，升到所提供数字的幂。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:384
+msgid "Interest Months"
+msgstr "利息月数"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:388
+msgid "The column or number to return the exponential value of."
+msgstr "返回指数值的列或数字。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:398
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:409
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:422
+msgid "The column or text to check."
+msgstr "要检查的栏目或文本。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:432
+msgid "Checks a date or number column's values to see if they're within the specified range."
+msgstr "检查日期或数字列的值是否在指定范围内。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:433
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:448
+msgid "Created At"
+msgstr "创建于"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:437
+msgid "The date or numeric column that should be within the start and end values."
+msgstr "应在开始和结束值内的日期或数字列。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:439
+msgid "The beginning of the range."
+msgstr "范围的开始。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:440
+msgid "The end of the range."
+msgstr "范围的尽头。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:447
+msgid "Checks a date column's values to see if they're within the relative range."
+msgstr "检查日期列的值是否在相对范围内。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:452
+msgid "The date column to return interval of."
+msgstr "返回日期列的间隔。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:456
+msgid "Period of interval, where negative values are back in time."
+msgstr "间隔期，负值在时间上回。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:460
+msgid "Type of internal like \"day\", \"month\", \"year\"."
+msgstr "像 \"日\"、\"月\"、\"年 \"这样的内部类型。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:477
+msgid "The column or value to return."
+msgstr "要返回的列或值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:480
+msgid "If value1 is empty, value2 gets returned if its not empty, and so on."
+msgstr "如果value1为空，如果value2不为空则返回，以此类推。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:487
+msgid "Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met."
+msgstr "根据case列表测试表达式，并返回第一个匹配case的对应值，如果没有满足其他条件，则返回一个可选的默认值。"
+
+#: frontend/src/metabase/lib/expressions/helper_text_strings.js:507
+msgid "The value that will be returned if the preceding condition is true, and so on."
+msgstr "如果前面的条件为真，将返回的值，以此类推。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:392
+#: frontend/src/metabase/lib/schema_metadata.js:402
+msgid "Is null"
+msgstr "是无效的"
+
+#: frontend/src/metabase/lib/schema_metadata.js:393
+#: frontend/src/metabase/lib/schema_metadata.js:403
+msgid "Not null"
+msgstr "不为零"
+
+#: frontend/src/metabase/lib/schema_metadata.js:544
+msgid "Additive sum of all the values of a column.\n"
+"e.x. total revenue over time."
+msgstr "一个列的所有值的加和。\n"
+"如x.一段时间内的总收入。"
+
+#: frontend/src/metabase/lib/schema_metadata.js:553
+msgid "Additive count of the number of rows.\n"
+"e.x. total number of sales over time."
+msgstr "行数的加法统计。\n"
+"如：×段时间内的销售总数。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:19
+msgid "Linked filters"
+msgstr "关联过滤器"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:67
+msgid "Label"
+msgstr "标签"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:74
+msgid "Default value"
+msgstr "默认值"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:81
+msgid "No default"
+msgstr "无缺省"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:140
+msgid "To view this, {0} must be connected to at least one field."
+msgstr "要查看这个，{0}必须连接到至少一个字段。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:166
+msgid "Limit this filter's choices"
+msgstr "限制该过滤器的选择"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:169
+msgid "If you have another dashboard filter, you can limit the choices that are listed for this filter based on the selection of the other one."
+msgstr "如果您有另一个仪表板过滤器，您可以根据另一个过滤器的选择来限制该过滤器列出的选择。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:170
+msgid "So first, {0}."
+msgstr "所以首先，{0}。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:174
+msgid "add another dashboard filter"
+msgstr "添加另一个仪表板过滤器"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:179
+msgid "If you toggle on one of these dashboard filters, selecting a value for that filter will limit the available choices for {0} filter."
+msgstr "如果您切换到这些仪表板过滤器中的一个，为该过滤器选择一个值将限制{0}过滤器的可用选择。"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:212
+msgid "Filtering column"
+msgstr "筛选列"
+
+#: frontend/src/metabase/parameters/components/ParameterSidebar.jsx:213
+msgid "Filtered column"
+msgstr "筛选栏"
+
+#: frontend/src/metabase/pulse/components/RecipientPicker.jsx:66
+msgid "Enter user names or email addresses"
+msgstr "输入用户名或电子邮件地址"
+
+#: frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx:245
+msgid "New snippet"
+msgstr "新片段"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:317
+msgid "{0}:00 PM"
+msgstr "{0}:00下午"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:319
+msgid "12:00 AM"
+msgstr "上午12:00"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:321
+msgid "{0}:00 AM"
+msgstr "{0}:00 AM"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:364
+msgid "Hourly"
+msgstr "每小时"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:368
+msgid "Daily at {0}"
+msgstr "每天在{0}"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:374
+msgid "Weekly at {0} on {1}"
+msgstr "每周在{0}上进行{1}。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:381
+msgid "Monthly on the {0} {1} at {2}"
+msgstr "每月在{0}{1}上{2}。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:439
+msgid "Delete this subscription"
+msgstr "删除此订阅"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:458
+msgid "Subscriptions"
+msgstr "订阅"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:502
+msgid "Create a dashboard subscription"
+msgstr "创建一个仪表板订阅"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:517
+msgid "Email it"
+msgstr "电子邮件"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:520
+msgid "You can send this dashboard regularly to users or email addresses."
+msgstr "您可以定期向用户或电子邮件地址发送此仪表板。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:536
+msgid "Send it to Slack"
+msgstr "发送到Slack"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:539
+msgid "Pick a channel and a schedule, and Metabase will do the rest."
+msgstr "选择一个频道和时间表，Metabase将做其余的工作。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:569
+msgid "Email this dashboard"
+msgstr "通过电子邮件发送此仪表板"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:605
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:686
+msgid "Don't send if there aren't results"
+msgstr "没有结果就不要发了"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:613
+msgid "Attach results"
+msgstr "附上结果"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:618
+msgid "Attachments can contain up to 2,000 rows of data."
+msgstr "附件最多可以包含2,000行数据。"
+
+#: frontend/src/metabase/sharing/components/SharingSidebar.jsx:665
+msgid "Send this dashboard to Slack"
+msgstr "将此仪表板发送到Slack"
+
+#: src/metabase/api/dashboard.clj
+msgid "Dashboard does not have a parameter with the ID {0}"
+msgstr "仪表盘没有一个ID为{0}的参数。"
+
+#: src/metabase/api/dashboard.clj
+msgid "Parameter {0} does not have any Fields associated with it"
+msgstr "参数{0}没有任何与之相关的字段。"
+
+#: src/metabase/api/database.clj
+msgid "include must be either empty or the value 'tables'"
+msgstr "include必须是空的，或者是值'tables'。"
+
+#: src/metabase/api/dataset.clj
+msgid "`database` is required for all queries whose type is not `internal`."
+msgstr "所有类型不是 \"内部 \"的查询都需要 \"数据库\"。"
+
+#: src/metabase/api/session.clj
+msgid "Password login is disabled for this instance."
+msgstr "本实例的密码登录被禁用。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled. Please contact your administrator."
+msgstr "您的账户已被禁用。请联系您的管理员。"
+
+#: src/metabase/api/session.clj
+msgid "Your account is disabled."
+msgstr "您的账户已被禁用。"
+
+#: src/metabase/api/slack.clj
+msgid "Invalid Slack token."
+msgstr "无效的Slack令牌。"
+
+#: src/metabase/cmd.clj
+msgid "The ''{0}'' command is only available in Metabase Enterprise Edition."
+msgstr "''{0}''命令仅在Metabase企业版中可用。"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are PRESENT."
+msgstr "Metabase企业版扩展是存在的。"
+
+#: src/metabase/core.clj
+msgid "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License."
+msgstr "Metabase企业版功能的使用受Metabase商业许可的约束。"
+
+#: src/metabase/core.clj
+msgid "See {0} for details."
+msgstr "详见{0}。"
+
+#: src/metabase/core.clj
+msgid "Metabase Enterprise Edition extensions are NOT PRESENT."
+msgstr "Metabase企业版扩展不存在。"
+
+#: src/metabase/email/messages.clj
+msgid "You''re invited to join {0}''s {1}"
+msgstr "你被邀请加入{0}的{1}。"
+
+#: src/metabase/email/messages.clj
+msgid "{0} created a {1} account"
+msgstr "{0}创建了一个{1}账户"
+
+#: src/metabase/email/messages.clj
+msgid "{0} accepted their {1} invite"
+msgstr "{0}接受了他们{1}的邀请"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Password Reset Request"
+msgstr "[{0}] 密码重置请求"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Notification"
+msgstr "[{0}] 通知"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Help make [{1}] better."
+msgstr "[{0}]帮助使[{1}]更好。"
+
+#: src/metabase/email/messages.clj
+msgid "[{0}] Tell us how things are going."
+msgstr "[{0}] 告诉我们事情的进展。"
+
+#: src/metabase/events.clj
+msgid "Error starting events listener"
+msgstr "错误启动事件监听器"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Should we sync user attributes when someone logs in via LDAP?"
+msgstr "当有人通过LDAP登录时，我们是否应该同步用户属性？"
+
+#: src/metabase/integrations/ldap.clj
+msgid "Comma-separated list of user attributes to skip syncing for LDAP users."
+msgstr "以逗号分隔的用户属性列表，以跳过LDAP用户的同步。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Invalid token"
+msgstr "无效令牌"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack API error: {0}"
+msgstr "Slack API错误。{0}"
+
+#: src/metabase/integrations/slack.clj
+msgid "Slack channel named `metabase_files` is missing!"
+msgstr "名为 \"metabase_files \"的Slack频道不见了!"
+
+#: src/metabase/integrations/slack.clj
+msgid "Please create or unarchive the channel in order to complete the Slack integration."
+msgstr "请创建或解密该频道，以完成Slack的整合。"
+
+#: src/metabase/integrations/slack.clj
+msgid "The channel is used for storing graphs that are included in Pulses and MetaBot answers."
+msgstr "该通道用于存储Pulses和MetaBot答案中包含的图形。"
+
+#: src/metabase/integrations/slack.clj
+msgid "Uploaded image"
+msgstr "上传的图片"
+
+#: src/metabase/integrations/slack.clj
+msgid "Error uploading file to Slack:"
+msgstr "上传文件到Slack时出错。"
+
+#: src/metabase/middleware/session.clj
+msgid "Invalid session. Expected an instance of Session."
+msgstr "无效会话。期待一个会话的实例。"
+
+#: src/metabase/middleware/session.clj
+msgid "Session cookie's SameSite is configured to \"None\", but site is"
+msgstr "Session cookie的SameSite配置为 \"None\"，但站点是"
+
+#: src/metabase/middleware/session.clj
+msgid "served over an insecure connection. Some browsers will reject "
+msgstr "通过不安全的连接提供服务。有些浏览器会拒绝 "
+
+#: src/metabase/middleware/session.clj
+msgid "cookies under these conditions. "
+msgstr "饼干在这些条件下。 "
+
+#: src/metabase/middleware/session.clj
+msgid "https://www.chromestatus.com/feature/5633521622188032"
+msgstr "https://www.chromestatus.com/feature/5633521622188032"
+
+#: src/metabase/models/collection.clj
+msgid "Top folder"
+msgstr "顶级文件夹"
+
+#: src/metabase/models/dashboard.clj
+msgid ":parameters must be a sequence of maps with String :id keys"
+msgstr ":参数必须是一个带有String :id键的映射序列。"
+
+#: src/metabase/models/field_values.clj
+msgid "Invalid human-readable-values: values must be a sequence; each item must be nil or a string"
+msgstr "无效的人类可读值：值必须是一个序列；每个项目必须是零或一个字符串。"
+
+#: src/metabase/models/field_values.clj
+msgid ":values must be present to fetch :human_readable_values"
+msgstr ":values必须存在才能获取 :human_readable_values。"
+
+#: src/metabase/models/field_values.clj
+msgid "Field values total length is > {0}."
+msgstr "字段值总长度>{0}。"
+
+#: src/metabase/models/native_query_snippet.clj
+msgid "snippet names cannot include '}' or start with spaces"
+msgstr "代码段名称不能包含'}'或以空格开头。"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Error executing chain filter query"
+msgstr "执行链式过滤器查询时出错"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Field {0} does not exist."
+msgstr "字段{0}不存在。"
+
+#: src/metabase/models/params/chain_filter.clj
+msgid "Cannot search against non-Text Field {0} {1}"
+msgstr "不能对非文本字段{0}{1}进行检索。"
+
+#: src/metabase/models/permissions.clj
+msgid "Granting permissions for group {0}: {1}"
+msgstr "授予{0}组的权限。{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Revoking permissions for group {0}: {1}"
+msgstr "撤销{0}组的权限。{1}"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have write access for native queries, you must have full data access."
+msgstr "无效的DB权限：如果你有本地查询的写权限，你必须有完整的数据访问权限。"
+
+#: src/metabase/models/permissions.clj
+msgid "Invalid DB permissions: if you have readonly native query access, you must also have data access."
+msgstr "无效的DB权限：如果你有只读的本机查询访问权限，你也必须有数据访问权限。"
+
+#: src/metabase/models/permissions.clj
+msgid "Changing permissions from: {0} to: {1}"
+msgstr "将权限从：{0}改为：{1}。{1}"
+
+#: src/metabase/models/user.clj
+msgid "login attribute keys must be a keyword or string"
+msgstr "登录属性键必须是关键字或字符串。"
+
+#: src/metabase/public_settings.clj
+msgid "The default language for all users across the Metabase UI, system emails, pulses, and alerts."
+msgstr "Metabase用户界面、系统邮件、脉冲和警报中所有用户的默认语言。"
+
+#: src/metabase/public_settings.clj
+msgid "Users can individually override this default language from their own account settings."
+msgstr "用户可以在自己的账户设置中单独覆盖该默认语言。"
+
+#: src/metabase/public_settings.clj
+msgid "Default page to show the user"
+msgstr "显示用户的默认页面"
+
+#: src/metabase/public_settings.clj
+msgid "Allow this origin to embed the full Metabase application"
+msgstr "允许该原点嵌入完整的Metabase应用。"
+
+#: src/metabase/public_settings.clj
+msgid "Values greater than {0} ({1}) are not allowed."
+msgstr "不允许有大于{0}（{1}）的值。"
+
+#: src/metabase/public_settings.clj
+msgid "This will replace the word \"Metabase\" wherever it appears."
+msgstr "这将取代所有出现的 \"Metabase \"一词。"
+
+#: src/metabase/public_settings.clj
+msgid "These are the primary colors used in charts and throughout Metabase. You might need to refresh your browser to see your changes take effect."
+msgstr "这些是图表和整个Metabase中使用的主要颜色。您可能需要刷新浏览器才能看到您的更改生效。"
+
+#: src/metabase/public_settings.clj
+msgid "For best results, use an SVG file with a transparent background."
+msgstr "为了达到最佳效果，请使用透明背景的SVG文件。"
+
+#: src/metabase/public_settings.clj
+msgid "The url or image that you want to use as the favicon."
+msgstr "你想作为favicon使用的url或图片。"
+
+#: src/metabase/public_settings.clj
+msgid "Allow logging in by email and password."
+msgstr "允许通过电子邮件和密码登录。"
+
+#: src/metabase/public_settings.clj
+msgid "This will affect things like grouping by week or filtering in GUI queries.\n"
+"  It won''t affect SQL queries."
+msgstr "这将会影响到诸如按周分组或在GUI查询中进行过滤。\n"
+"  它不会影响SQL查询。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Unable to validate token"
+msgstr "无法验证令牌"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Token format is invalid."
+msgstr "令牌格式无效。"
+
+#: src/metabase/public_settings/metastore.clj
+msgid "Error validating token"
+msgstr "验证令牌时出错"
+
+#: src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+msgid "Error filtering against {0} Field: unable to parse String {1} to a {2}"
+msgstr "错误过滤{0}字段：无法将字符串{1}解析为{2}。"
+
+#: src/metabase/task.clj
+msgid "Error fetching details for Job: {0}"
+msgstr "获取Job的详细信息时出错。{0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Starting sync task for Database {0}."
+msgstr "开始数据库{0}的同步任务。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Cannot sync Database {0}: Database does not exist."
+msgstr "无法同步数据库{0}。数据库不存在。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Update Field values task triggered for Database {0}."
+msgstr "触发数据库{0}的更新字段值任务。"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Skipping update, automatic Field value updates are disabled for Database {0}."
+msgstr "跳过更新，数据库{0}的字段值自动更新被禁用。"
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/13519
Closes https://github.com/metabase/metabase/issues/13558

As usual with these translation PRs, this one isn't really reviewable. But as always, I went through the process of using our script to pull from POEditor via the API, then verifying translations via ` /bin/i18n/build-translation-resources` to find and then manually remove extraneous newline characters and other errors.