### PR TITLE
Fix #13894: Always use "Previous results" for subsequent joins

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -95,7 +95,7 @@ class JoinClause extends React.Component {
               />
             ) : (
               <NotebookCellItem color={color}>
-                {`Choose a join type`}
+                {t`Choose a join type`}
               </NotebookCellItem>
             )
           }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -72,12 +72,16 @@ class JoinClause extends React.Component {
       return null;
     }
 
+    // first join's lhs is always the parent table
+    // subsequent should always be a string "Previous results" as per:
+    // https://github.com/metabase/metabase/pull/13895#issuecomment-735933018
+    const lhsTable = join.index() === 0 ? join.parentTable() : null;
     const joinedTable = join.joinedTable();
     const strategyOption = join.strategyOption();
     return (
       <Flex align="center" flex="1 1 auto" {...props}>
         <NotebookCellItem color={color} icon="table2">
-          {t`Previous results`}
+          {(lhsTable && lhsTable.displayName()) || t`Previous results`}
         </NotebookCellItem>
 
         <PopoverWithTrigger

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -72,22 +72,12 @@ class JoinClause extends React.Component {
       return null;
     }
 
-    let lhsTable;
-    if (join.index() === 0) {
-      // first join's lhs is always the parent table
-      lhsTable = join.parentTable();
-    } else if (join.parentDimension()) {
-      // subsequent can be one of the previously joined tables
-      // NOTE: `lhsDimension` would probably be a better name for `parentDimension`
-      lhsTable = join.parentDimension().field().table;
-    }
-
     const joinedTable = join.joinedTable();
     const strategyOption = join.strategyOption();
     return (
       <Flex align="center" flex="1 1 auto" {...props}>
         <NotebookCellItem color={color} icon="table2">
-          {(lhsTable && lhsTable.displayName()) || `Previous results`}
+          {t`Previous results`}
         </NotebookCellItem>
 
         <PopoverWithTrigger

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -58,6 +58,40 @@ describe("scenarios > question > notebook", () => {
   });
 
   describe("joins", () => {
+    it("should always display 'Previous results' for subsequent joins (metabase#13894)", () => {
+      // Go straight to orders table in custom questions
+      cy.visit("/question/new?database=1&table=2&mode=notebook");
+
+      // Orders (parent table) join People
+      cy.findByText("Join data").click();
+      popover()
+        .contains("People")
+        .click();
+
+      cy.log("**First join should display the parent table name**");
+      cy.findAllByText("Orders").should("have.length", 2);
+
+      cy.get(".Button")
+        .contains("Join data")
+        .as("joinButton");
+
+      // Add subsequent joins and assert on the UI
+      cy.get("@joinButton").click();
+
+      cy.log(
+        "**All subsequent joins should always display 'Previous results'**",
+      );
+      cy.findByText("Previous results");
+      popover()
+        .contains(/Products?/i)
+        .click();
+      cy.get("@joinButton").click();
+      popover()
+        .contains("People")
+        .click();
+      cy.findAllByText("Previous results").should("have.length", 2);
+    });
+
     it("should allow joins", () => {
       // start a custom question with orders
       cy.visit("/question/new");


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes #13894 
- Improves i18n by wrapping hard coded `Previous results` string into a template tag (cc @mazameli - heads-up if you need to notify translators)
- Adds one more sting to translations: `Choose a join type`

### Additional notes:
- Added a Cypress test
- Stress-tested `notebook.cy.spec.js` x20 ([20/20 passed](https://github.com/nemanjaglumac/metabase-tests/actions/runs/393936158) ✅)