### PR TITLE
Unset `DISPLAY` ENV in smoketests CI group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,7 +686,8 @@ jobs:
         type: string
     executor: << parameters.e >>
     environment:
-      CYPRESS_GROUP:  << parameters.cypress-group >>
+      CYPRESS_GROUP: << parameters.cypress-group >>
+      DISPLAY: ""
     steps:
       - run-yarn-command:
           command-name: Run Cypress tests


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Unsets the `DISPLAY` ENV in Cypress Smoketests for CircleCI (as per https://github.com/cypress-io/cypress/issues/4034#issuecomment-486773042)

### Additional notes:
- Although Cypress claims they fixed this issue, since we upgraded Cypress to v5.5.0 we were seeing failed runs. Enabling debug info has shown that there was indeed a problem with the `DISPLAY`.
- Unsetting that ENV for main Cypress tests removed any timeouts or failed runs.
- This commit introduces the same "fix" for Smoketests

#### LOGS (from the [last failed run](https://app.circleci.com/pipelines/github/metabase/metabase/10208/workflows/b656cb42-658d-4ce6-aec7-36bcaafe03a4/jobs/361797))
```
cypress:cli:run run to spawn.start args ["--run-project","/home/circleci/********/********","--config","baseUrl=http://localhost:4000,integrationFolder=frontend/test/********-smoketest","--config-file","frontend/test/cypress.json","--group","default","--key","************************************","--parallel","--record",true,"--reporter","junit","--reporter-options","mochaFile=cypress/results/results-[hash].xml"] +0ms
  cypress:cli DISPLAY environment variable is set to :99 on Linux
  cypress:cli Assuming this DISPLAY points at working X11 server,
  cypress:cli Cypress will not spawn own Xvfb
  cypress:cli 
  cypress:cli NOTE: if the X11 server is NOT working, Cypress will exit without explanation,
  cypress:cli   see https://github.com/cypress-io/cypress/issues/4034
  cypress:cli Solution: Unset the DISPLAY variable and try again:
  cypress:cli   DISPLAY= npx cypress run ... +0ms
  cypress:cli needs to start own Xvfb? false +0ms
  cypress:cli spawning, should retry on display problem? true +1ms
  cypress:cli passing DISPLAY :99 +3ms
  cypress:cli spawning Cypress with executable: /home/circleci/.cache/Cypress/5.5.0/Cypress/Cypress +0ms
  cypress:cli spawn args [ '--no-sandbox', '--', '--run-project', '/home/circleci/********/********', '--config', 'baseUrl=http://localhost:4000,integrationFolder=frontend/test/********-smoketest', '--config-file', 'frontend/test/cypress.json', '--group', 'default', '--key', '************************************', '--parallel', '--record', true, '--reporter', 'junit', '--reporter-options', 'mochaFile=cypress/results/results-[hash].xml', '--cwd', '/home/circleci/********/********' ] { detached: false, stdio: [ 'inherit', 'inherit', 'pipe' ] } +0ms
  cypress:cli piping child STDERR to process STDERR +5ms
```
...
```
[1179:1109/090555.285007:ERROR:browser_main_loop.cc(1417)] Unable to open X display.

undefined:0


illegal access
(Use `node --trace-uncaught ...` to show where the exception was thrown)
  cypress:cli child event fired { event: 'exit', code: 7, signal: null } +914ms
error Command failed with exit code 7.
```