### PR TITLE
Add deprecation warning to Pulse create/edit page

### DIFF
--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -18,7 +18,7 @@ import Icon from "metabase/components/Icon";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ModalContent from "metabase/components/ModalContent";
-import Subhead from "metabase/components/Subhead";
+import Subhead from "metabase/components/type/Subhead";
 import Text from "metabase/components/Text";
 
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -14,7 +14,6 @@ import WhatsAPulse from "./WhatsAPulse";
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/components/Button";
 import Icon from "metabase/components/Icon";
-import Link from "metabase/components/Link";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ModalContent from "metabase/components/ModalContent";

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -13,11 +13,13 @@ import WhatsAPulse from "./WhatsAPulse";
 
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/components/Button";
+import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
 import Icon from "metabase/components/Icon";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ModalContent from "metabase/components/ModalContent";
-import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
+import Subhead from "metabase/components/Subhead";
+import Text from "metabase/components/Text";
 
 import { color } from "metabase/lib/colors";
 import MetabaseSettings from "metabase/lib/settings";
@@ -161,22 +163,16 @@ export default class PulseEdit extends Component {
           <Flex
             bg={color("bg-medium")}
             p={2}
-            my={2}
+            my={3}
             align="top"
             style={{ borderRadius: 8 }}
             className="hover-parent hover--visibility"
           >
             <Icon name="warning" color={color("warning")} size={24} mr={1} />
             <Box ml={1}>
-              <h3>{t`Pulses are being phased out`}</h3>
-              <p className="m0 mt1 text-medium text-bold">{jt`You can now set up ${link} instead. We'll remove Pulses in a future release, and help you migrate any that you still have.`}</p>
+              <Subhead>{t`Pulses are being phased out`}</Subhead>
+              <Text className="m0 mt1 text-medium text-bold">{jt`You can now set up ${link} instead. We'll remove Pulses in a future release, and help you migrate any that you still have.`}</Text>
             </Box>
-            <Icon
-              className="hover-child text-brand-hover cursor-pointer bg-medium"
-              name="close"
-              ml="auto"
-              onClick={() => this.dismissPinMessage()}
-            />
           </Flex>
 
           <PulseEditName {...this.props} setPulse={this.setPulse} />

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -1,5 +1,6 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
+import { Box, Flex } from "grid-styled";
 import PropTypes from "prop-types";
 import { t, jt, ngettext, msgid } from "ttag";
 
@@ -12,11 +13,15 @@ import WhatsAPulse from "./WhatsAPulse";
 
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/components/Button";
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ModalContent from "metabase/components/ModalContent";
 import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
 
+import { color } from "metabase/lib/colors";
+import MetabaseSettings from "metabase/lib/settings";
 import { pulseIsValid, cleanPulse, emailIsEnabled } from "metabase/lib/pulse";
 import * as Urls from "metabase/lib/urls";
 
@@ -123,6 +128,12 @@ export default class PulseEdit extends Component {
     const { pulse, formInput } = this.props;
     const isValid = pulseIsValid(pulse, formInput.channels);
     const attachmentsEnabled = emailIsEnabled(pulse);
+    const link = (
+      <a
+        className="link"
+        href={MetabaseSettings.docsUrl("users-guide/07-dashboards")}
+      >{t`dashboard subscriptions`}</a>
+    );
     return (
       <div className="PulseEdit">
         <div className="PulseEdit-header flex align-center border-bottom py3">
@@ -148,6 +159,27 @@ export default class PulseEdit extends Component {
           </ModalWithTrigger>
         </div>
         <div className="PulseEdit-content pt2 pb4">
+          <Flex
+            bg={color("bg-medium")}
+            p={2}
+            my={2}
+            align="top"
+            style={{ borderRadius: 8 }}
+            className="hover-parent hover--visibility"
+          >
+            <Icon name="warning" color={color("warning")} size={24} mr={1} />
+            <Box ml={1}>
+              <h3>{t`Pulses are being phased out`}</h3>
+              <p className="m0 mt1 text-medium text-bold">{jt`You can now set up ${link} instead. We'll remove Pulses in a future release, and help you migrate any that you still have.`}</p>
+            </Box>
+            <Icon
+              className="hover-child text-brand-hover cursor-pointer bg-medium"
+              name="close"
+              ml="auto"
+              onClick={() => this.dismissPinMessage()}
+            />
+          </Flex>
+
           <PulseEditName {...this.props} setPulse={this.setPulse} />
           <PulseEditCollection {...this.props} setPulse={this.setPulse} />
           <PulseEditCards

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -19,7 +19,7 @@ import MetabaseAnalytics from "metabase/lib/analytics";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ModalContent from "metabase/components/ModalContent";
 import Subhead from "metabase/components/type/Subhead";
-import Text from "metabase/components/Text";
+import Text from "metabase/components/type/Text";
 
 import { color } from "metabase/lib/colors";
 import MetabaseSettings from "metabase/lib/settings";

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -171,7 +171,7 @@ export default class PulseEdit extends Component {
             <Icon name="warning" color={color("warning")} size={24} mr={1} />
             <Box ml={1}>
               <Subhead>{t`Pulses are being phased out`}</Subhead>
-              <Text className="m0 mt1 text-medium text-bold">{jt`You can now set up ${link} instead. We'll remove Pulses in a future release, and help you migrate any that you still have.`}</Text>
+              <Text>{jt`You can now set up ${link} instead. We'll remove Pulses in a future release, and help you migrate any that you still have.`}</Text>
             </Box>
           </Flex>
 


### PR DESCRIPTION
Tim made me realize that we didn't really think about messaging in the app itself to let folks know that we intended on replacing pulses with dashboard subscriptions. So this PR adds a banner message to the Pulse create/edit page.

The link right now just goes to the main dashboards doc page, but we'll want to update it to the presumable doc page on dashboard subscriptions before we ship the final 0.38 release.

Thoughts?

<img width="1551" alt="image" src="https://user-images.githubusercontent.com/2223916/101106518-0d993900-3585-11eb-81c6-37d3afea70d3.png">
