### PR TITLE
Refactor and unskip repro for #10829

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -125,13 +125,9 @@ describe("scenarios > dashboard > parameters", () => {
     cy.log(
       "**URL is updated correctly with the given parameter at this point**",
     );
-    cy.url().should("include", "category=Gizmo");
 
-    // Remove filter and save dashboard
-    cy.get(".Icon-pencil").click();
-    cy.get(".Dashboard .Icon-gear").click();
-    cy.findByText("Remove").click();
-    cy.findByText("Save").click();
+    cy.url().should("include", "category=Gizmo");
+    cy.get(".Icon-close").click();
     cy.findByText("You're editing this dashboard.").should("not.exist");
 
     cy.log("**URL should not include deleted parameter**");

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -106,7 +106,7 @@ describe("scenarios > dashboard > parameters", () => {
       .contains("4,939");
   });
 
-  it.skip("should remove previously deleted dashboard parameter from URL (metabase#10829)", () => {
+  it("should remove previously deleted dashboard parameter from URL (metabase#10829)", () => {
     // Mirrored issue in metabase-enterprise#275
 
     // Go directly to "Orders in a dashboard" dashboard
@@ -132,6 +132,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.get(".Dashboard .Icon-gear").click();
     cy.findByText("Remove").click();
     cy.findByText("Save").click();
+    cy.findByText("You're editing this dashboard.").should("not.exist");
 
     cy.log("**URL should not include deleted parameter**");
     cy.url().should("not.include", "category=Gizmo");

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -122,16 +122,28 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByPlaceholderText("Category")
       .click()
       .type("Gizmo{enter}");
+
     cy.log(
       "**URL is updated correctly with the given parameter at this point**",
     );
-
     cy.url().should("include", "category=Gizmo");
-    cy.get(".Icon-close").click();
+
+    // Remove filter name
+    cy.get(".Icon-pencil").click();
+    cy.get(".Dashboard")
+      .find(".Icon-gear")
+      .click();
+    cy.findByDisplayValue("Category")
+      .click()
+      .clear();
+    cy.findByText("Save").click();
     cy.findByText("You're editing this dashboard.").should("not.exist");
 
-    cy.log("**URL should not include deleted parameter**");
-    cy.url().should("not.include", "category=Gizmo");
+    cy.log("**Filter name should be 'unnamed' and the value cleared**");
+    cy.findByPlaceholderText(/unnamed/i);
+
+    cy.log("**URL should reset**");
+    cy.location("pathname").should("eq", "/dashboard/1");
   });
 
   it("should allow linked question to be changed without breaking (metabase#9299)", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- This PR updates the existing repro for #10829 in such a way that it reflects the issue more clearly. Instead of removing the whole filter, it now removes the name of a filter and asserts that URL resets.
- It shows that the issue was indeed solved.
- Closes #10829 

~~This PR unskips the repro for #10829 which was marked as fixed, and thus closed.~~

~~It is expected that this PR fails `parameters.cy.spec.js` test, showing that the issue wasn't actually solved. It needs to be reopened and fixed properly.~~

### Additional notes: 
~~- I tested this locally against the latest `master` and `release-x.37.x` branches and it fails consistently.~~
~~- If this confirms the issue wasn't fixed, reopen #10829~~

~~[This failed run](https://app.circleci.com/pipelines/github/metabase/metabase/10920/workflows/05379bd8-d464-4542-8fae-f9f7a77b9c90/jobs/391362) confirms the issue wasn't fixed:~~
```
AssertionError: Timed out retrying: expected 'http://localhost:4000/dashboard/1?category=Gizmo' to not include 'category=Gizmo'
    at Context.eval (http://localhost:4000/__cypress/tests?p=frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js:2706:14)
```

~~@paulrosenzweig if you decide to work on the issue directly in this PR, please include unskipped repro with the fix. Otherwise, please close this PR before continuing to work in a separate branch/PR. Thank you.~~