### PR TITLE
Cypress `table` helper functions improvements

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -87,12 +87,31 @@ export function selectDashboardFilter(selection, filterName) {
     .click({ force: true });
 }
 
-export function openOrdersTable() {
-  cy.visit("/question/new?database=1&table=2");
+export function openTable({ database = 1, table, mode = null } = {}) {
+  const url = "/question/new?";
+  const params = new URLSearchParams({ database, table });
+
+  if (mode === "notebook") {
+    params.append("mode", mode);
+  }
+
+  cy.visit(url + params.toString());
 }
 
-export function openProductsTable() {
-  cy.visit("/question/new?database=1&table=1");
+export function openProductsTable({ mode } = {}) {
+  return openTable({ table: 1, mode });
+}
+
+export function openOrdersTable({ mode } = {}) {
+  return openTable({ table: 2, mode });
+}
+
+export function openPeopleTable({ mode } = {}) {
+  return openTable({ table: 3, mode });
+}
+
+export function openReviewsTable({ mode } = {}) {
+  return openTable({ table: 4, mode });
 }
 
 export function setupLocalHostEmail() {

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   signInAsAdmin,
   openOrdersTable,
+  openReviewsTable,
   popover,
 } from "__support__/cypress";
 
@@ -69,7 +70,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     cy.findByText("Save").click();
 
     cy.log("**Numeric ratings should be remapped to custom strings**");
-    cy.visit("/question/new?database=1&table=4");
+    openReviewsTable();
     Object.values(customMap).forEach(rating => {
       cy.findAllByText(rating);
     });

--- a/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
@@ -5,6 +5,7 @@ import {
   signInAsNormalUser,
   createBasicAlert,
   popover,
+  openPeopleTable,
 } from "__support__/cypress";
 // Ported from alert.e2e.spec.js
 // *** We should also check that alerts can be set up through slack
@@ -151,7 +152,7 @@ describe("scenarios > alert", () => {
 
     it.skip("should fall back to raw data alert and show a warning", () => {
       // Create a time-multiseries q
-      cy.visit("/question/new?database=1&table=3"); // "People" table
+      openPeopleTable();
       cy.findByText("Summarize").click();
       cy.get(".Icon-notebook").click();
       cy.findByText("Summarize").click();

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -6,6 +6,7 @@ import {
   _typeUsingPlaceholder,
   signInAsAdmin,
   withSampleDataset,
+  openOrdersTable,
 } from "__support__/cypress";
 
 const customFormulas = [
@@ -70,8 +71,7 @@ describe("scenarios > question > custom columns", () => {
 
   it("can create a custom column (metabase#13241)", () => {
     const columnName = "Simple Math";
-    // go straight to "orders" in custom questions
-    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    openOrdersTable({ mode: "notebook" });
     cy.get(".Icon-add_data").click();
 
     popover().within(() => {
@@ -92,7 +92,7 @@ describe("scenarios > question > custom columns", () => {
 
   it("can create a custom column with an existing column name", () => {
     customFormulas.forEach(({ customFormula, columnName }) => {
-      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      openOrdersTable({ mode: "notebook" });
       cy.get(".Icon-add_data").click();
 
       popover().within(() => {
@@ -112,8 +112,7 @@ describe("scenarios > question > custom columns", () => {
   });
 
   it("should create custom column with fields from aggregated data (metabase#12762)", () => {
-    // go straight to "orders" in custom questions
-    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    openOrdersTable({ mode: "notebook" });
 
     cy.findByText("Summarize").click();
 
@@ -162,8 +161,7 @@ describe("scenarios > question > custom columns", () => {
 
   it.skip("should allow 'zoom in' drill-through when grouped by custom column (metabase#13289)", () => {
     const columnName = "TestColumn";
-    // go straight to "orders" in custom questions
-    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    openOrdersTable({ mode: "notebook" });
 
     // Add custom column that will be used later in summarize (group by)
     cy.findByText("Custom column").click();
@@ -214,8 +212,7 @@ describe("scenarios > question > custom columns", () => {
   });
 
   it.skip("should not return same results for columns with the same name (metabase#12649)", () => {
-    // go straight to "orders" in custom questions
-    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    openOrdersTable({ mode: "notebook" });
     // join with Products
     cy.findByText("Join data").click();
     cy.findByText("Products").click();

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -81,8 +81,7 @@ describe("scenarios > question > filter", () => {
     // NOTE: the original issue mentions "Is not" and "Does not contain" filters
     // we're testing for one filter only to keep things simple
 
-    // go straight to "orders" in custom questions
-    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    openOrdersTable({ mode: "notebook" });
     // join with Products
     cy.findByText("Join data").click();
     cy.findByText("Products").click();

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -4,6 +4,7 @@ import {
   restore,
   popover,
   createNativeQuestion,
+  openOrdersTable,
 } from "__support__/cypress";
 
 describe("scenarios > question > nested (metabase#12568)", () => {
@@ -196,7 +197,7 @@ describe("scenarios > question > nested", () => {
   });
 
   it.skip("should display granularity for aggregated fields in nested questions (metabase#13764)", () => {
-    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    openOrdersTable({ mode: "notebook" });
     // add initial aggregation ("Average of Total by Order ID")
     cy.findByText("Summarize").click();
     cy.findByText("Average of ...").click();

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -3,6 +3,7 @@ import {
   signInAsAdmin,
   popover,
   openOrdersTable,
+  openReviewsTable,
 } from "__support__/cypress";
 
 // test various entry points into the query builder
@@ -95,8 +96,7 @@ describe("scenarios > question > new", () => {
     });
 
     it("should allow using `Custom Expression` in orders metrics (metabase#12899)", () => {
-      // go straight to "orders" in custom questions
-      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      openOrdersTable({ mode: "notebook" });
       cy.findByText("Summarize").click();
       popover()
         .contains("Custom Expression")
@@ -114,7 +114,7 @@ describe("scenarios > question > new", () => {
       const FORMULA =
         "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))";
 
-      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      openOrdersTable({ mode: "notebook" });
       cy.findByText("Summarize").click();
       popover()
         .contains("Custom Expression")
@@ -131,8 +131,7 @@ describe("scenarios > question > new", () => {
     });
 
     it.skip("distinct inside custom expression should suggest non-numeric types (metabase#13469)", () => {
-      // go directly to custom question in "Reviews" table
-      cy.visit("/question/new?database=1&table=4&mode=notebook");
+      openReviewsTable({ mode: "notebook" });
       cy.findByText("Summarize").click();
       popover()
         .contains("Custom Expression")

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -255,7 +255,7 @@ describe("scenarios > question > notebook", () => {
     });
   });
 
-  describe.only("nested", () => {
+  describe("nested", () => {
     it("should create a nested question with post-aggregation filter", () => {
       openProductsTable({ mode: "notebook" });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -3,6 +3,7 @@ import {
   restore,
   signInAsAdmin,
   openOrdersTable,
+  openProductsTable,
   popover,
   modal,
   withSampleDataset,
@@ -59,8 +60,7 @@ describe("scenarios > question > notebook", () => {
 
   describe("joins", () => {
     it("should always display 'Previous results' for subsequent joins (metabase#13894)", () => {
-      // Go straight to orders table in custom questions
-      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      openOrdersTable({ mode: "notebook" });
 
       // Orders (parent table) join People
       cy.findByText("Join data").click();
@@ -255,10 +255,9 @@ describe("scenarios > question > notebook", () => {
     });
   });
 
-  describe("nested", () => {
+  describe.only("nested", () => {
     it("should create a nested question with post-aggregation filter", () => {
-      // start a custom question with orders
-      cy.visit("/question/new?database=1&table=1&mode=notebook");
+      openProductsTable({ mode: "notebook" });
 
       cy.findByText("Summarize").click();
       popover().within(() => {
@@ -302,7 +301,7 @@ describe("scenarios > question > notebook", () => {
   // TODO: add positive assertions to all 4 tests when we figure out implementation details
   describe.skip("arithmetic (metabase#13175)", () => {
     beforeEach(() => {
-      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      openOrdersTable({ mode: "notebook" });
     });
 
     it("should work on custom column with `case`", () => {

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -3,6 +3,7 @@ import {
   restore,
   withSampleDataset,
   openProductsTable,
+  openOrdersTable,
   popover,
   sidebar,
 } from "__support__/cypress";
@@ -155,8 +156,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it.skip("should drill-through on filtered aggregated results (metabase#13504)", () => {
-    // go straight to "orders" in custom questions
-    cy.visit("/question/new?database=1&table=2&mode=notebook");
+    openOrdersTable({ mode: "notebook" });
     cy.findByText("Summarize").click();
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds new helper function `openTable()` and expands the existing related helper functions, making it easier to open all 4 tables from the sample data set in both modes
- Replaces all hard coded occurrences in all our Cypress tests with those new functions
- If we ever need to change or update any of the values, we'll have to do it in one place only
- It is now much easier to read the test (do a code review). See the following example:

```javascript
/**
 * CUSTOM QUESTION
 */

// This:
cy.visit("/question/new?database=1&table=1&mode=notebook")

// becomes:
openProductsTable({mode: "notebook"})

/**
 * SIMPLE QUESTION
 */

// This:
cy.visit("/question/new?database=1&table=3")

// becomes:
openPeopleTable()
```

### External/additional data sets:
It would be even possible to apply this to external data sets, if we know the database id and tables ids.
For example:

```javascript
cy.visit("/question/new");
cy.findByText("Simple question").click();
cy.findByText(MYSQL_DB_NAME).click();
cy.findByText("Orders").click();
```
can be changed into this (ideally, without hard-coded values):
```javascript
openTable({database: 2, table: 6})
```

### Next steps:
If we save all these values (sample dataset id, table ids, etc.) in one config object that makes it quite easy and convenient to update them in the future. I'm preparing a separate PR for this step.