### PR TITLE
TagParam schema shouldn't be so strict (fixes #13868)

### DIFF
--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -59,7 +59,7 @@
 (def ^:private TagParam
   "Schema for a tag parameter declaration, passed in as part of the `:template-tags` list."
   (s/named
-   {(s/optional-key :id)           su/NonBlankString ; this is used internally by the frontend
+   {(s/optional-key :id)           su/NonBlankString     ; this is used internally by the frontend
     :name                          su/NonBlankString
     :display-name                  su/NonBlankString
     :type                          ParamType
@@ -68,9 +68,10 @@
     (s/optional-key :snippet-name) su/NonBlankString
     (s/optional-key :snippet-id)   su/IntGreaterThanZero
     (s/optional-key :database)     su/IntGreaterThanZero ; used by tags of `:type :snippet`
-    (s/optional-key :widget-type)  s/Keyword ; type of the [default] value if `:type` itself is `dimension`
+    (s/optional-key :widget-type)  s/Keyword             ; type of the [default] value if `:type` itself is `dimension`
     (s/optional-key :required)     s/Bool
-    (s/optional-key :default)      s/Any}
+    (s/optional-key :default)      s/Any
+    s/Keyword                      s/Any}
    "valid template-tags tag"))
 
 (def ^:private ParsedParamValue

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -324,3 +324,15 @@
       (is (thrown?
            clojure.lang.ExceptionInfo
            (values/query->params-map query))))))
+
+(deftest dont-be-too-strict-test
+  (testing "values-for-tag should allow unknown keys (used only by FE) (#13868)"
+    (is (= "2"
+           (#'values/value-for-tag
+            {:name                "id"
+             :display-name        "ID"
+             :type                :text
+             :required            true
+             :default             "100"
+             :filteringParameters "222b245f"}
+            [{:type :category, :target [:variable [:template-tag "id"]], :value "2"}])))))


### PR DESCRIPTION
The `TagParam` schema wasn't allowing any unknown keys but the FE was adding a `:filteringParams` key which broke the endpoint. Fixed by loosening up the schema.

Fixes #13868