### PR TITLE
Remove reset buttons from viz settings

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx
@@ -58,7 +58,6 @@ class FormattingWidget extends React.Component {
               onChange={settings => onChange({ ...value, [type]: settings })}
               column={column}
               whitelist={new Set(settings)}
-              noReset
             />
           </div>
         ))}

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.jsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import Icon from "metabase/components/Icon";
-
 import cx from "classnames";
 
 const ChartSettingsWidget = ({
@@ -32,20 +30,7 @@ const ChartSettingsWidget = ({
         disable: disabled,
       })}
     >
-      {title && (
-        <h4 className="mb1 flex align-center">
-          {title}
-          <Icon
-            size={12}
-            className={cx("ml1 text-light text-medium-hover cursor-pointer", {
-              hidden: !set || noReset,
-            })}
-            name="refresh"
-            tooltip="Reset to default"
-            onClick={() => onChange(undefined)}
-          />
-        </h4>
-      )}
+      {title && <h4 className="mb1 flex align-center">{title}</h4>}
       {description && <div className="mb1">{description}</div>}
       {Widget && (
         <Widget

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.jsx
@@ -7,15 +7,12 @@ const ChartSettingsWidget = ({
   description,
   hidden,
   disabled,
-  set,
   widget: Widget,
   value,
   onChange,
   props,
   // disables X padding for certain widgets so divider line extends to edge
   noPadding,
-  // disable reset button
-  noReset,
   // NOTE: pass along special props to support:
   // * adding additional fields
   // * substituting widgets

--- a/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
@@ -25,7 +25,6 @@ type Props = {
   whitelist?: Set<SettingId>,
   blacklist?: Set<SettingId>,
   inheritedSettings?: Settings,
-  noReset?: boolean,
 };
 
 const ColumnSettings = ({
@@ -35,7 +34,6 @@ const ColumnSettings = ({
   whitelist,
   blacklist,
   inheritedSettings = {},
-  noReset = false,
 }: Props) => {
   const storedSettings = value || {};
 
@@ -82,7 +80,6 @@ const ColumnSettings = ({
             hidden={false}
             unset={storedSettings[widget.id] === undefined}
             noPadding
-            noReset={noReset || widget.noReset}
           />
         ))
       ) : (

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -45,7 +45,6 @@ export type SettingDef = {
   widget?: string | React$Component<any, any, any>,
   writeDependencies?: SettingId[],
   readDependencies?: SettingId[],
-  noReset?: boolean,
 };
 
 export type WidgetDef = {
@@ -55,7 +54,6 @@ export type WidgetDef = {
   hidden: boolean,
   disabled: boolean,
   props: { [key: string]: any },
-  noReset?: boolean,
   // $FlowFixMe
   widget?: React$Component<any, any, any>,
   onChange: (value: any) => void,


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/13955

Every time you change most visualization settings, a dumb reset button appears next to its label. I can't think of a reason why we should keep these. Are there any legitimate cases I'm forgetting or missing?

## Before

<img width="348" alt="image" src="https://user-images.githubusercontent.com/2223916/101224128-a2ae3780-3642-11eb-8bde-070fc3831ea6.png">

## After

<img width="350" alt="image" src="https://user-images.githubusercontent.com/2223916/101224177-cec9b880-3642-11eb-8c37-f2e196108e77.png">
