### PR TITLE
Use collection layout for search results

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -161,7 +161,7 @@ export default class CollectionContent extends React.Component {
 
     return (
       <Box pt={2}>
-        <Box w={"80%"} ml="auto" mr="auto">
+        <Box w={"80%"} mx="auto">
           <Flex
             align="center"
             py={3}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -51,11 +51,11 @@ const ANALYTICS_CONTEXT = "Collection Landing";
 const ROW_HEIGHT = 72;
 
 @Search.loadList({
-  query: (state, props) => ({ collection: props.collectionId }),
+  query: (state, props) => ({ collection: props.params.collectionId }),
   wrapped: true,
 })
 @Collection.load({
-  id: (state, props) => props.collectionId,
+  id: (state, props) => props.params.collectionId,
   reload: true,
 })
 @connect((state, props) => {
@@ -144,6 +144,7 @@ export default class CollectionContent extends React.Component {
       selection,
       onToggleSelected,
       location,
+      children,
     } = this.props;
     const { selectedItems, selectedAction } = this.state;
 
@@ -440,6 +441,10 @@ export default class CollectionContent extends React.Component {
           </Modal>
         )}
         <ItemsDragLayer selected={selected} />
+        {
+          // Need to have this here so the child modals will show up
+          children
+        }
       </Box>
     );
   }

--- a/frontend/src/metabase/home/components/HomeLayout.jsx
+++ b/frontend/src/metabase/home/components/HomeLayout.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Box } from "grid-styled";
 
-import CollectionContent from "metabase/collections/containers/CollectionContent";
 import CollectionSidebar from "metabase/collections/containers/CollectionSidebar";
 
 import { PageWrapper } from "metabase/collections/components/Layout";
@@ -22,12 +21,8 @@ const HomeLayout = ({ params: { collectionId }, children }) => {
         ml={340}
         pb={4}
       >
-        <CollectionContent isRoot={isRoot} collectionId={collectionId} />
+        {children}
       </Box>
-      {
-        // Need to have this here so the child modals will show up
-        children
-      }
     </PageWrapper>
   );
 };

--- a/frontend/src/metabase/home/components/HomeLayout.jsx
+++ b/frontend/src/metabase/home/components/HomeLayout.jsx
@@ -6,7 +6,7 @@ import CollectionSidebar from "metabase/collections/containers/CollectionSidebar
 
 import { PageWrapper } from "metabase/collections/components/Layout";
 
-const CollectionLanding = ({ params: { collectionId }, children }) => {
+const HomeLayout = ({ params: { collectionId }, children }) => {
   const isRoot = collectionId === "root";
 
   return (
@@ -32,4 +32,4 @@ const CollectionLanding = ({ params: { collectionId }, children }) => {
   );
 };
 
-export default CollectionLanding;
+export default HomeLayout;

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -9,7 +9,6 @@ import { Box, Flex } from "grid-styled";
 import Search from "metabase/entities/search";
 import Database from "metabase/entities/databases";
 
-import Card from "metabase/components/Card";
 import EmptyState from "metabase/components/EmptyState";
 import EntityItem from "metabase/components/EntityItem";
 import Subhead from "metabase/components/Subhead";
@@ -36,13 +35,11 @@ export default class SearchApp extends React.Component {
             {({ list }) => {
               if (list.length === 0) {
                 return (
-                  <Card>
-                    <EmptyState
-                      title={t`No results`}
-                      message={t`Metabase couldn't find any results for your search.`}
-                      illustrationElement={<img src={NoResults} />}
-                    />
-                  </Card>
+                  <EmptyState
+                    title={t`No results`}
+                    message={t`Metabase couldn't find any results for your search.`}
+                    illustrationElement={<img src={NoResults} />}
+                  />
                 );
               }
 
@@ -145,7 +142,7 @@ export default class SearchApp extends React.Component {
 }
 
 const SearchResultSection = ({ title, items }) => (
-  <Card>
+  <Box>
     {items.map(item => {
       let extraInfo;
       switch (item.model) {
@@ -197,5 +194,5 @@ const SearchResultSection = ({ title, items }) => (
         </Link>
       );
     })}
-  </Card>
+  </Box>
 );

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -11,23 +11,21 @@ import Database from "metabase/entities/databases";
 
 import EmptyState from "metabase/components/EmptyState";
 import EntityItem from "metabase/components/EntityItem";
-import Subhead from "metabase/components/Subhead";
+import PageHeading from "metabase/components/PageHeading";
 import { FILTERS } from "metabase/components/ItemTypeFilterBar";
 
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import NoResults from "assets/img/no_results.svg";
 
-const PAGE_PADDING = [1, 2, 4];
-
 export default class SearchApp extends React.Component {
   render() {
     const { location } = this.props;
     return (
-      <Box mx={PAGE_PADDING}>
+      <Box w={"80%"} mx="auto" pt={2}>
         {location.query.q && (
           <Flex align="center" py={[2, 3]}>
-            <Subhead>{jt`Results for "${location.query.q}"`}</Subhead>
+            <PageHeading>{jt`Results for "${location.query.q}"`}</PageHeading>
           </Flex>
         )}
         <Box>

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -87,11 +87,12 @@ import DashboardCopyModal from "metabase/dashboard/components/DashboardCopyModal
 import DashboardDetailsModal from "metabase/dashboard/components/DashboardDetailsModal";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 
-import CollectionLanding from "metabase/components/CollectionLanding";
+import CollectionContent from "metabase/collections/containers/CollectionContent";
 import Overworld from "metabase/containers/Overworld";
 
 import ArchiveApp from "metabase/home/containers/ArchiveApp";
 import SearchApp from "metabase/home/containers/SearchApp";
+import HomeLayout from "metabase/home/components/HomeLayout";
 
 const MetabaseIsSetup = UserAuthWrapper({
   predicate: authData => !authData.hasSetupToken,
@@ -194,19 +195,21 @@ export const getRoutes = store => (
         <Route path="/explore" component={PostSetupApp} />
         <Route path="/explore/:databaseId" component={PostSetupApp} />
 
-        <Route path="search" title={t`Search`} component={SearchApp} />
         <Route path="archive" title={t`Archive`} component={ArchiveApp} />
 
         <Route path="collection/users" component={IsAdmin}>
           <IndexRoute component={UserCollectionList} />
         </Route>
 
-        <Route path="collection/:collectionId" component={CollectionLanding}>
-          <ModalRoute path="edit" modal={CollectionEdit} />
-          <ModalRoute path="archive" modal={ArchiveCollectionModal} />
-          <ModalRoute path="new_collection" modal={CollectionCreate} />
-          <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
-          <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
+        <Route component={HomeLayout}>
+          <Route path="collection/:collectionId" component={CollectionContent}>
+            <ModalRoute path="edit" modal={CollectionEdit} />
+            <ModalRoute path="archive" modal={ArchiveCollectionModal} />
+            <ModalRoute path="new_collection" modal={CollectionCreate} />
+            <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
+            <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
+          </Route>
+          <Route path="search" title={t`Search`} component={SearchApp} />
         </Route>
 
         <Route path="activity" component={HomepageApp} />


### PR DESCRIPTION
## What this does
This sets the stage for more layout moves by renaming the `CollectionLanding` to `HomeLayout` and creating a wrapper route that can use this sidebar layout to contain content other than just collections.

First batch of work for #13979 

## Steps to test
1. Search for any string in the searchbar
2. The search results should show up in the same overall layout as the rest of collections

![image](https://user-images.githubusercontent.com/5248953/101373974-95c85880-387b-11eb-9961-3a4061844820.png)
