### PR TITLE
Waterfall setting show/hide the total bar

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -136,7 +136,7 @@ function getXAxisProps(props, datas, warn) {
   // This compensates for the barshifting we do align ticks
   const xValues = isHistogram
     ? [...rawXValues, Math.max(...rawXValues) + xInterval]
-    : props.chartType === "waterfall"
+    : props.chartType === "waterfall" && props.settings["waterfall.show_total"]
     ? [...rawXValues, t`Total`]
     : rawXValues;
 
@@ -275,7 +275,7 @@ export function getDimensionsAndGroupsAndUpdateSeriesDisplayNames(
   const { settings, chartType } = props;
   const datas =
     chartType === "waterfall"
-      ? syntheticStackedBarsForWaterfallChart(originalDatas)
+      ? syntheticStackedBarsForWaterfallChart(originalDatas, settings)
       : originalDatas;
   const isStackedBar = isStacked(settings, datas) || chartType === "waterfall";
 

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -108,10 +108,12 @@ export function onRenderValueLabels(
         d.cumulativeY = d.y + total;
         total += d.y;
       });
-      data = [
-        ...data,
-        { ...data[0], x: t`Total`, y: total, cumulativeY: total },
-      ];
+      if (chart.settings["waterfall.show_total"]) {
+        data = [
+          ...data,
+          { ...data[0], x: t`Total`, y: total, cumulativeY: total },
+        ];
+      }
     }
 
     return data;

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -236,7 +236,8 @@ a positive value, the other is zero). This is done so we need not have
 conditional fill color.
 
 */
