### PR TITLE
Specify location on getQueryResults calls

### DIFF
--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -152,7 +152,8 @@
         job-ref (.getJobReference query-response)
         job-id (.getJobId job-ref)
         proj-id (.getProjectId job-ref)
-        response (#'bigquery/get-query-results client proj-id job-id nil)]
+        location (.getLocation job-ref)
+        response (#'bigquery/get-query-results client proj-id job-id location nil)]
     (#'bigquery/post-process-native @details respond response)))
 
 (defprotocol ^:private Insertable


### PR DESCRIPTION
You must specify the location on any getQueryResults calls to BigQuery.
It's supposed to be optional for anything but EU and US regions, but
useast1 seems to require it.

Fixes #13582

[ci bigquery]
