### PR TITLE
Waterfall settings: color settings for increases, decreases, total

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -512,6 +512,9 @@ function setChartColor({ series, settings, chartType }, chart, groups, index) {
     chart.on("pretransition", function(chart) {
       chart.selectAll("g.stack._0 rect.bar").style("fill", "transparent");
       chart
+        .selectAll("g.stack._3 rect.bar")
+        .style("fill", settings["waterfall.total_color"]);
+      chart
         .selectAll("g.stack._1 rect.bar")
         .style("fill", settings["waterfall.decrease_color"]);
       chart

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -469,10 +469,10 @@ function applyChartLineBarSettings(
         .style("fill", "transparent");
       chart
         .selectAll("svg g g.chart-body g.stack._1 rect.bar")
-        .style("fill", "red");
+        .style("fill", settings["waterfall.decrease_color"]);
       chart
         .selectAll("svg g g.chart-body g.stack._2 rect.bar")
-        .style("fill", "green");
+        .style("fill", settings["waterfall.increase_color"]);
     });
   }
 }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -459,22 +459,6 @@ function applyChartLineBarSettings(
         forceCenterBar || settings["graph.x_axis.scale"] !== "ordinal",
       );
   }
-
-  // FIXME scoped the chart-body
-  // FIXME should this be done in PostRender.js?
-  if (chartType === "waterfall") {
-    chart.on("pretransition", function(chart) {
-      chart
-        .selectAll("svg g g.chart-body g.stack._0 rect.bar")
-        .style("fill", "transparent");
-      chart
-        .selectAll("svg g g.chart-body g.stack._1 rect.bar")
-        .style("fill", settings["waterfall.decrease_color"]);
-      chart
-        .selectAll("svg g g.chart-body g.stack._2 rect.bar")
-        .style("fill", settings["waterfall.increase_color"]);
-    });
-  }
 }
 
 // TODO - give this a good name when I figure out what it does
