### PR TITLE
Fix waterfall X axis for time series

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -18,14 +18,6 @@ import {
 } from "./utils";
 
 import {
-  minTimeseriesUnit,
-  computeTimeseriesDataInverval,
-  getTimezone,
-} from "./timeseries";
-
-import { computeNumericDataInverval } from "./numeric";
-
-import {
   applyChartTimeseriesXAxis,
   applyChartQuantitativeXAxis,
   applyChartOrdinalXAxis,
@@ -56,6 +48,7 @@ import {
   getDatas,
   getFirstNonEmptySeries,
   getXValues,
+  getXInterval,
   syntheticStackedBarsForWaterfallChart,
   xValueForWaterfallTotal,
   isDimensionTimeseries,
@@ -101,30 +94,6 @@ function checkSeriesIsValid({ series, maxSeries }) {
     throw new Error(
       t`This chart type doesn't support more than ${maxSeries} series of data.`,
     );
-  }
-}
-
-function getXInterval({ settings, series }, xValues, warn) {
-  if (isTimeseries(settings)) {
-    // We need three pieces of information to define a timeseries range:
-    // 1. interval - it's really the "unit": month, day, etc
-    // 2. count - how many intervals per tick?
-    // 3. timezone - what timezone are values in? days vary in length by timezone
-    const unit = minTimeseriesUnit(series.map(s => s.data.cols[0].unit));
-    const timezone = getTimezone(series, warn);
-    const { count, interval } = computeTimeseriesDataInverval(xValues, unit);
-    return { count, interval, timezone };
-  } else if (isQuantitative(settings) || isHistogram(settings)) {
-    // Get the bin width from binning_info, if available
-    // TODO: multiseries?
-    const binningInfo = getFirstNonEmptySeries(series).data.cols[0]
-      .binning_info;
-    if (binningInfo) {
-      return binningInfo.bin_width;
-    }
-
-    // Otherwise try to infer from the X values
-    return computeNumericDataInverval(xValues);
   }
 }
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -57,6 +57,7 @@ import {
   getFirstNonEmptySeries,
   getXValues,
   syntheticStackedBarsForWaterfallChart,
+  xValueForWaterfallTotal,
   isDimensionTimeseries,
   isRemappedToString,
   isMultiCardSeries,
@@ -137,7 +138,7 @@ function getXAxisProps(props, datas, warn) {
   const xValues = isHistogram
     ? [...rawXValues, Math.max(...rawXValues) + xInterval]
     : props.chartType === "waterfall" && props.settings["waterfall.show_total"]
-    ? [...rawXValues, t`Total`]
+    ? [...rawXValues, xValueForWaterfallTotal(props)]
     : rawXValues;
 
   return {
@@ -272,10 +273,10 @@ export function getDimensionsAndGroupsAndUpdateSeriesDisplayNames(
   originalDatas,
   warn,
 ) {
-  const { settings, chartType } = props;
+  const { settings, chartType, series } = props;
   const datas =
     chartType === "waterfall"
-      ? syntheticStackedBarsForWaterfallChart(originalDatas, settings)
+      ? syntheticStackedBarsForWaterfallChart(originalDatas, settings, series)
       : originalDatas;
   const isStackedBar = isStacked(settings, datas) || chartType === "waterfall";
 

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -5,6 +5,8 @@ import d3 from "d3";
 import dc from "dc";
 import moment from "moment-timezone";
 
+import { t } from "ttag";
+
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { formatValue } from "metabase/lib/formatting";
 
@@ -115,6 +117,11 @@ export function applyChartTimeseriesXAxis(
     if (dimensionColumn.unit == null) {
       dimensionColumn = { ...dimensionColumn, unit: dataInterval.interval };
     }
+    const waterfallTotalX =
+      firstSeries.card.display === "waterfall" &&
+      chart.settings["waterfall.show_total"]
+        ? xValues[xValues.length - 1]
+        : null;
 
     // extract xInterval timezone for updating tickInterval
     const { timezone } = tickInterval;
@@ -126,12 +133,14 @@ export function applyChartTimeseriesXAxis(
       const { column, ...columnSettings } = chart.settings.column(
         dimensionColumn,
       );
-      return formatValue(timestamp, {
-        ...columnSettings,
-        column: { ...column, unit: tickFormatUnit },
-        type: "axis",
-        compact: chart.settings["graph.x_axis.axis_enabled"] === "compact",
-      });
+      return waterfallTotalX && waterfallTotalX.isSame(timestamp)
+        ? t`Total`
+        : formatValue(timestamp, {
+            ...columnSettings,
+            column: { ...column, unit: tickFormatUnit },
+            type: "axis",
+            compact: chart.settings["graph.x_axis.axis_enabled"] === "compact",
+          });
     };
     if (dataInterval.interval === "week") {
       // if tick interval is compressed then show months instead of weeks because they're nicer formatted


### PR DESCRIPTION
For the total bar, we need to synthesize an additional Moment object to
designate a point of time in the future as the X value.
In addition, the label needs to be treated as "Total" instead of the
actual (formatted) date/timestamp.

**Steps to test**:

1. Ask a question, Simple question
2. Choose Sample Dataset, Orders table
3. Summarize, Group by Created At
4. Filter, Created At, Previous 10 Months
5. Visualization, Waterfall
6. Settings, Display, Show total

**Expected**: The waterfall chart should be rendered correctly (not messed up or anything), as illustrated in the following screenshot:

![image](https://user-images.githubusercontent.com/7288/101219660-2cf19e00-3639-11eb-9f57-052bcbdadd3e.png)
