### PR TITLE
Waterfall chart: show the correct series values (positives and negatives) (#13661)

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -254,6 +254,7 @@ function getDimensionsAndGroupsForWaterfallChart(props, originalDatas, warn) {
         : beams[i - 1];
   }
   for (let k = 0; k < values.length; ++k) {
+    datas[0][k]._waterfallValue = datas[0][k][1];
     datas[0][k][1] = beams[k];
     datas[1][k][1] = negatives[k];
     datas[2][k][1] = positives[k];
@@ -965,6 +966,14 @@ export default function lineAreaBar(
   setupTooltips(props, datas, parent, brushChangeFunctions);
 
   parent.render();
+
+  datas.map(data => {
+    data.map(d => {
+      if (d._waterfallValue) {
+        d[1] = d._waterfallValue;
+      }
+    });
+  });
 
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)
   lineAndBarOnRender(parent, {


### PR DESCRIPTION
Also, position the value labels properly (horizontally centered).

This shows the value labels for waterfall.
Steps to try:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'Apples' as product, 10 as profit
union all
select 'Bananas' as product, 4 as profit
union all
select 'Oranges' as product, 5 as profit
union all
select 'Peaches' as product, -7 as profit
union all
select 'Mangos' as product, 2 as profit
```

4. Visualization, Waterfall
5. Settings, Waterfall options, Display, Show values on data points

~~Note: the vertical position of each value label is still wrong. This is known, it will be addressed later~~. *Update*: This is now fixed.

![image](https://user-images.githubusercontent.com/7288/99695226-2f9da200-2a42-11eb-9dee-20b6f63b88c2.png)
