### PR TITLE
Disable video uploads for successful Cypress tests

### DIFF
--- a/frontend/test/cypress.json
+++ b/frontend/test/cypress.json
@@ -4,6 +4,7 @@
   "pluginsFile": "frontend/test/cypress-plugins.js",
   "integrationFolder": ".",
   "supportFile": "frontend/test/__support__/cypress.js",
+  "videoUploadOnPasses": false,
   "viewportHeight": 800,
   "viewportWidth": 1280,
   "retries": {


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- It disables video uploads for Cypress tests that passed, hopefully saving us a couple of minutes for every CI run.

### Additional info:
- https://docs.cypress.io/guides/references/configuration.html#Videos
- ~~let's see how long will this CI run take~~ (unfortunately, parallelization is currently disabled in Cypress Dashboard so there wasn't much point in trying to measure and/or compare this run to a random previous one)