### PR TITLE
Revert dependency bump in build-drivers deps

### DIFF
--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -5,7 +5,7 @@
   cheshire/cheshire           {:mvn/version "5.8.1"}
   commons-codec/commons-codec {:mvn/version "1.14"}
   hiccup/hiccup               {:mvn/version "1.0.5"}
-  io.forward/yaml             {:mvn/version "1.0.10"}
+  io.forward/yaml             {:mvn/version "1.0.9"}  ; don't upgrade to 1.0.10 -- doesn't work on Java 8 (!)
   org.flatland/ordered        {:mvn/version "1.5.9"}  ; used by io.forward/yaml
   stencil/stencil             {:mvn/version "0.5.0"}}
 


### PR DESCRIPTION
DockerHub builds seemed to have stopped working after some dep bumps I did on Monday -- the newer Java YAML library under the hood is compiled for Java 11 so it doesn't work with Java 8. Revert dependency bump