### PR TITLE
Fingerprints reduce over table-rows-sample instead of realizing all

### DIFF
--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -21,8 +21,9 @@
              [4 "Wurstküche"]
              [5 "Brite Spot Family Restaurant"]]
             (->> (metadata-queries/table-rows-sample (Table (mt/id :venues))
-                                                     [(Field (mt/id :venues :id))
-                                                      (Field (mt/id :venues :name))])
+                   [(Field (mt/id :venues :id))
+                    (Field (mt/id :venues :name))]
+                   (constantly conj))
                  (sort-by first)
                  (take 5)))))
 
@@ -36,7 +37,8 @@
                        #'bigquery/page-callback        page-callback}
          (let [actual (->> (metadata-queries/table-rows-sample (Table (mt/id :venues))
                              [(Field (mt/id :venues :id))
-                              (Field (mt/id :venues :name))])
+                              (Field (mt/id :venues :name))]
+                             (constantly conj))
                            (sort-by first)
                            (take 5))]
          (is (= [[1 "Red Medicine"]

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -234,7 +234,8 @@
   (->> (metadata-queries/table-rows-sample (Table (mt/id :checkins))
          [(Field (mt/id :checkins :id))
           (Field (mt/id :checkins :venue_name))
-          (Field (mt/id :checkins :timestamp))])
+          (Field (mt/id :checkins :timestamp))]
+         (constantly conj))
        (sort-by first)
        (take 5)))
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -171,7 +171,8 @@
                 [5 "Brite Spot Family Restaurant"]]
                (vec (take 5 (metadata-queries/table-rows-sample (Table (mt/id :venues))
                               [(Field (mt/id :venues :id))
-                               (Field (mt/id :venues :name))])))))))))
+                               (Field (mt/id :venues :name))]
+                              (constantly conj))))))))))
 
 
 ;; ## Big-picture tests for the way data should look post-sync

--- a/modules/drivers/presto/test/metabase/driver/presto_test.clj
+++ b/modules/drivers/presto/test/metabase/driver/presto_test.clj
@@ -125,7 +125,8 @@
             ["Wurstküche"]
             ["Brite Spot Family Restaurant"]]
            (take 5 (metadata-queries/table-rows-sample (Table (mt/id :venues))
-                     [(Field (mt/id :venues :name))]))))))
+                     [(Field (mt/id :venues :name))]
+                     (constantly conj)))))))
 
 
 ;;; APPLY-PAGE

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -125,15 +125,9 @@
   `:rff`: [optional] a reducing function function (a function that given initial results metadata returns a reducing
   function) to reduce over the result set in the the query-processor rather than realizing the whole collection"
   {:style/indent 1}
-  ([table :- si/TableInstance, fields :- [si/FieldInstance]]
-   (table-rows-sample table fields nil))
-  ([table :- si/TableInstance, fields :- [si/FieldInstance]
-    {:keys [rff] :as opts} :- TableRowsSampleOptions]
+  ([table :- si/TableInstance, fields :- [si/FieldInstance], rff]
+   (table-rows-sample table fields rff nil))
+  ([table :- si/TableInstance, fields :- [si/FieldInstance], rff, opts :- TableRowsSampleOptions]
    (let [query   (table-rows-sample-query table fields opts)
-         qp      (resolve 'metabase.query-processor/process-query)
-         results (if rff
-                   (qp query {:rff rff})
-                   (qp query))]
-     (if rff
-       results
-       (get-in results [:data :rows])))))
+         qp      (resolve 'metabase.query-processor/process-query)]
+     (qp query {:rff rff}))))

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -122,8 +122,8 @@
 
   Options: a map of
   `:truncation-size`: [optional] size to truncate text fields if the driver supports expressions.
-  `:rff`: [optional] a reducing function to reduce over the result set in the the query-processor rather than
-  realizing the whole collection"
+  `:rff`: [optional] a reducing function function (a function that given initial results metadata returns a reducing
+  function) to reduce over the result set in the the query-processor rather than realizing the whole collection"
   {:style/indent 1}
   ([table :- si/TableInstance, fields :- [si/FieldInstance]]
    (table-rows-sample table fields nil))

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -96,28 +96,29 @@
   (s/maybe {(s/optional-key :truncation-size) s/Int
             (s/optional-key :rff)             s/Any}))
 
