### PR TITLE
Tweak collection sidebar item spacing

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -52,7 +52,7 @@ class CollectionsList extends React.Component {
                             className="absolute text-brand cursor-pointer"
                             align="center"
                             justifyContent="center"
-                            style={{ left: -16 }}
+                            style={{ left: -20 }}
                           >
                             <Icon
                               name={isOpen ? "chevrondown" : "chevronright"}

--- a/frontend/src/metabase/collections/constants.js
+++ b/frontend/src/metabase/collections/constants.js
@@ -1,2 +1,2 @@
 // unit to use for calculating collection sidebar spacing (in px)
-export const SIDEBAR_SPACER = 14;
+export const SIDEBAR_SPACER = 18;


### PR DESCRIPTION
Small tweak to add a bit more X padding to sidebar items, which in turn lets us give our chevron icons a bit more breathing room for easier click targets.

New:
![image](https://user-images.githubusercontent.com/5248953/101056986-8bdfe600-3559-11eb-895a-9fabb6c79626.png)

Old:
![image](https://user-images.githubusercontent.com/5248953/101056895-74a0f880-3559-11eb-9bf7-b138a857add3.png)
