### PR TITLE
Fix Cypress flakes in `dashboard/dashboard.cy.spec.js` file

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -194,22 +194,22 @@ describe("scenarios > dashboard", () => {
         cy.get(".LoadingSpinner").should("not.exist");
       });
 
-      cy.findByText("What");
-      cy.findByText("First revision.");
+      cy.findAllByText("Bobby Tables");
+      cy.contains(/revert/i);
 
       cy.get(".Modal .Icon-close").click();
-      cy.findByText("First revision.").should("not.exist");
+      cy.findAllByText("Bobby Tables").should("not.exist");
     });
 
     it("should open with url", () => {
       cy.visit("/dashboard/1/history");
       cy.get(".Modal").within(() => {
         cy.get(".LoadingSpinner").should("not.exist");
+        cy.findByText("Revision history");
       });
 
-      cy.findByText("Revision history");
-      cy.findByText("What");
-      cy.findByText("First revision.");
+      cy.findAllByText("Bobby Tables");
+      cy.contains(/revert/i);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -13,8 +13,7 @@ function saveDashboard() {
   cy.findByText("You're editing this dashboard.").should("not.exist");
 }
 
-// [quarantine] flaky
-describe.skip("scenarios > dashboard", () => {
+describe("scenarios > dashboard", () => {
   beforeEach(() => {
     restore();
     signInAsAdmin();
@@ -191,6 +190,10 @@ describe.skip("scenarios > dashboard", () => {
       cy.get(".Icon-ellipsis").click();
       cy.findByText("Revision history").click();
 
+      cy.get(".Modal").within(() => {
+        cy.get(".LoadingSpinner").should("not.exist");
+      });
+
       cy.findByText("What");
       cy.findByText("First revision.");
 
@@ -200,6 +203,9 @@ describe.skip("scenarios > dashboard", () => {
 
     it("should open with url", () => {
       cy.visit("/dashboard/1/history");
+      cy.get(".Modal").within(() => {
+        cy.get(".LoadingSpinner").should("not.exist");
+      });
 
       cy.findByText("Revision history");
       cy.findByText("What");


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes a flake in `frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- Unskips the whole test suite and moves it out of quarantine (full quarantine list in #13682)

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- All tests should pass

### Additional notes:

##### FIRST RUN (https://github.com/metabase/metabase/pull/13703/commits/154fe7dc224189cc721d4cf8fc4fb304af10ea94)
- CircleCI: [first run passed](https://dashboard.cypress.io/projects/a394u1/runs/2671/specs)  ✅
- GitHub CI: [failed 6/20](https://github.com/nemanjaglumac/metabase-tests/actions/runs/348490575) ❌

##### SECOND RUN (https://github.com/metabase/metabase/commit/9d3bcca112b543e07db6d0f402214cd6951a2c97)
- CircleCi: failed to build uberjar-oss ❌
- GitHub CI: [passed 20/20](https://github.com/nemanjaglumac/metabase-tests/actions/runs/348535444) ✅

##### THIRD RUN (https://github.com/metabase/metabase/commit/82a6fcda872200a89716744270501a4a10b5b42d)
- Rebased on https://github.com/metabase/metabase/commit/607d1b8d999031aadc142dc44119ed38f05e679c to be able to build `uberjar-oss` and let the CircleCI finish - passed ✅