### PR TITLE
Fix `unused var` linter error on a release branch

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -3,7 +3,6 @@ import {
   signInAsAdmin,
   popover,
   openOrdersTable,
-  sidebar,
 } from "__support__/cypress";
 
 // test various entry points into the query builder


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes linter error (unused var) on a `release-x.37.x` branch that I introduced with https://github.com/metabase/metabase/commit/d8e09bf775c81aefcbd6a773adf0ecfa43691632

### Additional context:
It affected this merge: https://app.circleci.com/pipelines/github/metabase/metabase/10378/workflows/08d629b7-db62-4f8f-ad42-2ad42e5871cf/jobs/367623