### PR TITLE
Docker image that runs release script (WIP)

### DIFF
--- a/bin/release-using-docker-image.sh
+++ b/bin/release-using-docker-image.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+set -eou pipefail
+
+# switch to the Metabase root directory
+script_directory=`dirname "${BASH_SOURCE[0]}"`
+cd "$script_directory/.."
+
+# --no-cache
+docker build \
+       --network host \
+       --pull \
+       -t metabase/release \
+       --file bin/release/Dockerfile \
+       .
+
+docker run \
+       --network host \
+       -v /var/run/docker.sock:/var/run/docker.sock \
+       --mount type=bind,source="$(readlink -f ~/.aws)",target=/root/.aws,readonly \
+       --mount type=bind,source="$(readlink -f ~/.ssh)",target=/root/.ssh,readonly \
+       --env DOCKERHUB_EMAIL="$DOCKERHUB_EMAIL" \
+       --env DOCKERHUB_USERNAME="$DOCKERHUB_USERNAME" \
+       --env DOCKERHUB_PASSWORD="$DOCKERHUB_PASSWORD" \
+       --env GITHUB_TOKEN="$GITHUB_TOKEN" \
+       --env SLACK_WEBHOOK_URL="$SLACK_WEBHOOK_URL" \
+       --env AWS_DEFAULT_PROFILE="$AWS_DEFAULT_PROFILE" \
+       -it metabase/release

--- a/bin/release/Dockerfile
+++ b/bin/release/Dockerfile
@@ -1,0 +1,26 @@
+# -*- mode: dockerfile; coding: utf-8; -*-
+
+FROM adoptopenjdk/openjdk11:alpine-jre
+
+LABEL maintainer="Cam Saul <cam@metabase.com>"
+
+WORKDIR /metabase
+
+ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
+
+RUN apk upgrade && apk add --update-cache --no-cache aws-cli bash coreutils curl docker git java-cacerts nodejs openssh-client wget yarn zip
+
+# Install Leiningen
+ADD https://raw.github.com/technomancy/leiningen/stable/bin/lein /usr/local/bin/lein
+RUN chmod 744 /usr/local/bin/lein
+RUN lein upgrade
+
+# Install Clojure CLI
+ADD https://download.clojure.org/install/linux-install-1.10.1.727.sh /tmp/linux-install-1.10.1.727.sh
+RUN chmod +x /tmp/linux-install-1.10.1.727.sh
+RUN /tmp/linux-install-1.10.1.727.sh
+
+# Copy Metabase source
+COPY . /metabase
+
+ENTRYPOINT ["/metabase/bin/release.sh"]


### PR DESCRIPTION
WIP PR to create a Docker image that runs the release script.

For the time being there's a convenience script you can run 

```bash
bin/release-using-docker-image.sh
```

that builds the release Docker image (if needed) and then runs the release script. You still have to set all the env vars as mentioned in [the dox](https://github.com/metabase/metabase/tree/master/bin/release).

This mounts your `~/.ssh`  and `~/.aws` directories as read-only volumes in the Docker image, so the release script can push commits to GitHub and to S3/CloudFront. To make this script work on CircleCI, we'd need to tweak the release script to let AWS and Git credentials be set via env vars. The former is pretty straightforward since the AWS CLI already supports env vars for credentials (we'd just need to tweak the release script to pass those along); Git is a little trickier. Creating a credential store programatically might do the trick: https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage, but we'd have to tweak the release script to fetch repos with HTTP basic auth as opposed to SSH, and the core repo which gets copied over would need to have its config tweaked 