### PR TITLE
Simple refingerprinting

### DIFF
--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -288,6 +288,13 @@ const forms = {
         description: t`By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen.`,
         hidden: !engine,
       },
+      {
+        name: "refingerprint",
+        type: "boolean",
+        title: t`Periodically refingerprint tables`,
+        description: t`Metabase will scan a subset of values of fields to gather statistics to make your Metabase instance smarter.`,
+        hidden: !engine,
+      },
       { name: "is_full_sync", type: "hidden" },
       { name: "is_on_demand", type: "hidden" },
       {

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7744,3 +7744,22 @@ databaseChangeLog:
             columnName: is_active
             columnDataType: boolean
             defaultValueBoolean: true
+
+ # Add refingerprint to database to mark if fingerprinting or
+ # not. Nullable in first pass so can be opt in and then in a
+ # subsequent pass can be globally turned on where null, respecting
+ # people who turned it on and then off.
+
+  - changeSet:
+      id: 275
+      author: dpsutton
+      comment: 'Add refingerprint to Database'
+      changes:
+        - addColumn:
+            tableName: metabase_database
+            columns:
+              - column:
+                  name: refingerprint
+                  type: boolean
+                  constraints:
+                    nullable: true

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -550,9 +550,10 @@
 (api/defendpoint PUT "/:id"
   "Update a `Database`."
   [id :as {{:keys [name engine details is_full_sync is_on_demand description caveats points_of_interest schedules
-                   auto_run_queries]} :body}]
+                   auto_run_queries refingerprint]} :body}]
   {name               (s/maybe su/NonBlankString)
    engine             (s/maybe DBEngineString)
+   refingerprint      (s/maybe s/Bool)
    details            (s/maybe su/Map)
    schedules          (s/maybe ExpandedSchedulesMap)
    description        (s/maybe s/Str)                ; s/Str instead of su/NonBlankString because we don't care
@@ -581,6 +582,7 @@
                                                    {:name               name
                                                     :engine             engine
                                                     :details            details
+                                                    :refingerprint      refingerprint
                                                     :is_full_sync       full-sync?
                                                     :is_on_demand       (boolean is_on_demand)
                                                     :description        description

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -195,8 +195,8 @@
         metadata                        (matching-metadata field-id-or-name source-metadata)
         {:keys [min-value max-value]
          :as   min-max}                 (extract-bounds (when (integer? field-id-or-name) field-id-or-name)
-         (:fingerprint metadata)
-         field-id->filters)
+                                                        (:fingerprint metadata)
+                                                        field-id->filters)
         [new-strategy resolved-options] (resolve-options strategy strategy-param metadata min-value max-value)
         resolved-options                (merge min-max resolved-options)]
     ;; Bail out and use unmodifed version if we can't converge on a nice version.

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -17,9 +17,11 @@
             [schema.core :as s])
   (:import java.time.temporal.Temporal))
 
-(def SyncDatabaseResults [{:start-time Temporal
-                           :end-time   Temporal
-                           :steps      [sync-util/StepNameWithMetadata]}])
+(def SyncDatabaseResults
+  "Schema for results returned from `sync-database!`"
+  [{:start-time Temporal
+    :end-time   Temporal
+    :steps      [sync-util/StepNameWithMetadata]}])
 
 (s/defn sync-database! :- SyncDatabaseResults
   "Perform all the different sync operations synchronously for `database`.

--- a/src/metabase/sync/analyze.clj
+++ b/src/metabase/sync/analyze.clj
@@ -125,7 +125,8 @@
           results)))))
 
 (s/defn refingerprint-db!
-  "Refingerprint "
+  "Refingerprint a subset of tables in a given DATABASE.
+  This will re-fingerprint tables up to a threshold amount of `fingerprint/max-refingerprint-field-count`."
   [database :- i/DatabaseInstance]
   (sync-util/sync-operation :refingerprint database (format "Refingerprinting tables for %s" (sync-util/name-for-logging database))
     (let [tables (sync-util/db->sync-tables database)

--- a/src/metabase/sync/analyze.clj
+++ b/src/metabase/sync/analyze.clj
@@ -120,9 +120,8 @@
   (sync-util/sync-operation :analyze database (format "Analyze data for %s" (sync-util/name-for-logging database))
     (let [tables (sync-util/db->sync-tables database)]
       (sync-util/with-emoji-progress-bar [emoji-progress-bar (inc (* 3 (count tables)))]
-        (let [results (sync-util/run-sync-operation "analyze" database (make-analyze-steps tables (maybe-log-progress emoji-progress-bar)))]
-          (update-fields-last-analyzed-for-db! database tables)
-          results)))))
+        (u/prog1 (sync-util/run-sync-operation "analyze" database (make-analyze-steps tables (maybe-log-progress emoji-progress-bar)))
+          (update-fields-last-analyzed-for-db! database tables))))))
 
 (s/defn refingerprint-db!
   "Refingerprint a subset of tables in a given DATABASE.

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -151,7 +151,10 @@
    [:not-in :visibility_type ["retired" "sensitive"]]
    [:not= :base_type "type/Structured"]])
 
