### PR TITLE
Waterfall: Refactor stacked bar computation to fix for negative values

### DIFF
--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -223,6 +223,57 @@ function parseTimestampAndWarn(value, unit) {
   return { parsedValue: m };
 }
 
+/*
+
+A waterfall chart is essentially a stacked bar chart.
+It consists of the following (from the topmost):
+- the "green bar" for the positives/increases
+- the "red bar" for the negatives/decreases
+- the "invisible beam" supporting either the green or red bar
+
+Note the green and red bars are mutually exclusive (i.e. if one has
+a positive value, the other is zero). This is done so we need not have
+conditional fill color.
+
+*/
+export function syntheticStackedBarsForWaterfallChart(datas) {
+  const stackedBarsDatas = datas.slice();
+
+  const mainSeries = stackedBarsDatas[0];
+  const mainValues = mainSeries.map(d => d[1]);
+  const totalValue = mainValues.reduce((total, value) => total + value, 0);
+  const total = ["Total", totalValue];
+  // $FlowFixMe cloning for the total bar
+  total._origin = {
+    seriesIndex: mainSeries[0]._origin.seriesIndex,
+    rowIndex: mainSeries.length,
+    cols: mainSeries[0]._origin.cols,
+    row: total,
+  };
+
+  const values = [...mainValues, totalValue];
+  let offset = 0;
+  const beams = [];
+  for (let i = 0; i < values.length - 1; ++i) {
+    beams.push(offset);
+    offset += values[i];
+  }
+  // The last one is the total bar, anchor it at 0
+  beams.push(0);
+
+  stackedBarsDatas[0] = [...mainSeries, total];
+  stackedBarsDatas.push(stackedBarsDatas[0].map(k => k.slice())); // negatives
+  stackedBarsDatas.push(stackedBarsDatas[0].map(k => k.slice())); // positives
+  for (let k = 0; k < values.length; ++k) {
+    stackedBarsDatas[0][k]._waterfallValue = stackedBarsDatas[0][k][1];
+    stackedBarsDatas[0][k][1] = beams[k];
+    stackedBarsDatas[1][k][1] = values[k] < 0 ? values[k] : 0;
+    stackedBarsDatas[2][k][1] = values[k] > 0 ? values[k] : 0;
+  }
+
+  return stackedBarsDatas;
+}
+
 /************************************************************ PROPERTIES ************************************************************/
 
 export const isTimeseries = settings =>

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -252,12 +252,15 @@ export function syntheticStackedBarsForWaterfallChart(datas) {
   };
 
   const values = [...mainValues, totalValue];
-  let offset = 0;
-  const beams = [];
-  for (let i = 0; i < values.length - 1; ++i) {
-    beams.push(offset);
-    offset += values[i];
-  }
+  const { beams } = mainValues.reduce(
+    (t, value) => {
+      return {
+        beams: [...t.beams, t.offset],
+        offset: t.offset + value,
+      };
+    },
+    { beams: [], offset: 0 },
+  );
   // The last one is the total bar, anchor it at 0
   beams.push(0);
 

--- a/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -4,6 +4,7 @@ import {
   getDatas,
   getXValues,
   parseXValue,
+  syntheticStackedBarsForWaterfallChart,
 } from "metabase/visualizations/lib/renderer_utils";
 
 describe("getXValues", () => {
@@ -208,5 +209,93 @@ describe("getDatas", () => {
     const warn = () => {};
     const [[[m]]] = getDatas({ settings, series }, warn);
     expect(moment.isMoment(m)).toBe(true);
+  });
+});
+
+describe("syntheticStackedBarsForWaterfallChart", () => {
+  const cols = [
+    {
+      name: "PRODUCT",
+      base_type: "type/Text",
+    },
+    {
+      name: "PROFIT",
+      base_type: "type/Integer",
+    },
+  ];
+
+  function prepareDatas(...rows) {
+    const data = rows.map((row, rowIndex) => {
+      const seriesIndex = 0;
+      const point = row.slice();
+      point._origin = { cols, row, rowIndex, seriesIndex };
+      return point;
+    });
+    return Array.of(data);
+  }
+
+  it("should create the stacked bars for 1 row", () => {
+    const datas = prepareDatas(["Apples", 10]);
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    expect(typeof stackedBarsDatas.length).toEqual("number");
+    expect(stackedBarsDatas.length).toEqual(3);
+    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+      stacked.map(e => e[1]),
+    );
+    expect(beams).toEqual([0, 0]);
+    expect(negatives).toEqual([0, 0]);
+    expect(positives).toEqual([10, 10]);
+  });
+
+  it("should create the stacked bars for 2 rows", () => {
+    const datas = prepareDatas(["Apples", 10], ["Bananas", 4]);
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    expect(typeof stackedBarsDatas.length).toEqual("number");
+    expect(stackedBarsDatas.length).toEqual(3);
+    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+      stacked.map(e => e[1]),
+    );
+    expect(beams).toEqual([0, 10, 0]);
+    expect(negatives).toEqual([0, 0, 0]);
+    expect(positives).toEqual([10, 4, 14]);
+  });
+
+  it("should create the stacked bars for 3 rows", () => {
+    const datas = prepareDatas(["Apples", 10], ["Bananas", 4], ["Oranges", 5]);
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    expect(typeof stackedBarsDatas.length).toEqual("number");
+    expect(stackedBarsDatas.length).toEqual(3);
+    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+      stacked.map(e => e[1]),
+    );
+    expect(beams).toEqual([0, 10, 14, 0]);
+    expect(negatives).toEqual([0, 0, 0, 0]);
+    expect(positives).toEqual([10, 4, 5, 19]);
+  });
+
+  it("should work with all-negative values", () => {
+    const datas = prepareDatas(["X", -14], ["Y", -3], ["Z", -10]);
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    expect(typeof stackedBarsDatas.length).toEqual("number");
+    expect(stackedBarsDatas.length).toEqual(3);
+    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+      stacked.map(e => e[1]),
+    );
+    expect(beams).toEqual([0, -14, -17, 0]);
+    expect(negatives).toEqual([-14, -3, -10, -27]);
+    expect(positives).toEqual([0, 0, 0, 0]);
+  });
+
+  it("should work with mixed (positives & negatives) values", () => {
+    const datas = prepareDatas(["P", -2], ["Q", 24], ["R", -5]);
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    expect(typeof stackedBarsDatas.length).toEqual("number");
+    expect(stackedBarsDatas.length).toEqual(3);
+    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+      stacked.map(e => e[1]),
+    );
+    expect(beams).toEqual([0, -2, 22, 0]);
+    expect(negatives).toEqual([-2, 0, -5, 0]);
+    expect(positives).toEqual([0, 24, 0, 17]);
   });
 });


### PR DESCRIPTION
This also simplifies the renderer, as most of the usual logic for stacked bar can be reused for waterfall.

Steps to test:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'X' as product, -13 as profit 
union all 
select 'Y' as product, -5 as profit 
union all 
select 'Z' as product, 2 as profit 
```

4. Visualization, Waterfall

![image](https://user-images.githubusercontent.com/7288/100274994-29ad3280-2f14-11eb-8314-27a0a39ac1b3.png)
