### PR TITLE
Fix `snippet` Cypress test for CI

### DIFF
--- a/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsNormalUser, restore, modal } from "__support__/cypress";
+import { signInAsAdmin, restore, modal } from "__support__/cypress";
 
 // HACK which lets us type (even very long words) without losing focus
 // this is needed for fields where autocomplete suggestions are enabled
@@ -12,9 +12,14 @@ function _clearAndIterativelyTypeUsingLabel(label, string) {
   }
 }
 
+// NOTE: - Had to change user role to "admin" on 2020-11-19.
+//       - Normal users don't have permission to create/edit snippets in `ee` version.
+//       - CI runs this test twice (both contexts), so it fails on `ee`.
+//       - There is a related issue: https://github.com/metabase/metabase-enterprise/issues/543
+// TODO: Once the above issue is (re)solved, change back to `signInAsNormalUser`
 describe("scenarios > question > snippets", () => {
   before(restore);
-  beforeEach(signInAsNormalUser);
+  beforeEach(signInAsAdmin);
 
   it("should let you create and use a snippet", () => {
     cy.visit("/question/new");


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- Fixes `snippets.cy.spec.js` file that was part of CI related failures.
- Changes user role to an `admin` so that this test can be safely run in CI until https://github.com/metabase/metabase-enterprise/issues/543 gets resolved
- Adds note explaining the reason behind this failure, along with a TODO

### Additional notes:
- With #13841 merged, all tests in CI should pass for this PR.

### Recent failures:
- https://dashboard.cypress.io/projects/a394u1/runs/2960/failures
- https://dashboard.cypress.io/projects/a394u1/runs/2963/failures