### PR TITLE
Reproduce datetime downloads

### DIFF
--- a/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
@@ -8,6 +8,24 @@ const testCases = [
   { type: "xlsx", firstSheetName: "Query result" },
 ];
 
+function testWorkbookDatetimes(workbook, download_type, sheetName) {
+  expect(workbook.SheetNames[0]).to.eq(sheetName);
+  expect(workbook.Sheets[sheetName]["A1"].v).to.eq("birth_date");
+  expect(workbook.Sheets[sheetName]["B1"].v).to.eq("created_at");
+
+  // Excel and CSV will have different formats
+  if (download_type === "csv") {
+    expect(workbook.Sheets[sheetName]["A2"].v).to.eq("2020-06-03");
+    expect(workbook.Sheets[sheetName]["B2"].v).to.eq("2020-06-03T23:41:23");
+  } else if (download_type === "xlsx") {
+    // We tell the xlsx library to read raw and not parse dates
+    // So for the _date_ format we expect an integer
+    // And for timestamp, we expect a float
+    expect(workbook.Sheets[sheetName]["A2"].v).to.eq(43985);
+    expect(workbook.Sheets[sheetName]["B2"].v).to.eq(43985.98707175926);
+  }
+}
+
 describe("scenarios > question > download", () => {
   before(restore);
   beforeEach(() => {
@@ -54,6 +72,96 @@ describe("scenarios > question > download", () => {
             expect(workbook.Sheets[sheetName]["A2"].v).to.eq(18760);
           });
         });
+    });
+  });
+
+  describe("for unsaved questions - metabase#10803", () => {
+    it("should format the date properly", () => {
+      // Setup the query
+      cy.visit("/question/new");
+      cy.findByText("Native query").click();
+      cy.get(".ace_editor").type(
+        "SELECT PARSEDATETIME('2020-06-03', 'yyyy-MM-dd') AS \"birth_date\", PARSEDATETIME('2020-06-03 23:41:23', 'yyyy-MM-dd hh:mm:ss') AS \"created_at\"",
+      );
+      cy.get(".Icon-play")
+        .first()
+        .click();
+      cy.get(".Icon-download").click();
+
+      cy.wrap(testCases).each(testCase => {
+        cy.log(`downloading a ${testCase.type} file`);
+        const downloadClassName = `.Icon-${testCase.type}`;
+        const endpoint = `/api/dataset/${testCase.type}`;
+
+        cy.get(downloadClassName)
+          .parent()
+          .parent()
+          .get('input[name="query"]')
+          .invoke("val")
+          .then(download_query_params => {
+            cy.request({
+              url: endpoint,
+              method: "POST",
+              form: true,
+              body: { query: download_query_params },
+              encoding: "binary",
+            }).then(resp => {
+              let workbook = xlsx.read(resp.body, {
+                type: "binary",
+                raw: true,
+              });
+
+              testWorkbookDatetimes(
+                workbook,
+                testCase.type,
+                testCase.firstSheetName,
+              );
+            });
+          });
+      });
+    });
+  });
+
+  describe("for saved questions - metabase#10803", () => {
+    it("should format the date properly", () => {
+      cy.request("POST", "/api/card", {
+        name: "Data formats",
+        dataset_query: {
+          type: "native",
+          native: {
+            query:
+              "SELECT PARSEDATETIME('2020-06-03', 'yyyy-MM-dd') AS \"birth_date\", PARSEDATETIME('2020-06-03 23:41:23', 'yyyy-MM-dd hh:mm:ss') AS \"created_at\"",
+            "template-tags": {},
+          },
+          database: 1,
+        },
+        display: "table",
+        description: null,
+        visualization_settings: {},
+        collection_id: null,
+      }).then(({ body }) => {
+        cy.wrap(testCases).each(testCase => {
+          cy.log(`downloading a ${testCase.type} file`);
+          const endpoint = `/api/card/${body.id}/query/${testCase.type}`;
+
+          cy.request({
+            url: endpoint,
+            method: "POST",
+            encoding: "binary",
+          }).then(resp => {
+            let workbook = xlsx.read(resp.body, {
+              type: "binary",
+              raw: true,
+            });
+
+            testWorkbookDatetimes(
+              workbook,
+              testCase.type,
+              testCase.firstSheetName,
+            );
+          });
+        });
+      });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
@@ -125,7 +125,7 @@ describe("scenarios > question > download", () => {
   describe("for saved questions - metabase#10803", () => {
     it("should format the date properly", () => {
       cy.request("POST", "/api/card", {
-        name: "Data formats",
+        name: "10803",
         dataset_query: {
           type: "native",
           native: {

--- a/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
@@ -106,7 +106,7 @@ describe("scenarios > question > download", () => {
               body: { query: download_query_params },
               encoding: "binary",
             }).then(resp => {
-              let workbook = xlsx.read(resp.body, {
+              const workbook = xlsx.read(resp.body, {
                 type: "binary",
                 raw: true,
               });
@@ -149,7 +149,7 @@ describe("scenarios > question > download", () => {
             method: "POST",
             encoding: "binary",
           }).then(resp => {
-            let workbook = xlsx.read(resp.body, {
+            const workbook = xlsx.read(resp.body, {
               type: "binary",
               raw: true,
             });


### PR DESCRIPTION
Adds a test for formatting of dates and timestamps in CSV and Excel downloads.

Reproduces #10803 

~~Includes commits from #13430 - this test introduces both the `for unsaved questions` and `for saved questions` tests.~~
Rebased on top of master, since those commits were already squashed and merged. (Nemanja)