### PR TITLE
add guard against null aggregation options

### DIFF
--- a/frontend/src/metabase/lib/query/aggregation.js
+++ b/frontend/src/metabase/lib/query/aggregation.js
@@ -120,7 +120,7 @@ export function hasOptions(aggregation: any): boolean {
   return Array.isArray(aggregation) && aggregation[0] === "aggregation-options";
 }
 export function getOptions(aggregation: any): AggregationOptions {
-  return hasOptions(aggregation) ? aggregation[2] : {};
+  return hasOptions(aggregation) && aggregation[2] ? aggregation[2] : {};
 }
 export function getContent(aggregation: any): Aggregation {
   return hasOptions(aggregation) ? aggregation[1] : aggregation;

--- a/frontend/test/metabase/lib/query/aggregation.unit.spec.js
+++ b/frontend/test/metabase/lib/query/aggregation.unit.spec.js
@@ -1,0 +1,10 @@
+import { getName } from "metabase/lib/query/aggregation";
+
+describe("getName", () => {
+  it("should work with blank display name", () => {
+    // we no longer allow this state, but some existing expressions are missing names
+    expect(getName(["aggregation-options", ["+", ["count"], 3], null])).toEqual(
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #10844 

You're prevented from created metrics with unnamed custom expressions, but if any existed they would cause failures. I added a guard to avoid the exception.

I'll change the base branch to `release-0.37.x` once it exists.