-(defn table-rows-sample-query
-  ([table fields {:keys [truncation-size] :as _opts}]
-   (let [driver             (-> table table/database driver.u/database->driver)
-         text-fields        (filter (comp #{:type/Text} :base_type) fields)
-         field->expressions (when (and truncation-size (driver/supports? driver :expressions))
-                              (into {} (for [field text-fields]
-                                         [field [(str (gensym "substring"))
-                                                 [:substring [:field-id (u/get-id field)] 1 truncation-size]]])))]
-     {:database   (:db_id table)
-      :type       :query
-      :query      {:source-table (u/get-id table)
-                   :expressions  (into {} (vals field->expressions))
-                   :fields       (vec (for [field fields]
-                                        (if-let [[expression-name _] (get field->expressions field)]
-                                          [:expression expression-name]
-                                          [:field-id (u/get-id field)])))
-                   :limit        max-sample-rows}
-      :middleware {:format-rows?           false
-                   :skip-results-metadata? true}})))
+(defn- table-rows-sample-query
+  "Returns the mbql query to query a table for sample rows"
+  [table fields {:keys [truncation-size] :as _opts}]
+  (let [driver             (-> table table/database driver.u/database->driver)
+        text-fields        (filter (comp #{:type/Text} :base_type) fields)
+        field->expressions (when (and truncation-size (driver/supports? driver :expressions))
+                             (into {} (for [field text-fields]
+                                        [field [(str (gensym "substring"))
+                                                [:substring [:field-id (u/get-id field)] 1 truncation-size]]])))]
+    {:database   (:db_id table)
+     :type       :query
+     :query      {:source-table (u/get-id table)
+                  :expressions  (into {} (vals field->expressions))
+                  :fields       (vec (for [field fields]
+                                       (if-let [[expression-name _] (get field->expressions field)]
+                                         [:expression expression-name]
+                                         [:field-id (u/get-id field)])))
+                  :limit        max-sample-rows}
+     :middleware {:format-rows?           false
+                  :skip-results-metadata? true}}))
 
 (s/defn table-rows-sample
-  "Run a basic MBQL query to fetch a sample of rows belonging to a Table.
+  "Run a basic MBQL query to fetch a sample of rows of FIELDS belonging to a TABLE.
 
   Options: a map of
   `:truncation-size`: [optional] size to truncate text fields if the driver supports expressions.

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -66,9 +66,7 @@
                                 (update count-info :updated-fingerprints inc))))
                           (empty-stats-map (count fingerprints))
                           (map vector fields fingerprints)))))]
