### PR TITLE
Fix MB_EDITION ENTERPRISE vs ee confusion

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,9 +4,14 @@ set -e
 
 MB_EDITION=${MB_EDITION:=oss}
 
+if [ "$MB_EDITION" != ee ] && [ "$MB_EDITION" != oss ]; then
+    echo "MB_EDITION must be either 'ee' or 'oss'."
+    exit 1
+fi
+
 # Generate the resources/version.properties file
 version() {
-    VERSION_INFO=$(./bin/version $MB_EDITION)
+    VERSION_INFO=$(./bin/version)
     IFS=', ' read -a info <<< ${VERSION_INFO}
 
     echo "Tagging uberjar with version '$VERSION_INFO'..."
@@ -51,13 +56,8 @@ drivers() {
 
 uberjar() {
     lein clean
-    if [ "$MB_EDITION" = "ENTERPRISE" ]; then
-        echo "Running 'lein with-profile +ee uberjar'..."
-        lein with-profile +ee uberjar
-    else
-        echo "Running 'lein uberjar'..."
-        lein uberjar
-    fi
+    echo "Running 'lein with-profile +$MB_EDITION uberjar'..."
+    lein with-profile +$MB_EDITION uberjar
 }
 
 all() {

--- a/bin/docker/build_image.sh
+++ b/bin/docker/build_image.sh
@@ -7,6 +7,10 @@ PROJECT_ROOT="$BASEDIR/../.."
 
 DOCKERHUB_NAMESPACE=metabase
 
+if [ ! -z "$MB_EDITION" ] && [ "$MB_EDITION" != ee ] && [ "$MB_EDITION" != oss ]; then
+    echo "MB_EDITION must be either 'ee' or 'oss'."
+    exit 1
+fi
 
 BUILD_TYPE=$1
 if [ -z $BUILD_TYPE ]; then
@@ -37,7 +41,7 @@ fi
 
 
 if [ "$BUILD_TYPE" == "release" ]; then
-    if [ "$MB_EDITION" = "ENTERPRISE" ]; then
+    if [ "$MB_EDITION" = ee ]; then
         DOCKERHUB_REPO=metabase-enterprise
     else
         DOCKERHUB_REPO=metabase

--- a/bin/release/release/uberjar.clj
+++ b/bin/release/release/uberjar.clj
@@ -39,7 +39,7 @@
                         "PATH"      (env/env :path)
                         "HOME"      (env/env :user-home)}
                        (when (= (c/edition) :ee)
-                         {"MB_EDITION" "ENTERPRISE"}))}
+                         {"MB_EDITION" "ee"}))}
           "bin/build")
     (u/step "Verify uberjar exists"
       (u/assert-file-exists c/uberjar-path))))

--- a/bin/test-load-and-dump.sh
+++ b/bin/test-load-and-dump.sh
@@ -5,28 +5,33 @@ set -eou pipefail xtrace
 SOURCE_DB="$(pwd)/frontend/test/__runner__/test_db_fixture.db"
 DEST_DB="$(pwd)/dump.db"
 
-MB_EDTION=${MB_EDITION:=oss}
+MB_EDITION=${MB_EDITION:=oss}
+
+if [ "$MB_EDITION" != ee ] && [ "$MB_EDITION" != oss ]; then
+    echo "MB_EDITION must be either 'ee' or 'oss'."
+    exit 1
+fi
 
 echo -e "\n********************************************************************************"
 echo "Migrating $SOURCE_DB..."
 echo -e "********************************************************************************\n"
 
-MB_DB_TYPE=h2 MB_DB_FILE="$SOURCE_DB" lein with-profiles +$MB_EDITION run migrate up
+MB_DB_TYPE=h2 MB_DB_FILE="$SOURCE_DB" lein with-profile +$MB_EDITION run migrate up
 
 echo -e "\n********************************************************************************"
 echo "Loading data from H2 $SOURCE_DB into Postgres/MySQL..."
 echo -e "********************************************************************************\n"
 
-lein with-profiles +$MB_EDITION run load-from-h2 "$SOURCE_DB"
+lein with-profile +$MB_EDITION run load-from-h2 "$SOURCE_DB"
 
 echo -e "\n********************************************************************************"
 echo "Dumping data from Postgres/MySQL into H2 $DEST_DB..."
 echo -e "********************************************************************************\n"
 
-lein with-profiles +$MB_EDITION run dump-to-h2 "$DEST_DB"
+lein with-profile +$MB_EDITION run dump-to-h2 "$DEST_DB"
 
 echo -e "\n********************************************************************************"
 echo "Comparing contents of $SOURCE_DB and $DEST_DB..."
 echo -e "********************************************************************************\n"
 
-lein with-profiles +$MB_EDITION compare-h2-dbs "$SOURCE_DB" "$DEST_DB"
+lein with-profile +$MB_EDITION compare-h2-dbs "$SOURCE_DB" "$DEST_DB"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,7 +117,7 @@ const config = (module.exports = {
       icepick: __dirname + "/node_modules/icepick/icepick.min",
       // conditionally load either the EE plugins file or a empty file in the CE code tree
       "ee-plugins":
-        process.env.MB_EDITION === "ENTERPRISE"
+        process.env.MB_EDITION === "ee"
           ? ENTERPRISE_SRC_PATH + "/plugins"
           : SRC_PATH + "/lib/noop",
     },


### PR DESCRIPTION
In some places we were using `MB_EDITION=ENTERPRISE` (build/release scripts) and in others we were using `MB_EDITION=ee` (CircleCI). Some were using both (frontend webpack.config.json)

This unifies the usage so we now use `MB_EDITION=ee` everywhere. Adds some extra validation to make sure you're using a valid option.