### PR TITLE
MBQL: fix generated SQL for custom columns referring to aggregations (#12762)

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -109,7 +109,7 @@ describe("scenarios > question > custom columns", () => {
     });
   });
 
-  it.skip("should create custom column with fields from aggregated data (metabase#12762)", () => {
+  it("should create custom column with fields from aggregated data (metabase#12762)", () => {
     // go straight to "orders" in custom questions
     cy.visit("/question/new?database=1&table=2&mode=notebook");
 


### PR DESCRIPTION
Fixes a bug where we were a bit too eager lifting field references from `:source-query` when building custom expression subselect.

Fixes #12762