-export function syntheticStackedBarsForWaterfallChart(datas) {
+export function syntheticStackedBarsForWaterfallChart(datas, settings = {}) {
+  const showTotal = settings && settings["waterfall.show_total"];
   const stackedBarsDatas = datas.slice();
 
   const mainSeries = stackedBarsDatas[0];
@@ -253,7 +254,6 @@ export function syntheticStackedBarsForWaterfallChart(datas) {
     };
   }
 
-  const values = [...mainValues, totalValue];
   const { beams } = mainValues.reduce(
     (t, value) => {
       return {
@@ -263,10 +263,16 @@ export function syntheticStackedBarsForWaterfallChart(datas) {
     },
     { beams: [], offset: 0 },
   );
-  // The last one is the total bar, anchor it at 0
-  beams.push(0);
 
-  stackedBarsDatas[0] = [...mainSeries, total];
+  const values = mainValues.slice();
+  if (showTotal) {
+    values.push(totalValue);
+    stackedBarsDatas[0] = [...mainSeries, total];
+    // The last one is the total bar, anchor it at 0
+    beams.push(0);
+  } else {
+    stackedBarsDatas[0] = mainSeries;
+  }
   stackedBarsDatas.push(stackedBarsDatas[0].map(k => k.slice())); // negatives
   stackedBarsDatas.push(stackedBarsDatas[0].map(k => k.slice())); // positives
   for (let k = 0; k < values.length; ++k) {

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -19,6 +19,12 @@ export default class WaterfallChart extends LineAreaBarChart {
   static settings = {
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
+    "waterfall.show_total": {
+      section: t`Display`,
+      title: t`Show total`,
+      widget: "toggle",
+      default: true,
+    },
     ...GRAPH_DISPLAY_VALUES_SETTINGS,
     ...GRAPH_DATA_SETTINGS,
   };

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-waterfall.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-waterfall.unit.spec.js
@@ -153,6 +153,21 @@ describe("LineAreaBarRenderer-waterfall", () => {
     ]);
   });
 
+  it("should render a waterfall chart without the total bar", () => {
+    const onHoverChange = jest.fn();
+    const settings = {
+      "waterfall.show_total": false,
+    };
+    const rows = [["A", 3], ["B", 5], ["C", 7]];
+    renderLineAreaBar(element, [MainSeries(settings, rows)], {
+      onHoverChange,
+    });
+
+    // 9 elements: 3 stacked bars for (3 rows, no total)
+    const barElements = qsa(".bar, .dot");
+    expect(barElements.length).toEqual(9);
+  });
+
   function getDataKeyValues(hover) {
     return hover.data.map(({ key, value }) => ({ key, value }));
   }

--- a/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -236,7 +236,13 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
 
   it("should create the stacked bars for 1 row", () => {
     const datas = prepareDatas(["Apples", 10]);
-    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    const settings = {
+      "waterfall.show_total": true,
+    };
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(
+      datas,
+      settings,
+    );
     expect(typeof stackedBarsDatas.length).toEqual("number");
     expect(stackedBarsDatas.length).toEqual(3);
     const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
@@ -249,7 +255,13 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
 
   it("should create the stacked bars for 2 rows", () => {
     const datas = prepareDatas(["Apples", 10], ["Bananas", 4]);
-    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    const settings = {
+      "waterfall.show_total": true,
+    };
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(
+      datas,
+      settings,
+    );
     expect(typeof stackedBarsDatas.length).toEqual("number");
     expect(stackedBarsDatas.length).toEqual(3);
     const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
@@ -262,7 +274,13 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
 
   it("should create the stacked bars for 3 rows", () => {
     const datas = prepareDatas(["Apples", 10], ["Bananas", 4], ["Oranges", 5]);
-    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    const settings = {
+      "waterfall.show_total": true,
+    };
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(
+      datas,
+      settings,
+    );
     expect(typeof stackedBarsDatas.length).toEqual("number");
     expect(stackedBarsDatas.length).toEqual(3);
     const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
@@ -275,7 +293,13 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
 
   it("should work with all-negative values", () => {
     const datas = prepareDatas(["X", -14], ["Y", -3], ["Z", -10]);
-    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    const settings = {
+      "waterfall.show_total": true,
+    };
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(
+      datas,
+      settings,
+    );
     expect(typeof stackedBarsDatas.length).toEqual("number");
     expect(stackedBarsDatas.length).toEqual(3);
     const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
@@ -288,7 +312,13 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
 
   it("should work with mixed (positives & negatives) values", () => {
     const datas = prepareDatas(["P", -2], ["Q", 24], ["R", -5]);
-    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(datas);
+    const settings = {
+      "waterfall.show_total": true,
+    };
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(
+      datas,
+      settings,
+    );
     expect(typeof stackedBarsDatas.length).toEqual("number");
     expect(stackedBarsDatas.length).toEqual(3);
     const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
@@ -297,5 +327,24 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
     expect(beams).toEqual([0, -2, 22, 0]);
     expect(negatives).toEqual([-2, 0, -5, 0]);
     expect(positives).toEqual([0, 24, 0, 17]);
+  });
+
+  it("should work even when the total bar is not meant to shown", () => {
+    const datas = prepareDatas(["A", 3], ["B", 5], ["C", 7]);
+    const settings = {
+      "waterfall.show_total": false,
+    };
+    const stackedBarsDatas = syntheticStackedBarsForWaterfallChart(
+      datas,
+      settings,
+    );
+    expect(typeof stackedBarsDatas.length).toEqual("number");
+    expect(stackedBarsDatas.length).toEqual(3);
+    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+      stacked.map(e => e[1]),
+    );
+    expect(beams).toEqual([0, 3, 8]);
+    expect(negatives).toEqual([0, 0, 0]);
+    expect(positives).toEqual([3, 5, 7]);
   });
 });


### PR DESCRIPTION
**Steps to test**

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'Apples' as product, 10 as profit
union all
select 'Bananas' as product, -4 as profit
union all
select 'Oranges' as product, 7 as profit
```

4. Visualization, Waterfall
5. Settings, Display

**Expected**: There should be a toggle for "Show total".

![image](https://user-images.githubusercontent.com/7288/100663184-cbfd5980-330a-11eb-9def-0f400c51bf2d.png)