-(def ^:dynamic *refingerprint?* false)
+(def ^:dynamic *refingerprint?*
+  "Whether we are refingerprinting or doing the normal fingerprinting. Refingerprinting should get fields that already
+  are analyzed and have fingerprints."
+  false)
 
 (s/defn ^:private honeysql-for-fields-that-need-fingerprint-updating :- {:where s/Any}
   "Return appropriate WHERE clause for all the Fields whose Fingerprint needs to be re-calculated."

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -135,7 +135,10 @@
          [:< :fingerprint_version version]
          [:in :base_type not-yet-seen]]))))
 
-(def ^:private base-clause
+(def ^:private fields-to-fingerprint-base-clause
+  "Base clause to get fields for fingerprinting. When refingerprinting, run as is. When fingerprinting in analysis, only
+  look for fields without a fingerprint or whose version can be updated. This clauses is added on by
+  `versions-clauses`"
   [:and
    [:= :active true]
    [:or
@@ -152,7 +155,7 @@
 (s/defn ^:private honeysql-for-fields-that-need-fingerprint-updating :- {:where s/Any}
   "Return appropriate WHERE clause for all the Fields whose Fingerprint needs to be re-calculated."
   ([]
-   {:where (cond-> base-clause
+   {:where (cond-> fields-to-fingerprint-base-clause
              (not *refingerprint?*) (conj (cons :or (versions-clauses))))})
 
   ([table :- i/TableInstance]

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -144,13 +144,6 @@
    [:not-in :visibility_type ["retired" "sensitive"]]
    [:not= :base_type "type/Structured"]])
 
-(def ^:private base-clause-for-refingerprinting
-  [:and
-   [:= :active true]
-   [:not (mdb/isa :special_type :type/PK)]
-   [:not-in :visibility_type ["retired" "sensitive"]]
-   [:not= :base_type "type/Structured"]])
-
 (def ^:dynamic *refingerprint?*
   "Whether we are refingerprinting or doing the normal fingerprinting. Refingerprinting should get fields that already
   are analyzed and have fingerprints."
@@ -159,9 +152,8 @@
 (s/defn ^:private honeysql-for-fields-that-need-fingerprint-updating :- {:where s/Any}
   "Return appropriate WHERE clause for all the Fields whose Fingerprint needs to be re-calculated."
   ([]
-   {:where (if *refingerprint?*
-             base-clause-for-refingerprinting
-             (conj base-clause (cons :or (versions-clauses))))})
+   {:where (cond-> base-clause
+             (not *refingerprint?*) (conj (cons :or (versions-clauses))))})
 
   ([table :- i/TableInstance]
    (h/merge-where (honeysql-for-fields-that-need-fingerprint-updating)

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -135,22 +135,34 @@
          [:< :fingerprint_version version]
          [:in :base_type not-yet-seen]]))))
 
+(def ^:private base-clause
+  [:and
+   [:= :active true]
+   [:or
+    [:not (mdb/isa :special_type :type/PK)]
+    [:= :special_type nil]]
+   [:not-in :visibility_type ["retired" "sensitive"]]
+   [:not= :base_type "type/Structured"]])
+
+(def ^:private base-clause-for-refingerprinting
+  [:and
+   [:= :active true]
+   [:not (mdb/isa :special_type :type/PK)]
+   [:not-in :visibility_type ["retired" "sensitive"]]
+   [:not= :base_type "type/Structured"]])
+
+(def ^:dynamic *refingerprint?* false)
+
 (s/defn ^:private honeysql-for-fields-that-need-fingerprint-updating :- {:where s/Any}
   "Return appropriate WHERE clause for all the Fields whose Fingerprint needs to be re-calculated."
   ([]
-   {:where [:and
-            [:= :active true]
-            [:or
-             [:not (mdb/isa :special_type :type/PK)]
-             [:= :special_type nil]]
-            [:not-in :visibility_type ["retired" "sensitive"]]
-            [:not= :base_type "type/Structured"]
-            (cons :or (versions-clauses))]})
+   {:where (if *refingerprint?*
+             base-clause-for-refingerprinting
+             (conj base-clause (cons :or (versions-clauses))))})
 
   ([table :- i/TableInstance]
    (h/merge-where (honeysql-for-fields-that-need-fingerprint-updating)
                   [:= :table_id (u/get-id table)])))
-
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                      FINGERPRINTING ALL FIELDS IN A TABLE                                      |
@@ -176,19 +188,55 @@
         stats))
     (empty-stats-map 0)))
 
