### PR TITLE
Waterfall: add the total bar

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -897,21 +897,20 @@ export default function lineAreaBar(
   checkSeriesIsValid(props);
 
   if (props.chartType === "waterfall") {
-    props.series.map(series => {
+    _.each(props.series, series => {
       const rows = series.data.rows;
       const finalRow = rows[rows.length - 1];
       if (!finalRow._waterfallTotal) {
         const totalValue = rows.reduce((t, d) => t + d[1], 0);
         const totalRow = ["Total", totalValue];
-        rows.push(totalRow);
-        const _origin = {
+        totalRow._waterfallTotal = totalValue;
+        totalRow._origin = {
           seriesIndex: finalRow._origin.seriesIndex,
           rowIndex: rows.length,
           cols: series.data.cols,
           row: totalRow,
         };
-        totalRow._origin = _origin;
-        totalRow._waterfallTotal = totalValue;
+        series.data.rows = [...series.data.rows, totalRow];
       }
     });
   }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -901,7 +901,7 @@ export default function lineAreaBar(
       const rows = series.data.rows;
       const finalRow = rows[rows.length - 1];
       if (!finalRow._waterfallTotal) {
-        const totalValue = rows.reduce((t, d) => (t += d[1]), 0);
+        const totalValue = rows.reduce((t, d) => t + d[1], 0);
         const totalRow = ["Total", totalValue];
         rows.push(totalRow);
         const _origin = {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -136,7 +136,7 @@ function getXAxisProps(props, datas, warn) {
   const xValues = isHistogram
     ? [...rawXValues, Math.max(...rawXValues) + xInterval]
     : props.chartType === "waterfall"
-    ? [...rawXValues, "Total"]
+    ? [...rawXValues, t`Total`]
     : rawXValues;
 
   return {

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -107,7 +107,6 @@ export function onRenderValueLabels(
         d.cumulativeY = d.y + total;
         total += d.y;
       });
-      data[data.length - 1].cumulativeY = data[data.length - 1].y;
     }
 
     return data;

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -107,6 +107,7 @@ export function onRenderValueLabels(
         d.cumulativeY = d.y + total;
         total += d.y;
       });
+      data[data.length - 1].cumulativeY = data[data.length - 1].y;
     }
 
     return data;


### PR DESCRIPTION
This is carried out by adding a new row in the chart series.

Steps to test:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'Apples' as product, 10 as profit
union all
select 'Bananas' as product, 4 as profit
union all
select 'Oranges' as product, 5 as profit
union all
select 'Peaches' as product, -7 as profit
union all
select 'Mangos' as product, 2 as profit
```

4. Visualization, Waterfall

![image](https://user-images.githubusercontent.com/7288/99988352-63d8d180-2d66-11eb-9903-337a251e96d9.png)
