### PR TITLE
Fix old MBQL syntax in tests

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -23,8 +23,10 @@ describe("scenarios > admin > permissions", () => {
           query: {
             "source-table": 2,
             aggregation: [["count"]],
-            breakout: [["datetime-field", ORDERS.CREATED_AT, "week"]],
-            filter: ["<", ORDERS.CREATED_AT, "2016-06-01"],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"],
+            ],
+            filter: ["<", ["field-id", ORDERS.CREATED_AT], "2016-06-01"],
           },
           type: "query",
         },

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -178,85 +178,85 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
         special_type: "type/Category",
       });
-    });
-    // 2. create a question based on Reviews
-    cy.request("POST", `/api/card`, {
-      name: "13062Q",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": 4,
+      // 2. create a question based on Reviews
+      cy.request("POST", `/api/card`, {
+        name: "13062Q",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": 4,
+          },
+          type: "query",
         },
-        type: "query",
-      },
-      display: "table",
-      visualization_settings: {},
-    }).then(({ body: { id: questionId } }) => {
-      // 3. create a dashboard
-      cy.request("POST", "/api/dashboard", {
-        name: "13062D",
-      }).then(({ body: { id: dashboardId } }) => {
-        // add filter to the dashboard
-        cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-          parameters: [
-            {
-              id: "18024e69",
-              name: "Category",
-              slug: "category",
-              type: "category",
-            },
-          ],
-        });
-
-        // add previously created question to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-          cardId: questionId,
-        }).then(({ body: { id: dashCardId } }) => {
-          // connect filter to that question
-          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-            cards: [
+        display: "table",
+        visualization_settings: {},
+      }).then(({ body: { id: questionId } }) => {
+        // 3. create a dashboard
+        cy.request("POST", "/api/dashboard", {
+          name: "13062D",
+        }).then(({ body: { id: dashboardId } }) => {
+          // add filter to the dashboard
+          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+            parameters: [
               {
-                id: dashCardId,
-                card_id: questionId,
-                row: 0,
-                col: 0,
-                sizeX: 8,
-                sizeY: 6,
-                parameter_mappings: [
-                  {
-                    parameter_id: "18024e69",
-                    card_id: questionId,
-                    target: ["dimension", ["field-id", 31]], // 31 = REVIEWS.RATING
-                  },
-                ],
+                id: "18024e69",
+                name: "Category",
+                slug: "category",
+                type: "category",
               },
             ],
           });
+
+          // add previously created question to the dashboard
+          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+            cardId: questionId,
+          }).then(({ body: { id: dashCardId } }) => {
+            // connect filter to that question
+            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+              cards: [
+                {
+                  id: dashCardId,
+                  card_id: questionId,
+                  row: 0,
+                  col: 0,
+                  sizeX: 8,
+                  sizeY: 6,
+                  parameter_mappings: [
+                    {
+                      parameter_id: "18024e69",
+                      card_id: questionId,
+                      target: ["dimension", ["field-id", REVIEWS.RATING]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+
+          // NOTE: The actual "Assertion" phase begins here
+          cy.log("**Reported failing on Metabase 1.34.3 and 0.36.2**");
+
+          cy.log("**The first case**");
+          // set filter values (ratings 5 and 4) directly through the URL
+          cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
+
+          // drill-through
+          cy.findByText("xavier").click();
+          cy.findByText("=").click();
+
+          cy.findByText("Reviewer is xavier");
+          cy.findByText("Rating is equal to 2 selections");
+          cy.contains("Reprehenderit non error"); // xavier's review
+
+          cy.log("**The second case**");
+          // go back to the dashboard
+          cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
+          cy.findByText("2 selections");
+
+          cy.findByText("13062Q").click(); // the card title
+          cy.findByText("Rating is equal to 2 selections");
+          cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
         });
-
-        // NOTE: The actual "Assertion" phase begins here
-        cy.log("**Reported failing on Metabase 1.34.3 and 0.36.2**");
-
-        cy.log("**The first case**");
-        // set filter values (ratings 5 and 4) directly through the URL
-        cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
-
-        // drill-through
-        cy.findByText("xavier").click();
-        cy.findByText("=").click();
-
-        cy.findByText("Reviewer is xavier");
-        cy.findByText("Rating is equal to 2 selections");
-        cy.contains("Reprehenderit non error"); // xavier's review
-
-        cy.log("**The second case**");
-        // go back to the dashboard
-        cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
-        cy.findByText("2 selections");
-
-        cy.findByText("13062Q").click(); // the card title
-        cy.findByText("Rating is equal to 2 selections");
-        cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
       });
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -116,13 +116,21 @@ describe("scenarios > dashboard", () => {
           filter: [">", ["field-literal", "sum", "type/Float"], 100],
           query: {
             "source-table": 2,
-            aggregation: [["sum", ORDERS.TOTAL]],
+            aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
             breakout: [
-              ["datetime-field", ORDERS.CREATED_AT, "day"],
-              ["fk->", ORDERS.PRODUCT_ID, PRODUCTS.ID],
-              ["fk->", ORDERS.PRODUCT_ID, PRODUCTS.CATEGORY],
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "day"],
+              [
+                "fk->",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["field-id", PRODUCTS.ID],
+              ],
+              [
+                "fk->",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["field-id", PRODUCTS.CATEGORY],
+              ],
             ],
-            filter: ["=", ORDERS.USER_ID, 1],
+            filter: ["=", ["field-id", ORDERS.USER_ID], 1],
           },
           type: "query",
         },

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -14,7 +14,9 @@ describe("scenarios > question > nested (metabase#12568)", () => {
           query: {
             "source-table": 2,
             aggregation: [["count"]],
-            breakout: [["datetime-field", ORDERS.CREATED_AT, "week"]],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"],
+            ],
           },
           type: "query",
         },

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -18,8 +18,8 @@ describe("scenarios > question > null", () => {
           database: 1,
           query: {
             "source-table": 2,
-            fields: [ORDERS.DISCOUNT],
-            filter: ["=", ORDERS.ID, 1],
+            fields: [["field-id", ORDERS.DISCOUNT]],
+            filter: ["=", ["field-id", ORDERS.ID], 1],
           },
           type: "query",
         },

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -32,7 +32,8 @@ describe("scenarios > question > null", () => {
       cy.findByText("13571").click();
 
       cy.log("**'No Results since at least v0.34.3**");
-      cy.findByText("No results!").should("not.exist");
+      cy.findByText("Discount");
+      cy.findByText("Empty");
     });
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes a wrong query syntax I've been using in some of the Cypress tests.
_example:_ `ORDERS.ID` instead of `["field-id", ORDERS.ID]`
- Adds a positive assertion for repro for #13571 (now that the issue is fixed and we know how the result is displayed). I know it's not technically a part of this PR, but it felt silly to open a separate PR just for this. As a rule, asserting that something doesn't exist in Cypress can lead to false positives.

### Additional info:
- discovered this by accident
- tests are passing because it seems it was still a valid syntax, just obsolete
- @dacort sent me a reference to [a piece of our documentation](https://github.com/metabase/metabase/blob/master/backend/mbql/src/metabase/mbql/normalize.clj#L13-L14) that could explain why this is still working.

> Rewriting deprecated MBQL 95/98 syntax and other things that are still supported for backwards-compatibility in
  canonical MBQL 2000 syntax. For example `{:breakout [:count 10]}` becomes `{:breakout [[:count [:field-id 10]]]}`.
