### PR TITLE
Bump snowflake driverfor "GEOGRAPHY" type (#13505) [ci drivers]

### DIFF
--- a/modules/drivers/snowflake/project.clj
+++ b/modules/drivers/snowflake/project.clj
@@ -2,7 +2,7 @@
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[net.snowflake/snowflake-jdbc "3.12.7"]]
+  [[net.snowflake/snowflake-jdbc "3.12.13"]]
 
   :profiles
   {:provided

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -101,6 +101,7 @@
     :CHARACTER                  :type/Text
     :STRING                     :type/Text
     :TEXT                       :type/Text
+    :GEOGRAPHY                  :type/SerializedJSON
     :BINARY                     :type/*
     :VARBINARY                  :type/*
     :BOOLEAN                    :type/Boolean


### PR DESCRIPTION
just bumping the driver gets us the GEOGRAPHY type in the snowflake
types enum. We mark it automatically as `:type/*` but can do better
marking as `:type/SerializedJSON`.

Results look like (from metadata-queries/table-rows-sample)

```clojure
[["1"
  true
  #t "2020-10-23T00:00"
  1
  "{\n  \"coordinates\": [\n    0,\n    0\n  ],\n  \"type\": \"Point\"\n}"]]
```

and field information:

```clojure
{:name "E",
 :id 1857,
 :special_type :type/Category,
 :database_type "GEOGRAPHY",
 :base_type :type/SerializedJSON}
```

```sql
create or replace table metabase_bug (
    a string,
    b number,
    c boolean,
    d timestamp_ntz,
    e geography
);

insert into metabase_bug values
    ('1', 1, true, current_date(), 'POINT(0 0)');
```

fixes https://github.com/metabase/metabase/issues/13505