### PR TITLE
Unquarantine enterprise `custom_drill_through/drill_through.cy.spec.js`

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
@@ -3,12 +3,10 @@ import {
   signInAsAdmin,
   restore,
   modal,
-  // describeWithToken,
+  describeWithToken,
 } from "__support__/cypress";
 
-// [quarantine] flaky
-// TODO: change back to `describeWithToken`
-describe.skip("drill through", () => {
+describeWithToken("drill through", () => {
   before(restore);
 
   beforeEach(signInAsAdmin);


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Unskips `enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js` (full quarantine list in #13682).

### Additional notes:
- Enterprise tests are not even being run in the CI (that functionality is yet to be implemented)
- Using `[ci skip]` for that same reason