+(s/defn fingerprint-fields-for-db!*
+  "Invokes `fingerprint-fields!` on every table in `database`"
+  ([database :- i/DatabaseInstance
+    tables :- [i/TableInstance]
+    log-progress-fn]
+   (fingerprint-fields-for-db!* database tables log-progress-fn (constantly true)))
+  ;; TODO: Maybe the driver should have a function to tell you if it supports fingerprinting?
+  ([database :- i/DatabaseInstance
+    tables :- [i/TableInstance]
+    log-progress-fn
+    continue?]
+   (qp.store/with-store
+     ;; store is bound so DB timezone can be used in date coercion logic
+     (qp.store/store-database! database)
+     (reduce (fn [acc table]
+               (log-progress-fn (if *refingerprint?* "fingerprint-fields" "refingerprint-fields") table)
+               (let [results (if (= :googleanalytics (:engine database))
+                               (empty-stats-map 0)
+                               (fingerprint-fields! table))
+                     new-acc (merge-with + acc results)]
+                 (if (continue? new-acc)
+                   new-acc
+                   (reduced new-acc))))
+             (empty-stats-map 0)
+             tables))))
+
 (s/defn fingerprint-fields-for-db!
   "Invokes `fingerprint-fields!` on every table in `database`"
   [database :- i/DatabaseInstance
    tables :- [i/TableInstance]
    log-progress-fn]
   ;; TODO: Maybe the driver should have a function to tell you if it supports fingerprinting?
-  (qp.store/with-store
-    ;; store is bound so DB timezone can be used in date coercion logic
-    (qp.store/store-database! database)
-    (apply merge-with + (for [table tables
-                              :let  [result (if (= :googleanalytics (:engine database))
-                                              (empty-stats-map 0)
-                                              (fingerprint-fields! table))]]
-                          (do
-                            (log-progress-fn "fingerprint-fields" table)
-                            result)))))
+  (fingerprint-fields-for-db!* database tables log-progress-fn))
+
+(def max-refingerprint-field-count
+  "Maximum number of fields to refingerprint. Balance updating our fingerprinting values while not spending too much
+  time in the db."
+  1000)
+
+(s/defn refingerprint-fields-for-db!
+  "Invokes `fingeprint-fields!` on every table in `database` up to some limit."
+  [database :- i/DatabaseInstance
+   tables :- [i/TableInstance]
+   log-progress-fn]
+  (binding [*refingerprint?* true]
+    (fingerprint-fields-for-db!* database
+                                 ;; our rudimentary refingerprint strategy is to shuffle the tables and fingerprint
+                                 ;; until we are over some threshold of fields
+                                 (shuffle tables)
+                                 log-progress-fn
+                                 (fn [stats-acc]
+                                   (< (:fingerprints-attempted stats-acc) max-refingerprint-field-count)))))

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -85,13 +85,13 @@
      (let [start-time    (System/nanoTime)
            tracking-hash (str (java.util.UUID/randomUUID))]
        (events/publish-event! begin-event-name {:database_id (u/get-id database-or-id), :custom_id tracking-hash})
-       (f)
-       (let [total-time-ms (int (/ (- (System/nanoTime) start-time)
+       (let [return        (f)
+             total-time-ms (int (/ (- (System/nanoTime) start-time)
                                    1000000.0))]
          (events/publish-event! end-event-name {:database_id  (u/get-id database-or-id)
                                                 :custom_id    tracking-hash
-                                                :running_time total-time-ms}))
-       nil))))
+                                                :running_time total-time-ms})
+         return)))))
 
 (defn- with-start-and-finish-logging*
   "Logs start/finish messages using `log-fn`, timing `f`"
@@ -433,7 +433,8 @@
                        :end-time   end-time
                        :steps      step-metadata}]
     (store-sync-summary! operation database sync-metadata)
