### PR TITLE
Fix scalar error when rendering null

### DIFF
--- a/frontend/src/metabase/query_builder/components/VisualizationError.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError.jsx
@@ -63,6 +63,16 @@ class VisualizationError extends Component {
           />
         );
       }
+    } else if (error instanceof Error) {
+      return (
+        <div className={cx(className, "QueryError2 flex justify-center")}>
+          <div className="QueryError-image QueryError-image--queryError mr4" />
+          <div className="QueryError2-details">
+            <h1 className="text-bold">{t`There was a problem with this visualization`}</h1>
+            <ErrorDetails className="pt2" details={error} />
+          </div>
+        </div>
+      );
     } else if (
       card &&
       card.dataset_query &&

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -206,7 +206,8 @@ export default class Scalar extends Component {
     // use the compact version of formatting if the component is narrower than
     // the cutoff and the formatted value is longer than the cutoff
     const displayCompact =
-      (fullScalarValue || "").length > COMPACT_MIN_LENGTH &&
+      fullScalarValue !== null &&
+      fullScalarValue.length > COMPACT_MIN_LENGTH &&
       width < COMPACT_MAX_WIDTH;
     const displayValue = displayCompact ? compactScalarValue : fullScalarValue;
 

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -206,7 +206,8 @@ export default class Scalar extends Component {
     // use the compact version of formatting if the component is narrower than
     // the cutoff and the formatted value is longer than the cutoff
     const displayCompact =
-      fullScalarValue.length > COMPACT_MIN_LENGTH && width < COMPACT_MAX_WIDTH;
+      (fullScalarValue || "").length > COMPACT_MIN_LENGTH &&
+      width < COMPACT_MAX_WIDTH;
     const displayValue = displayCompact ? compactScalarValue : fullScalarValue;
 
     const clicked = {

--- a/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
@@ -51,4 +51,16 @@ describe("MetricForm", () => {
     );
     getByText("12.3k");
   });
+
+  it.only("should render null", () => {
+    const { getByText } = render(
+      <Scalar
+        isDashboard // displays title
+        series={series(null)}
+        settings={settings}
+        visualizationIsClickable={() => false}
+      />,
+    );
+    getByText("Scalar Title"); // just confirms that it rendered
+  });
 });

--- a/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
@@ -52,7 +52,7 @@ describe("MetricForm", () => {
     getByText("12.3k");
   });
 
-  it.only("should render null", () => {
+  it("should render null", () => {
     const { getByText } = render(
       <Scalar
         isDashboard // displays title


### PR DESCRIPTION
Fixes #13801 

This PR fixes the direct cause of the crash and makes the QB error display work better. I poked at fixing the core issue with Visualizations globally, but I didn't see why the error boundary wasn't triggering.