### PR TITLE
Tag untranslated strings

### DIFF
--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -62,7 +62,7 @@ export default class VisualizationResult extends Component {
         <div className={cx(className, "flex")}>
           <ErrorMessage
             type="noRows"
-            title="No results!"
+            title={t`No results!`}
             message={t`This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific.`}
             action={
               <div>

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -268,7 +268,7 @@ export default class PieChart extends Component {
       others.length === 1
         ? others[0]
         : {
-            key: "Other",
+            key: t`Other`,
             value: otherTotal,
             percentage: otherTotal / total,
             color: color("text-light"),
@@ -352,7 +352,7 @@ export default class PieChart extends Component {
             showPercentInTooltip && slice.percentage != null
               ? [
                   {
-                    key: "Percentage",
+                    key: t`Percentage`,
                     value: formatPercent(slice.percentage),
                   },
                 ]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/11542 by tagging "No results!" in viz results, and "Other" and "Percentage" in Pie charts.

Some of the strings mentioned in 11542 were already fixed:
- "Add filter" in all the filter popovers and sidebar
- "Pick your starting data" in the notebook

I think we should permanently close 11542 with this and subsequently open individual issues for untagged strings we find, or at least clusters of untagged strings in particular areas like https://github.com/metabase/metabase/issues/8964, so that it's easier for us to know what we've fixed. @flamber, let me know if you disagree.