### PR TITLE
Start each test in `parameters.cy.spec.js` in isolation

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -2,8 +2,10 @@ import { signInAsAdmin, modal, popover, restore } from "__support__/cypress";
 // NOTE: some overlap with parameters-embedded.cy.spec.js
 
 describe("scenarios > dashboard > parameters", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should be visible if previously added", () => {
     cy.visit("/dashboard/1");


### PR DESCRIPTION
### Status
MERGED

### What does this test accomplish?
- Restores sample dataset before each test in `parameter.cy.spec.js`, allowing them to start in complete isolation.

### Additional notes:
- This should be an imperative, not only for this spec but for all our tests. If results of a previous test are polluting and affecting the next one, it makes it hard to debug and can lead to unpredictable consequences.
- With test retries in Cypress enabled, this danger is even more apparent. See the example below:
- There should never be a reason to run tests sequentially. If there is a legitimate need for that, that should be ONE test.

#### Explanation of the [failed run](https://app.circleci.com/pipelines/github/metabase/metabase/10917/workflows/511ce73f-ccf9-4743-91b0-2796bb1f4783/jobs/391165):
1. This particular test (repro for #10829 ) should have started from a dashboard without ANY filter
2. `City` filter "spilled over" from one of the previous tests which lead to a chain reaction
3. In the first test run `Category` filter is added, but Cypress fails because there are now two "gear" icons and it doesn't know which one to click
4. Cypress retries adding **another** `Category` filter - it fails again for the same reason
5. It retries the second time, adding the third `Category filter`

![image](https://user-images.githubusercontent.com/31325167/101247428-e889ff00-3719-11eb-83ee-024cdb6b3d75.png)
