### PR TITLE
Fix #12140

### DIFF
--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
@@ -56,19 +56,6 @@ export default class ExpressionPopover extends React.Component {
               }
             }}
           />
-          {error &&
-            (Array.isArray(error) ? (
-              error.map(error => (
-                <div
-                  className="text-error mb1"
-                  style={{ whiteSpace: "pre-wrap" }}
-                >
-                  {error.message}
-                </div>
-              ))
-            ) : (
-              <div className="text-error mb1">{error.message}</div>
-            ))}
           {onChangeName && (
             <input
               className="input block full my1"

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -1,0 +1,125 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { t } from "ttag";
+import cx from "classnames";
+
+import Popover from "metabase/components/Popover";
+
+import { isObscured } from "metabase/lib/dom";
+
+const SUGGESTION_SECTION_NAMES = {
+  fields: t`Fields`,
+  aggregations: t`Aggregations`,
+  operators: t`Operators`,
+  metrics: t`Metrics`,
+  other: t`Other`,
+};
+
+export default class ExpressionEditorSuggestions extends React.Component {
+  static propTypes = {
+    suggestions: PropTypes.array,
+    onSuggestionClicked: PropTypes.func, // signature is f(selectedSuggestion, acceptSuggestion)
+  };
+
+  componentWillReceiveProps(newProps) {
+    this.setState({
+      highlightedSuggestion: 0,
+    });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevState &&
+      prevState.highlightedSuggestion !== this.state.highlightedSuggestion
+    ) {
+      if (this._selectedRow && isObscured(this._selectedRow)) {
+        this._selectedRow.scrollIntoView({ block: "nearest" });
+      }
+    }
+  }
+
+  // when a given suggestion is clicked
+  onSuggestionMouseDown(event, index) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.setState({ highlightedSuggestion: index }, () => {
+      const suggestion = this.props.suggestions[
+        this.state.highlightedSuggestion
+      ];
+      const { onSuggestionClicked } = this.props;
+      if (onSuggestionClicked) {
+        onSuggestionClicked(suggestion, () => {
+          this.setState({ highlightedSuggestion: 0 });
+        });
+      }
+    });
+  }
+
+  render() {
+    const { suggestions } = this.props;
+
+    if (!suggestions.length) return null;
+
+    return (
+      <Popover
+        className="not-rounded border-dark"
+        hasArrow={false}
+        tetherOptions={{
+          attachment: "top left",
+          targetAttachment: "bottom left",
+        }}
+        sizeToFit
+      >
+        <ul className="pb1" style={{ minWidth: 150, overflowY: "auto" }}>
+          {suggestions.map((suggestion, i) =>
+            // insert section title. assumes they're sorted by type
+            [
+              (i === 0 || suggestion.type !== suggestions[i - 1].type) && (
+                <li className="mx2 h6 text-uppercase text-bold text-medium py1 pt2">
+                  {SUGGESTION_SECTION_NAMES[suggestion.type] || suggestion.type}
+                </li>
+              ),
+              <li
+                ref={r => {
+                  if (i === this.state.highlightedSuggestion) {
+                    this._selectedRow = r;
+                  }
+                }}
+                style={{ paddingTop: 5, paddingBottom: 5 }}
+                className={cx(
+                  "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
+                  {
+                    "text-white bg-brand":
+                      i === this.state.highlightedSuggestion,
+                  },
+                )}
+                onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
+              >
+                {suggestion.range ? (
+                  <span>
+                    {suggestion.name.slice(0, suggestion.range[0])}
+                    <span
+                      className={cx("text-brand text-bold hover-child", {
+                        "text-white bg-brand":
+                          i === this.state.highlightedSuggestion,
+                      })}
+                    >
+                      {suggestion.name.slice(
+                        suggestion.range[0],
+                        suggestion.range[1],
+                      )}
+                    </span>
+                    {suggestion.name.slice(suggestion.range[1])}
+                  </span>
+                ) : (
+                  suggestion.name
+                )}
+              </li>,
+            ],
+          )}
+        </ul>
+      </Popover>
+    );
+  }
+}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -23,10 +23,6 @@ export default class ExpressionEditorSuggestions extends React.Component {
     highlightedIndex: PropTypes.number.isRequired,
   };
 
-  componentWillReceiveProps(newProps) {
-    console.log("newProps:", newProps); // NOCOMMIT
-  }
-
   componentDidUpdate(prevProps, prevState) {
     if (
       (prevProps && prevProps.highlightedIndex) !== this.props.highlightedIndex

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -19,19 +19,17 @@ const SUGGESTION_SECTION_NAMES = {
 export default class ExpressionEditorSuggestions extends React.Component {
   static propTypes = {
     suggestions: PropTypes.array,
-    onSuggestionClicked: PropTypes.func, // signature is f(selectedSuggestion, acceptSuggestion)
+    onSuggestionMouseDown: PropTypes.func, // signature is f(index)
+    highlightedIndex: PropTypes.number.isRequired,
   };
 
   componentWillReceiveProps(newProps) {
-    this.setState({
-      highlightedSuggestion: 0,
-    });
+    console.log("newProps:", newProps); // NOCOMMIT
   }
 
   componentDidUpdate(prevProps, prevState) {
     if (
-      prevState &&
-      prevState.highlightedSuggestion !== this.state.highlightedSuggestion
+      (prevProps && prevProps.highlightedIndex) !== this.props.highlightedIndex
     ) {
       if (this._selectedRow && isObscured(this._selectedRow)) {
         this._selectedRow.scrollIntoView({ block: "nearest" });
@@ -43,23 +41,16 @@ export default class ExpressionEditorSuggestions extends React.Component {
   onSuggestionMouseDown(event, index) {
     event.preventDefault();
     event.stopPropagation();
-    this.setState({ highlightedSuggestion: index }, () => {
-      const suggestion = this.props.suggestions[
-        this.state.highlightedSuggestion
-      ];
-      const { onSuggestionClicked } = this.props;
-      if (onSuggestionClicked) {
-        onSuggestionClicked(suggestion, () => {
-          this.setState({ highlightedSuggestion: 0 });
-        });
-      }
-    });
+
+    this.props.onSuggestionMouseDown && this.props.onSuggestionMouseDown(index);
   }
 
   render() {
-    const { suggestions } = this.props;
+    const { suggestions, highlightedIndex } = this.props;
 
-    if (!suggestions.length) return null;
+    if (!suggestions.length) {
+      return null;
+    }
 
     return (
       <Popover
@@ -82,7 +73,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
               ),
               <li
                 ref={r => {
-                  if (i === this.state.highlightedSuggestion) {
+                  if (i === highlightedIndex) {
                     this._selectedRow = r;
                   }
                 }}
@@ -91,7 +82,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
                   "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
                   {
                     "text-white bg-brand":
-                      i === this.state.highlightedSuggestion,
+                      i === highlightedIndex,
                   },
                 )}
                 onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
@@ -102,7 +93,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
                     <span
                       className={cx("text-brand text-bold hover-child", {
                         "text-white bg-brand":
-                          i === this.state.highlightedSuggestion,
+                          i === highlightedIndex,
                       })}
                     >
                       {suggestion.name.slice(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -77,8 +77,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
                 className={cx(
                   "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
                   {
-                    "text-white bg-brand":
-                      i === highlightedIndex,
+                    "text-white bg-brand": i === highlightedIndex,
                   },
                 )}
                 onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
@@ -88,8 +87,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
                     {suggestion.name.slice(0, suggestion.range[0])}
                     <span
                       className={cx("text-brand text-bold hover-child", {
-                        "text-white bg-brand":
-                          i === highlightedIndex,
+                        "text-white bg-brand": i === highlightedIndex,
                       })}
                     >
                       {suggestion.name.slice(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -133,20 +133,12 @@ export default class ExpressionEditorTextfield extends React.Component {
       const parserOptions = this._getParserOptions(newProps);
       const source = format(newProps.expression, parserOptions);
 
-      console.log("source:", source); // NOCOMMIT
-
       const { expression, compileError, syntaxTree } =
         source && source.length
-          ? this._processSource({
-              source,
-              ...this._getParserOptions(newProps),
-            })
-          : {
-              expression: [null, ""],
-              compileError: null,
-              syntaxTree: null,
-            };
-
+        && this._processSource({
+          source,
+          ...this._getParserOptions(newProps),
+        });
       this.setState({
         source,
         expression,
@@ -202,10 +194,6 @@ export default class ExpressionEditorTextfield extends React.Component {
       this.clearSuggestions();
       return;
     }
-
-    console.log("suggestions:", suggestions); // NOCOMMIT
-    console.log("highlightedSuggestionIndex:", highlightedSuggestionIndex); // NOCOMMIT
-    console.log("e.keyCode:", e.keyCode); // NOCOMMIT
 
     if (!suggestions.length) {
       if (
@@ -291,11 +279,17 @@ export default class ExpressionEditorTextfield extends React.Component {
       suggestions,
       helpText,
       syntaxTree,
-    } = this._processSource({
+    } = source ? this._processSource({
       source,
       targetOffset,
       ...this._getParserOptions(),
-    });
+    }) : {
+      expression: null,
+      compileError: null,
+      suggestions: [],
+      helpText: null,
+      syntaxTree: null
+    };
 
     const isValid = expression !== undefined;
     // don't show suggestions if

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -134,8 +134,9 @@ export default class ExpressionEditorTextfield extends React.Component {
       const source = format(newProps.expression, parserOptions);
 
       const { expression, compileError, syntaxTree } =
-        source && source.length
-        && this._processSource({
+        source &&
+        source.length &&
+        this._processSource({
           source,
           ...this._getParserOptions(newProps),
         });
@@ -211,13 +212,15 @@ export default class ExpressionEditorTextfield extends React.Component {
     } else if (e.keyCode === KEYCODE_UP) {
       this.setState({
         highlightedSuggestionIndex:
-          (highlightedSuggestionIndex + suggestions.length - 1) % suggestions.length,
+          (highlightedSuggestionIndex + suggestions.length - 1) %
+          suggestions.length,
       });
       e.preventDefault();
     } else if (e.keyCode === KEYCODE_DOWN) {
       this.setState({
         highlightedSuggestionIndex:
-          (highlightedSuggestionIndex + suggestions.length + 1) % suggestions.length,
+          (highlightedSuggestionIndex + suggestions.length + 1) %
+          suggestions.length,
       });
       e.preventDefault();
     }
@@ -279,17 +282,19 @@ export default class ExpressionEditorTextfield extends React.Component {
       suggestions,
       helpText,
       syntaxTree,
-    } = source ? this._processSource({
-      source,
-      targetOffset,
-      ...this._getParserOptions(),
-    }) : {
-      expression: null,
-      compileError: null,
-      suggestions: [],
-      helpText: null,
-      syntaxTree: null
-    };
+    } = source
+      ? this._processSource({
+          source,
+          targetOffset,
+          ...this._getParserOptions(),
+        })
+      : {
+          expression: null,
+          compileError: null,
+          suggestions: [],
+          helpText: null,
+          syntaxTree: null,
+        };
 
     const isValid = expression !== undefined;
     // don't show suggestions if

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -134,12 +134,12 @@ export default class ExpressionEditorTextfield extends React.Component {
       const source = format(newProps.expression, parserOptions);
 
       const { expression, compileError, syntaxTree } =
-        source &&
-        source.length &&
-        this._processSource({
-          source,
-          ...this._getParserOptions(newProps),
-        });
+        source && source.length
+          ? this._processSource({
+              source,
+              ...this._getParserOptions(newProps),
+            })
+          : { expression: null, compileError: null, syntaxTree: null };
       this.setState({
         source,
         expression,

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -73,7 +73,7 @@ describe("scenarios > question > new", () => {
       cy.findByText("604.96");
     });
 
-    it("should keep manually entered parenthesis intact (metabase#13306)", () => {
+    it.skip("should keep manually entered parenthesis intact (metabase#13306)", () => {
       const FORMULA =
         "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))";
 

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -73,7 +73,7 @@ describe("scenarios > question > new", () => {
       cy.findByText("604.96");
     });
 
-    it.skip("should keep manually entered parenthesis intact (metabase#13306)", () => {
+    it("should keep manually entered parenthesis intact (metabase#13306)", () => {
       const FORMULA =
         "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))";
 


### PR DESCRIPTION
I was working on #13175 and ran into some issues trying to test stuff so I ended up fixing #12140 while working on it.

Fixes #12140

I thought `ExpressionEditorTextfield` was way too hairy so I split off the suggestions popover code into its own component. The version of the widget used in notebook mode didn't show error messages for whatever reason so I moved the error display code from the version of the widget used in the other place into `ExpressionEditorTextfield` itself so now it shows errors in both cases.

I fixed behavior so it doesn't try to parse empty input and display parse errors when there is no input.