### PR TITLE
Enable the OOM killer

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -113,6 +113,7 @@ chown metabase:metabase $new_db_dir $new_db_dir/* 2>/dev/null  # all that fussin
 JAVA_OPTS="${JAVA_OPTS} -XX:+IgnoreUnrecognizedVMOptions"
 JAVA_OPTS="${JAVA_OPTS} -Dfile.encoding=UTF-8"
 JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log"
+JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError"
 JAVA_OPTS="${JAVA_OPTS} -server"
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then


### PR DESCRIPTION
Enable the OOM killer, which will allow Docker / Kubernetes / ECS to restart a container when an OOM occurs
