### PR TITLE
Add docstrings to chain filter endpoints

### DIFF
--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -471,12 +471,14 @@
 ;;; ------------------------------------------------ Chain Filtering -------------------------------------------------
 
 (api/defendpoint GET "/dashboard/:uuid/params/:param-key/values"
+  "Fetch filter values for dashboard parameter `param-key`."
   [uuid param-key :as {:keys [query-params]}]
   (let [dashboard (dashboard-with-uuid uuid)]
     (binding [api/*current-user-permissions-set* (atom #{"/"})]
       (dashboard-api/chain-filter dashboard param-key query-params))))
 
 (api/defendpoint GET "/dashboard/:uuid/params/:param-key/search/:prefix"
+  "Fetch filter values for dashboard parameter `param-key`, with specified `prefix`."
   [uuid param-key prefix :as {:keys [query-params]}]
   (let [dashboard (dashboard-with-uuid uuid)]
     (binding [api/*current-user-permissions-set* (atom #{"/"})]


### PR DESCRIPTION
This is just to remove warnings about missing API endpoint docstrings that can be seen at startup.

The docstring contents are based on my very cursory understanding of the chain filter code called from those endpoints, so feel free to update as you see fit.