-    (metadata-queries/table-rows-sample table fields
-                                        {:truncation-size truncation-size
-                                         :rff             rff})))
+    (metadata-queries/table-rows-sample table fields rff {:truncation-size truncation-size})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    WHICH FIELDS NEED UPDATED FINGERPRINTS?                                     |

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -48,25 +48,27 @@
 
 (s/defn ^:private fingerprint-table!
   [table :- i/TableInstance, fields :- [i/FieldInstance]]
-  (transduce identity
-             (redux/post-complete
-               (f/fingerprint-fields fields)
-               (fn [fingerprints]
-                 (reduce (fn [count-info [field fingerprint]]
-                           (cond
-                             (instance? Throwable fingerprint)
-                             (update count-info :failed-fingerprints inc)
+  (let [rff (fn [_metadata]
+              (redux/post-complete
+                (f/fingerprint-fields fields)
+                (fn [fingerprints]
+                  (reduce (fn [count-info [field fingerprint]]
+                            (cond
+                              (instance? Throwable fingerprint)
+                              (update count-info :failed-fingerprints inc)
 
-                             (some-> fingerprint :global :distinct-count zero?)
-                             (update count-info :no-data-fingerprints inc)
+                              (some-> fingerprint :global :distinct-count zero?)
+                              (update count-info :no-data-fingerprints inc)
 
-                             :else
-                             (do
-                               (save-fingerprint! field fingerprint)
-                               (update count-info :updated-fingerprints inc))))
-                         (empty-stats-map (count fingerprints))
-                         (map vector fields fingerprints))))
-             (metadata-queries/table-rows-sample table fields {:truncation-size truncation-size})))
+                              :else
+                              (do
+                                (save-fingerprint! field fingerprint)
+                                (update count-info :updated-fingerprints inc))))
+                          (empty-stats-map (count fingerprints))
+                          (map vector fields fingerprints)))))]
+    (metadata-queries/table-rows-sample table fields
+                                        {:truncation-size truncation-size
+                                         :rff             rff})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    WHICH FIELDS NEED UPDATED FINGERPRINTS?                                     |

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -63,7 +63,6 @@
               "Did not truncate a text field")))))
 
   (testing "substring checking"
-    ;; turn off validation so we can just return the query that is emitted and check for expressions
     (with-redefs [table/database (constantly (database/map->DatabaseInstance {:id 5678}))]
       (let [table  (table/map->TableInstance {:id 1234})
             fields [(field/map->FieldInstance {:id 4321 :base_type :type/Text})]]

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -48,7 +48,7 @@
                   ["BCD Tofu House"]]
         table    (Table (mt/id :venues))
         fields   [(Field (mt/id :venues :name))]
-        fetch!   #(->> (metadata-queries/table-rows-sample table fields (when % {:truncation-size %}))
+        fetch!   #(->> (metadata-queries/table-rows-sample table fields (constantly conj) (when % {:truncation-size %}))
                        ;; since order is not guaranteed do some sorting here so we always get the same results
                        (sort-by first)
                        (take 5))]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -102,7 +102,7 @@
             fields (db/select Field :table_id (u/id table) :name "year_column")]
         (testing "Can select from this table"
           (is (= [[#t "2001-01-01"] [#t "2002-01-01"] [#t "1999-01-01"]]
-                 (metadata-queries/table-rows-sample table fields))))
+                 (metadata-queries/table-rows-sample table fields (constantly conj)))))
         (testing "We can fingerprint this table"
           (is (= 1
                  (:updated-fingerprints (#'fingerprint/fingerprint-table! table fields)))))))))

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -62,7 +62,8 @@
             ["800 Degrees Neapolitan Pizzeria"]
             ["BCD Tofu House"]]
            (->> (metadata-queries/table-rows-sample (Table (mt/id :venues))
-                  [(Field (mt/id :venues :name))])
+                  [(Field (mt/id :venues :name))]
+                  (constantly conj))
                 ;; since order is not guaranteed do some sorting here so we always get the same results
                 (sort-by first)
                 (take 5))))))

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer :all]
             [metabase
              [db :as mdb]
+             [query-processor :as qp]
              [test :as mt]
              [util :as u]]
             [metabase.db.metadata-queries :as metadata-queries]
