### PR TITLE
Waterfall: Ensure the correct tooltip and value label for the total

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -111,8 +111,8 @@ export function getClickHoverObject(
           col: col,
         };
       });
+      dimensions = rawCols.map((column, i) => ({ column, value: rawRow[i] }));
     }
-    dimensions = rawCols.map((column, i) => ({ column, value: rawRow[i] }));
   } else if (isBreakoutMultiseries) {
     // an area doesn't have any data, but might have a breakout series to show
     const { _breakoutValue: value, _breakoutColumn: column } = card;

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { t } from "ttag";
 import { COMPACT_CURRENCY_OPTIONS } from "metabase/lib/formatting";
 import { moveToFront } from "metabase/lib/dom";
 import { isHistogramBar } from "./renderer_utils";
@@ -101,12 +102,16 @@ export function onRenderValueLabels(
       })
       .filter(d => !(isBarLike(display) && d.y === 0));
 
-    if (display === "waterfall") {
+    if (display === "waterfall" && data.length > 0) {
       let total = 0;
       data.forEach(d => {
         d.cumulativeY = d.y + total;
         total += d.y;
       });
+      data = [
+        ...data,
+        { ...data[0], x: t`Total`, y: total, cumulativeY: total },
+      ];
     }
 
     return data;


### PR DESCRIPTION
Steps to test:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'Apples' as product, 10 as profit
union all
select 'Bananas' as product, 4 as profit
union all
select 'Oranges' as product, 5 as profit
union all
select 'Peaches' as product, -7 as profit
union all
select 'Mangos' as product, 2 as profit
```

4. Visualization, Waterfall
5. Settings, Display, Show values on data points

![image](https://user-images.githubusercontent.com/7288/100476198-d533bf80-3099-11eb-84a8-b2bd38df08f9.png)
