### PR TITLE
Hide the regular series color widgets for waterfall charts.

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -149,7 +149,8 @@ export function seriesSetting({
   return {
     ...nestedSettings(settingId, {
       objectName: "series",
-      getHidden: ([{ card }], settings) => card.display === "waterfall",
+      getHidden: ([{ card }], settings, extraProps) =>
+        card.display === "waterfall",
       getObjects: (series, settings) => series,
       getObjectKey: keyForSingleSeries,
       getSettingDefintionsForObject: getSettingDefintionsForSingleSeries,

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -149,6 +149,7 @@ export function seriesSetting({
   return {
     ...nestedSettings(settingId, {
       objectName: "series",
+      getHidden: ([{ card }], settings) => card.display === "waterfall",
       getObjects: (series, settings) => series,
       getObjectKey: keyForSingleSeries,
       getSettingDefintionsForObject: getSettingDefintionsForSingleSeries,


### PR DESCRIPTION
Since the waterfall rendering only uses the increase, decrease, and
total colors, there is no need to let the user pick the regular series
colors.

**Steps to test**

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'X' as product, 5 as profit 
union all 
select 'Y' as product, 2 as profit 
```

4. Visualization, Waterfall
5. Settings, Display

**Expected**: There must **not** be any color pickers (which were used to choose the color for each series)
 after _Value formatting_.

![image](https://user-images.githubusercontent.com/7288/101082582-86d26500-3560-11eb-8ed3-dbcca96db17b.png)
