### PR TITLE
Basic multi-level pivoting

### DIFF
--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -19,6 +19,7 @@ import ScatterPlot from "./visualizations/ScatterPlot";
 import Funnel from "./visualizations/Funnel";
 import Gauge from "./visualizations/Gauge";
 import ObjectDetail from "./visualizations/ObjectDetail";
+import PivotTable from "./visualizations/PivotTable";
 
 export default function() {
   registerVisualization(Scalar);
@@ -37,5 +38,6 @@ export default function() {
   registerVisualization(MapViz);
   registerVisualization(Funnel);
   registerVisualization(ObjectDetail);
+  registerVisualization(PivotTable);
   setDefaultVisualization(Table);
 }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -1,0 +1,145 @@
+import React, { Component } from "react";
+import { t } from "ttag";
+
+import { isDimension } from "metabase/lib/schema_metadata";
+import { getOptionFromColumn } from "metabase/visualizations/lib/settings/utils";
+import { multiLevelPivot } from "metabase/lib/data_grid";
+// import { formatColumn } from "metabase/lib/formatting";
+import { columnSettings } from "metabase/visualizations/lib/settings/column";
+
+import type { VisualizationProps } from "metabase-types/types/Visualization";
+
+export default class PivotTable extends Component {
+  props: VisualizationProps;
+  static uiName = t`Pivot Table`;
+  static identifier = "pivot";
+  static iconName = "table";
+
+  static isSensible({ cols }) {
+    return (
+      cols.every(
+        col => col.source === "aggregation" || col.source === "breakout",
+      ) && cols.filter(col => col.source === "breakout").length < 5
+    );
+  }
+
+  static checkRenderable(foo) {
+    console.log("checkRenderable", foo);
+    // todo: raise when we can't render
+  }
+
+  static seriesAreCompatible(initialSeries, newSeries) {
+    return false;
+  }
+
+  static settings = {
+    ...columnSettings({ hidden: true }),
+    "pivot_table.table_rows": {
+      section: null,
+      title: t`Fields to use for the table rows`,
+      widget: "fields",
+      getProps: ([{ data }], settings) => {
+        if (!data) {
+          return {};
+        }
+        return {
+          options: data.cols.filter(isDimension).map(getOptionFromColumn),
+          addAnother: t`Add a column`,
+          columns: data.cols,
+        };
+      },
+      getDefault: () => [null],
+    },
+    "pivot_table.table_columns": {
+      section: null,
+      title: t`Fields to use for the table columns`,
+      widget: "fields",
+      getProps: ([{ data }], settings) => {
+        if (!data) {
+          return {};
+        }
+        return {
+          options: data.cols.filter(isDimension).map(getOptionFromColumn),
+          addAnother: t`Add a column`,
+          columns: data.cols,
+        };
+      },
+      getDefault: () => [null],
+    },
+    "pivot_table.table_values": {
+      section: null,
+      title: t`Fields to use for the table values`,
+      widget: "fields",
+      getProps: ([{ data }], settings) => ({
+        options: data.cols.map(getOptionFromColumn),
+      }),
+      getDefault: () => [null],
+    },
+  };
+
+  componentDidMount() {
+    this.element.setAttribute("border", "1");
+  }
+
+  render() {
+    const { settings, data } = this.props;
+    console.log({ settings, cols: data.cols });
+    const [rowIndexes, columnIndexes, valueIndexes] = [
+      "pivot_table.table_rows",
+      "pivot_table.table_columns",
+      "pivot_table.table_values",
+    ].map(settingName =>
+      settings[settingName]
+        .map(colOption =>
+          data.cols.findIndex(
+            col => getOptionFromColumn(col).value === colOption,
+          ),
+        )
+        .filter(index => index !== -1),
+    );
+
+    let pivoted;
+    try {
+      pivoted = multiLevelPivot(data, columnIndexes, rowIndexes, valueIndexes);
+    } catch (e) {
+      console.warn(e);
+    }
+    console.log({ pivoted });
+    if (!pivoted) {
+      return <div>no data - check for error</div>;
+    }
+    const { headerRows, bodyRows } = pivoted;
+
+    return (
+      <div className="overflow-scroll">
+        <table ref={e => (this.element = e)}>
+          <thead>
+            {headerRows.map((row, rowIndex) => (
+              <tr>
+                {rowIndex === 0 &&
+                  rowIndexes.map(index => (
+                    <th rowSpan={headerRows.length}>
+                      {data.cols[index].display_name}
+                    </th>
+                  ))}
+
+                {row.map(({ value, span }) => (
+                  <th colSpan={span}>{value}</th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {bodyRows.map(row => (
+              <tr>
+                {row.map(({ value, span }) => (
+                  <td rowSpan={span}>{value}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -1,4 +1,4 @@
-import { pivot } from "metabase/lib/data_grid";
+import { pivot, multiLevelPivot } from "metabase/lib/data_grid";
 
 import { TYPE } from "metabase/lib/types";
 
@@ -82,7 +82,6 @@ describe("data_grid", () => {
     it("should not return null column names from null values", () => {
       const data = makeData([[null, null, 1]]);
       const pivotedData = pivot(data, 0, 1, 2);
-      console.log("pivotedData", pivotedData);
       expect(pivotedData.rows.length).toEqual(1);
       expect(pivotedData.cols.length).toEqual(2);
       expect(pivotedData.cols[0].name).toEqual(jasmine.any(String));
@@ -109,6 +108,50 @@ describe("data_grid", () => {
       expect(pivotedData.rows.map(row => [...row])).toEqual([
         ["a", 1, null, 3],
         ["b", 4, 5, 6],
+      ]);
+    });
+  });
+
+  describe("multiLevelPivot", () => {
+    const data = makeData([
+      ["a", "x", 1],
+      ["a", "y", 2],
+      ["a", "z", 3],
+      ["b", "x", 4],
+      ["b", "y", 5],
+      ["b", "z", 6],
+    ]);
+    it("should produce header rows with spans", () => {
+      const { headerRows } = multiLevelPivot(data, [0, 1], [], [2]);
+      expect(headerRows).toEqual([
+        [{ span: 3, value: "a" }, { span: 3, value: "b" }],
+        [
+          { span: 1, value: "x" },
+          { span: 1, value: "y" },
+          { span: 1, value: "z" },
+          { span: 1, value: "x" },
+          { span: 1, value: "y" },
+          { span: 1, value: "z" },
+        ],
+      ]);
+    });
+    it("should produce body rows with spans", () => {
+      const { bodyRows } = multiLevelPivot(data, [], [0, 1], [2]);
+      expect(bodyRows).toEqual([
+        [
+          { span: 3, value: "a" },
+          { span: 1, value: "x" },
+          { span: 1, value: [1] },
+        ],
+        [{ span: 1, value: "y" }, { span: 1, value: [2] }],
+        [{ span: 1, value: "z" }, { span: 1, value: [3] }],
+        [
+          { span: 3, value: "b" },
+          { span: 1, value: "x" },
+          { span: 1, value: [4] },
+        ],
+        [{ span: 1, value: "y" }, { span: 1, value: [5] }],
+        [{ span: 1, value: "z" }, { span: 1, value: [6] }],
       ]);
     });
   });


### PR DESCRIPTION
Part of #13662

This add a new viz type for pivot tables. It's currently only available in a 90s vibe skin:

![image](https://user-images.githubusercontent.com/691495/98428494-c431f880-206f-11eb-9af7-340dbb661fbf.png)

Here's a link to see that locally if you're running this branch on localhost:3000: [link](http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjIsImFnZ3JlZ2F0aW9uIjpbWyJjb3VudCJdXSwiYnJlYWtvdXQiOltbImRhdGV0aW1lLWZpZWxkIixbImZpZWxkLWlkIiwxMl0sInllYXIiXSxbImRhdGV0aW1lLWZpZWxkIixbImZrLT4iLFsiZmllbGQtaWQiLDEzXSxbImZpZWxkLWlkIiw3XV0sInllYXIiXSxbImZrLT4iLFsiZmllbGQtaWQiLDExXSxbImZpZWxkLWlkIiwyNl1dLFsiZmstPiIsWyJmaWVsZC1pZCIsMTNdLFsiZmllbGQtaWQiLDRdXV19LCJ0eXBlIjoicXVlcnkifSwiZGlzcGxheSI6InBpdm90IiwiZGlzcGxheUlzTG9ja2VkIjp0cnVlLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7InBpdm90X3RhYmxlLnRhYmxlX3Jvd3MiOlsiU09VUkNFIiwiQ1JFQVRFRF9BVCJdLCJwaXZvdF90YWJsZS50YWJsZV9jb2x1bW5zIjpbIkNBVEVHT1JZIiwiQ1JFQVRFRF9BVF8yIl0sInBpdm90X3RhYmxlLnRhYmxlX3ZhbHVlcyI6WyJjb3VudCJdfX0=)

---

As this moves forward, I'm still not sure whether to extend the existing table components ("interactive" and "simple") to support multiple tiers of column and row headers or keep this separate. They will share a lot of functionality, but the existing components are already pretty complicated.

The pivoting code is currently separate from Table's single level pivot. It could be more easily merged but I don't want to do that unless the components will share a data representation.

I'll do some quick cleanup before merging this, but I think it's enough of a foundation for the [next steps](https://github.com/metabase/metabase/issues/13662).