-    (log-sync-summary operation database sync-metadata)))
+    (log-sync-summary operation database sync-metadata)
+    sync-metadata))
 
 (defn sum-numbers
   "Similar to a 2-arg call to `map`, but will add all numbers that result from the invocations of `f`. Used mainly for

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -71,7 +71,7 @@
       ;; only run analysis if this is a "full sync" database
       (when (:is_full_sync database)
         (let [results (analyze/analyze-db! database)]
-          (when (should-refingerprint-fields? results)
+          (when (and (:refingerprint database) (should-refingerprint-fields? results))
             (analyze/refingerprint-db! database)))))))
 
 (jobs/defjob ^{org.quartz.DisallowConcurrentExecution true} SyncAndAnalyzeDatabase [job-context]

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -6,6 +6,7 @@
              [jobs :as jobs]
              [triggers :as triggers]]
             [clojurewerkz.quartzite.schedule.cron :as cron]
+            [java-time :as t]
             [metabase
              [task :as task]
              [util :as u]]
@@ -37,6 +38,26 @@
 ;; The DisallowConcurrentExecution on the two defrecords below attaches an annotation to the generated class that will
 ;; constrain the job execution to only be one at a time. Other triggers wanting the job to run will misfire.
 
+(def ^:private analyze-duration-threshold-for-refingerprinting
+  "If the `analyze-db!` step is shorter than this number of MINUTES, then we may refingerprint fields."
+  5)
+
+(defn- should-refingerprint-fields?
+  "Whether to refingerprint fields in the database. Looks at the runtime of the last analysis and if any fields were
+  fingerprinted. If no fields were fingerprinted and the run was shorter than the threshold, it will re-fingerprint
+  some fields."
+  [{:keys [start-time end-time steps] :as _analyze-results}]
+  (let [attempted (some->> steps
+                           (filter (fn [[step-name _results]] (= step-name "fingerprint-fields")))
+                           first
+                           second
+                           :fingerprints-attempted)]
+    (and (number? attempted)
+         (zero? attempted)
+         start-time
+         end-time
+         (< (.toMinutes (t/duration start-time end-time)) analyze-duration-threshold-for-refingerprinting))))
+
 (defn- sync-and-analyze-database!
   "The sync and analyze database job, as a function that can be used in a test"
   [job-context]
@@ -49,7 +70,9 @@
       (sync-metadata/sync-db-metadata! database)
       ;; only run analysis if this is a "full sync" database
       (when (:is_full_sync database)
-        (analyze/analyze-db! database)))))
+        (let [results (analyze/analyze-db! database)]
+          (when (should-refingerprint-fields? results)
+            (analyze/refingerprint-db! database)))))))
 
 (jobs/defjob ^{org.quartz.DisallowConcurrentExecution true} SyncAndAnalyzeDatabase [job-context]
   (sync-and-analyze-database! job-context))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -50,6 +50,7 @@
     :cache_field_values_schedule "0 50 0 * * ? *"
     :metadata_sync_schedule      "0 50 * * * ? *"
     :options                     nil
