### PR TITLE
#13751 Repro: Custom column based filter should allow strings

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -199,3 +199,29 @@ export function createBasicAlert({ firstAlert, includeNormal } = {}) {
   cy.findByText("Done").click();
   cy.findByText("Let's set up your alert").should("not.exist");
 }
+
+// Functions specific to QA databases that we started supporting recently in CI
+export function addPostgresDatabase(db_display_name = "QA Postgres12") {
+  cy.visit("/admin/databases/create");
+  cy.contains("Database type")
+    .closest(".Form-field")
+    .find("a")
+    .click();
+  cy.contains("PostgreSQL").click({ force: true });
+  cy.contains("Additional JDBC connection string options");
+
+  typeAndBlurUsingLabel("Name", db_display_name);
+  typeAndBlurUsingLabel("Host", "localhost");
+  // TODO: "Port" label and input field are misconfigured (input field is missing `aria-labeledby` attribute)
+  // typeAndBlurUsingLabel("Port", "5432") => this will not work (switching to placeholder temporarily)
+  cy.findByPlaceholderText("5432")
+    .click()
+    .type("5432");
+  typeAndBlurUsingLabel("Database name", "sample");
+  typeAndBlurUsingLabel("Username", "metabase");
+  typeAndBlurUsingLabel("Password", "metasample123");
+
+  cy.findByText("Save")
+    .should("not.be.disabled")
+    .click();
+}

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -202,26 +202,35 @@ export function createBasicAlert({ firstAlert, includeNormal } = {}) {
 
 // Functions specific to QA databases that we started supporting recently in CI
 export function addPostgresDatabase(db_display_name = "QA Postgres12") {
-  cy.visit("/admin/databases/create");
-  cy.contains("Database type")
-    .closest(".Form-field")
-    .find("a")
-    .click();
-  cy.contains("PostgreSQL").click({ force: true });
-  cy.contains("Additional JDBC connection string options");
-
-  typeAndBlurUsingLabel("Name", db_display_name);
-  typeAndBlurUsingLabel("Host", "localhost");
-  // TODO: "Port" label and input field are misconfigured (input field is missing `aria-labeledby` attribute)
-  // typeAndBlurUsingLabel("Port", "5432") => this will not work (switching to placeholder temporarily)
-  cy.findByPlaceholderText("5432")
-    .click()
-    .type("5432");
-  typeAndBlurUsingLabel("Database name", "sample");
-  typeAndBlurUsingLabel("Username", "metabase");
-  typeAndBlurUsingLabel("Password", "metasample123");
-
-  cy.findByText("Save")
-    .should("not.be.disabled")
-    .click();
+  cy.request("POST", "/api/database", {
+    engine: "postgres",
+    name: db_display_name,
+    details: {
+      host: "localhost",
+      dbname: "sample",
+      port: 5432,
+      user: "metabase",
+      password: "metasample123", // NOTE: we're inconsistent in where we use `pass` vs `password` as a key
+      authdb: null,
+      "additional-options": null,
+      "use-srv": false,
+      "tunnel-enabled": false,
+    },
+    auto_run_queries: true,
+    is_full_sync: true,
+    schedules: {
+      cache_field_values: {
+        schedule_day: null,
+        schedule_frame: null,
+        schedule_hour: 0,
+        schedule_type: "daily",
+      },
+      metadata_sync: {
+        schedule_day: null,
+        schedule_frame: null,
+        schedule_hour: null,
+        schedule_type: "hourly",
+      },
+    },
+  });
 }

--- a/frontend/test/metabase-db/postgres/add.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/add.cy.spec.js
@@ -2,33 +2,8 @@ import {
   signInAsAdmin,
   restore,
   modal,
-  typeAndBlurUsingLabel,
+  addPostgresDatabase,
 } from "__support__/cypress";
-
-function addPostgresDatabase() {
-  cy.visit("/admin/databases/create");
-  cy.contains("Database type")
-    .closest(".Form-field")
-    .find("a")
-    .click();
-  cy.contains("PostgreSQL").click({ force: true });
-  cy.contains("Additional JDBC connection string options");
-
-  typeAndBlurUsingLabel("Name", "QA Postgres12");
-  typeAndBlurUsingLabel("Host", "localhost");
-  // TODO: "Port" label and input field are misconfigured (input field is missing `aria-labeledby` attribute)
-  // typeAndBlurUsingLabel("Port", "5432") => this will not work (switching to placeholder temporarily)
-  cy.findByPlaceholderText("5432")
-    .click()
-    .type("5432");
-  typeAndBlurUsingLabel("Database name", "sample");
-  typeAndBlurUsingLabel("Username", "metabase");
-  typeAndBlurUsingLabel("Password", "metasample123");
-
-  cy.findByText("Save")
-    .should("not.be.disabled")
-    .click();
-}
 
 describe("postgres > admin > add", () => {
   beforeEach(() => {

--- a/frontend/test/metabase-db/postgres/add.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/add.cy.spec.js
@@ -2,7 +2,7 @@ import {
   signInAsAdmin,
   restore,
   modal,
-  addPostgresDatabase,
+  typeAndBlurUsingLabel,
 } from "__support__/cypress";
 
 describe("postgres > admin > add", () => {
@@ -13,59 +13,35 @@ describe("postgres > admin > add", () => {
   });
 
   it("should add a database and redirect to listing", () => {
-    cy.route({
-      method: "POST",
-      url: "/api/database",
-    }).as("createDatabase");
+    cy.route("POST", "/api/database").as("createDatabase");
 
-    addPostgresDatabase();
+    cy.visit("/admin/databases/create");
+    cy.contains("Database type")
+      .closest(".Form-field")
+      .find("a")
+      .click();
+    cy.contains("PostgreSQL").click({ force: true });
+    cy.contains("Additional JDBC connection string options");
 
-    cy.wait("@createDatabase");
+    typeAndBlurUsingLabel("Name", "QA Postgres12");
+    typeAndBlurUsingLabel("Host", "localhost");
+    // TODO: "Port" label and input field are misconfigured (input field is missing `aria-labeledby` attribute)
+    // typeAndBlurUsingLabel("Port", "5432") => this will not work (switching to placeholder temporarily)
+    cy.findByPlaceholderText("5432")
+      .click()
+      .type("5432");
+    typeAndBlurUsingLabel("Database name", "sample");
+    typeAndBlurUsingLabel("Username", "metabase");
+    typeAndBlurUsingLabel("Password", "metasample123");
+
+    cy.findByText("Save")
+      .should("not.be.disabled")
+      .click();
 
     cy.url().should("match", /\/admin\/databases\?created=\d+$/);
     cy.contains("Your database has been added!");
     modal()
       .contains("I'm good thanks")
       .click();
-  });
-
-  it("should show row details when clicked on its entity key (metabase#13263)", () => {
-    cy.route({
-      method: "POST",
-      url: "/api/database",
-    }).as("createDatabase");
-
-    addPostgresDatabase();
-
-    cy.wait("@createDatabase");
-
-    cy.url().should("match", /\/admin\/databases\?created=\d+$/);
-    cy.contains("Your database has been added!");
-    modal()
-      .contains("I'm good thanks")
-      .click();
-
-    // Repro starts here
-    cy.visit("/");
-    cy.findByText("Ask a question").click();
-    cy.findByText("Simple question").click();
-    cy.findByText("QA Postgres12").click();
-    cy.findByText("Orders").click();
-
-    // We're clicking on ID: 1 (the first order) => do not change!
-    // It is tightly coupled to the assertion ("37.65"), which is "Subtotal" value for that order.
-    cy.get(".Table-ID")
-      .eq(0)
-      .click();
-
-    // Wait until "doing science" spinner disappears (DOM is ready for assertions)
-    // TODO: if this proves to be reliable, extract it as a helper function for waiting on DOM to render
-    cy.get(".LoadingSpinner").should("not.exist");
-
-    // Assertions
-    cy.log("**Fails in v0.36.6**");
-    // This could be omitted because real test is searching for "37.65" on the page
-    cy.findByText("There was a problem with your question").should("not.exist");
-    cy.contains("37.65");
   });
 });

--- a/frontend/test/metabase-db/postgres/add.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/add.cy.spec.js
@@ -37,6 +37,8 @@ describe("postgres > admin > add", () => {
     cy.findByText("Save")
       .should("not.be.disabled")
       .click();
+    
+    cy.wait("@createDatabase");
 
     cy.url().should("match", /\/admin\/databases\?created=\d+$/);
     cy.contains("Your database has been added!");

--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -1,0 +1,58 @@
+import {
+  signInAsAdmin,
+  restore,
+  addPostgresDatabase,
+  popover,
+} from "__support__/cypress";
+
+describe("postgres > question > custom columns", () => {
+  before(() => {
+    restore();
+    signInAsAdmin();
+    addPostgresDatabase();
+  });
+
+  it.skip("should allow using strings in filter based on a custom column (metabase#13751)", () => {
+    const CC_NAME = "C-States";
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("QA Postgres12").click();
+    cy.findByText("People").click();
+
+    cy.log("**-- 1. Create custom column using `regexextract()` --**");
+
+    cy.get(".Icon-add_data").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']").type(
+        'regexextract([State], "^C[A-Z]")',
+      );
+      cy.findByPlaceholderText("Something nice and descriptive").type(CC_NAME);
+      cy.get(".Button")
+        .contains("Done")
+        .should("not.be.disabled")
+        .click();
+    });
+
+    cy.log("**-- 2. Add filter based on custom column--**");
+
+    cy.findByText("Add filters to narrow your answer").click();
+    // ADd filt
+    popover().within(() => {
+      cy.findByText(CC_NAME).click();
+      cy.get(".AdminSelect").click();
+      cy.log(
+        "**It fails here already because it doesn't find any condition for strings. Only numbers.**",
+      );
+      cy.findByText("Is");
+      cy.get("input").type("CO");
+      cy.get(".Button")
+        .contains("Add filter")
+        .should("not.be.disabled")
+        .click();
+    });
+
+    cy.findByText("Visualize").click();
+    cy.findByText("Arnold Adams");
+  });
+});

--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -37,7 +37,6 @@ describe("postgres > question > custom columns", () => {
     cy.log("**-- 2. Add filter based on custom column--**");
 
     cy.findByText("Add filters to narrow your answer").click();
-    // ADd filt
     popover().within(() => {
       cy.findByText(CC_NAME).click();
       cy.get(".AdminSelect").click();

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -1,0 +1,36 @@
+import {
+  signInAsAdmin,
+  restore,
+  addPostgresDatabase,
+} from "__support__/cypress";
+
+describe("postgres > user > query", () => {
+  before(() => {
+    restore();
+    signInAsAdmin();
+    addPostgresDatabase();
+  });
+
+  it("should show row details when clicked on its entity key (metabase#13263)", () => {
+    cy.visit("/question/new");
+    cy.findByText("Simple question").click();
+    cy.findByText("QA Postgres12").click();
+    cy.findByText("Orders").click();
+
+    // We're clicking on ID: 1 (the first order) => do not change!
+    // It is tightly coupled to the assertion ("37.65"), which is "Subtotal" value for that order.
+    cy.get(".Table-ID")
+      .eq(0)
+      .click();
+
+    // Wait until "doing science" spinner disappears (DOM is ready for assertions)
+    // TODO: if this proves to be reliable, extract it as a helper function for waiting on DOM to render
+    cy.get(".LoadingSpinner").should("not.exist");
+
+    // Assertions
+    cy.log("**Fails in v0.36.6**");
+    // This could be omitted because real test is searching for "37.65" on the page
+    cy.findByText("There was a problem with your question").should("not.exist");
+    cy.contains("37.65");
+  });
+});


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #13751 
- Extracts `addPostgresDatabase()` into a global Cypress helper function (not directly related to this repro)

### How to test this manually?
- Spin up QA Postgres image:
`docker run --rm -p 5432:5432 --name meta-postgres12-sample metabase/qa-databases:postgres-sample-12`
- `yarn test-cypress-open --testFiles frontend/test/metabase-db`
- `frontend/test/metabase-db/postgres/custom-column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix