### PR TITLE
tweak webpack config for more legible output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -234,6 +234,21 @@ if (NODE_ENV === "hot") {
     headers: {
       "Access-Control-Allow-Origin": "*",
     },
+    // tweak stats to make the output in the console more legible
+    // TODO - once we update webpack to v4+ we can just use `errors-warnings` preset
+    stats: {
+      assets: false,
+      cached: false,
+      cachedAssets: false,
+      chunks: false,
+      chunkModules: false,
+      chunkOrigins: false,
+      modules: false,
+      color: true,
+      hash: false,
+      warnings: true,
+      errorDetals: false,
+    },
     // if webpack doesn't reload UI after code change in development
     // watchOptions: {
     //     aggregateTimeout: 300,


### PR DESCRIPTION
This is one of those "very angry at myself for not doing this years ago" PRs. When running `yarn run dev` or `yarn run build-hot` there's a lot of info that gets printed, most of which I've rarely / never needed and crowds up the console. This configures the output to present more useful day to day info, like any warnings or errors and dispenses with the detailed chunk /module info.

Before:
![image](https://user-images.githubusercontent.com/5248953/97352876-9d064a80-1869-11eb-86a9-374206db531e.png)

After
![image](https://user-images.githubusercontent.com/5248953/97352995-d8087e00-1869-11eb-9e45-7deaa4bc51f7.png)

Best part is if there is an error, it's much easier to spot now. 
![image](https://user-images.githubusercontent.com/5248953/97354253-7f39e500-186b-11eb-90b5-114aec1e07a3.png)
