### PR TITLE
Consolidate sandboxing reproduction tests

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -7,7 +7,15 @@ import {
   signInAsNormalUser,
   signOut,
   withSampleDataset,
+  USER_GROUPS,
 } from "__support__/cypress";
+
+const {
+  ALL_USERS_GROUP,
+  ADMIN_GROUP,
+  DATA_GROUP,
+  COLLECTION_GROUP,
+} = USER_GROUPS;
 
 const new_user = {
   first_name: "Barb",
@@ -27,7 +35,7 @@ const sandboxed_user = {
   },
   // Because of the specific restrictions and the way testing dataset was set up,
   // this user needs to also have access to "collections" (group_id: 4) in order to see saved questions
-  group_ids: [1, 4],
+  group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
 };
 
 const [ATTR_UID, ATTR_CAT] = Object.keys(sandboxed_user.login_attributes);
@@ -128,8 +136,6 @@ describeWithToken("formatting > sandboxes", () => {
     it("should change sandbox permissions as admin", () => {
       signOut();
       signInAsAdmin();
-      const ADMIN_GROUP = 2;
-      const DATA_GROUP = 5;
 
       // Changes Orders permssions to use filter and People to use SQL filter
       withSampleDataset(
@@ -279,7 +285,6 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it.skip("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {
-      const COLLECTION_GROUP_ID = 4;
       withSampleDataset(
         ({ PEOPLE, PEOPLE_ID, ORDERS_ID, PRODUCTS_ID, REVIEWS_ID }) => {
           cy.log(
@@ -291,7 +296,7 @@ describeWithToken("formatting > sandboxes", () => {
               user_id: ["dimension", ["field-id", PEOPLE.ID]],
             },
             card_id: null,
-            group_id: COLLECTION_GROUP_ID,
+            group_id: COLLECTION_GROUP,
             table_id: PEOPLE_ID,
           });
 
@@ -301,7 +306,7 @@ describeWithToken("formatting > sandboxes", () => {
             ({ body: { groups, revision } }) => {
               // Update permissions for `collections` group [id: 4]
               // This mutates the original `groups` object => we'll pass it next to the `PUT` request
-              groups[COLLECTION_GROUP_ID] = {
+              groups[COLLECTION_GROUP] = {
                 1: {
                   schemas: {
                     PUBLIC: {
@@ -361,7 +366,6 @@ describeWithToken("formatting > sandboxes", () => {
     it.skip("SB question with `case` CC should substitue the `else` argument's table (metabase-enterprise#548)", () => {
       const QUESTION_NAME = "EE_548";
       const CC_NAME = "CC_548"; // Custom column
-      const COLLECTION_GROUP_ID = 4;
 
       withSampleDataset(({ ORDERS, ORDERS_ID }) => {
         cy.log("**-- 1. Sandbox `Orders` table on `user_id` attribute --**");
@@ -371,7 +375,7 @@ describeWithToken("formatting > sandboxes", () => {
             user_id: ["dimension", ["field-id", ORDERS.USER_ID]],
           },
           card_id: null,
-          group_id: COLLECTION_GROUP_ID,
+          group_id: COLLECTION_GROUP,
           table_id: ORDERS_ID,
         });
 
@@ -391,7 +395,7 @@ describeWithToken("formatting > sandboxes", () => {
           ({ body: { groups, revision } }) => {
             // Update permissions for `collections` group [id: 4]
             // This mutates the original `groups` object => we'll pass it next to the `PUT` request
-            groups[COLLECTION_GROUP_ID] = {
+            groups[COLLECTION_GROUP] = {
               1: {
                 schemas: {
                   PUBLIC: {
@@ -564,7 +568,6 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it.skip("advanced sandboxing based on saved question with joins should allow sandboxed user to use joins (metabase-enterprise#524)", () => {
-      const COLLECTION_GROUP_ID = 4;
       const [ORDERS_ALIAS, PRODUCTS_ALIAS, REVIEWS_ALIAS] = [
         "Orders",
         "Products",
@@ -668,7 +671,7 @@ describeWithToken("formatting > sandboxes", () => {
                 ],
               },
               card_id: CARD_ID,
-              group_id: COLLECTION_GROUP_ID,
+              group_id: COLLECTION_GROUP,
               table_id: ORDERS_ID,
             });
 
@@ -688,7 +691,7 @@ describeWithToken("formatting > sandboxes", () => {
                 ],
               },
               card_id: CARD_ID,
-              group_id: COLLECTION_GROUP_ID,
+              group_id: COLLECTION_GROUP,
               table_id: PRODUCTS_ID,
             });
 
@@ -698,7 +701,7 @@ describeWithToken("formatting > sandboxes", () => {
               ({ body: { groups, revision } }) => {
                 // Update permissions for `collections` group [id: 4]
                 // This mutates the original `groups` object => we'll pass it next to the `PUT` request
-                groups[COLLECTION_GROUP_ID] = {
+                groups[COLLECTION_GROUP] = {
                   1: {
                     schemas: {
                       PUBLIC: {
@@ -757,8 +760,6 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it.skip("advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)", () => {
-      const COLLECTION_GROUP_ID = 4;
-
       withSampleDataset(({ PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID }) => {
         cy.log("**-- Remap Product ID's display value to `title` --**");
 
@@ -798,7 +799,7 @@ describeWithToken("formatting > sandboxes", () => {
               [ATTR_UID]: ["variable", ["template-tag", "sandbox"]],
             },
             card_id: CARD_ID,
-            group_id: COLLECTION_GROUP_ID,
+            group_id: COLLECTION_GROUP,
             table_id: ORDERS_ID,
           });
         });
@@ -834,7 +835,7 @@ describeWithToken("formatting > sandboxes", () => {
               [ATTR_CAT]: ["variable", ["template-tag", "sandbox"]],
             },
             card_id: CARD_ID,
-            group_id: COLLECTION_GROUP_ID,
+            group_id: COLLECTION_GROUP,
             table_id: PRODUCTS_ID,
           });
         });
@@ -845,7 +846,7 @@ describeWithToken("formatting > sandboxes", () => {
           ({ body: { groups, revision } }) => {
             // Update permissions for `collections` group [id: 4]
             // This mutates the original `groups` object => we'll pass it next to the `PUT` request
-            groups[COLLECTION_GROUP_ID] = {
+            groups[COLLECTION_GROUP] = {
               1: {
                 schemas: {
                   PUBLIC: {

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -326,12 +326,7 @@ describeWithToken("formatting > sandboxes", () => {
       );
 
       signOut();
-
-      cy.log("**-- Logging in as sandboxed user --**");
-      cy.request("POST", "/api/session", {
-        username: sandboxed_user.email,
-        password: sandboxed_user.password,
-      });
+      signInAsSandboxedUser();
 
       // Go straight to orders table in custom questions
       cy.visit("/question/new?database=1&table=2&mode=notebook");
@@ -442,12 +437,7 @@ describeWithToken("formatting > sandboxes", () => {
           visualization_settings: {},
         }).then(({ body: { id: QUESTION_ID } }) => {
           signOut();
-
-          cy.log("**-- Logging in as sandboxed user --**");
-          cy.request("POST", "/api/session", {
-            username: sandboxed_user.email,
-            password: sandboxed_user.password,
-          });
+          signInAsSandboxedUser();
 
           cy.server();
           cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
@@ -546,12 +536,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("Not now").click();
 
       signOut();
-
-      // Sign in as newly created sandboxed_user ("User 1")
-      cy.visit("/");
-      cy.findByLabelText("Email address").type(sandboxed_user.email);
-      cy.findByLabelText("Password").type(sandboxed_user.password);
-      cy.findByText("Sign in").click();
+      signInAsSandboxedUser();
 
       // Find saved question in "Our analytics"
       cy.findByText("Browse all items").click();
@@ -734,12 +719,7 @@ describeWithToken("formatting > sandboxes", () => {
             );
 
             signOut();
-
-            cy.log("**-- Logging in as sandboxed user --**");
-            cy.request("POST", "/api/session", {
-              username: sandboxed_user.email,
-              password: sandboxed_user.password,
-            });
+            signInAsSandboxedUser();
 
             // Go straight to orders table in custom questions
             cy.visit("/question/new?database=1&table=2&mode=notebook");
@@ -887,12 +867,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
 
       signOut();
-
-      cy.log("**-- Logging in as sandboxed user --**");
-      cy.request("POST", "/api/session", {
-        username: sandboxed_user.email,
-        password: sandboxed_user.password,
-      });
+      signInAsSandboxedUser();
 
       openOrdersTable();
 
@@ -914,3 +889,11 @@ describeWithToken("formatting > sandboxes", () => {
     });
   });
 });
+
+function signInAsSandboxedUser() {
+  cy.log("**-- Logging in as sandboxed user --**");
+  cy.request("POST", "/api/session", {
+    username: sandboxed_user.email,
+    password: sandboxed_user.password,
+  });
+}

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -293,7 +293,7 @@ describeWithToken("formatting > sandboxes", () => {
 
           cy.request("POST", "/api/mt/gtap", {
             attribute_remappings: {
-              user_id: ["dimension", ["field-id", PEOPLE.ID]],
+              [ATTR_UID]: ["dimension", ["field-id", PEOPLE.ID]],
             },
             card_id: null,
             group_id: COLLECTION_GROUP,
@@ -372,7 +372,7 @@ describeWithToken("formatting > sandboxes", () => {
 
         cy.request("POST", "/api/mt/gtap", {
           attribute_remappings: {
-            user_id: ["dimension", ["field-id", ORDERS.USER_ID]],
+            [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
           },
           card_id: null,
           group_id: COLLECTION_GROUP,
@@ -665,7 +665,7 @@ describeWithToken("formatting > sandboxes", () => {
 
             cy.request("POST", "/api/mt/gtap", {
               attribute_remappings: {
-                user_id: [
+                [ATTR_UID]: [
                   "dimension",
                   ["joined-field", ORDERS_ALIAS, ["field-id", ORDERS.USER_ID]],
                 ],
@@ -681,7 +681,7 @@ describeWithToken("formatting > sandboxes", () => {
 
             cy.request("POST", "/api/mt/gtap", {
               attribute_remappings: {
-                user_id: [
+                [ATTR_UID]: [
                   "dimension",
                   [
                     "joined-field",

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -78,6 +78,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
     });
 
+    // TODO: Remove manual waiting
     it("should make a JOINs table", () => {
       openOrdersTable();
       cy.wait(1000)
@@ -184,6 +185,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.visit("/browse/1");
       cy.findByText("Orders").click();
 
+      // TODO: Refactor - asserting on the number of rows proved to be risky.
       // Table filter - only 10 rows should show up
       cy.contains("Showing 10");
 
@@ -232,6 +234,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("10");
     });
 
+    // TODO: Restore before each test and avoid using hard coded question IDs
     it("should be sandboxed with a filter (on a saved JOINed question)", () => {
       cy.visit("/question/5");
 

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -283,7 +283,9 @@ describeWithToken("formatting > sandboxes", () => {
       restore();
       signInAsAdmin();
       createUser(sandboxed_user).then(({ body: { id: USER_ID } }) => {
-        // dismiss the "it's ok to play around" modal
+        cy.log(
+          "**-- Dismiss `it's ok to play around` modal for new users --**",
+        );
         cy.request("PUT", `/api/user/${USER_ID}/qbnewb`, {});
       });
     });

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -412,6 +412,85 @@ describeWithToken("formatting > sandboxes", () => {
       });
     });
 
+    it.skip("drill-through should work on implicit joined tables with sandboxes (metabase#13641)", () => {
+      const QUESTION_NAME = "13641";
+
+      withSampleDataset(({ ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID }) => {
+        cy.log(ORDERS);
+        cy.log(PRODUCTS);
+
+        cy.log("**-- 1. Sandbox `Orders` table on `user_id` attribute --**");
+
+        cy.request("POST", "/api/mt/gtap", {
+          attribute_remappings: {
+            [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
+          },
+          card_id: null,
+          group_id: COLLECTION_GROUP,
+          table_id: ORDERS_ID,
+        });
+
+        updatePermissionsGraph({
+          schema: {
+            [PRODUCTS_ID]: "all",
+            [ORDERS_ID]: { query: "segmented", read: "all" },
+          },
+        });
+
+        cy.log(
+          "**-- 2. Create question based on steps in [#13641](https://github.com/metabase/metabase/issues/13641)--**",
+        );
+        cy.request("POST", "/api/card", {
+          name: QUESTION_NAME,
+          dataset_query: {
+            database: 1,
+            query: {
+              aggregation: [["count"]],
+              breakout: [
+                [
+                  "fk->",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["field-id", PRODUCTS.CATEGORY],
+                ],
+              ],
+              "source-table": ORDERS_ID,
+            },
+            type: "query",
+          },
+          display: "bar",
+          visualization_settings: {},
+        });
+      });
+
+      signOut();
+      signInAsSandboxedUser();
+
+      cy.server();
+      cy.route("POST", "/api/card/*/query").as("cardQuery");
+      cy.route("POST", "/api/dataset").as("dataset");
+
+      // Find saved question in "Our analytics"
+      cy.visit("/collection/root");
+      cy.findByText(QUESTION_NAME).click();
+
+      cy.wait("@cardQuery");
+      // Drill-through
+      cy.get(".Visualization").within(() => {
+        // Click on the first bar in a graph (Category: "Doohickey")
+        cy.get(".bar")
+          .eq(0)
+          .click({ force: true });
+      });
+      cy.findByText("View these Orders").click();
+
+      cy.log("**Reported failing on v1.37.0.2**");
+      cy.wait("@dataset").then(xhr => {
+        expect(xhr.response.body.error).not.to.exist;
+      });
+      cy.findByText("Category is Doohickey");
+      cy.findByText("97.44"); // Subtotal for order #10
+    });
+
     it("should allow drill-through for sandboxed user (metabase-enterprise#535)", () => {
       const PRODUCTS_ALIAS = "Products";
       const QUESTION_NAME = "EE_535";

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   describeWithToken,
   openOrdersTable,
+  openPeopleTable,
   popover,
   restore,
   signInAsAdmin,
@@ -261,7 +262,7 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should filter categories on saved SQL question (for a new question - column number)", () => {
-      cy.visit("/question/new?database=1&table=3");
+      openPeopleTable();
       cy.get(".TableInteractive-cellWrapper--firstColumn").should(
         "have.length",
         2,
@@ -269,7 +270,7 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should filter categories on saved SQL question (for a new question - row number)", () => {
-      cy.visit("/question/new?database=1&table=3");
+      openPeopleTable();
       cy.get(".TableInteractive-headerCellData").should("have.length", 4);
     });
   });
@@ -314,8 +315,7 @@ describeWithToken("formatting > sandboxes", () => {
       signOut();
       signInAsSandboxedUser();
 
-      // Go straight to orders table in custom questions
-      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      openOrdersTable({ mode: "notebook" });
       cy.findByText("Summarize").click();
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();
@@ -366,7 +366,7 @@ describeWithToken("formatting > sandboxes", () => {
           },
         });
 
-        cy.log("**-- 4. Create and save a question --**");
+        cy.log("**-- 2. Create and save a question --**");
 
         cy.request("POST", "/api/card", {
           name: QUESTION_NAME,
@@ -637,8 +637,7 @@ describeWithToken("formatting > sandboxes", () => {
             signOut();
             signInAsSandboxedUser();
 
-            // Go straight to orders table in custom questions
-            cy.visit("/question/new?database=1&table=2&mode=notebook");
+            openOrdersTable({ mode: "notebook" });
 
             // `Orders` join `Products`
             cy.findByText("Join data").click();

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -35,6 +35,13 @@ export const USERS = {
   },
 };
 
+export const USER_GROUPS = {
+  ALL_USERS_GROUP: 1,
+  ADMIN_GROUP: 2,
+  COLLECTION_GROUP: 4,
+  DATA_GROUP: 5,
+};
+
 export function signIn(user = "admin") {
   cy.log(`**--- Logging in as ${user} ---**`);
   cy.request("POST", "/api/session", USERS[user]);

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -2,6 +2,7 @@ import {
   snapshot,
   restore,
   USERS,
+  USER_GROUPS,
   withSampleDataset,
   signInAsAdmin,
 } from "__support__/cypress";
@@ -62,9 +63,7 @@ describe("snapshots", () => {
     });
   }
 
-  const ALL_USERS_GROUP = 1;
-  const COLLECTION_GROUP = 4;
-  const DATA_GROUP = 5;
+  const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
 
   function addUsersAndGroups() {
     // groups


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Groups all sandboxing reproductions into one context (one describe block with the same preparation steps for each test)
- Adds `USER_GROUPS` object and makes it available globally
- Abstracts repeated code into helper functions
- Includes refactor of `EE#535` reproduction (9b5ba270a80ce58ba6e6604f16b6b3423a89eac7)
- Includes repro for #13641 (4675c1cf581c2213f56e0ca63105d1e4389f6c53)

### Notes
- All tests should pass in CI