### PR TITLE
Repro for #13098: Summarized distinct datetime column granularity [ci skip]

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -113,5 +113,26 @@ describe("scenarios > question > new", () => {
         .parent()
         .contains("Reviewer");
     });
+
+    it.skip("summarizing by distinct datetime should allow granular selection (metabase#13098)", () => {
+      // Go straight to orders table in custom questions
+      cy.visit("/question/new?database=1&table=2&mode=notebook");
+
+      cy.findByText("Summarize").click();
+      popover().within(() => {
+        cy.findByText("Number of distinct values of ...").click();
+        cy.log(
+          "**Test fails at this point as there isn't an extra field next to 'Created At'**",
+        );
+        // instead of relying on DOM structure that might change
+        // (i.e. find "Created At" -> parent -> parent -> parent -> find "by month")
+        // access it directly from the known common parent
+        cy.get(".List-item")
+          .contains("by month")
+          .click({ force: true });
+      });
+      // this should be among the granular selection choices
+      cy.findByText("Hour of day").click();
+    });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- reproduces #13098

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/new.cy.spec.js`
- replace `it.skip()` with `it.only()` to test this case in isolation
- test should fail until the related issue is fixed

### Additional notes:
- once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- make sure test is passing and
- merge it together with the fix