### PR TITLE
Fix `settings/settings.cy.spec.js` flakes

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -6,38 +6,40 @@ import {
   popover,
 } from "__support__/cypress";
 
-// [quarantine] flaky
-describe.skip("scenarios > admin > settings", () => {
+describe("scenarios > admin > settings", () => {
   before(restore);
   beforeEach(signInAsAdmin);
 
   it("should surface an error when validation for any field fails (metabase#4506)", () => {
     const BASE_URL = Cypress.config().baseUrl;
     const DOMAIN_AND_PORT = BASE_URL.replace("http://", "");
-    const ERR_MESSAGE = `Invalid site URL: "${BASE_URL}!"`;
 
     cy.server();
     cy.route("PUT", "/api/setting/site-url").as("url");
 
     cy.visit("/admin/settings/general");
 
-    // Needed to strip down protocol from the url to accomodate our UI (<select> PORT | <input> DOMAIN_AND_PORT)
+    // Needed to strip down the protocol from URL to accomodate our UI (<select> PORT | <input> DOMAIN_AND_PORT)
     cy.findByDisplayValue(DOMAIN_AND_PORT) // findByDisplayValue comes from @testing-library/cypress
       .click()
-      .type("!")
+      .type("foo", { delay: 100 })
       .blur();
 
     cy.wait("@url")
       .wait("@url") // cy.wait("@url.2") doesn't work for some reason
       .should(xhr => {
         expect(xhr.status).to.eq(500);
-        expect(xhr.response.body.cause).to.eq(ERR_MESSAGE);
+        // Switching to regex match for assertions - the test was flaky because of the "typing" issue
+        // i.e. it sometimes doesn't type the whole string "foo", but only "oo".
+        // We only care that the `cause` is starting with "Invalid site URL"
+        expect(xhr.response.body.cause).to.match(/^Invalid site URL/);
       });
 
     // NOTE: This test is not concerned with HOW we style the error message - only that there is one.
     //       If we update UI in the future (for example: we show an error within a popup/modal), the test in current form could fail.
     cy.log("**Making sure we display an error message in UI**");
-    cy.get(".SaveStatus").contains(`Error: ${ERR_MESSAGE}`);
+    // Same reasoning for regex as above
+    cy.get(".SaveStatus").contains(/^Error: Invalid site URL/);
   });
 
   it("should render the proper auth options", () => {


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes a flake in `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- Unskips the whole test suite and moves it out of quarantine (full quarantine list in #13682)

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- All tests should pass

### Additional notes:
- isolated flake (`it.only("should surface an error when validation for any field fails (metabase#4506)", () => {...})`) passed 10x (https://github.com/nemanjaglumac/metabase-tests/actions/runs/348275781)
- the whole spec passed 20x (https://github.com/nemanjaglumac/metabase-tests/actions/runs/348306177)