### PR TITLE
Alternative restyling of drill-through and actions popover

### DIFF
--- a/frontend/src/metabase/css/core/bordered.css
+++ b/frontend/src/metabase/css/core/bordered.css
@@ -84,6 +84,9 @@
 :local(.border-brand) {
   border-color: var(--color-brand) !important;
 }
+.border-brand-light {
+  border-color: color(var(--color-brand) alpha(-80%)) !important;
+}
 
 .border-transparent {
   border-color: transparent;

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -17,7 +17,7 @@
   --color-success: #84bb4c;
   --color-error: #ed6e6e;
   --color-warning: #f9cf48;
-  --color-text-dark: #2e353b;
+  --color-text-dark: #4c5773;
   --color-text-medium: #74838f;
   --color-text-light: #c7cfd4;
   --color-text-white: #ffffff;

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -219,8 +219,12 @@
   background-color: color(var(--color-accent7) alpha(-85%));
 }
 
-.bg-green {
+.bg-green,
+.bg-green-hover:hover {
   background-color: var(--color-accent1);
+}
+.bg-green-light {
+  background-color: color(var(--color-accent1) alpha(-90%));
 }
 .bg-green-saturated,
 .bg-green-saturated-hover:hover {

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -215,6 +215,10 @@
   background-color: var(--color-accent2);
 }
 
+.bg-purple-light {
+  background-color: color(var(--color-accent7) alpha(-85%));
+}
+
 .bg-green {
   background-color: var(--color-accent1);
 }

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -213,3 +213,7 @@
 .text-measure {
   max-width: 620px;
 }
+
+.text-transparent {
+  color: rgba(256, 0, 0, 0);
+}

--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -29,7 +29,7 @@ const colors = {
   success: "#84BB4C",
   error: "#ED6E6E",
   warning: "#F9CF48",
-  "text-dark": "#2E353B",
+  "text-dark": "#4C5773",
   "text-medium": "#74838f",
   "text-light": "#C7CFD4",
   "text-white": "#FFFFFF",

--- a/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
@@ -30,6 +30,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       name: "exploratory-dashboard",
       section: "auto",
       icon: "bolt",
+      buttonType: "token",
       title: t`X-ray`,
       url: () => {
         const filters = query

--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -40,6 +40,7 @@ export default function QuickFilterDrill({
       name: "filter-column",
       section: "filter",
       title: t`Filter`,
+      buttonType: "horizontal",
       // eslint-disable-next-line react/display-name
       popover: ({ onChangeCardAndRun, onClose }: ClickActionPopoverProps) => (
         <FilterPopover

--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -39,8 +39,9 @@ export default function QuickFilterDrill({
     {
       name: "filter-column",
       section: "filter",
-      title: t`Filter`,
+      title: t`Filter by this column`,
       buttonType: "horizontal",
+      icon: "filter",
       // eslint-disable-next-line react/display-name
       popover: ({ onChangeCardAndRun, onClose }: ClickActionPopoverProps) => (
         <FilterPopover

--- a/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
+++ b/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
@@ -31,6 +31,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       name: "compare-dashboard",
       section: "auto",
       icon: "bolt",
+      buttonType: "token",
       title: t`Compare to the rest`,
       url: () => {
         const filters = query

--- a/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
@@ -33,7 +33,8 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     {
       name: "distribution",
       title: t`Distribution`,
-      section: "sum",
+      buttonType: "large",
+      section: "summarize",
       question: () => question.distribution(column),
     },
   ];

--- a/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
@@ -33,7 +33,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     {
       name: "distribution",
       title: t`Distribution`,
-      section: "distribution",
+      section: "sum",
       question: () => question.distribution(column),
     },
   ];

--- a/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
@@ -35,6 +35,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       title: t`Distribution`,
       buttonType: "large",
       section: "summarize",
+      icon: "bar",
       question: () => question.distribution(column),
     },
   ];

--- a/frontend/src/metabase/modes/components/drill/FormatAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/FormatAction.jsx
@@ -24,7 +24,8 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     {
       name: "formatting",
       section: "formatting",
-      title: t`Formatting`,
+      buttonType: "text",
+      title: t`Formatting options…`,
       action: () =>
         showChartSettings({
           widget: {

--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -36,6 +36,8 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       name: "object-detail",
       section: "details",
       title: t`View details`,
+      buttonType: "horizontal-no-outline",
+      icon: "document",
       default: true,
       question: () =>
         field ? question.drillPK(field, clicked && clicked.value) : question,

--- a/frontend/src/metabase/modes/components/drill/PivotByDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/PivotByDrill.jsx
@@ -45,6 +45,7 @@ export default (name: string, icon: string, fieldFilter: FieldFilter) => ({
     {
       name: "pivot-by-" + name.toLowerCase(),
       section: "breakout",
+      buttonType: "token",
       title: clicked ? (
         name
       ) : (

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -18,9 +18,9 @@ function getFiltersForColumn(column) {
   ) {
     return [
       { name: "<", operator: "<" },
+      { name: ">", operator: ">" },
       { name: "=", operator: "=" },
       { name: "≠", operator: "!=" },
-      { name: ">", operator: ">" },
     ];
   } else {
     return [{ name: "=", operator: "=" }, { name: "≠", operator: "!=" }];
@@ -52,6 +52,8 @@ export default function QuickFilterDrill({
       {
         name: "view-fks",
         section: "filter",
+        buttonType: "horizontal-no-outline",
+        icon: "filter",
         title: (
           <span>
             {jt`View this ${singularize(
@@ -68,6 +70,7 @@ export default function QuickFilterDrill({
   return operators.map(({ name, operator }) => ({
     name: operator,
     section: "filter",
+    buttonType: "token",
     title: <span className="h2">{name}</span>,
     question: () => question.filter(operator, column, value),
   }));

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -41,6 +41,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       section: "sort",
       buttonType: "text",
       title: t`Ascending`,
+      icon: "expand_arrow",
       question: () => query.replaceSort(["asc", fieldRef]).question(),
     });
   }
@@ -50,6 +51,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       section: "sort",
       buttonType: "text",
       title: t`Descending`,
+      icon: "expand_arrow",
       question: () => query.replaceSort(["desc", fieldRef]).question(),
     });
   }

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -39,7 +39,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     actions.push({
       name: "sort-ascending",
       section: "sort",
-      buttonType: "text",
+      buttonType: "sort",
       title: t`Ascending`,
       icon: "expand_arrow",
       question: () => query.replaceSort(["asc", fieldRef]).question(),
@@ -49,7 +49,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     actions.push({
       name: "sort-descending",
       section: "sort",
-      buttonType: "text",
+      buttonType: "sort",
       title: t`Descending`,
       icon: "expand_arrow",
       question: () => query.replaceSort(["desc", fieldRef]).question(),

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -39,6 +39,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     actions.push({
       name: "sort-ascending",
       section: "sort",
+      buttonType: "text",
       title: t`Ascending`,
       question: () => query.replaceSort(["asc", fieldRef]).question(),
     });
@@ -47,6 +48,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     actions.push({
       name: "sort-descending",
       section: "sort",
+      buttonType: "text",
       title: t`Descending`,
       question: () => query.replaceSort(["desc", fieldRef]).question(),
     });

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -40,7 +40,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       name: "sort-ascending",
       section: "sort",
       buttonType: "sort",
-      title: t`Asc`,
+      title: t`Sort asc.`,
       icon: "expand_arrow",
       question: () => query.replaceSort(["asc", fieldRef]).question(),
     });
@@ -50,7 +50,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       name: "sort-descending",
       section: "sort",
       buttonType: "sort",
-      title: t`Desc`,
+      title: t`Sort desc.`,
       icon: "expand_arrow",
       question: () => query.replaceSort(["desc", fieldRef]).question(),
     });

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -40,7 +40,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       name: "sort-ascending",
       section: "sort",
       buttonType: "sort",
-      title: t`Ascending`,
+      title: t`Asc`,
       icon: "expand_arrow",
       question: () => query.replaceSort(["asc", fieldRef]).question(),
     });
@@ -50,7 +50,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       name: "sort-descending",
       section: "sort",
       buttonType: "sort",
-      title: t`Descending`,
+      title: t`Desc`,
       icon: "expand_arrow",
       question: () => query.replaceSort(["desc", fieldRef]).question(),
     });

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
@@ -39,6 +39,7 @@ export default ({
       name: "summarize-by-time",
       buttonType: "large",
       section: "summarize",
+      icon: "line",
       title: (
         <span>
           {capitalize(aggregator.short)} {t`over time`}

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
@@ -37,7 +37,8 @@ export default ({
     )
     .map(aggregator => ({
       name: "summarize-by-time",
-      section: "sum",
+      buttonType: "large",
+      section: "summarize",
       title: (
         <span>
           {capitalize(aggregator.short)} {t`over time`}

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
@@ -37,7 +37,7 @@ export default ({
     )
     .map(aggregator => ({
       name: "summarize-by-time",
-      section: "distribution",
+      section: "sum",
       title: (
         <span>
           {capitalize(aggregator.short)} {t`over time`}

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
@@ -15,14 +15,17 @@ import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 const AGGREGATIONS = {
   sum: {
     section: "sum",
+    buttonType: "token",
     title: t`Sum`,
   },
   avg: {
     section: "sum",
+    buttonType: "token",
     title: t`Avg`,
   },
   distinct: {
     section: "sum",
+    buttonType: "token",
     title: t`Distincts`,
   },
 };

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
@@ -26,7 +26,7 @@ const AGGREGATIONS = {
   distinct: {
     section: "sum",
     buttonType: "token",
-    title: t`Distincts`,
+    title: t`Distinct values`,
   },
 };
 

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
@@ -26,7 +26,7 @@ const AGGREGATIONS = {
   distinct: {
     section: "sum",
     buttonType: "token",
-    title: t`Distinct values`,
+    title: t`Distincts`,
   },
 };
 

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
@@ -21,14 +21,6 @@ const AGGREGATIONS = {
     section: "sum",
     title: t`Avg`,
   },
-  min: {
-    section: "sum",
-    title: t`Min`,
-  },
-  max: {
-    section: "sum",
-    title: t`Max`,
-  },
   distinct: {
     section: "sum",
     title: t`Distincts`,

--- a/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx
@@ -52,6 +52,8 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     {
       name: "underlying-records",
       section: "records",
+      buttonType: "horizontal",
+      icon: "table_spaced",
       title: ngettext(
         msgid`View this ${inflectedTableName}`,
         `View these ${inflectedTableName}`,

--- a/frontend/src/metabase/modes/components/drill/ZoomDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ZoomDrill.jsx
@@ -24,6 +24,8 @@ export default ({
       name: "timeseries-zoom",
       section: "zoom",
       title: t`Zoom in`,
+      buttonType: "horizontal",
+      icon: "zoom_in",
       question: () => question.pivot(drilldown.breakouts, dimensions),
     },
   ];

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.css
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.css
@@ -1,10 +1,10 @@
 .token {
   padding: 4px 12px 4px 12px;
   border-radius: 100px;
-  border: 1px solid color(var(--color-accent1) alpha(-65%));
+  border: 1px solid color(var(--color-brand) alpha(-65%));
 }
 .token:hover {
-  background-color: var(--color-accent1);
+  background-color: var(--color-brand);
 }
 .sort {
   padding: 4px 12px 4px 12px;

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.css
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.css
@@ -1,0 +1,15 @@
+.token {
+  padding: 4px 12px 4px 12px;
+  border-radius: 100px;
+  border: 1px solid color(var(--color-accent1) alpha(-65%));
+}
+.token:hover {
+  background-color: var(--color-accent1);
+}
+.sort {
+  padding: 4px 12px 4px 12px;
+  text-align: center;
+}
+.large-button {
+  padding: 12px;
+}

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -16,6 +16,7 @@ import type {
   ClickAction,
 } from "metabase-types/types/Visualization";
 
+import cx from "classnames";
 import _ from "underscore";
 
 const SECTIONS = {
@@ -36,6 +37,9 @@ const SECTIONS = {
   },
   filter: {
     icon: "funnel_outline",
+  },
+  summarize: {
+    icon: "summarize",
   },
   sum: {
     icon: "sum",
@@ -174,20 +178,40 @@ export default class ChartClickActions extends Component {
         ) : (
           <div className="text-bold">
             {sections.map(([key, actions]) => (
-              <div key={key} className="flex align-center">
+              <div className="px2 py1">
+                {SECTIONS[key].icon == "summarize" ? (
+                  <p className="text-bold text-medium block">Summarize</p>
+                ) : null}
+                <div
+                  key={key}
+                  className={cx(
+                    "flex justify-center",
+                    {
+                      "border-top": SECTIONS[key].icon == "pencil",
+                    },
+                    {
+                      "align-center":
+                        SECTIONS[key].icon == "pencil" ||
+                        SECTIONS[key].icon == "sort",
+                    },
+                  )}
+                >
+                  {/*
                 <Icon
                   name={(SECTIONS[key] && SECTIONS[key].icon) || "unknown"}
                   className="mr1 pl2 text-medium"
                   size={16}
                 />
-                {actions.map((action, index) => (
-                  <ChartClickAction
-                    index={index}
-                    action={action}
-                    isLastItem={index === actions.length - 1}
-                    handleClickAction={this.handleClickAction}
-                  />
-                ))}
+                */}
+                  {actions.map((action, index) => (
+                    <ChartClickAction
+                      index={index}
+                      action={action}
+                      isLastItem={index === actions.length - 1}
+                      handleClickAction={this.handleClickAction}
+                    />
+                  ))}
+                </div>
               </div>
             ))}
           </div>
@@ -206,8 +230,13 @@ export const ChartClickAction = ({
   isLastItem: any,
   handleClickAction: any,
 }) => {
-  const className =
-    "text-small text-brand-hover cursor-pointer no-decoration p2 flex-auto";
+  const className = cx("text-small cursor-pointer no-decoration", {
+    "p1 text-brand-hover justify-evenly": action.buttonType == "text",
+    "p2 rounded flex-full bg-purple text-white":
+      action.buttonType == "horizontal",
+    "bordered rounded p1 mr1": action.buttonType == "token",
+    "p4 mr1 text-white rounded bg-brand block": action.buttonType == "large",
+  });
   // NOTE: Tom Robinson 4/16/2018: disabling <Link> for `question` click actions
   // for now since on dashboards currently they need to go through
   // navigateToNewCardFromDashboard to merge in parameters.,

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -178,21 +178,23 @@ export default class ChartClickActions extends Component {
         ) : (
           <div className="text-bold">
             {sections.map(([key, actions]) => (
-              <div className="px2 py1">
-                {SECTIONS[key].icon == "summarize" ? (
-                  <p className="text-bold text-medium block">Summarize</p>
-                ) : null}
+              <div className="px2 pb1">
+                {SECTIONS[key].icon === "summarize" && (
+                  <p className="text-bold text-medium text-small block">
+                    Summarize
+                  </p>
+                )}
                 <div
                   key={key}
                   className={cx(
                     "flex justify-center",
                     {
-                      "border-top": SECTIONS[key].icon == "pencil",
+                      "border-top": SECTIONS[key].icon === "pencil",
                     },
                     {
                       "align-center":
-                        SECTIONS[key].icon == "pencil" ||
-                        SECTIONS[key].icon == "sort",
+                        SECTIONS[key].icon === "pencil" ||
+                        SECTIONS[key].icon === "sort",
                     },
                   )}
                 >
@@ -231,11 +233,13 @@ export const ChartClickAction = ({
   handleClickAction: any,
 }) => {
   const className = cx("text-small cursor-pointer no-decoration", {
-    "p1 text-brand-hover justify-evenly": action.buttonType == "text",
-    "p2 rounded flex-full bg-purple text-white":
-      action.buttonType == "horizontal",
-    "bordered rounded p1 mr1": action.buttonType == "token",
-    "p4 mr1 text-white rounded bg-brand block": action.buttonType == "large",
+    "px2 pt2 pb1 text-brand-hover justify-evenly": action.buttonType === "text",
+    "p2 rounded flex-full bg-light bg-brand-hover text-brand text-white-hover":
+      action.buttonType === "horizontal",
+    "bordered border-brand circular text-brand bg-brand-hover text-white-hover px2 py1 mr1":
+      action.buttonType === "token",
+    "px2 pt2 pb2 mr1 text-brand text-white-hover rounded bg-light bg-brand-hover":
+      action.buttonType === "large",
   });
   // NOTE: Tom Robinson 4/16/2018: disabling <Link> for `question` click actions
   // for now since on dashboards currently they need to go through
@@ -250,23 +254,51 @@ export const ChartClickAction = ({
   // } else
   if (action.url) {
     return (
-      <Link
-        to={action.url()}
-        className={className}
-        onClick={() =>
-          MetabaseAnalytics.trackEvent(
-            "Actions",
-            "Executed Click Action",
-            getGALabelForAction(action),
-          )
-        }
-      >
-        {action.title}
-      </Link>
+      <div>
+        <Link
+          to={action.url()}
+          className={className}
+          onClick={() =>
+            MetabaseAnalytics.trackEvent(
+              "Actions",
+              "Executed Click Action",
+              getGALabelForAction(action),
+            )
+          }
+        >
+          {action.title}
+        </Link>
+      </div>
     );
   } else {
     return (
-      <div className={className} onClick={() => handleClickAction(action)}>
+      <div
+        className={cx(
+          className,
+          {
+            "flex flex-column align-center": action.buttonType === "large",
+          },
+          {
+            "flex flex-row justify-center":
+              action.buttonType === "text" ||
+              action.buttonType === "horizontal",
+          },
+        )}
+        onClick={() => handleClickAction(action)}
+      >
+        {action.icon && (
+          <Icon
+            className={cx(
+              "flex",
+              {
+                mr1: action.buttonType !== "large",
+              },
+              { mb1: action.buttonType === "large" },
+            )}
+            size={action.buttonType === "large" ? 20 : 12}
+            name={action.icon}
+          />
+        )}
         {action.title}
       </div>
     );

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -176,7 +176,7 @@ export default class ChartClickActions extends Component {
         {popover ? (
           popover
         ) : (
-          <div className="text-bold px2 py1">
+          <div className="text-bold px2 pt1 pb2">
             {sections.map(([key, actions]) => (
               <div className="py1">
                 {SECTIONS[key].icon === "summarize" && (
@@ -185,7 +185,7 @@ export default class ChartClickActions extends Component {
                   </p>
                 )}
                 {SECTIONS[key].icon === "breakout" && (
-                  <p className="text-bold text-medium text-small block">
+                  <p className="mt0 text-bold text-medium text-small block">
                     Break out by…
                   </p>
                 )}
@@ -197,13 +197,13 @@ export default class ChartClickActions extends Component {
                 <div
                   key={key}
                   className={cx(
-                    "flex justify-center",
+                    "flex",
                     {
                       "border-top pt2 text-medium":
                         SECTIONS[key].icon === "pencil",
                     },
                     {
-                      "align-center":
+                      "align-center justify-center":
                         SECTIONS[key].icon === "pencil" ||
                         SECTIONS[key].icon === "sort",
                     },
@@ -245,13 +245,14 @@ export const ChartClickAction = ({
 }) => {
   const className = cx("text-small cursor-pointer no-decoration", {
     "px2 text-brand-hover justify-evenly": action.buttonType === "text",
-    "p2 bordered border-brand rounded flex-full bg-brand-hover text-brand text-white-hover":
+    "px3 py1 mr1 rounded text-brand-hover bg-light justify-between": action.buttonType === "sort",
+    "p2 mr1 bg-purple-light rounded flex-full bg-purple-hover text-purple text-white-hover":
       action.buttonType === "horizontal",
       "p1 rounded flex-full bg-brand-hover text-brand text-white-hover":
         action.buttonType === "horizontal-no-outline",
-    "bordered border-brand circular text-brand bg-brand-hover text-white-hover px2 py1 mr1":
+    "bordered border-brand-light circular text-brand bg-brand-hover text-white-hover px2 py1 mr1":
       action.buttonType === "token",
-    "px2 pt2 pb2 mr1 bordered border-brand text-brand text-white-hover rounded bg-brand-hover":
+    "flex-auto px3 pt2 pb2 mr1 bg-brand-light text-brand text-white-hover rounded bg-brand-hover":
       action.buttonType === "large",
   });
   // NOTE: Tom Robinson 4/16/2018: disabling <Link> for `question` click actions
@@ -308,7 +309,7 @@ export const ChartClickAction = ({
               },
               { mb1: action.buttonType === "large" },
             )}
-            size={action.buttonType === "large" ? 20 : 12}
+            size={action.buttonType === "large" ? 20 : action.buttonType === "horizontal" ? 16 : 12}
             name={action.icon}
           />
         )}

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -23,7 +23,7 @@ import _ from "underscore";
 
 const SECTIONS = {
   records: {
-    icon: "table2",
+    icon: "table_spaced",
   },
   zoom: {
     icon: "zoom_in",
@@ -38,13 +38,13 @@ const SECTIONS = {
     icon: "breakout",
   },
   filter: {
-    icon: "funnel_outline",
+    icon: "filter",
   },
   summarize: {
-    icon: "summarize",
+    icon: "bar",
   },
   sum: {
-    icon: "sum",
+    icon: "number",
   },
   averages: {
     icon: "curve",
@@ -178,50 +178,28 @@ export default class ChartClickActions extends Component {
         {popover ? (
           popover
         ) : (
-          <div className="text-bold px2 py1">
+          <div className="text-bold pr1">
             {sections.map(([key, actions]) => (
-              <div className={cx("py1", { pb1: SECTIONS[key].icon === "sum" })}>
-                {SECTIONS[key].icon === "breakout" && (
-                  <p className="mt0 text-bold text-medium text-small block">
-                    Break out by…
-                  </p>
-                )}
-                {SECTIONS[key].icon === "bolt" && (
-                  <p className="text-bold text-medium text-small block">
-                    Automatic explorations
-                  </p>
-                )}
-                <div
-                  key={key}
-                  className={cx(
-                    "flex",
-                    {
-                      "border-top pt2 text-medium":
-                        SECTIONS[key].icon === "pencil",
-                    },
-                    {
-                      "align-center justify-center":
-                        SECTIONS[key].icon === "pencil" ||
-                        SECTIONS[key].icon === "sort",
-                    },
-                  )}
-                >
-                  {/*
-                <Icon
-                  name={(SECTIONS[key] && SECTIONS[key].icon) || "unknown"}
-                  className="mr1 pl2 text-medium"
-                  size={16}
-                />
-                */}
-                  {actions.map((action, index) => (
-                    <ChartClickAction
-                      index={index}
-                      action={action}
-                      isLastItem={index === actions.length - 1}
-                      handleClickAction={this.handleClickAction}
-                    />
-                  ))}
+              <div key={key} className="flex align-center">
+                <div className="mr2 bg-light" style={{ padding: "8px" }}>
+                  <Icon
+                    name={(SECTIONS[key] && SECTIONS[key].icon) || "unknown"}
+                    className={cx(
+                      "m1",
+                      { "text-transparent": SECTIONS[key].icon === "pencil" },
+                      { "text-brand": SECTIONS[key].icon !== "pencil" },
+                    )}
+                    size={16}
+                  />
                 </div>
+                {actions.map((action, index) => (
+                  <ChartClickAction
+                    index={index}
+                    action={action}
+                    isLastItem={index === actions.length - 1}
+                    handleClickAction={this.handleClickAction}
+                  />
+                ))}
               </div>
             ))}
           </div>
@@ -240,18 +218,16 @@ export const ChartClickAction = ({
   isLastItem: any,
   handleClickAction: any,
 }) => {
-  const className = cx("text-small cursor-pointer no-decoration", {
-    "px2 text-brand-hover justify-evenly": action.buttonType === "text",
-    "sort mr1 flex-auto rounded text-white-hover bg-light bg-brand-hover justify-between":
-      action.buttonType === "sort",
-    "px2 py1 mr1 bg-purple-light rounded flex-full bg-purple-hover text-purple text-white-hover":
-      action.buttonType === "horizontal",
-    "p1 rounded flex-full bg-brand-hover text-brand text-white-hover":
-      action.buttonType === "horizontal-no-outline",
-    "token text-green text-white-hover mr1": action.buttonType === "token",
-    "large-button mr1 bg-green-light text-green text-white-hover rounded bg-green-hover":
-      action.buttonType === "large",
-  });
+  const className = cx(
+    "mr1 circular text-small cursor-pointer",
+    {
+      "token text-white-hover text-brand no-decoration":
+        action.buttonType !== "text",
+    },
+    {
+      "text-medium text-brand-hover px1": action.buttonType === "text",
+    },
+  );
   // NOTE: Tom Robinson 4/16/2018: disabling <Link> for `question` click actions
   // for now since on dashboards currently they need to go through
   // navigateToNewCardFromDashboard to merge in parameters.,
@@ -284,32 +260,11 @@ export const ChartClickAction = ({
   } else {
     return (
       <div
-        className={cx(
-          className,
-          {
-            "flex flex-column align-center": action.buttonType === "large",
-          },
-          {
-            "flex flex-row justify-left":
-              action.buttonType === "text" ||
-              action.buttonType === "horizontal",
-          },
-        )}
+        className={cx(className, {
+          "flex flex-column align-center": action.buttonType === "large",
+        })}
         onClick={() => handleClickAction(action)}
       >
-        {action.icon && (
-          <Icon
-            className={cx(
-              "flex",
-              {
-                mr1: action.buttonType !== "large",
-              },
-              { mb1: action.buttonType === "large" },
-            )}
-            size={action.buttonType === "large" ? 16 : 12}
-            name={action.icon}
-          />
-        )}
         {action.title}
       </div>
     );

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -34,17 +34,14 @@ const SECTIONS = {
   breakout: {
     icon: "breakout",
   },
+  filter: {
+    icon: "funnel_outline",
+  },
   sum: {
     icon: "sum",
   },
   averages: {
     icon: "curve",
-  },
-  distribution: {
-    icon: "bar",
-  },
-  filter: {
-    icon: "funnel_outline",
   },
   dashboard: {
     icon: "dashboard",
@@ -177,7 +174,7 @@ export default class ChartClickActions extends Component {
         ) : (
           <div className="text-bold">
             {sections.map(([key, actions]) => (
-              <div key={key} className="border-row-divider flex align-center">
+              <div key={key} className="flex align-center">
                 <Icon
                   name={(SECTIONS[key] && SECTIONS[key].icon) || "unknown"}
                   className="mr1 pl2 text-medium"
@@ -210,7 +207,7 @@ export const ChartClickAction = ({
   handleClickAction: any,
 }) => {
   const className =
-    "text-brand-hover cursor-pointer no-decoration p2 flex-auto";
+    "text-small text-brand-hover cursor-pointer no-decoration p2 flex-auto";
   // NOTE: Tom Robinson 4/16/2018: disabling <Link> for `question` click actions
   // for now since on dashboards currently they need to go through
   // navigateToNewCardFromDashboard to merge in parameters.,

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -20,11 +20,11 @@ import cx from "classnames";
 import _ from "underscore";
 
 const SECTIONS = {
-  zoom: {
-    icon: "zoom_in",
-  },
   records: {
     icon: "table2",
+  },
+  zoom: {
+    icon: "zoom_in",
   },
   details: {
     icon: "document",
@@ -176,9 +176,9 @@ export default class ChartClickActions extends Component {
         {popover ? (
           popover
         ) : (
-          <div className="text-bold">
+          <div className="text-bold px2 py1">
             {sections.map(([key, actions]) => (
-              <div className="px2 pb1">
+              <div className="py1">
                 {SECTIONS[key].icon === "summarize" && (
                   <p className="text-bold text-medium text-small block">
                     Summarize
@@ -189,7 +189,8 @@ export default class ChartClickActions extends Component {
                   className={cx(
                     "flex justify-center",
                     {
-                      "border-top": SECTIONS[key].icon === "pencil",
+                      "border-top pt2 text-medium":
+                        SECTIONS[key].icon === "pencil",
                     },
                     {
                       "align-center":
@@ -233,12 +234,12 @@ export const ChartClickAction = ({
   handleClickAction: any,
 }) => {
   const className = cx("text-small cursor-pointer no-decoration", {
-    "px2 pt2 pb1 text-brand-hover justify-evenly": action.buttonType === "text",
-    "p2 rounded flex-full bg-light bg-brand-hover text-brand text-white-hover":
+    "px2 text-brand-hover justify-evenly": action.buttonType === "text",
+    "p2 bordered border-brand rounded flex-full bg-brand-hover text-brand text-white-hover":
       action.buttonType === "horizontal",
     "bordered border-brand circular text-brand bg-brand-hover text-white-hover px2 py1 mr1":
       action.buttonType === "token",
-    "px2 pt2 pb2 mr1 text-brand text-white-hover rounded bg-light bg-brand-hover":
+    "px2 pt2 pb2 mr1 bordered border-brand text-brand text-white-hover rounded bg-brand-hover":
       action.buttonType === "large",
   });
   // NOTE: Tom Robinson 4/16/2018: disabling <Link> for `question` click actions
@@ -279,7 +280,7 @@ export const ChartClickAction = ({
             "flex flex-column align-center": action.buttonType === "large",
           },
           {
-            "flex flex-row justify-center":
+            "flex flex-row justify-left":
               action.buttonType === "text" ||
               action.buttonType === "horizontal",
           },

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -7,6 +7,8 @@ import Icon from "metabase/components/Icon";
 import Popover from "metabase/components/Popover";
 import { Link } from "react-router";
 
+import "./ChartClickActions.css";
+
 import MetabaseAnalytics from "metabase/lib/analytics";
 
 import { performAction } from "metabase/visualizations/lib/action";
@@ -176,14 +178,9 @@ export default class ChartClickActions extends Component {
         {popover ? (
           popover
         ) : (
-          <div className="text-bold px2 pt1 pb2">
+          <div className="text-bold px2 py1">
             {sections.map(([key, actions]) => (
-              <div className="py1">
-                {SECTIONS[key].icon === "summarize" && (
-                  <p className="text-bold text-medium text-small block">
-                    Summarize
-                  </p>
-                )}
+              <div className={cx("py1", { pb1: SECTIONS[key].icon === "sum" })}>
                 {SECTIONS[key].icon === "breakout" && (
                   <p className="mt0 text-bold text-medium text-small block">
                     Break out by…
@@ -245,14 +242,14 @@ export const ChartClickAction = ({
 }) => {
   const className = cx("text-small cursor-pointer no-decoration", {
     "px2 text-brand-hover justify-evenly": action.buttonType === "text",
-    "px3 py1 mr1 rounded text-brand-hover bg-light justify-between": action.buttonType === "sort",
-    "p2 mr1 bg-purple-light rounded flex-full bg-purple-hover text-purple text-white-hover":
+    "sort mr1 flex-auto rounded text-white-hover bg-light bg-brand-hover justify-between":
+      action.buttonType === "sort",
+    "px2 py1 mr1 bg-purple-light rounded flex-full bg-purple-hover text-purple text-white-hover":
       action.buttonType === "horizontal",
-      "p1 rounded flex-full bg-brand-hover text-brand text-white-hover":
-        action.buttonType === "horizontal-no-outline",
-    "bordered border-brand-light circular text-brand bg-brand-hover text-white-hover px2 py1 mr1":
-      action.buttonType === "token",
-    "flex-auto px3 pt2 pb2 mr1 bg-brand-light text-brand text-white-hover rounded bg-brand-hover":
+    "p1 rounded flex-full bg-brand-hover text-brand text-white-hover":
+      action.buttonType === "horizontal-no-outline",
+    "token text-green text-white-hover mr1": action.buttonType === "token",
+    "large-button mr1 bg-green-light text-green text-white-hover rounded bg-green-hover":
       action.buttonType === "large",
   });
   // NOTE: Tom Robinson 4/16/2018: disabling <Link> for `question` click actions
@@ -309,7 +306,7 @@ export const ChartClickAction = ({
               },
               { mb1: action.buttonType === "large" },
             )}
-            size={action.buttonType === "large" ? 20 : action.buttonType === "horizontal" ? 16 : 12}
+            size={action.buttonType === "large" ? 16 : 12}
             name={action.icon}
           />
         )}

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -184,6 +184,16 @@ export default class ChartClickActions extends Component {
                     Summarize
                   </p>
                 )}
+                {SECTIONS[key].icon === "breakout" && (
+                  <p className="text-bold text-medium text-small block">
+                    Break out by…
+                  </p>
+                )}
+                {SECTIONS[key].icon === "bolt" && (
+                  <p className="text-bold text-medium text-small block">
+                    Automatic explorations
+                  </p>
+                )}
                 <div
                   key={key}
                   className={cx(
@@ -237,6 +247,8 @@ export const ChartClickAction = ({
     "px2 text-brand-hover justify-evenly": action.buttonType === "text",
     "p2 bordered border-brand rounded flex-full bg-brand-hover text-brand text-white-hover":
       action.buttonType === "horizontal",
+      "p1 rounded flex-full bg-brand-hover text-brand text-white-hover":
+        action.buttonType === "horizontal-no-outline",
     "bordered border-brand circular text-brand bg-brand-hover text-white-hover px2 py1 mr1":
       action.buttonType === "token",
     "px2 pt2 pb2 mr1 bordered border-brand text-brand text-white-hover rounded bg-brand-hover":


### PR DESCRIPTION
This is a much smaller set of changes than https://github.com/metabase/metabase/pull/13695/:
- Gets rid of `Min` and `Max`
- Reorders the action sections
- Gives `Formatting` a different style to downplay it
- Tweaks some of the iconography

<img width="1520" alt="image" src="https://user-images.githubusercontent.com/2223916/98749343-43754400-2370-11eb-992e-9d5935abf583.png">
