### PR TITLE
Fix null handling in filters regression

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -69,7 +69,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Add filter").click();
   });
 
-  it.skip("should filter a joined table by 'Is not' filter (metabase#13534)", () => {
+  it("should filter a joined table by 'Is not' filter (metabase#13534)", () => {
     // NOTE: the original issue mentions "Is not" and "Does not contain" filters
     // we're testing for one filter only to keep things simple
 

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Products").click();
     // add filter
     cy.findByText("Filter").click();
-    cy.findByText("Product").click();
+    cy.findByText("Products").click();
     cy.findByText("Category").click();
     cy.findByText("Is").click();
     cy.findByText("Is not").click();

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -80,7 +80,12 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Products").click();
     // add filter
     cy.findByText("Filter").click();
-    cy.findByText("Products").click();
+    popover().within(() => {
+      // we've run into weird "name normalization" issue
+      // where it displays "Product" locally, and "Products" in CI
+      // also, we need to eliminate "Product ID" - that's why I used `$`
+      cy.contains(/products?$/i).click();
+    });
     cy.findByText("Category").click();
     cy.findByText("Is").click();
     cy.findByText("Is not").click();
@@ -92,7 +97,7 @@ describe("scenarios > question > filter", () => {
     // wait for results to load
     cy.get(".LoadingSpinner").should("not.exist");
     cy.log("**The point of failure in 0.37.0-rc3**");
-    cy.findAllByText("Doohickey");
+    cy.contains("37.65");
     cy.findByText("There was a problem with your question").should("not.exist");
     // this is not the point of this repro, but additionally make sure the filter is working as intended on "Gizmo"
     cy.findByText("3621077291879").should("not.exist"); // one of the "Gizmo" EANs

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -217,7 +217,7 @@ describe("scenarios > question > native", () => {
     cy.contains("Native query").click();
     cy.get(".ace_content")
       .should("be.visible")
-      .type(`SELECT null AS "V" UNION ALL SELECT 'This has a value' AS "V"`);
+      .type(`SELECT null AS "V", 1 as "N" UNION ALL SELECT 'This has a value' AS "V", 2 as "N"`);
     cy.findByText("Save").click();
 
     modal().within(() => {

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -209,7 +209,7 @@ describe("scenarios > question > native", () => {
     cy.location("pathname").should("match", /\/question\/\d+/);
   });
 
-  it.skip(`shouldn't remove rows containing NULL when using "Is not" or "Does not contain" filter (metabase#13332)`, () => {
+  it(`shouldn't remove rows containing NULL when using "Is not" or "Does not contain" filter (metabase#13332)`, () => {
     const FILTERS = ["Is not", "Does not contain"];
     const QUESTION = "QQ";
 

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -217,7 +217,9 @@ describe("scenarios > question > native", () => {
     cy.contains("Native query").click();
     cy.get(".ace_content")
       .should("be.visible")
-      .type(`SELECT null AS "V", 1 as "N" UNION ALL SELECT 'This has a value' AS "V", 2 as "N"`);
+      .type(
+        `SELECT null AS "V", 1 as "N" UNION ALL SELECT 'This has a value' AS "V", 2 as "N"`,
+      );
     cy.findByText("Save").click();
 
     modal().within(() => {

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -640,8 +640,8 @@
 (defn- correct-null-behaviour
   [driver [op & args]]
   (let [field-arg (mbql.u/match-one args
-                    FieldInstance               &match
-                    #{:field-id :field-literal} &match)]
+                    FieldInstance                             &match
+                    #{:joined-field :field-id :field-literal} &match)]
     ;; We must not transform the head again else we'll have an infinite loop
     ;; (and we can't do it at the call-site as then it will be harder to fish out field references)
     [:or (into [op] (map (partial ->honeysql driver)) args)

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -230,4 +230,13 @@
     (is (= [[nil] ["bar"]]
            (query-on-dataset-with-nils {:filter [:not [:contains [:field-literal "A" :type/Text] "f"]]})))
     (is (= [[nil] ["bar"]]
-           (query-on-dataset-with-nils {:filter [:!= [:field-literal "A" :type/Text] "foo"]})))))
+           (query-on-dataset-with-nils {:filter [:!= [:field-literal "A" :type/Text] "foo"]}))))
+  (testing "Null behaviour correction fix should work with joined fields (#13534)"
+    (is (= [[1000]]
+           (mt/rows
+             (mt/run-mbql-query checkins
+               {:filter      [:!= &u.users.name "foo"]
+                :aggregation [:count]
+                :joins       [{:source-table $$users
+                               :alias        "u"
+                               :condition    [:= $user_id &u.users.id]}]}))))))


### PR DESCRIPTION
Fixes a regression where the code emitted for `:does-not-contain` & co didn't correctly account for fields wrapped in `joined-fields`.

Also fixes Cypress test for the original feature.

Fixes #13534