### PR TITLE
Improve Cypress helper functions with log messages

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -36,6 +36,7 @@ export const USERS = {
 };
 
 export function signIn(user = "admin") {
+  cy.log(`**Logging in as ${user}**`);
   cy.request("POST", "/api/session", USERS[user]);
 }
 export function signOut() {

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -36,16 +36,19 @@ export const USERS = {
 };
 
 export function signIn(user = "admin") {
-  cy.log(`**Logging in as ${user}**`);
+  cy.log(`**--- Logging in as ${user} ---**`);
   cy.request("POST", "/api/session", USERS[user]);
 }
+
 export function signOut() {
+  cy.log(`**--- Signing out ---**`);
   cy.clearCookie("metabase.SESSION");
 }
 
 export function signInAsAdmin() {
   signIn("admin");
 }
+
 export function signInAsNormalUser() {
   signIn("normal");
 }
@@ -53,7 +56,9 @@ export function signInAsNormalUser() {
 export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }
+
 export function restore(name = "default") {
+  cy.log(`**--- Restore Data Set ---**`);
   cy.request("POST", `/api/testing/restore/${name}`);
 }
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds helpful log message to various helper functions in `frontend/test/__support__/cypress.js`.
    - `--- Logging in as ${user} ---` to `signIn()`
    - `--- Signing out ---` to `signOut()` and
    - `--- Restore Data Set ---` to `restore()`

### Additional notes:
This is a silly little addition that helps a lot. We have 5 pre-seeded users in our test DB, and we're often switching context (logging in as different users). This log will always make it clear who is the currently logged in user.

![image](https://user-images.githubusercontent.com/31325167/98750456-4860e480-23be-11eb-8923-2a67520476f9.png)
