### PR TITLE
Repro for #12872: `Between Dates` filter (in)consistency

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -115,10 +115,15 @@ describe("scenarios > question > filter", () => {
             aggregation: [["count"]],
             filter: [
               "and",
-              ["between", PRODUCTS.CREATED_AT, "2019-04-15", "2019-04-15"],
               [
                 "between",
-                ["joined-field", "Products", ["field-id", 7]],
+                ["field-id", PRODUCTS.CREATED_AT],
+                "2019-04-15",
+                "2019-04-15",
+              ],
+              [
+                "between",
+                ["joined-field", "Products", ["field-id", PRODUCTS.CREATED_AT]],
                 "2019-04-15",
                 "2019-04-15",
               ],
@@ -128,8 +133,8 @@ describe("scenarios > question > filter", () => {
                 alias: "Products",
                 condition: [
                   "=",
-                  PRODUCTS.ID,
-                  ["joined-field", "Products", ["field-id", 8]],
+                  ["field-id", PRODUCTS.ID],
+                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
                 ],
                 fields: "all",
                 "source-table": 1,


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- reproduces #12872 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- replace `it.skip()` with `it.only()` to test it in isolation
- the test should fail until the related issue is fixed

### Additional notes:
- once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- make sure test is passing and
- merge it together with the fix