### PR TITLE
Allow SSL client certificates to work in pgsql

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -134,7 +134,7 @@
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
    [org.mariadb.jdbc/mariadb-java-client "2.6.2"]                     ; MySQL/MariaDB driver
-   [org.postgresql/postgresql "42.2.8"]                               ; Postgres driver
+   [org.postgresql/postgresql "42.2.18"]                              ; Postgres driver
    [org.slf4j/slf4j-api "1.7.30"]                                     ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
    [org.tcrawley/dynapath "1.1.0"]                                    ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
    [org.threeten/threeten-extra "1.5.0"]                               ; extra Java 8 java.time classes like DayOfMonth and Quarter

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -287,8 +287,7 @@
 (def ^:private ssl-params
   "Params to include in the JDBC connection spec for an SSL connection."
   {:ssl        true
-   :sslmode    "require"
-   :sslfactory "org.postgresql.ssl.NonValidatingFactory"})
+   :sslmode    "require"})
 
 (def ^:private disable-ssl-params
   "Params to include in the JDBC connection spec to disable SSL."
@@ -296,19 +295,24 @@
 
 (defmethod sql-jdbc.conn/connection-details->spec :postgres
   [_ {ssl? :ssl, :as details-map}]
-  (-> details-map
-      (update :port (fn [port]
-                      (if (string? port)
-                        (Integer/parseInt port)
-                        port)))
-      ;; remove :ssl in case it's false; DB will still try (& fail) to connect if the key is there
-      (dissoc :ssl)
-      (merge (if ssl?
-               ssl-params
-               disable-ssl-params))
-      (set/rename-keys {:dbname :db})
-      db.spec/postgres
-      (sql-jdbc.common/handle-additional-options details-map)))
+  (let [props (-> details-map
+                  (update :port (fn [port]
+                                  (if (string? port)
+                                    (Integer/parseInt port)
+                                    port)))
+                  ;; remove :ssl in case it's false; DB will still try (& fail) to connect if the key is there
+                  (dissoc :ssl))
+        ;; this happens via ->> so that the users props will override the ssl-params stuff.
+        ;; if the user has specified a sslmode, it must always take precedence over our default.
+        props (->> props
+                   (merge (if ssl?
+                            ssl-params
+                            disable-ssl-params)))
+        props (-> props
+                  (set/rename-keys {:dbname :db})
+                  db.spec/postgres
+                  (sql-jdbc.common/handle-additional-options details-map))]
+    props))
 
 (defmethod sql-jdbc.execute/set-timezone-sql :postgres
   [_]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -58,8 +58,7 @@
             :OpenSourceSubProtocolOverride true
             :user                          "camsaul"
             :ssl                           true
-            :sslmode                       "require"
-            :sslfactory                    "org.postgresql.ssl.NonValidatingFactory"}
+            :sslmode                       "require"}
            (sql-jdbc.conn/connection-details->spec :postgres
              {:ssl    true
               :host   "localhost"
@@ -76,7 +75,30 @@
              {:host               "localhost"
               :port               "5432"
               :dbname             "cool"
-              :additional-options "prepareThreshold=0"})))))
+              :additional-options "prepareThreshold=0"}))))
+  (testing "user-specified SSL options should always take precendence over defaults"
+    (is (= {:classname                     "org.postgresql.Driver"
+            :subprotocol                   "postgresql"
+            :subname                       "//localhost:5432/bird_sightings"
+            :OpenSourceSubProtocolOverride true
+            :user                          "camsaul"
+            :ssl                           true
+            :sslmode                       "verify-ca"
+            :sslcert                       "my-cert"
+            :sslkey                        "my-key"
+            :sslfactory                    "myfactoryoverride"
+            :sslrootcert                   "myrootcert"}
+           (sql-jdbc.conn/connection-details->spec :postgres
+             {:ssl         true
+              :host        "localhost"
+              :port        5432
+              :dbname      "bird_sightings"
+              :user        "camsaul"
+              :sslmode     "verify-ca"
+              :sslcert     "my-cert"
+              :sslkey      "my-key"
+              :sslfactory  "myfactoryoverride"
+              :sslrootcert "myrootcert"})))))
 
 
 ;;; ------------------------------------------- Tests for sync edge cases --------------------------------------------


### PR DESCRIPTION
When a user specifies a `sslmode` or `sslfactory`, we should honor that instead of overwriting their selections.

The NonValidatingFactory isn't something we should default to - it just checks that an SSL certificate is present, it does not attempt
any sort of validation of said certificate, and it also explicitly blocks support for client certificates.

Resolves metabase/metabase#13796
