### PR TITLE
Fix Cypress flake in `admin/settings/settings` spec file

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -64,7 +64,7 @@ describe("scenarios > admin > settings", () => {
     cy.findByText("Save changes");
   });
 
-  it.skip("should save a setting", () => {
+  it("should save a setting", () => {
     cy.server();
     cy.route("PUT", "**/admin-email").as("saveSettings");
 
@@ -81,8 +81,9 @@ describe("scenarios > admin > settings", () => {
 
     emailInput()
       .click()
-      .clear()
-      .type("other.email@metabase.com")
+      // "hack" substitute for `cy.clear()` as per:
+      // https://github.com/cypress-io/cypress/issues/2056#issuecomment-702607741
+      .type("{selectall}other.email@metabase.com")
       .blur();
     cy.wait("@saveSettings");
 
@@ -91,12 +92,9 @@ describe("scenarios > admin > settings", () => {
     emailInput().should("have.value", "other.email@metabase.com");
 
     // reset the email
-    emailInput()
-      .click()
-      .clear()
-      .type("bob@metabase.com")
-      .blur();
-    cy.wait("@saveSettings");
+    cy.request("PUT", "/api/setting/admin-email", {
+      value: "bob@metabase.com",
+    });
   });
 
   it("should check for working https before enabling a redirect", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- fixes Cypress flake in `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`

### Additional notes:
- although this flake does not appear that often, it was skipped in https://github.com/metabase/metabase/commit/91ff78a2a24cadfa176cccc88b231aecdbfc37c3
- the flake is related (like many others) to the `cy.type()` and/or `cy.clear()` commands
- this is the example of [the latest failed run](https://app.circleci.com/pipelines/github/metabase/metabase/9910/workflows/b1fef466-db72-4669-be78-b3d55d1f5422/jobs/348726) in CI (it's clear that `clear()` /pun intended/  didn't do its job)
- there is a "hack" proposed in [this comment](https://github.com/cypress-io/cypress/issues/2056#issuecomment-702607741) that uses `.type("{selectall}some-text")`
- this PR tries that approach (it was successful locally)