### PR TITLE
Repro for #13626: Pie chart shows spinner for `0` or `null` [ci skip]

### DIFF
--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -109,6 +109,7 @@ describe("scenarios > question > null", () => {
           cy.findByText("13626D");
 
           cy.log("**Reported failing in v0.37.0.2**");
+          // TODO: Once the issue is fixed, add a positive asssertion here
           cy.get(".DashCard").within(() => {
             cy.get(".LoadingSpinner").should("not.exist");
           });

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -37,6 +37,86 @@ describe("scenarios > question > null", () => {
     });
   });
 
+  it.skip("(metabase#13626)", () => {
+    // Preparation for the test: "Arrange and Act phase" - see repro steps in #13626
+    withSampleDataset(({ ORDERS }) => {
+      // 1. create a question
+      cy.request("POST", "/api/card", {
+        name: "13626",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": 2,
+            aggregation: [["sum", ["expression", "NewDiscount"]]],
+            breakout: [["field-id", ORDERS.ID]],
+            expressions: {
+              NewDiscount: [
+                "case",
+                [[["=", ["field-id", ORDERS.ID], 2], 0]],
+                { default: ["field-id", ORDERS.DISCOUNT] },
+              ],
+            },
+            filter: ["=", ["field-id", ORDERS.ID], 1, 2, 3],
+          },
+          type: "query",
+        },
+        display: "pie",
+        visualization_settings: {},
+      }).then(({ body: { id: questionId } }) => {
+        // 2. create a dashboard
+        cy.request("POST", "/api/dashboard", {
+          name: "13626D",
+        }).then(({ body: { id: dashboardId } }) => {
+          // add filter (ID) to the dashboard
+          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+            parameters: [
+              {
+                id: "1f97c149",
+                name: "ID",
+                slug: "id",
+                type: "id",
+              },
+            ],
+          });
+
+          // add previously created question to the dashboard
+          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+            cardId: questionId,
+          }).then(({ body: { id: dashCardId } }) => {
+            // connect filter to that question
+            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+              cards: [
+                {
+                  id: dashCardId,
+                  card_id: questionId,
+                  row: 0,
+                  col: 0,
+                  sizeX: 8,
+                  sizeY: 6,
+                  parameter_mappings: [
+                    {
+                      parameter_id: "1f97c149",
+                      card_id: questionId,
+                      target: ["dimension", ["field-id", ORDERS.ID]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+          // NOTE: The actual "Assertion" phase begins here
+          cy.visit(`/dashboard/${dashboardId}?id=1`);
+          cy.findByText("13626D");
+
+          cy.log("**Reported failing in v0.37.0.2**");
+          cy.get(".DashCard").within(() => {
+            cy.get(".LoadingSpinner").should("not.exist");
+          });
+        });
+      });
+    });
+  });
+
   describe("aggregations with null values", () => {
     beforeEach(() => {
       cy.server();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13626 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/nulls.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

@camsaul - please tag me once this issue is fixed. We're not sure how that resulting card/diagram is going to look, and I need to add a positive assertion to the test.