### PR TITLE
[[null]] is a valid response

### DIFF
--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -20,9 +20,8 @@ type ColumnSetting = {
   enabled: boolean,
 };
 
-// Many aggregations result in [[null]] if there are no rows to aggregate after filters
 export const datasetContainsNoResults = (data: DatasetData): boolean =>
-  data.rows.length === 0 || _.isEqual(data.rows, [[null]]);
+  data.rows == null || data.rows.length === 0;
 
 /**
  * @returns min and max for a value in a column

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -10,7 +10,7 @@ describe("scenarios > question > null", () => {
   before(restore);
   beforeEach(signInAsAdmin);
 
-  it.skip("should display rows whose value is `null` (metabase#13571)", () => {
+  it("should display rows whose value is `null` (metabase#13571)", () => {
     withSampleDataset(({ ORDERS }) => {
       cy.request("POST", "/api/card", {
         name: "13571",

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -3,11 +3,38 @@ import {
   signInAsAdmin,
   openOrdersTable,
   popover,
+  withSampleDataset,
 } from "__support__/cypress";
 
 describe("scenarios > question > null", () => {
   before(restore);
   beforeEach(signInAsAdmin);
+
+  it.skip("should display rows whose value is `null` (metabase#13571)", () => {
+    withSampleDataset(({ ORDERS }) => {
+      cy.request("POST", "/api/card", {
+        name: "13571",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": 2,
+            fields: [ORDERS.DISCOUNT],
+            filter: ["=", ORDERS.ID, 1],
+          },
+          type: "query",
+        },
+        display: "table",
+        visualization_settings: {},
+      });
+
+      // find and open previously created question
+      cy.visit("/collection/root");
+      cy.findByText("13571").click();
+
+      cy.log("**'No Results since at least v0.34.3**");
+      cy.findByText("No results!").should("not.exist");
+    });
+  });
 
   describe("aggregations with null values", () => {
     beforeEach(() => {


### PR DESCRIPTION
Previously, this said that a result of `[[null]]` was an empty result
set, but in reality, it's a valid result set of a single column with a
null value.
    
Resolves #13571