### PR TITLE
CI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,7 +478,7 @@ jobs:
             MB_DB_HOST: localhost
             MB_EDITION: << parameters.edition >>
           command: >
-            if [ -f "/home/circleci/metabase/metabase/load-and-dump.<< parameters.db-type >>.success" ]; then
+            if [ ! -f "/home/circleci/metabase/metabase/load-and-dump.<< parameters.db-type >>.success" ]; then
                 ./bin/test-load-and-dump.sh &&
                 touch /home/circleci/metabase/metabase/load-and-dump.<< parameters.db-type >>.success
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,19 +641,19 @@ jobs:
       # restore already-built frontend
       - restore_cache:
           keys:
-            - frontend-v4-{{ checksum "./frontend-checksums.txt" }}
+            - frontend-v4-<< parameters.edition >>-{{ checksum "./frontend-checksums.txt" }}
       - run:
           name: Build frontend if needed
           environment:
             MB_EDITION: << parameters.edition >>
           command: >
-            if [ ! -f './resources/frontend_client/index.html' ];
-              then ./bin/build version frontend;
+            if [ ! -f './resources/frontend_client/index.html' ]; then
+                ./bin/build version frontend;
             fi
           no_output_timeout: 5m
       # Cache the built frontend
       - save_cache:
-          key: frontend-v4-{{ checksum "./frontend-checksums.txt" }}
+          key: frontend-v4-<< parameters.edition >>-{{ checksum "./frontend-checksums.txt" }}
           paths:
             - /home/circleci/metabase/metabase/resources/frontend_client
 
@@ -679,12 +679,12 @@ jobs:
       - run:
           name: Build uberjar if needed
           environment:
+            # INTERACTIVE=false will tell the clojure build scripts not to do interactive retries etc.
+            INTERACTIVE: "false"
             MB_EDITION: << parameters.edition >>
           command: >
             if [ ! -f './target/uberjar/metabase.jar' ]; then
-              # INTERACTIVE=false will tell the clojure build scripts not to do interactive retries etc.
-              export INTERACTIVE=false;
-              ./bin/build version drivers uberjar;
+              ./bin/build version drivers uberjar
             fi
           no_output_timeout: 10m
       - store_artifacts:

--- a/bin/reflection-linter
+++ b/bin/reflection-linter
@@ -2,7 +2,7 @@
 
 printf "\e[1;34mChecking for reflection warnings. This may take a few minutes, so sit tight...\e[0m\n"
 
-warnings=`lein with-profile +ci check-reflection-warnings 2>&1 | grep Reflection | grep metabase | sort | uniq`
+warnings=`lein with-profile +ci,+ee check-reflection-warnings 2>&1 | grep Reflection | grep metabase | sort | uniq`
 
 if [ ! -z "$warnings" ]; then
     printf "\e[1;31mYour code has introduced some reflection warnings.\e[0m 😞\n"


### PR DESCRIPTION
*  Fix Circle config logic that skips the migrate-to-H2 tests if they've passed with the current source files
*  Run reflection warning tests with EE profile