+    :refingerprint               nil
     :auto_run_queries            true}))
 
 (defn- table-defaults []

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -114,10 +114,12 @@
                                                                                        3 #{:type/URL}
                                                                                        4 #{:type/Float}}]
              (#'fingerprint/honeysql-for-fields-that-need-fingerprint-updating)))))
-  (testing "when refingerprinting doesn't check for versions and special type being nil"
+  (testing "when refingerprinting doesn't check for versions"
     (is (= {:where [:and
                     [:= :active true]
-                    [:not (mdb/isa :special_type :type/PK)]
+                    [:or
+                     [:not (mdb/isa :special_type :type/PK)]
+                     [:= :special_type nil]]
                     [:not-in :visibility_type ["retired" "sensitive"]]
                     [:not= :base_type "type/Structured"]]}
            (binding [fingerprint/*refingerprint?* true]

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -222,6 +222,17 @@
       (testing "\nsame test but with sync triggered programatically rather than via the API"
         (tests analyze-table!)))))
 
+(deftest analyze-db!-return-value-test
+  (testing "Returns values"
+    (mt/with-temp* [Table [table (fake-table)]
+                    Field [field (fake-field table)]]
+      (let [results (analyze-table! table)]
+        (testing "has the steps performed"
+          (is (= ["fingerprint-fields" "classify-fields" "classify-tables"]
+                 (->> results :steps (map first)))))
+        (testing "has start and finish times"
+          (is (seq (select-keys results [:start-time :end-time]))))))))
+
 (deftest analyze-unhidden-tables-test
   (testing "un-hiding a table should cause it to be analyzed"
     (mt/with-temp* [Table [table (fake-table)]

--- a/test/metabase/sync_test.clj
+++ b/test/metabase/sync_test.clj
@@ -198,7 +198,12 @@
                 {:name         "studio"
                  :display_name "Studio"
                  :fields       [(field:studio-name) (field:studio-studio)]})
-               studio))))))
+               studio)))))
+  (testing "stuff"
+    (mt/with-temp Database [db {:engine ::sync-test}]
+      (let [results (sync/sync-database! db)]
+        (is (= ["metadata" "analyze" "field-values"]
+               (map :name results)))))))
 
 (deftest sync-table-test
   (mt/with-temp* [Database [db {:engine ::sync-test}]


### PR DESCRIPTION
If scheduled analyze task is short, refingerprint tables

- make the sync steps return their values rather than log and nil
- dynamic var in fingerprint.clj to swap out query clauses for fields
- update the fingerprint runner to not consume whole list when
    refingerprinting
- algorithm for fields to refingerprint: shuffle table and do up to
    1000 fields
- we refingerprint after analyzing in the task if two conditions hold:
   1. the analysis lasted under 5 minutes
      Don't want to hog our CPU or connections
   2. no fields were fingerprinted.
      The first analysis will fingerprint everything and analyze
      fields base on that. Seems subsequently we almost never
      fingerprint unless its a new field.
- manual overrides to prevent these refingerprinting. In this PR it is opt IN and a nullable boolean. This allows us to opt in and opt out again. In the future we can make this opt OUT and default the value to true where is not null.

# Gist
![image](https://user-images.githubusercontent.com/6377293/98042021-73f53500-1de8-11eb-8005-81be3bf1d0cf.png)

largely the important code changes:

## run from the every 50 minutes sync task
```clojure
;; logic in metabase.task.sync-databases
(defn- should-refingerprint-fields?
  "Whether to refingerprint fields in the database. Looks at the runtime of the last analysis and if any fields were
  fingerprinted. If no fields were fingerprinted and the run was shorter than the threshold, it will re-fingerprint
  some fields."
  [{:keys [start-time end-time steps] :as _analyze-results}]
  (let [attempted (some->> steps
                           (filter (fn [[step-name _results]] (= step-name "fingerprint-fields")))
                           first
                           second
                           :fingerprints-attempted)]
    (and (number? attempted)
         (zero? attempted)
         start-time
         end-time
         (< (.toMinutes (t/duration start-time end-time)) analyze-duration-threshold-for-refingerprinting))))

;; logic in the task runner
      (sync-metadata/sync-db-metadata! database)
      ;; only run analysis if this is a "full sync" database
      (when (:is_full_sync database)
        (let [results (analyze/analyze-db! database)]
          (when (and (:refingerprint database) (should-refingerprint-fields? results))
            (analyze/refingerprint-db! database))))
```

## super simple refingerprinting strategy:
```clojure
(s/defn refingerprint-fields-for-db!
  "Invokes `fingeprint-fields!` on every table in `database` up to some limit."
  [database :- i/DatabaseInstance
   tables :- [i/TableInstance]
   log-progress-fn]
  (binding [*refingerprint?* true]
    (fingerprint-fields-for-db!* database
                                 ;; our rudimentary refingerprint strategy is to shuffle the tables and fingerprint
                                 ;; until we are over some threshold of fields
                                 (shuffle tables) ;; in future can have UI to select important tables or possibly look at
                                                           ;; query stats for frequently used/ frequently changed
                                 log-progress-fn
                                 (fn [stats-acc] ;; reduce over the shuffled tables until predicate signals we should stop
                                                          ;; in future could make this time based limitation
                                   (< (:fingerprints-attempted stats-acc) max-refingerprint-field-count)))))
```

Mostly everything else is details.

TODO for the future to make it better:

- better strategies for what to refingerprint. Right now just picks
tables at random. We don't have a place to write down frequency of use
of tables nor if the fingerprints are changing substantially (for some
notion of substantial). Also, only date and number fingerprints are
used by the app at the moment. Could just bias to these fields for the
moment.
- Our analysis doesn't override if there's already a special_type (Or
other field things). We don't capture if special_type and other
aspects of a field are manually computed (and therefore a candidate to
use ongoing fingerprint results (state fields based on percentage of
state values, etc). If this becomes the case and our analysis can
become more mature to improving insights and knowing its not
clobbering a human override/input we could just make the initial
fingerprint smarter.

As it stands this step is after the normal fingerprinting so that we
don't accidentally do too much work and because we can't really use
the information in the analysis/classify steps yet.
