### PR TITLE
Fix `metrics.cy.spec.js` flakes (#13682)

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -223,6 +223,7 @@ describe.skip("scenarios > admin > datamodel > metrics", () => {
       cy.findByText("Save changes")
         .should("not.be.disabled")
         .click();
+      cy.findByText("New metric");
 
       cy.log("**Refresh the page and assert**");
       cy.reload();

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -1,7 +1,6 @@
 import { restore, signInAsAdmin, popover, modal } from "__support__/cypress";
 
-// [quarantine] flaky
-describe.skip("scenarios > admin > datamodel > metrics", () => {
+describe("scenarios > admin > datamodel > metrics", () => {
   before(restore);
   beforeEach(() => {
     signInAsAdmin();
@@ -185,54 +184,32 @@ describe.skip("scenarios > admin > datamodel > metrics", () => {
 
   describe("custom metrics", () => {
     it("should save the metric using custom expressions (metabase#13022)", () => {
-      cy.visit("/admin/datamodel/metrics");
-      cy.findByText("New metric").click();
-
-      cy.log("**Create new metric based on Custom Expression**");
-      cy.findByText("Select a table").click();
-      popover().within(() => {
-        cy.findByText("Sample Dataset");
-        cy.findByText("Orders").click();
-      });
-      // "Count" is selected by defauult
-      cy.get(".QueryOption")
-        .contains("Count")
-        .click();
-      // Override it with "Custom Expression"
-      popover().within(() => {
-        cy.findByText("Custom Expression").click();
-        cy.get("[contenteditable='true']")
-          .click()
-          .type("{selectall}Sum([Discount] * [Quantity])", { delay: 100 });
-        cy.findByPlaceholderText("Name (required)")
-          .click()
-          .type("CE", { delay: 100 });
-        cy.findByText("Done").click();
+      cy.request("POST", "/api/metric", {
+        name: "13022_Metric",
+        desription: "desc",
+        table_id: 2,
+        definition: {
+          "source-table": 2,
+          aggregation: [
+            [
+              "aggregation-options",
+              ["sum", ["*", ["field-id", 9], ["field-id", 10]]],
+              { "display-name": "CE" },
+            ],
+          ],
+        },
       });
 
-      const metricName = "Test CE Metric";
-      // Give it a name
-      cy.findByPlaceholderText("Something descriptive but not too long").type(
-        metricName,
+      cy.log(
+        "**Navigate to the metrics page and assert the metric was indeed saved**",
       );
-      // and description
-      cy.findByPlaceholderText(
-        "This is a good place to be more specific about less obvious metric rules",
-      ).type("Description");
-      // Save the custom metric
-      cy.findByText("Save changes")
-        .should("not.be.disabled")
-        .click();
-      cy.findByText("New metric");
-
-      cy.log("**Refresh the page and assert**");
-      cy.reload();
-      cy.location("pathname").should("eq", "/admin/datamodel/metrics");
+      cy.visit("/admin/datamodel/metrics");
       cy.findByText(
         'Unexpected input given to normalize. Expected type to be "object", found "string".',
       ).should("not.exist");
 
-      cy.findByText(metricName);
+      cy.findByText("13022_Metric"); // Name
+      cy.findByText("Orders, CE"); // Definition
     });
   });
 });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes a flake in `frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js`
- Unskips the whole test suite and moves it out of quarantine (full quarantine list in #13682)

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js`
- All tests should pass

### Additional notes:
1. It seems this failed [only once](https://dashboard.cypress.io/projects/a394u1/analytics/top-failures/254e5552-d2f7-5aa9-84b3-0c3554f7ae7c-2511d6d7-96a9-7fea-0575-0e2f9975b2a7?branches=%5B%7B%22label%22%3A%22master%22%2C%22suggested%22%3Afalse%2C%22value%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222020-10-07%22%2C%22endDate%22%3A%222020-11-06%22%7D&viewBy=TEST_CASE) on `master` in the last 30 days. The reason behind this was a race condition of some sort, so I added a step/check in between to give the page enough time to load.

2. However, it failed [16/552 (3%)](https://dashboard.cypress.io/projects/a394u1/analytics/top-failures/cc8a26c9-f21d-b984-bd2d-8aeac1047d48-d86d2599-5704-6e9b-523c-de8f35d996d7?branches=%5B%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222020-10-07%22%2C%22endDate%22%3A%222020-11-06%22%7D&viewBy=TEST_CASE) on different branches for different people with completely different reason. It is again a timing issue, so I am inclined to fix that part as well, regardless of this test [passing 20/20](https://github.com/nemanjaglumac/metabase-tests/actions/runs/348725119) in GitHub CI.

##### FIRST RUN (https://github.com/metabase/metabase/pull/13709/commits/1f9fc047095a163f41491f9cda8e51f5bb1cae55)
- CircleCI: [first run passed](https://dashboard.cypress.io/projects/a394u1/runs/2698/specs) ✅ (but it doesn't count - I forgot to unskip the top level `describe` block)
- GitHub CI: [20/20 passed](https://github.com/nemanjaglumac/metabase-tests/actions/runs/348725119)  ✅

##### SECOND RUN (https://github.com/metabase/metabase/pull/13709/commits/5c9b5bcc282896de60972b1cd3796cecc007aef6)
- CircleCI: [passed](https://dashboard.cypress.io/projects/a394u1/runs/2703/specs) ✅
- GitHub CI: [18/20 passed](https://github.com/nemanjaglumac/metabase-tests/actions/runs/349754611) ✅
(2 other jobs had a network issue unrelated to this test (`Get yarn cache` at 0.1MB/s), so I cancelled them) 