### PR TITLE
MBQL: correctly alias duplicate col names in breakouts (#10511)

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -142,3 +142,48 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     cy.get(".bar").should("have.length.of.at.least", 10);
   });
 });
+
+describe("scenarios > question > nested", () => {
+  before(() => {
+    restore();
+    signInAsAdmin();
+  });
+
+  it("should handle duplicate column names in nested queries (metabase#10511)", () => {
+    withSampleDataset(({ ORDERS, PRODUCTS }) => {
+      cy.request("POST", "/api/card", {
+        name: "10511",
+        dataset_query: {
+          database: 1,
+          query: {
+            filter: [">", ["field-literal", "count", "type/Integer"], 5],
+            "source-query": {
+              "source-table": 2,
+              aggregation: [["count"]],
+              breakout: [
+                ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+                [
+                  "datetime-field",
+                  [
+                    "fk->",
+                    ["field-id", ORDERS.PRODUCT_ID],
+                    ["field-id", PRODUCTS.CREATED_AT],
+                  ],
+                  "month",
+                ],
+              ],
+            },
+          },
+          type: "query",
+        },
+        display: "table",
+        visualization_settings: {},
+      }).then(({ body: { id: questionId } }) => {
+        cy.visit(`/question/${questionId}`);
+        cy.findByText("10511");
+        cy.findAllByText("June, 2016");
+        cy.findAllByText("13");
+      });
+    });
+  });
+});

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -577,7 +577,7 @@
                                           (remove (set fields-fields))
                                           (mapv (fn [field-clause]
                                                   (as driver field-clause unique-name-fn)))))
-      (apply h/group new-hsql (map (partial ->honeysql driver) breakout-fields))))))
+      (apply h/group new-hsql (map (partial ->honeysql driver) breakout-fields)))))
 
 (defmethod apply-top-level-clause [:sql :fields]
   [driver _ honeysql-form {fields :fields}]


### PR DESCRIPTION
Makes sure breakout names are unique.  

- Reproduces #10511 with Cypress
- Fixes #10511

