### PR TITLE
Add Cypress repro PR template [ci skip]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/cypress_repro.md
+++ b/.github/PULL_REQUEST_TEMPLATE/cypress_repro.md
@@ -1,0 +1,31 @@
+### Status
+
+PENDING CI / PENDING REVIEW / READY _(choose one and update accordingly)_
+
+### What does this PR accomplish?
+
+- Reproduces #XXXXX
+
+### How to test this manually?
+
+- `yarn test-cypress-open`
+- `relative/path/to/the/file` _(optionally, include the line number on which the test starts)_
+> _(For still unfixed bug)_
+- Replace `it.skip()` with `it.only()` to test this in isolation
+- The test should fail until the related issue is fixed
+> _(For a fixed bug)_
+- The test should pass
+
+### Additional notes:
+
+> _(For still unfixed bug)_
+- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
+- Make sure the test is passing and
+- Merge it together with the fix
+> _(For a fixed bug)_
+- Please merge this repro unskipped
+- The bug was fixed in #YYYYY
+
+### Questions:
+
+- this is optional


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds a Cypress repro pull request template, in a way that it doesn't override or interfere with the default [`PULL_REQUEST_TEMPLATE.md`](https://github.com/metabase/metabase/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

### Additional notes:
- I am writing a fair amount of Cypress repros on a daily basis. Writing the same PR text from the scratch every time is tedious and wasteful, but I still want to include as much useful information for the devs as possible. This PR semi-automates that process.
- In order to use this template, append `?template=cypress_repro.md` to the pull request URL.
- [GitHub blog](https://github.blog/2018-01-25-multiple-issue-and-pull-request-templates/) and [related documentation](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/about-automation-for-issues-and-pull-requests-with-query-parameters).