### PR TITLE
Fix formatting temporal values with custom day of week

### DIFF
--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -25,12 +25,11 @@ export async function loadLocalization(locale) {
   setLocalization(translationsObject);
 }
 
-// Tell Moment.js to use the value of the start-of-week Setting for its current locale. Returns false if we were
-/// unable to update the start of week (e.g. because Settings aren't loaded yet), or true if we were able to set it.
-export function updateMomentStartOfWeek() {
+// Tell Moment.js to use the value of the start-of-week Setting for its current locale
+function updateMomentStartOfWeek() {
   const startOfWeekDayName = MetabaseSettings.get("start-of-week");
   if (!startOfWeekDayName) {
-    return false;
+    return;
   }
 
   const START_OF_WEEK_DAYS = [
@@ -45,7 +44,7 @@ export function updateMomentStartOfWeek() {
 
   const startOfWeekDayNumber = START_OF_WEEK_DAYS.indexOf(startOfWeekDayName);
   if (startOfWeekDayNumber === -1) {
-    return false;
+    return;
   }
   console.log(
     "Setting moment.js start of week for Locale",
@@ -60,8 +59,6 @@ export function updateMomentStartOfWeek() {
       dow: startOfWeekDayNumber,
     },
   });
-
-  return true;
 }
 
 // if the start of week Setting is updated, update the moment start of week

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -1,5 +1,7 @@
 import moment from "moment-timezone";
 
+import { updateMomentStartOfWeek } from "./i18n.js";
+
 const NUMERIC_UNIT_FORMATS = {
   // workaround for https://github.com/metabase/metabase/issues/1992
   year: value =>
@@ -16,7 +18,7 @@ const NUMERIC_UNIT_FORMATS = {
       .startOf("hour"),
   "day-of-week": value =>
     moment()
-      .day(value - 1)
+      .weekday(value - 1)
       .startOf("day"),
   "day-of-month": value =>
     moment("2016-01-01") // initial date must be in month with 31 days to format properly
@@ -40,9 +42,17 @@ const NUMERIC_UNIT_FORMATS = {
       .startOf("quarter"),
 };
 
+let hasSetMomentStartOfWeek = false;
+
 // only attempt to parse the timezone if we're sure we have one (either Z or ±hh:mm or +-hhmm)
 // moment normally interprets the DD in YYYY-MM-DD as an offset :-/
 export function parseTimestamp(value, unit = null, local = false) {
+  // make sure the moment start of week is set correctly the first time we parse something. updateMomentStartOfWeek()
+  // will return true if it was able to set it.
+  if (!hasSetMomentStartOfWeek) {
+    hasSetMomentStartOfWeek = updateMomentStartOfWeek();
+  }
+
   let m;
   if (moment.isMoment(value)) {
     m = value;

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -1,7 +1,5 @@
 import moment from "moment-timezone";
 
-import { updateMomentStartOfWeek } from "./i18n.js";
-
 const NUMERIC_UNIT_FORMATS = {
   // workaround for https://github.com/metabase/metabase/issues/1992
   year: value =>
@@ -42,17 +40,9 @@ const NUMERIC_UNIT_FORMATS = {
       .startOf("quarter"),
 };
 
-let hasSetMomentStartOfWeek = false;
-
 // only attempt to parse the timezone if we're sure we have one (either Z or ±hh:mm or +-hhmm)
 // moment normally interprets the DD in YYYY-MM-DD as an offset :-/
 export function parseTimestamp(value, unit = null, local = false) {
-  // make sure the moment start of week is set correctly the first time we parse something. updateMomentStartOfWeek()
-  // will return true if it was able to set it.
-  if (!hasSetMomentStartOfWeek) {
-    hasSetMomentStartOfWeek = updateMomentStartOfWeek();
-  }
-
   let m;
   if (moment.isMoment(value)) {
     m = value;

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -35,6 +35,7 @@ function updateMomentStartOfWeek(startOfWeekDayName) {
   hasSetMomentStartOfWeek = true;
 }
 
+MetabaseSettings.on("user-locale", updateMomentStartOfWeek);
 MetabaseSettings.on("start-of-week", updateMomentStartOfWeek);
 
 const NUMERIC_UNIT_FORMATS = {

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -1,43 +1,5 @@
 import moment from "moment-timezone";
 
-import MetabaseSettings from "metabase/lib/settings";
-
-// when the start of week setting changes or gets a value, update the start of week used by Moment.js
-let hasSetMomentStartOfWeek = false;
-
-function updateMomentStartOfWeek(startOfWeekDayName) {
-  if (!startOfWeekDayName) {
-    return;
-  }
-
-  const START_OF_WEEK_DAYS = [
-    "sunday",
-    "monday",
-    "tuesday",
-    "wednesday",
-    "thursday",
-    "friday",
-    "saturday",
-  ];
-
-  let startOfWeekDayNumber = START_OF_WEEK_DAYS.indexOf(startOfWeekDayName);
-  if (startOfWeekDayNumber === -1) {
-    return;
-  }
-
-  moment.updateLocale(moment.locale(), {
-    week: {
-      // Moment.js dow range Sunday (0) - Saturday (6)
-      dow: startOfWeekDayNumber,
-    },
-  });
-
-  hasSetMomentStartOfWeek = true;
-}
-
-MetabaseSettings.on("user-locale", updateMomentStartOfWeek);
-MetabaseSettings.on("start-of-week", updateMomentStartOfWeek);
-
 const NUMERIC_UNIT_FORMATS = {
   // workaround for https://github.com/metabase/metabase/issues/1992
   year: value =>
@@ -54,7 +16,7 @@ const NUMERIC_UNIT_FORMATS = {
       .startOf("hour"),
   "day-of-week": value =>
     moment()
-      .weekday(value - 1)
+      .day(value - 1)
       .startOf("day"),
   "day-of-month": value =>
     moment("2016-01-01") // initial date must be in month with 31 days to format properly
@@ -81,11 +43,6 @@ const NUMERIC_UNIT_FORMATS = {
 // only attempt to parse the timezone if we're sure we have one (either Z or ±hh:mm or +-hhmm)
 // moment normally interprets the DD in YYYY-MM-DD as an offset :-/
 export function parseTimestamp(value, unit = null, local = false) {
-  // if Moment start of week hasn't been set yet for whatever reason then go ahead and do so now.
-  if (!hasSetMomentStartOfWeek) {
-    updateMomentStartOfWeek();
-  }
-
   let m;
   if (moment.isMoment(value)) {
     m = value;

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -51,14 +51,23 @@ function updateLocaleInfo() {
     return;
   }
 
-  const START_OF_WEEK_DAYS = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
-  const startOfWeekDayNumber = _.indexOf(START_OF_WEEK_DAYS, startOfWeekDayName) || 0;
+  const START_OF_WEEK_DAYS = [
+    "sunday",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+  ];
+  const startOfWeekDayNumber =
+    _.indexOf(START_OF_WEEK_DAYS, startOfWeekDayName) || 0;
 
   moment.updateLocale(moment.locale(), {
     week: {
       // Moment.js dow range Sunday (0) - Saturday (6)
-      dow: startOfWeekDayNumber
-    }
+      dow: startOfWeekDayNumber,
+    },
   });
 }
 

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -41,7 +41,7 @@ describe("scenarios > admin > permissions", () => {
     cy.get(".axis.x").contains("April 25, 2016");
   });
 
-  it.skip("should display days on X-axis correctly when grouped by 'Day of the Week' (metabase#13604)", () => {
+  it("should display days on X-axis correctly when grouped by 'Day of the Week' (metabase#13604)", () => {
     withSampleDataset(({ ORDERS }) => {
       cy.request("POST", "/api/card", {
         name: "13604",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"include": ["frontend/src/**", "enterprise/frontent/src/**"]}


### PR DESCRIPTION
Fixes #13604

We had to tell Moment.js what the first day of the week should be (https://momentjs.com/docs/#/customization/dow-doy/) and then switch to Locale-aware day-of-week formatting (https://momentjs.com/docs/#/get-set/weekday/)

