### PR TITLE
Fix admin settings `auth` cypress test

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -46,10 +46,9 @@ describe("scenarios > admin > settings", () => {
     // Ported from `SettingsAuthenticationOptions.e2e.spec.js`
     // Google sign in
     cy.visit("/admin/settings/authentication");
-    cy.findByText("Sign in with Google");
-    cy.findAllByText("Configure")
-      .first()
-      .click();
+
+    configureAuth("Sign in with Google");
+
     cy.contains(
       "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID.",
     );
@@ -58,10 +57,9 @@ describe("scenarios > admin > settings", () => {
 
     // SSO
     cy.visit("/admin/settings/authentication");
-    cy.findByText("LDAP").click();
-    cy.findAllByText("Configure")
-      .last()
-      .click();
+
+    configureAuth("LDAP");
+
     cy.findByText("LDAP Authentication");
     cy.findByText("User Schema");
     cy.findByText("Save changes");
@@ -314,3 +312,10 @@ describe("scenarios > admin > settings", () => {
     });
   });
 });
+
+function configureAuth(providerTitle) {
+  cy.findByText(providerTitle)
+    .closest(".rounded.bordered")
+    .contains("Configure")
+    .click();
+}


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- Fixes an issue in `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js` when it was failing for EE CircleCI group. 
- Extracts and abstracts steps around `configure` button into a helper function

### Additional notes:
- example of this test failing in CI: https://dashboard.cypress.io/projects/a394u1/runs/2957/failures
- it was failing because of this command:
```javascript
cy.findAllByText("Configure")
  .last()
  .click();
```
In `oss` version the last "Configure" is indeed LDAP, while in `ee` it is JWT. The context changes so it invalidates the steps after this one.