### PR TITLE
Smoketest: run nightly at 1am PST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1045,7 +1045,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0 9 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
1 am PST = 09:00 UTC

CircleCI cron is for UTC:
https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow
