### PR TITLE
Remove object count from log output

### DIFF
--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -69,7 +69,7 @@
       (throw e))))
 
 (defn- insert-entity! [target-db-conn {table-name :table, entity-name :name} objs]
-  (print (u/format-color 'blue "Transferring %d instances of %s..." (count objs) entity-name))
+  (print (u/format-color 'blue "Transferring %s data..." entity-name))
   (flush)
   ;; The connection closes prematurely on occasion when we're inserting thousands of rows at once. Break into
   ;; smaller chunks so connection stays alive


### PR DESCRIPTION
`count` caused the lazy `objs` to be realized, causing the entire table to be scanned. For tables with very high numbers of rows this stalls the program and effectively eliminates the usefulness of chunking `objs`.

If the count is _really_ that big a deal, it can be determined, in multiples of `chunk-size`, but counting the number of dots after the log line, as printed by `insert-chunk!`.