### PR TITLE
Fix env variable name to reflect one actually used in Docker image

### DIFF
--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -14,10 +14,10 @@ You'll just need to set a JVM option to let it know explicitly how much memory i
 
 Adjust this number as appropriate for your shared hosting instance. Make sure to set the number lower than the total amount of RAM available on your instance, because Metabase isn't the only process that'll be running. Generally, leaving 1-2 GB of RAM for these other processes should be enough; for example, you might set `-Xmx` to `1g` for an instance with 2 GB of RAM, `2g` for one with 4 GB of RAM, `6g` for an instance with 8 GB of RAM, and so forth. You may need to experiment with these settings a bit to find the right number.
 
-As above, you can use the environment variable `JAVA_OPTIONS` to set JVM args instead of passing them directly to `java`. This is useful when running the Docker image,
+As above, you can use the environment variable `JAVA_OPTS` to set JVM args instead of passing them directly to `java`. This is useful when running the Docker image,
 for example.
 
-    docker run -d -p 3000:3000 -e "JAVA_OPTIONS=-Xmx2g" metabase/metabase
+    docker run -d -p 3000:3000 -e "JAVA_OPTS=-Xmx2g" metabase/metabase
 
 ### Diagnosing memory issues causing OutOfMemoryErrors
 

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -14,10 +14,10 @@ You'll just need to set a JVM option to let it know explicitly how much memory i
 
 Adjust this number as appropriate for your shared hosting instance. Make sure to set the number lower than the total amount of RAM available on your instance, because Metabase isn't the only process that'll be running. Generally, leaving 1-2 GB of RAM for these other processes should be enough; for example, you might set `-Xmx` to `1g` for an instance with 2 GB of RAM, `2g` for one with 4 GB of RAM, `6g` for an instance with 8 GB of RAM, and so forth. You may need to experiment with these settings a bit to find the right number.
 
-As above, you can use the environment variable `JAVA_TOOL_OPTIONS` to set JVM args instead of passing them directly to `java`. This is useful when running the Docker image,
+As above, you can use the environment variable `JAVA_OPTIONS` to set JVM args instead of passing them directly to `java`. This is useful when running the Docker image,
 for example.
 
-    docker run -d -p 3000:3000 -e "JAVA_TOOL_OPTIONS=-Xmx2g" metabase/metabase
+    docker run -d -p 3000:3000 -e "JAVA_OPTIONS=-Xmx2g" metabase/metabase
 
 ### Diagnosing memory issues causing OutOfMemoryErrors
 


### PR DESCRIPTION
I've confirmed it with the latest metabase image. JAVA_TOOL_OPTIONS is not referenced anywhere in the entry script.