### PR TITLE
Repro for #12839: Can't use filter based on CE from aggregated results

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -193,7 +193,7 @@ describe("scenarios > question > filter", () => {
   });
 
   it.skip("should filter using Custom Expression from aggregated results (metabase#12839)", () => {
-    const CE_NAME = "Last Year";
+    const CE_NAME = "Simple Math";
 
     withSampleDataset(({ PRODUCTS }) => {
       cy.request("POST", "/api/card", {
@@ -207,8 +207,8 @@ describe("scenarios > question > filter", () => {
                 [
                   "aggregation-options",
                   ["+", 1, 1],
-                  { "display-name": CE_NAME }
-                ]
+                  { "display-name": CE_NAME },
+                ],
               ],
               breakout: [["field-id", PRODUCTS.CATEGORY]],
               "source-table": 1,

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -204,20 +204,11 @@ describe("scenarios > question > filter", () => {
             filter: [">", ["field-literal", CE_NAME, "type/Float"], 0],
             "source-query": {
               aggregation: [
-                ["avg", ["field-id", PRODUCTS.PRICE]],
                 [
                   "aggregation-options",
-                  [
-                    "count-where",
-                    [
-                      "time-interval",
-                      ["field-id", PRODUCTS.CREATED_AT],
-                      -1,
-                      "year",
-                    ],
-                  ],
-                  { "display-name": CE_NAME },
-                ],
+                  ["+", 1, 1],
+                  { "display-name": CE_NAME }
+                ]
               ],
               breakout: [["field-id", PRODUCTS.CATEGORY]],
               "source-table": 1,


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #12839 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

- Most likely the fix for this issue will fix #13857 which seems like a duplicate