@@ -118,83 +119,63 @@
 
 ;; Make sure that the above functions are used correctly to determine which Fields get (re-)fingerprinted
 (defn- field-was-fingerprinted? {:style/indent 0} [fingerprint-versions field-properties]
-  (let [fingerprinted? (atom false)]
-    (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted fingerprint-versions
-                  metadata-queries/table-rows-sample                           (constantly [[1] [2] [3] [4] [5]])
-                  fingerprint/save-fingerprint!                                (fn [& _] (reset! fingerprinted? true))]
-      (tt/with-temp* [Table [table]
-                      Field [_ (assoc field-properties :table_id (u/get-id table))]]
-        [(fingerprint/fingerprint-fields! table)
-         @fingerprinted?]))))
-
-(def ^:private default-stat-map
-  {:no-data-fingerprints 0, :failed-fingerprints 0, :updated-fingerprints 0, :fingerprints-attempted 0})
-
-(def ^:private one-updated-map
-  (merge default-stat-map {:updated-fingerprints 1, :fingerprints-attempted 1}))
+  (with-redefs [i/fingerprint-version->types-that-should-be-re-fingerprinted fingerprint-versions]
+    (tt/with-temp* [Table [table]
+                    Field [field (assoc field-properties :table_id (u/get-id table))]]
+      (contains? (set (#'fingerprint/fields-to-fingerprint table)) field))))
 
 ;; Field is a subtype of newer fingerprint version
 (deftest fingerprint-fields!-test
   (testing "field is a substype of newer fingerprint version"
-    (is (= [one-updated-map true]
-           (field-was-fingerprinted?
-             {2 #{:type/Float}}
-             {:base_type :type/Decimal, :fingerprint_version 1}))))
+    (is (field-was-fingerprinted?
+          {2 #{:type/Float}}
+          {:base_type :type/Decimal, :fingerprint_version 1})))
 
   (testing "field is *not* a subtype of newer fingerprint version"
-    (is (= [default-stat-map false]
-           (field-was-fingerprinted?
-             {2 #{:type/Text}}
-             {:base_type :type/Decimal, :fingerprint_version 1}))))
+    (is (not (field-was-fingerprinted?
+               {2 #{:type/Text}}
+               {:base_type :type/Decimal, :fingerprint_version 1}))))
 
   (testing "Field is a subtype of one of several types for newer fingerprint version"
-    (is (= [one-updated-map true]
-           (field-was-fingerprinted?
-             {2 #{:type/Float :type/Text}}
-             {:base_type :type/Decimal, :fingerprint_version 1}))))
+    (is (field-was-fingerprinted?
+          {2 #{:type/Float :type/Text}}
+          {:base_type :type/Decimal, :fingerprint_version 1})))
 
   (testing "Field has same version as latest fingerprint version"
-    (is (= [default-stat-map false]
-           (field-was-fingerprinted?
-             {1 #{:type/Float}}
-             {:base_type :type/Decimal, :fingerprint_version 1}))))
+    (is (not (field-was-fingerprinted?
+               {1 #{:type/Float}}
+               {:base_type :type/Decimal, :fingerprint_version 1}))))
 
   (testing "field has newer version than latest fingerprint version (should never happen)"
-    (is (= [default-stat-map false]
-           (field-was-fingerprinted?
-             {1 #{:type/Float}}
-             {:base_type :type/Decimal, :fingerprint_version 2}))))
+    (is (not (field-was-fingerprinted?
+               {1 #{:type/Float}}
+               {:base_type :type/Decimal, :fingerprint_version 2}))))
 
   (testing "field has same exact type as newer fingerprint version"
-    (is (= [one-updated-map true]
-           (field-was-fingerprinted?
-             {2 #{:type/Float}}
-             {:base_type :type/Float, :fingerprint_version 1}))))
+    (is (field-was-fingerprinted?
+          {2 #{:type/Float}}
+          {:base_type :type/Float, :fingerprint_version 1})))
 
   (testing "field is parent type of newer fingerprint version type"
-    (is (= [default-stat-map false]
-           (field-was-fingerprinted?
-             {2 #{:type/Decimal}}
-             {:base_type :type/Float, :fingerprint_version 1}))))
+    (is (not (field-was-fingerprinted?
+               {2 #{:type/Decimal}}
+               {:base_type :type/Float, :fingerprint_version 1}))))
 
   (testing "several new fingerprint versions exist"
-    (is (= [one-updated-map true]
-           (field-was-fingerprinted?
-             {2 #{:type/Float}
-              3 #{:type/Text}}
-             {:base_type :type/Decimal, :fingerprint_version 1}))))
+    (is (field-was-fingerprinted?
+          {2 #{:type/Float}
+           3 #{:type/Text}}
+          {:base_type :type/Decimal, :fingerprint_version 1})))
 
-  (is (= [one-updated-map true]
-         (field-was-fingerprinted?
-           {2 #{:type/Text}
-            3 #{:type/Float}}
-           {:base_type :type/Decimal, :fingerprint_version 1})))
+  (is (field-was-fingerprinted?
+        {2 #{:type/Text}
+         3 #{:type/Float}}
+        {:base_type :type/Decimal, :fingerprint_version 1}))
 
   (testing "field is sensitive"
-    (is (= [default-stat-map false]
-           (field-was-fingerprinted?
-             {1 #{:type/Text}}
-             {:base_type :type/Text, :fingerprint_version 1, :visibility_type :sensitive})))))
+    (is (not (field-was-fingerprinted?
+               {1 #{:type/Text}}
+               {:base_type :type/Text, :fingerprint_version 1, :visibility_type :sensitive})))))
 
 
 (deftest fingerprint-table!-test
@@ -205,6 +186,7 @@
                                 :fingerprint_version 1
                                 :last_analyzed       #t "2017-08-09T00:00:00"}]
       (with-redefs [i/latest-fingerprint-version       3
+                    qp/process-query                   (fn [_ _ {:keys [rff]}] )
                     metadata-queries/table-rows-sample (constantly [[1] [2] [3] [4] [5]])
                     fingerprinters/fingerprinter       (constantly (fingerprinters/constant-fingerprinter {:experimental {:fake-fingerprint? true}}))]
         (is (= {:no-data-fingerprints 0, :failed-fingerprints    0,


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/13288

Pass the fingerprinting transducer into the query processor to reduce over the result set rather than building up a vector of results and then fingerprinting.

One possibility is to make this rff function to `table-sample-rows` required rather than optional so that no one accidentally does this again in the future.