### PR TITLE
Consolidate table metadata requests

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -1483,7 +1483,12 @@ export default class StructuredQuery extends AtomicQuery {
     // source-table, if set
     const tableId = this.sourceTableId();
     if (tableId) {
-      addDependency({ type: "table", id: tableId, foreignTables });
+      addDependency({
+        type: "table",
+        id: tableId,
+        databaseId: this.databaseId(),
+        foreignTables,
+      });
     }
 
     // any explicitly joined tables


### PR DESCRIPTION
Possible fix for #13100 

This PR attempts to consolidate metadata loading requests.

When loading metadata for initial dashboard load or when listing cards, we check to see if there are >5 tables from a single db. If there are, we load the entire db's metadata instead. This probably speeds up many cases when browsers block parallel http1 requests.

I expect there are some cases where this slow things down though. I'll need to poke it things a bit more before merging.

I also want to look at any special cases around the saved questions db. Edge cases there both might break things and provide better optimization paths.