### PR TITLE
Repro for #13604: Wrong day names on X-axis

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -2,16 +2,12 @@ import { restore, withSampleDataset, signInAsAdmin } from "__support__/cypress";
 
 describe("scenarios > admin > permissions", () => {
   before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    signInAsAdmin();
+    setFirstWeekDayTo("monday");
+  });
 
   it("should correctly apply start of the week to a bar chart (metabase#13516)", () => {
-    // set the beginning of the week to "Monday"
-    cy.visit("/admin/settings/localization");
-    cy.findByText("Sunday").click();
-    cy.findByText("Monday").click({ force: true });
-    // make sure popover closed
-    cy.findByText("Thursday").should("not.be.visible");
-
     // programatically create and save a question based on Orders table
     // filter: created before June 1st, 2016
     // summarize: Count by CreatedAt: Week
@@ -44,4 +40,55 @@ describe("scenarios > admin > permissions", () => {
     // that's why we have to assert on the x-axis, instead of a popover that shows on a dot hover
     cy.get(".axis.x").contains("April 25, 2016");
   });
+
+  it.skip("should display days on X-axis correctly when grouped by 'Day of the Week' (metabase#13604)", () => {
+    withSampleDataset(({ ORDERS }) => {
+      cy.request("POST", "/api/card", {
+        name: "13604",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": 2,
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "datetime-field",
+                ["field-id", ORDERS.CREATED_AT],
+                "day-of-week",
+              ],
+            ],
+            filter: [
+              "between",
+              ["field-id", ORDERS.CREATED_AT],
+              "2020-03-02", // Monday
+              "2020-03-03", // Tuesday
+            ],
+          },
+          type: "query",
+        },
+        display: "bar",
+        visualization_settings: {
+          "graph.dimensions": ["CREATED_AT"],
+          "graph.metrics": ["count"],
+          "graph.x_axis.scale": "ordinal",
+        },
+      });
+    });
+
+    cy.visit("/collection/root");
+    cy.findByText("13604").click();
+
+    cy.log("**Reported failing on v0.37.0.2 and labeled as `.Regression`**");
+    cy.get(".axis.x")
+      .contains(/sunday/i)
+      .should("not.exist");
+    cy.get(".axis.x").contains(/monday/i);
+    cy.get(".axis.x").contains(/tuesday/i);
+  });
 });
+
+function setFirstWeekDayTo(day) {
+  cy.request("PUT", "/api/setting/start-of-week", {
+    value: day.toLowerCase(),
+  });
+}


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #13604 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix
