### PR TITLE
Fix chain filtering with temporal string params like 'last32weeks'

### DIFF
--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -280,5 +280,5 @@
 (s/defn date-string->filter :- mbql.s/Filter
   "Takes a string description of a *date* (not datetime) range such as 'lastmonth' or '2016-07-15~2016-08-6' and
    returns a corresponding MBQL filter clause for a given field reference."
-  [date-string :- s/Str, field :- (s/cond-pre su/IntGreaterThanZero mbql.s/Field)]
+  [date-string :- s/Str field :- (s/cond-pre su/IntGreaterThanZero mbql.s/Field)]
   (execute-decoders all-date-string-decoders :filter (params/wrap-field-id-if-needed field) date-string))

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -308,3 +308,9 @@
     (testing "search for something crazy = should return empty results"
       (is (= []
              (mt/$ids (chain-filter/chain-filter-search %venues.category_id {%venues.price 4} "zzzzz")))))))
+
+(deftest time-interval-test
+  (testing "chain-filter should accept time interval strings like `past32weeks` for temporal Fields"
+    (mt/$ids
+      (is (= [:time-interval $checkins.date -32 :week {:include-current false}]
+             (#'chain-filter/filter-clause $$checkins %checkins.date "past32weeks"))))))


### PR DESCRIPTION
I was working on fixing some other chain filtering bugs when I ran in to this. Linked/chain filtering with a parameter like this:

![image](https://user-images.githubusercontent.com/1455846/100028116-09119b00-2da3-11eb-8bf8-d24cfeeb0fe3.png)

would fail because the chain filter API endpoint was not properly handling parameters like `past32weeks` and converting them to the correct MBQL `:time-interval` clauses.

Not sure if there are any open issues associated with this or not