### PR TITLE
Pivot table column settings

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -71,7 +71,8 @@ function getHeaderRows(values, { valueColumns, formatters }) {
       formatters: otherFormatters,
     });
     rowLists.push(rows);
-    const span = rows.length === 0 ? 1 : sumSpan(rows[0]);
+    const span =
+      rows.length === 0 ? 1 : rows[0].reduce((sum, { span }) => sum + span, 0);
     return { value: currentFormatter(value), span };
   });
   const followingRows = _.zip(...rowLists).map(a => a.flat());
@@ -110,15 +111,11 @@ function getBodyRows(tree, context, valueList = []) {
     const rows = getBodyRows(children, context, [...valueList, value]);
     const item = {
       value: context.rowHeaderFormatters[valueList.length](value),
-      span: sumSpan(rows.map(row => row[0])),
+      span: rows.length,
     };
     const [first, ...rest] = rows;
     return [[item, ...first], ...rest];
   });
-}
-
-function sumSpan(a) {
-  return a.reduce((sum, { span }) => sum + span, 0);
 }
 
 function updateValueObject(row, indexes, seenValues) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import cx from "classnames";
+import { t } from "ttag";
+import { DragSource, DropTarget } from "react-dnd";
+import _ from "underscore";
+
+const ChartSettingFieldsPartition = ({ value = {}, partitions, onChange }) => (
+  <div>
+    {partitions.map(({ name, title }, index) => (
+      <div className={cx("py2", { "border-top": index > 0 })}>
+        <h4 className="mb2">{title}</h4>
+        <Partition
+          partitionName={name}
+          columns={value[name]}
+          value={value}
+          onChange={onChange}
+        />
+      </div>
+    ))}
+  </div>
+);
+
+@DropTarget(
+  "columns",
+  {
+    canDrop: (props, monitor) => true,
+    drop: ({ partitionName }, monitor, component) => ({ partitionName }),
+  },
+  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
+)
+class Partition extends React.Component {
+  render() {
+    const {
+      columns = [],
+      partitionName,
+      connectDropTarget,
+      value,
+      onChange,
+    } = this.props;
+    return connectDropTarget(
+      <div>
+        {columns.length === 0 ? (
+          <div>{t`Drag fields here`}</div>
+        ) : (
+          columns.map(col => (
+            <Column
+              partitionName={partitionName}
+              column={col}
+              value={value}
+              onChange={onChange}
+            />
+          ))
+        )}
+      </div>,
+    );
+  }
+}
+
+@DragSource(
+  "columns",
+  {
+    beginDrag: ({ column, partitionName }) => ({ column, partitionName }),
+    endDrag: ({ value, onChange }, monitor, component) => {
+      if (!monitor.didDrop()) {
+        return;
+      }
+
+      const { column, partitionName: oldPartition } = monitor.getItem();
+      const { partitionName: newPartition } = monitor.getDropResult();
+
+      onChange({
+        ...value,
+        // remove column from old partition
+        [oldPartition]: value[oldPartition].filter(
+          col => !_.isEqual(col.field_ref, column.field_ref),
+        ),
+        // add it to the new one
+        [newPartition]: [...value[newPartition], column],
+      });
+    },
+  },
+  (connect, monitor) => ({
+    connectDragSource: connect.dragSource(),
+    isDragging: monitor.isDragging(),
+  }),
+)
+class Column extends React.Component {
+  render() {
+    const { column, connectDragSource, isDragging } = this.props;
+    return connectDragSource(
+      <div
+        className={cx("text-dark p1 bordered rounded dropshadow text-bold", {
+          disabled: isDragging,
+        })}
+      >
+        {column.display_name}
+      </div>,
+    );
+  }
+}
+
+export default ChartSettingFieldsPartition;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -4,6 +4,8 @@ import { t } from "ttag";
 import { DragSource, DropTarget } from "react-dnd";
 import _ from "underscore";
 
+import Grabber from "metabase/components/Grabber";
+
 const ChartSettingFieldsPartition = ({ value = {}, partitions, onChange }) => (
   <div>
     {partitions.map(({ name, title }, index) => (
@@ -67,6 +69,10 @@ class Partition extends React.Component {
 
       const { column, partitionName: oldPartition } = monitor.getItem();
       const { partitionName: newPartition } = monitor.getDropResult();
+      if (newPartition === oldPartition) {
+        // dropped in the starting partition
+        return;
+      }
 
       onChange({
         ...value,
@@ -89,11 +95,13 @@ class Column extends React.Component {
     const { column, connectDragSource, isDragging } = this.props;
     return connectDragSource(
       <div
-        className={cx("text-dark p1 bordered rounded dropshadow text-bold", {
-          disabled: isDragging,
-        })}
+        className={cx(
+          "text-dark p1 mb1 bordered rounded dropshadow text-bold flex justify-between",
+          { disabled: isDragging },
+        )}
       >
         {column.display_name}
+        <Grabber style={{ width: 10 }} />
       </div>,
     );
   }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -25,23 +25,34 @@ class ChartSettingFieldsPartition extends React.Component {
     return (
       <div>
         {this.props.partitions.map(({ name, title, columnFilter }, index) => (
-          <div className={cx("py2", { "border-top": index > 0 })}>
-            <h4 className="mb2">{title}</h4>
-            <Partition
-              columnFilter={columnFilter}
-              partitionName={name}
-              columns={value[name]}
-              value={value}
-              updateDisplayedValue={this.updateDisplayedValue}
-              commitDisplayedValue={this.commitDisplayedValue}
-            />
-          </div>
+          <Partition
+            className={cx("py2", { "border-top": index > 0 })}
+            title={title}
+            columnFilter={columnFilter}
+            partitionName={name}
+            columns={value[name]}
+            value={value}
+            updateDisplayedValue={this.updateDisplayedValue}
+            commitDisplayedValue={this.commitDisplayedValue}
+          />
         ))}
       </div>
     );
   }
 }
 
+@DropTarget(
+  "columns",
+  {
+    // Using a drop target here is a hack to work around another issue.
+    // The version of react-dnd we're on has a bug where endDrag isn't called.
+    // Drop is still called here, so we trigger commit here.
+    drop: (props, monitor, component) => {
+      props.commitDisplayedValue();
+    },
+  },
+  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
+)
 class Partition extends React.Component {
   render() {
     const {
@@ -51,9 +62,13 @@ class Partition extends React.Component {
       updateDisplayedValue,
       commitDisplayedValue,
       value,
+      connectDropTarget,
+      title,
+      className,
     } = this.props;
-    return (
-      <div>
+    return connectDropTarget(
+      <div className={className}>
+        <h4 className="mb2">{title}</h4>
         {columns.length === 0 ? (
           <EmptyPartition
             columnFilter={columnFilter}
@@ -74,7 +89,7 @@ class Partition extends React.Component {
             />
           ))
         )}
-      </div>
+      </div>,
     );
   }
 }
@@ -127,7 +142,7 @@ class EmptyPartition extends React.Component {
         columnsDup[hoverIndex] = columns[dragIndex];
         updateDisplayedValue({ ...value, [itemPartition]: columnsDup });
         item.index = hoverIndex;
-      } else if (partitionName !== itemPartition && dragIndex !== hoverIndex) {
+      } else if (partitionName !== itemPartition) {
         updateDisplayedValue({
           ...value,
           [itemPartition]: [
@@ -161,7 +176,7 @@ class EmptyPartition extends React.Component {
       index,
     }),
     endDrag: (props, monitor, component) => {
-      props.commitDisplayedValue();
+      // props.commitDisplayedValue();
     },
   },
   (connect, monitor) => ({

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -6,27 +6,34 @@ import _ from "underscore";
 
 import Grabber from "metabase/components/Grabber";
 
-const ChartSettingFieldsPartition = ({ value = {}, partitions, onChange }) => (
-  <div>
-    {partitions.map(({ name, title }, index) => (
-      <div className={cx("py2", { "border-top": index > 0 })}>
-        <h4 className="mb2">{title}</h4>
-        <Partition
-          partitionName={name}
-          columns={value[name]}
-          value={value}
-          onChange={onChange}
-        />
-      </div>
-    ))}
-  </div>
-);
+const ChartSettingFieldsPartition = ({ value = {}, partitions, onChange }) => {
+  return (
+    <div>
+      {partitions.map(({ name, title }, index) => (
+        <div className={cx("py2", { "border-top": index > 0 })}>
+          <h4 className="mb2">{title}</h4>
+          <Partition
+            partitionName={name}
+            columns={value[name]}
+            value={value}
+            onChange={onChange}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
 
 @DropTarget(
   "columns",
   {
     canDrop: (props, monitor) => true,
-    drop: ({ partitionName }, monitor, component) => ({ partitionName }),
+    drop: ({ partitionName }, monitor, component) => {
+      if (monitor.didDrop()) {
+        return;
+      }
+      return { partitionName };
+    },
   },
   (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
 )
@@ -44,10 +51,11 @@ class Partition extends React.Component {
         {columns.length === 0 ? (
           <div>{t`Drag fields here`}</div>
         ) : (
-          columns.map(col => (
+          columns.map((col, index) => (
             <Column
               partitionName={partitionName}
               column={col}
+              index={index}
               value={value}
               onChange={onChange}
             />
@@ -58,30 +66,93 @@ class Partition extends React.Component {
   }
 }
 
+function swap(a, i1, i2) {
+  const aDupe = [...a];
+  aDupe[i1] = a[i2];
+  aDupe[i2] = a[i1];
+  return aDupe;
+}
+
+@DropTarget(
+  "columns",
+  {
+    canDrop: (props, monitor) => true,
+    hover: (props, monitor, component) => {
+      const item = monitor.getItem();
+      const { index: dragIndex, partitionName: itemPartition } = item;
+      const hoverIndex = props.index;
+
+      if (dragIndex === hoverIndex) {
+        return;
+      }
+
+      if (props.partitionName === itemPartition) {
+        props.onChange({
+          ...props.value,
+          [itemPartition]: swap(
+            props.value[itemPartition],
+            dragIndex,
+            hoverIndex,
+          ),
+        });
+        item.index = hoverIndex;
+      }
+    },
+    drop: ({ index, column, partitionName }, monitor, component) => ({
+      index,
+      column,
+      partitionName,
+    }),
+  },
+  (connect, monitor) => ({ connectDropTarget: connect.dropTarget() }),
+)
 @DragSource(
   "columns",
   {
-    beginDrag: ({ column, partitionName }) => ({ column, partitionName }),
+    beginDrag: ({ column, partitionName, index }) => ({
+      column,
+      partitionName,
+      index,
+    }),
     endDrag: ({ value, onChange }, monitor, component) => {
       if (!monitor.didDrop()) {
         return;
       }
 
+      const {
+        column: targetColumn,
+        partitionName: newPartition,
+      } = monitor.getDropResult();
+
       const { column, partitionName: oldPartition } = monitor.getItem();
-      const { partitionName: newPartition } = monitor.getDropResult();
-      if (newPartition === oldPartition) {
-        // dropped in the starting partition
+
+      if (targetColumn && _.isEqual(column.field_ref, targetColumn.field_ref)) {
         return;
       }
 
-      onChange({
+      value = {
         ...value,
         // remove column from old partition
         [oldPartition]: value[oldPartition].filter(
           col => !_.isEqual(col.field_ref, column.field_ref),
         ),
+      };
+
+      const targetIndex =
+        targetColumn == null
+          ? value[newPartition].length
+          : value[newPartition].findIndex(col =>
+              _.isEqual(col.field_ref, targetColumn.field_ref),
+            );
+
+      onChange({
+        ...value,
         // add it to the new one
-        [newPartition]: [...value[newPartition], column],
+        [newPartition]: [
+          ...value[newPartition].slice(0, targetIndex),
+          column,
+          ...value[newPartition].slice(targetIndex),
+        ],
       });
     },
   },
@@ -92,17 +163,24 @@ class Partition extends React.Component {
 )
 class Column extends React.Component {
   render() {
-    const { column, connectDragSource, isDragging } = this.props;
-    return connectDragSource(
-      <div
-        className={cx(
-          "text-dark p1 mb1 bordered rounded dropshadow text-bold flex justify-between",
-          { disabled: isDragging },
-        )}
-      >
-        {column.display_name}
-        <Grabber style={{ width: 10 }} />
-      </div>,
+    const {
+      column,
+      connectDragSource,
+      connectDropTarget,
+      isDragging,
+    } = this.props;
+    return connectDropTarget(
+      connectDragSource(
+        <div
+          className={cx(
+            "text-dark p1 mb1 bordered rounded dropshadow text-bold flex justify-between",
+            { disabled: isDragging },
+          )}
+        >
+          {column.display_name}
+          <Grabber style={{ width: 10 }} />
+        </div>,
+      ),
     );
   }
 }

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -9,6 +9,7 @@ import ChartSettingToggle from "metabase/visualizations/components/settings/Char
 import ChartSettingButtonGroup from "metabase/visualizations/components/settings/ChartSettingButtonGroup";
 import ChartSettingFieldPicker from "metabase/visualizations/components/settings/ChartSettingFieldPicker";
 import ChartSettingFieldsPicker from "metabase/visualizations/components/settings/ChartSettingFieldsPicker";
+import ChartSettingFieldsPartition from "metabase/visualizations/components/settings/ChartSettingFieldsPartition";
 import ChartSettingColorPicker from "metabase/visualizations/components/settings/ChartSettingColorPicker";
 import ChartSettingColorsPicker from "metabase/visualizations/components/settings/ChartSettingColorsPicker";
 
@@ -73,6 +74,7 @@ const WIDGETS = {
   buttonGroup: ChartSettingButtonGroup,
   field: ChartSettingFieldPicker,
   fields: ChartSettingFieldsPicker,
+  fieldsPartition: ChartSettingFieldsPartition,
   color: ChartSettingColorPicker,
   colors: ChartSettingColorsPicker,
 };

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -48,7 +48,7 @@ export default class PivotTable extends Component {
           columnFilter: isDimension,
           title: t`Fields to use for the table columns`,
         },
-        { name: "values", title: t`Fields to use for the table rows` },
+        { name: "values", title: t`Fields to use for the table values` },
       ],
       getProps: ([{ data }], settings) => ({
         columns: data.cols,

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -202,6 +202,63 @@ describe("data_grid", () => {
         ],
       ]);
     });
+    it("should work with three levels of row grouping", () => {
+      // three was picked because there was a bug during development that showed up with at least three
+      const data = {
+        rows: [
+          ["a1", "b1", "c1", 1],
+          ["a1", "b1", "c2", 1],
+          ["a1", "b2", "c1", 1],
+          ["a1", "b2", "c2", 1],
+          ["a2", "b1", "c1", 1],
+          ["a2", "b1", "c2", 1],
+          ["a2", "b2", "c1", 1],
+          ["a2", "b2", "c2", 1],
+        ],
+        cols: [
+          { name: "D1", display_name: "Dimension 1", base_type: TYPE.Text },
+          { name: "D2", display_name: "Dimension 2", base_type: TYPE.Text },
+          { name: "D3", display_name: "Dimension 3", base_type: TYPE.Text },
+          { name: "M1", display_name: "Metric", base_type: TYPE.Integer },
+        ],
+      };
+
+      const { headerRows, bodyRows } = multiLevelPivot(
+        data,
+        [],
+        [0, 1, 2],
+        [3],
+      );
+      expect(headerRows).toEqual([]);
+      expect(bodyRows).toEqual([
+        [
+          { span: 4, value: "a1" },
+          { span: 2, value: "b1" },
+          { span: 1, value: "c1" },
+          { span: 1, value: "1" },
+        ],
+        [{ span: 1, value: "c2" }, { span: 1, value: "1" }],
+        [
+          { span: 2, value: "b2" },
+          { span: 1, value: "c1" },
+          { span: 1, value: "1" },
+        ],
+        [{ span: 1, value: "c2" }, { span: 1, value: "1" }],
+        [
+          { span: 4, value: "a2" },
+          { span: 2, value: "b1" },
+          { span: 1, value: "c1" },
+          { span: 1, value: "1" },
+        ],
+        [{ span: 1, value: "c2" }, { span: 1, value: "1" }],
+        [
+          { span: 2, value: "b2" },
+          { span: 1, value: "c1" },
+          { span: 1, value: "1" },
+        ],
+        [{ span: 1, value: "c2" }, { span: 1, value: "1" }],
+      ]);
+    });
     it("should format values", () => {
       const data = {
         rows: [[1, "2020-01-01T00:00:00", 1000]],


### PR DESCRIPTION
Part of #13662 

In the first PR, I used existing settings widgets. Those didn't really work since you could duplicate the same column. This PR adds a settings widget to partition columns by dragging them.

<img width="1177" alt="Screen Shot 2020-11-11 at 7 55 01 PM" src="https://user-images.githubusercontent.com/691495/98881573-506d6280-2458-11eb-8561-981ce937ec31.png">

Things I'll add in this PR before merging:
- [x] Update the options when the query changes
- [x] Sorting columns within a partition
- [x] Block drags that don't make sense (e.g. unaggregated data into "values")

Things I'll add in future PRs after other work happens:
- The ability to expand these columns to access column settings.