### PR TITLE
Repro for #13571: Display rows whose value is `null`

### DIFF
--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -3,11 +3,38 @@ import {
   signInAsAdmin,
   openOrdersTable,
   popover,
+  withSampleDataset,
 } from "__support__/cypress";
 
 describe("scenarios > question > null", () => {
   before(restore);
   beforeEach(signInAsAdmin);
+
+  it.skip("should display rows whose value is `null` (metabase#13571)", () => {
+    withSampleDataset(({ ORDERS }) => {
+      cy.request("POST", "/api/card", {
+        name: "13571",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": 2,
+            fields: [ORDERS.DISCOUNT],
+            filter: ["=", ORDERS.ID, 1],
+          },
+          type: "query",
+        },
+        display: "table",
+        visualization_settings: {},
+      });
+
+      // find and open previously created question
+      cy.visit("/collection/root");
+      cy.findByText("13571").click();
+
+      cy.log("**'No Results reported in v0.37.0**");
+      cy.contains("37.65"); // subtotal for order #1
+    });
+  });
 
   describe("aggregations with null values", () => {
     beforeEach(() => {

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -31,8 +31,8 @@ describe("scenarios > question > null", () => {
       cy.visit("/collection/root");
       cy.findByText("13571").click();
 
-      cy.log("**'No Results reported in v0.37.0**");
-      cy.contains("37.65"); // subtotal for order #1
+      cy.log("**'No Results since at least v0.34.3**");
+      cy.findByText("No results!").should("not.exist");
     });
   });
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- reproduces #13571 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/nulls.cy.spec.js`
- replace `it.skip()` with `it.only()` to test this in isolation
- the test should fail until related issue is fixed

### Additional notes:
- once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- make sure test is passing and
- merge it together with the fix