### PR TITLE
switch to folder for collection icon

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -786,7 +786,7 @@ export const getCollectionsPermissionsGrid = createSelector(
 
     return {
       type: "collection",
-      icon: "collection",
+      icon: "folder",
       crumbs,
       groups,
       permissions: {

--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -87,7 +87,7 @@ const CollectionItem = props => {
 };
 
 CollectionItem.defaultProps = {
-  iconName: "all",
+  iconName: "folder",
 };
 
 export default CollectionItem;

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -62,7 +62,7 @@ const Collections = createEntity({
   objectSelectors: {
     getName: collection => collection && collection.name,
     getUrl: collection => Urls.collection(collection.id),
-    getIcon: collection => "all",
+    getIcon: collection => "folder",
   },
 
   selectors: {

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -167,7 +167,7 @@ const SearchResultSection = ({ title, items }) => (
           extraInfo = (
             <div className="inline-block">
               <Flex align="center" color={color("text-medium")}>
-                <Icon name="all" size={10} mr="4px" />
+                <Icon name="folder" size={10} mr="4px" />
                 <span
                   className="text-small text-bold"
                   style={{ lineHeight: 1 }}


### PR DESCRIPTION
## What this does
Switches from using the "all" icon to the "folder" icon to represent collections. Now that we're using the folder icon in the collection sidebar we want to make sure we're using the same iconography across the app. This change is most noticeable in the picker where you choose where to save a collection.

## Steps to test
1. Create a new dashboard
2. Change the default collection
3. You should see the folder icon next to each item instead of the "all" card stack.

![image](https://user-images.githubusercontent.com/5248953/101365635-0d918580-3872-11eb-9efb-ea79df6cbd9e.png)