@@ -522,6 +506,18 @@ function setChartColor({ series, settings, chartType }, chart, groups, index) {
     chart.ordinalColors(
       series.map(single => colorsByKey[keyForSingleSeries(single)]),
     );
+  }
+
+  if (chartType === "waterfall") {
+    chart.on("pretransition", function(chart) {
+      chart.selectAll("g.stack._0 rect.bar").style("fill", "transparent");
+      chart
+        .selectAll("g.stack._1 rect.bar")
+        .style("fill", settings["waterfall.decrease_color"]);
+      chart
+        .selectAll("g.stack._2 rect.bar")
+        .style("fill", settings["waterfall.increase_color"]);
+    });
   }
 }
 

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -227,6 +227,7 @@ function parseTimestampAndWarn(value, unit) {
 
 A waterfall chart is essentially a stacked bar chart.
 It consists of the following (from the topmost):
+- the "total bar" which has a value only for the last one
 - the "green bar" for the positives/increases
 - the "red bar" for the negatives/decreases
 - the "invisible beam" supporting either the green or red bar
@@ -266,20 +267,23 @@ export function syntheticStackedBarsForWaterfallChart(datas, settings = {}) {
 
   const values = mainValues.slice();
   if (showTotal) {
-    values.push(totalValue);
     stackedBarsDatas[0] = [...mainSeries, total];
     // The last one is the total bar, anchor it at 0
     beams.push(0);
+    values.push(0);
   } else {
     stackedBarsDatas[0] = mainSeries;
   }
   stackedBarsDatas.push(stackedBarsDatas[0].map(k => k.slice())); // negatives
   stackedBarsDatas.push(stackedBarsDatas[0].map(k => k.slice())); // positives
+  stackedBarsDatas.push(stackedBarsDatas[0].map(k => k.slice())); // total
   for (let k = 0; k < values.length; ++k) {
     stackedBarsDatas[0][k]._waterfallValue = stackedBarsDatas[0][k][1];
     stackedBarsDatas[0][k][1] = beams[k];
     stackedBarsDatas[1][k][1] = values[k] < 0 ? values[k] : 0;
     stackedBarsDatas[2][k][1] = values[k] > 0 ? values[k] : 0;
+    stackedBarsDatas[3][k][1] =
+      !showTotal || k < values.length - 1 ? 0 : totalValue;
   }
 
   return stackedBarsDatas;

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -31,17 +31,20 @@ export default class WaterfallChart extends LineAreaBarChart {
       widget: "color",
       default: color("accent3"),
     },
-    "waterfall.total_color": {
-      section: t`Display`,
-      props: { title: t`Total color` },
-      widget: "color",
-      default: color("accent7"),
-    },
     "waterfall.show_total": {
       section: t`Display`,
       title: t`Show total`,
       widget: "toggle",
       default: true,
+    },
+    "waterfall.total_color": {
+      section: t`Display`,
+      props: { title: t`Total color` },
+      widget: "color",
+      default: color("accent7"),
+      getHidden: (series, vizSettings) =>
+        vizSettings["waterfall.show_total"] !== true,
+      readDependencies: ["waterfall.show_total"],
     },
     ...GRAPH_DISPLAY_VALUES_SETTINGS,
     ...GRAPH_DATA_SETTINGS,

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -21,19 +21,19 @@ export default class WaterfallChart extends LineAreaBarChart {
     ...GRAPH_AXIS_SETTINGS,
     "waterfall.increase_color": {
       section: t`Display`,
-      title: t`Increase color`,
+      props: { title: t`Increase color` },
       widget: "color",
       default: color("accent1"),
     },
     "waterfall.decrease_color": {
       section: t`Display`,
-      title: t`Decrease color`,
+      props: { title: t`Decrease color` },
       widget: "color",
       default: color("accent3"),
     },
     "waterfall.total_color": {
       section: t`Display`,
-      title: t`Total color`,
+      props: { title: t`Total color` },
       widget: "color",
       default: color("accent7"),
     },

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -5,10 +5,11 @@ import { assocIn } from "icepick";
 
 import {
   GRAPH_DATA_SETTINGS,
-  GRAPH_COLORS_SETTINGS,
   GRAPH_AXIS_SETTINGS,
   GRAPH_DISPLAY_VALUES_SETTINGS,
 } from "../lib/settings/graph";
+
+import { color } from "metabase/lib/colors";
 
 export default class WaterfallChart extends LineAreaBarChart {
   static uiName = t`Waterfall`;
@@ -17,8 +18,25 @@ export default class WaterfallChart extends LineAreaBarChart {
   static noun = t`waterfall chart`;
 
   static settings = {
-    ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
+    "waterfall.increase_color": {
+      section: t`Display`,
+      title: t`Increase color`,
+      widget: "color",
+      default: color("accent1"),
+    },
+    "waterfall.decrease_color": {
+      section: t`Display`,
+      title: t`Decrease color`,
+      widget: "color",
+      default: color("accent3"),
+    },
+    "waterfall.total_color": {
+      section: t`Display`,
+      title: t`Total color`,
+      widget: "color",
+      default: color("accent7"),
+    },
     "waterfall.show_total": {
       section: t`Display`,
       title: t`Show total`,

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-waterfall.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-waterfall.unit.spec.js
@@ -74,9 +74,9 @@ describe("LineAreaBarRenderer-waterfall", () => {
       onHoverChange,
     });
 
-    // 6 elements: 3 stacked bars for (1 row, 1 total)
+    // 8 elements: 4 stacked bars for (1 row, 1 total)
     const barElements = qsa(".bar, .dot");
-    expect(barElements.length).toEqual(6);
+    expect(barElements.length).toEqual(8);
 
     // hover over each bar
     dispatchUIEvent(barElements[0], "mousemove");
@@ -98,9 +98,9 @@ describe("LineAreaBarRenderer-waterfall", () => {
       onHoverChange,
     });
 
-    // 9 elements: 3 stacked bars for (2 rows, 1 total)
+    // 12 elements: 4 stacked bars for (2 rows, 1 total)
     const barElements = qsa(".bar, .dot");
-    expect(barElements.length).toEqual(9);
+    expect(barElements.length).toEqual(12);
 
     // hover over each bar
     dispatchUIEvent(barElements[0], "mousemove");
@@ -127,9 +127,9 @@ describe("LineAreaBarRenderer-waterfall", () => {
       onHoverChange,
     });
 
-    // 12 elements: 3 stacked bars for (3 rows, 1 total)
+    // 16 elements: 4 stacked bars for (3 rows, 1 total)
     const barElements = qsa(".bar, .dot");
-    expect(barElements.length).toEqual(12);
+    expect(barElements.length).toEqual(16);
 
     // hover over each bar
     dispatchUIEvent(barElements[0], "mousemove");
@@ -163,9 +163,9 @@ describe("LineAreaBarRenderer-waterfall", () => {
       onHoverChange,
     });
 
-    // 9 elements: 3 stacked bars for (3 rows, no total)
+    // 12 elements: 4 stacked bars for (3 rows, no total)
     const barElements = qsa(".bar, .dot");
-    expect(barElements.length).toEqual(9);
+    expect(barElements.length).toEqual(12);
   });
 
   function getDataKeyValues(hover) {

--- a/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -244,13 +244,14 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
       settings,
     );
     expect(typeof stackedBarsDatas.length).toEqual("number");
-    expect(stackedBarsDatas.length).toEqual(3);
-    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+    expect(stackedBarsDatas.length).toEqual(4);
+    const [beams, negatives, positives, total] = stackedBarsDatas.map(stacked =>
       stacked.map(e => e[1]),
     );
     expect(beams).toEqual([0, 0]);
     expect(negatives).toEqual([0, 0]);
-    expect(positives).toEqual([10, 10]);
+    expect(positives).toEqual([10, 0]);
+    expect(total).toEqual([0, 10]);
   });
 
   it("should create the stacked bars for 2 rows", () => {
@@ -263,13 +264,14 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
       settings,
     );
     expect(typeof stackedBarsDatas.length).toEqual("number");
-    expect(stackedBarsDatas.length).toEqual(3);
-    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+    expect(stackedBarsDatas.length).toEqual(4);
+    const [beams, negatives, positives, total] = stackedBarsDatas.map(stacked =>
       stacked.map(e => e[1]),
     );
     expect(beams).toEqual([0, 10, 0]);
     expect(negatives).toEqual([0, 0, 0]);
-    expect(positives).toEqual([10, 4, 14]);
+    expect(positives).toEqual([10, 4, 0]);
+    expect(total).toEqual([0, 0, 14]);
   });
 
   it("should create the stacked bars for 3 rows", () => {
@@ -282,13 +284,14 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
       settings,
     );
     expect(typeof stackedBarsDatas.length).toEqual("number");
-    expect(stackedBarsDatas.length).toEqual(3);
-    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+    expect(stackedBarsDatas.length).toEqual(4);
+    const [beams, negatives, positives, total] = stackedBarsDatas.map(stacked =>
       stacked.map(e => e[1]),
     );
     expect(beams).toEqual([0, 10, 14, 0]);
     expect(negatives).toEqual([0, 0, 0, 0]);
-    expect(positives).toEqual([10, 4, 5, 19]);
+    expect(positives).toEqual([10, 4, 5, 0]);
+    expect(total).toEqual([0, 0, 0, 19]);
   });
 
   it("should work with all-negative values", () => {
@@ -301,13 +304,14 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
       settings,
     );
     expect(typeof stackedBarsDatas.length).toEqual("number");
-    expect(stackedBarsDatas.length).toEqual(3);
-    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+    expect(stackedBarsDatas.length).toEqual(4);
+    const [beams, negatives, positives, total] = stackedBarsDatas.map(stacked =>
       stacked.map(e => e[1]),
     );
     expect(beams).toEqual([0, -14, -17, 0]);
-    expect(negatives).toEqual([-14, -3, -10, -27]);
+    expect(negatives).toEqual([-14, -3, -10, 0]);
     expect(positives).toEqual([0, 0, 0, 0]);
+    expect(total).toEqual([0, 0, 0, -27]);
   });
 
   it("should work with mixed (positives & negatives) values", () => {
@@ -320,13 +324,14 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
       settings,
     );
     expect(typeof stackedBarsDatas.length).toEqual("number");
-    expect(stackedBarsDatas.length).toEqual(3);
-    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+    expect(stackedBarsDatas.length).toEqual(4);
+    const [beams, negatives, positives, total] = stackedBarsDatas.map(stacked =>
       stacked.map(e => e[1]),
     );
     expect(beams).toEqual([0, -2, 22, 0]);
     expect(negatives).toEqual([-2, 0, -5, 0]);
-    expect(positives).toEqual([0, 24, 0, 17]);
+    expect(positives).toEqual([0, 24, 0, 0]);
+    expect(total).toEqual([0, 0, 0, 17]);
   });
 
   it("should work even when the total bar is not meant to shown", () => {
@@ -339,12 +344,13 @@ describe("syntheticStackedBarsForWaterfallChart", () => {
       settings,
     );
     expect(typeof stackedBarsDatas.length).toEqual("number");
-    expect(stackedBarsDatas.length).toEqual(3);
-    const [beams, negatives, positives] = stackedBarsDatas.map(stacked =>
+    expect(stackedBarsDatas.length).toEqual(4);
+    const [beams, negatives, positives, total] = stackedBarsDatas.map(stacked =>
       stacked.map(e => e[1]),
     );
     expect(beams).toEqual([0, 3, 8]);
     expect(negatives).toEqual([0, 0, 0]);
     expect(positives).toEqual([3, 5, 7]);
+    expect(total).toEqual([0, 0, 0]);
   });
 });


### PR DESCRIPTION
**Steps to test**

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'X' as product, 5 as profit 
union all 
select 'Y' as product, -8 as profit 
union all 
select 'Z' as product, 2 as profit 
```

4. Visualization, Waterfall
5. Settings, Display

**Expected**: There should be 3 widgets to choose the color for increase, decrease, and total. Use the color picker to change the color in the chart (for increase or decrease or total).

![image](https://user-images.githubusercontent.com/7288/100945344-e32c7a80-34b5-11eb-9cfc-1b6a400f9003.png)
