### PR TITLE
Show engine in Task trouble shooting logs

### DIFF
--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
@@ -76,10 +76,10 @@ class TasksApp extends React.Component {
               const db = task.db_id ? databaseByID[task.db_id] : null;
               const name = db ? db.name : null;
               const engine = db ? db.engine : null;
+              // only want unknown if there is a db on the task and we don't have info
               return (
                 <tr key={task.id}>
                   <td className="text-bold">{task.task}</td>
-                  // only want unknown if there is a db on the task and we don't have info
                   <td>{task.db_id ? name || t`Unknown name` : null}</td>
                   <td>{task.db_id ? engine || t`Unknown engine` : null}</td>
                   <td>{task.started_at}</td>

--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { t } from "ttag";
 import { Box, Flex } from "grid-styled";
 
+import Database from "metabase/entities/databases";
 import Task from "metabase/entities/tasks";
 
 import AdminHeader from "metabase/components/AdminHeader";
@@ -12,16 +13,22 @@ import Tooltip from "metabase/components/Tooltip";
 @Task.loadList({
   pageSize: 50,
 })
+@Database.loadList()
 class TasksApp extends React.Component {
   render() {
     const {
       tasks,
+      databases,
       page,
       pageSize,
       onNextPage,
       onPreviousPage,
       children,
     } = this.props;
+    let db_id_to_engine = {};
+    for (const db of databases) {
+      db_id_to_engine[db.id] = db.engine;
+    }
     return (
       <Box p={3}>
         <Flex align="center">
@@ -53,18 +60,26 @@ class TasksApp extends React.Component {
 
         <table className="ContentTable mt2">
           <thead>
-            <th>{t`Task`}</th>
-            <th>{t`DB ID`}</th>
-            <th>{t`Started at`}</th>
-            <th>{t`Ended at`}</th>
-            <th>{t`Duration (ms)`}</th>
-            <th>{t`Details`}</th>
+            <tr>
+              <th>{t`Task`}</th>
+              <th>{t`DB ID`}</th>
+              <th>{t`Engine`}</th>
+              <th>{t`Started at`}</th>
+              <th>{t`Ended at`}</th>
+              <th>{t`Duration (ms)`}</th>
+              <th>{t`Details`}</th>
+            </tr>
           </thead>
           <tbody>
             {tasks.map(task => (
               <tr key={task.id}>
                 <td className="text-bold">{task.task}</td>
                 <td>{task.db_id}</td>
+                <td>
+                  {task.db_id
+                    ? db_id_to_engine[task.db_id] || "Unknown engine"
+                    : null}
+                </td>
                 <td>{task.started_at}</td>
                 <td>{task.ended_at}</td>
                 <td>{task.duration}</td>

--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
@@ -25,7 +25,7 @@ class TasksApp extends React.Component {
       onPreviousPage,
       children,
     } = this.props;
-    let db_id_to_engine = {};
+    const db_id_to_engine = {};
     for (const db of databases) {
       db_id_to_engine[db.id] = db.engine;
     }

--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
@@ -25,9 +25,10 @@ class TasksApp extends React.Component {
       onPreviousPage,
       children,
     } = this.props;
-    const db_id_to_engine = {};
+    const databaseByID = {};
+    // index databases by id for lookup
     for (const db of databases) {
-      db_id_to_engine[db.id] = db.engine;
+      databaseByID[db.id] = db;
     }
     return (
       <Box p={3}>
@@ -62,8 +63,8 @@ class TasksApp extends React.Component {
           <thead>
             <tr>
               <th>{t`Task`}</th>
-              <th>{t`DB ID`}</th>
-              <th>{t`Engine`}</th>
+              <th>{t`DB Name`}</th>
+              <th>{t`DB Engine`}</th>
               <th>{t`Started at`}</th>
               <th>{t`Ended at`}</th>
               <th>{t`Duration (ms)`}</th>
@@ -71,26 +72,28 @@ class TasksApp extends React.Component {
             </tr>
           </thead>
           <tbody>
-            {tasks.map(task => (
-              <tr key={task.id}>
-                <td className="text-bold">{task.task}</td>
-                <td>{task.db_id}</td>
-                <td>
-                  {task.db_id
-                    ? db_id_to_engine[task.db_id] || "Unknown engine"
-                    : null}
-                </td>
-                <td>{task.started_at}</td>
-                <td>{task.ended_at}</td>
-                <td>{task.duration}</td>
-                <td>
-                  <Link
-                    className="link text-bold"
-                    to={`/admin/troubleshooting/tasks/${task.id}`}
-                  >{t`View`}</Link>
-                </td>
-              </tr>
-            ))}
+            {tasks.map(task => {
+              const db = task.db_id ? databaseByID[task.db_id] : null;
+              const name = db ? db.name : null;
+              const engine = db ? db.engine : null;
+              return (
+                <tr key={task.id}>
+                  <td className="text-bold">{task.task}</td>
+                  // only want unknown if there is a db on the task and we don't have info
+                  <td>{task.db_id ? name || t`Unknown name` : null}</td>
+                  <td>{task.db_id ? engine || t`Unknown engine` : null}</td>
+                  <td>{task.started_at}</td>
+                  <td>{task.ended_at}</td>
+                  <td>{task.duration}</td>
+                  <td>
+                    <Link
+                      className="link text-bold"
+                      to={`/admin/troubleshooting/tasks/${task.id}`}
+                    >{t`View`}</Link>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         {


### PR DESCRIPTION
## Including database engine


<img width="1152" alt="image" src="https://user-images.githubusercontent.com/6377293/97368599-4acd2580-1879-11eb-8c0e-95897a7bc93d.png">

---
#### When no database:

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/6377293/97368633-5882ab00-1879-11eb-8e31-c5f7e38ff717.png">


in an effort to get better feedback when people raise issues about
long running sync processes, include the database engine in the logs.

Also wrapped `th` in a `tr` inside the `thead` to remove react warning
