### PR TITLE
Improve yarn test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "lint-prettier": "yarn && prettier -l '{enterprise/,}frontend/**/*.{js,jsx,css}' || (echo '\nThese files are not formatted correctly. Did you forget to \"yarn prettier\"?' && false)",
     "lint-flow": "yarn && flow check",
     "lint-docs-links": "yarn && ./bin/verify-doc-links",
-    "lint-yaml": "yamllint",
+    "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",
     "test": "yarn test-unit && yarn test-timezones && yarn test-integration && yarn test-cypress",
     "test-unit": "yarn && jest --maxWorkers=2 --config jest.unit.conf.json",
     "test-unit-watch": "yarn test-unit --watch",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   },
   "scripts": {
     "dev": "concurrently --kill-others -p name -n 'backend,frontend,docs' -c 'blue,green,yellow' 'lein run' 'yarn build-hot' 'yarn docs'",
-    "lint": "yarn lint-eslint && yarn lint-prettier && yarn lint-flow && yarn lint-docs-links",
+    "lint": "yarn lint-eslint && yarn lint-prettier && yarn lint-flow && yarn lint-docs-links && yarn lint-yaml",
     "lint-eslint": "yarn && eslint --ext .js --ext .jsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 enterprise/frontend/src frontend/src enterprise/frontend/test frontend/test",
     "lint-prettier": "yarn && prettier -l '{enterprise/,}frontend/**/*.{js,jsx,css}' || (echo '\nThese files are not formatted correctly. Did you forget to \"yarn prettier\"?' && false)",
     "lint-flow": "yarn && flow check",

--- a/package.json
+++ b/package.json
@@ -203,10 +203,10 @@
     "ci": "yarn ci-frontend && yarn ci-backend",
     "ci-frontend": "yarn lint && yarn test",
     "ci-backend": "lein docstring-checker && lein bikeshed && lein eastwood && lein test",
-    "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-no-build",
+    "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-no-build && yarn test-cypress-smoketest",
     "test-cypress-open": "./bin/build-for-test && yarn test-cypress-no-build --open",
     "test-cypress-no-build": "yarn && CONFIG_FILE=frontend/test/cypress.json babel-node ./frontend/test/__runner__/run_cypress_tests.js",
-    "test-cypress-smoketest": "yarn run test-cypress-no-build --testFiles frontend/test/metabase-smoketest"
+    "test-cypress-smoketest": "yarn test-cypress-no-build --testFiles frontend/test/metabase-smoketest"
   },
   "lint-staged": {
     "frontend/**/*.{js,jsx,css}": [


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Improves our local/dev testing scripts in such a way that:
1. `yarn lint` now includes yaml linter
    - `yarn yaml-lint` in turn is now expanded and is checking for `*.yml` files as well
2. `yarn test-cypress` now includes smoke tests

### Additional notes:
Developers and contributors are expected to run tests scripts before important PR merges, especially for stuff that goes directly into `master`. We can't rely on CI for everything. For example, smoke test check is running nightly in CI. As such, it will not catch breaking changes introduced by some commit/PR.

For an example of a breaking change, see the fix in: https://github.com/metabase/metabase/pull/13897

#### Hint:
- `yarn ci` runs ALL tests (backend and frontend)
- `yarn ci-frontend` runs both `yarn lint` and `yarn test` (full coverage - unit, integration, e2e/cypress...)