### PR TITLE
Repro for #13062: Multiple dashboard filter values not parsed on drill-through (numeric values)

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -234,7 +234,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
     cy.log("**Test the second case reported in this issue**");
     // go back to the dashboard
-    cy.visit("/dashboard/2?category=5&category=4");
+    cy.visit("/dashboard/6?category=5&category=4");
     cy.findByText("2 selections");
 
     cy.findByText("Reviews").click(); // the card title


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- reproduces #13062 

### How should this be tested
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js`
- all tests should pass

### Additional notes:
- it seems that this issue was fixed recently 