### PR TITLE
CI: Ensure the use of lockfile when running yarn

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -25,7 +25,12 @@ version() {
 
 frontend-deps() {
     echo "Running 'yarn' to download javascript dependencies..." &&
-    yarn
+    if [[ -z "${CI}" ]]; then
+        yarn
+    else
+        echo "CI run: enforce the lockfile"
+        yarn install --frozen-lockfile
+    fi
 }
 
 frontend() {


### PR DESCRIPTION
This makes the dependencies reproducible in the CI run, making it less susceptible to external disturbances (e.g. https://yarnpkg.com/ being unreachable) since there isn't just-in-time version resolution anymore and likely all the necessary packages are available in the build cache.
