### PR TITLE
Use home layout for archive

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -160,8 +160,8 @@ export default class CollectionContent extends React.Component {
     const collectionHasPins = pinned.length > 0;
 
     return (
-      <Box pt={2}>
-        <Box w={"80%"} mx="auto">
+      <Box>
+        <Box>
           <Flex
             align="center"
             py={3}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -161,7 +161,7 @@ export default class CollectionContent extends React.Component {
 
     return (
       <Box pt={2}>
-        <Box w={"80%"} ml="auto" mr="auto">
+        <Box w={"80%"} mx="auto">
           <Flex
             align="center"
             py={3}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -51,11 +51,11 @@ const ANALYTICS_CONTEXT = "Collection Landing";
 const ROW_HEIGHT = 72;
 
 @Search.loadList({
-  query: (state, props) => ({ collection: props.collectionId }),
+  query: (state, props) => ({ collection: props.params.collectionId }),
   wrapped: true,
 })
 @Collection.load({
-  id: (state, props) => props.collectionId,
+  id: (state, props) => props.params.collectionId,
   reload: true,
 })
 @connect((state, props) => {
@@ -144,6 +144,7 @@ export default class CollectionContent extends React.Component {
       selection,
       onToggleSelected,
       location,
+      children,
     } = this.props;
     const { selectedItems, selectedAction } = this.state;
 
@@ -440,6 +441,10 @@ export default class CollectionContent extends React.Component {
           </Modal>
         )}
         <ItemsDragLayer selected={selected} />
+        {
+          // Need to have this here so the child modals will show up
+          children
+        }
       </Box>
     );
   }

--- a/frontend/src/metabase/home/components/HomeLayout.jsx
+++ b/frontend/src/metabase/home/components/HomeLayout.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Box } from "grid-styled";
 
-import CollectionContent from "metabase/collections/containers/CollectionContent";
 import CollectionSidebar from "metabase/collections/containers/CollectionSidebar";
 
 import { PageWrapper } from "metabase/collections/components/Layout";
@@ -22,12 +21,8 @@ const HomeLayout = ({ params: { collectionId }, children }) => {
         ml={340}
         pb={4}
       >
-        <CollectionContent isRoot={isRoot} collectionId={collectionId} />
+        {children}
       </Box>
-      {
-        // Need to have this here so the child modals will show up
-        children
-      }
     </PageWrapper>
   );
 };

--- a/frontend/src/metabase/home/components/HomeLayout.jsx
+++ b/frontend/src/metabase/home/components/HomeLayout.jsx
@@ -6,7 +6,7 @@ import CollectionSidebar from "metabase/collections/containers/CollectionSidebar
 
 import { PageWrapper } from "metabase/collections/components/Layout";
 
-const CollectionLanding = ({ params: { collectionId }, children }) => {
+const HomeLayout = ({ params: { collectionId }, children }) => {
   const isRoot = collectionId === "root";
 
   return (
@@ -32,4 +32,4 @@ const CollectionLanding = ({ params: { collectionId }, children }) => {
   );
 };
 
-export default CollectionLanding;
+export default HomeLayout;

--- a/frontend/src/metabase/home/components/HomeLayout.jsx
+++ b/frontend/src/metabase/home/components/HomeLayout.jsx
@@ -21,7 +21,9 @@ const HomeLayout = ({ params: { collectionId }, children }) => {
         ml={340}
         pb={4}
       >
-        {children}
+        <Box w={"80%"} mx="auto" pt={2}>
+          {children}
+        </Box>
       </Box>
     </PageWrapper>
   );

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -45,7 +45,7 @@ export default class ArchiveApp extends Component {
     } = this.props;
     return (
       <Box>
-        <Box py={2}>
+        <Box py={[2, 3]}>
           <PageHeading>{t`Archive`}</PageHeading>
         </Box>
         <Box>

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -7,7 +7,6 @@ import { Box, Flex } from "grid-styled";
 import ArchivedItem from "../../components/ArchivedItem";
 import Button from "metabase/components/Button";
 import BulkActionBar from "metabase/components/BulkActionBar";
-import Card from "metabase/components/Card";
 import PageHeading from "metabase/components/PageHeading";
 import StackedCheckBox from "metabase/components/StackedCheckBox";
 import VirtualizedList from "metabase/components/VirtualizedList";
@@ -45,55 +44,49 @@ export default class ArchiveApp extends Component {
       onToggleSelected,
     } = this.props;
     return (
-      <Box mx={4}>
-        <Box mt={2} py={2}>
+      <Box>
+        <Box py={2}>
           <PageHeading>{t`Archive`}</PageHeading>
         </Box>
-        <Box w={2 / 3}>
-          <Card
-            style={{
-              height: list.length > 0 ? ROW_HEIGHT * list.length : "auto",
-            }}
-          >
-            {list.length > 0 ? (
-              <VirtualizedList
-                items={list}
-                rowHeight={ROW_HEIGHT}
-                renderItem={({ item, index }) => (
-                  <ArchivedItem
-                    type={item.type}
-                    name={item.getName()}
-                    icon={item.getIcon()}
-                    color={item.getColor()}
-                    isAdmin={isAdmin}
-                    onUnarchive={
-                      item.setArchived
-                        ? async () => {
-                            await item.setArchived(false);
-                            reload();
-                          }
-                        : null
-                    }
-                    onDelete={
-                      item.delete
-                        ? async () => {
-                            await item.delete();
-                            reload();
-                          }
-                        : null
-                    }
-                    selected={selection.has(item)}
-                    onToggleSelected={() => onToggleSelected(item)}
-                    showSelect={selected.length > 0}
-                  />
-                )}
-              />
-            ) : (
-              <Flex p={5} align="center" justify="center">
-                <h2>{t`Items you archive will appear here.`}</h2>
-              </Flex>
-            )}
-          </Card>
+        <Box>
+          {list.length > 0 ? (
+            <VirtualizedList
+              items={list}
+              rowHeight={ROW_HEIGHT}
+              renderItem={({ item, index }) => (
+                <ArchivedItem
+                  type={item.type}
+                  name={item.getName()}
+                  icon={item.getIcon()}
+                  color={item.getColor()}
+                  isAdmin={isAdmin}
+                  onUnarchive={
+                    item.setArchived
+                      ? async () => {
+                          await item.setArchived(false);
+                          reload();
+                        }
+                      : null
+                  }
+                  onDelete={
+                    item.delete
+                      ? async () => {
+                          await item.delete();
+                          reload();
+                        }
+                      : null
+                  }
+                  selected={selection.has(item)}
+                  onToggleSelected={() => onToggleSelected(item)}
+                  showSelect={selected.length > 0}
+                />
+              )}
+            />
+          ) : (
+            <Flex p={5} align="center" justify="center">
+              <h2>{t`Items you archive will appear here.`}</h2>
+            </Flex>
+          )}
         </Box>
         <BulkActionBar showing={selected.length > 0}>
           <Flex align="center" py={2} px={4}>

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -9,7 +9,6 @@ import { Box, Flex } from "grid-styled";
 import Search from "metabase/entities/search";
 import Database from "metabase/entities/databases";
 
-import Card from "metabase/components/Card";
 import EmptyState from "metabase/components/EmptyState";
 import EntityItem from "metabase/components/EntityItem";
 import Subhead from "metabase/components/Subhead";
@@ -36,13 +35,11 @@ export default class SearchApp extends React.Component {
             {({ list }) => {
               if (list.length === 0) {
                 return (
-                  <Card>
-                    <EmptyState
-                      title={t`No results`}
-                      message={t`Metabase couldn't find any results for your search.`}
-                      illustrationElement={<img src={NoResults} />}
-                    />
-                  </Card>
+                  <EmptyState
+                    title={t`No results`}
+                    message={t`Metabase couldn't find any results for your search.`}
+                    illustrationElement={<img src={NoResults} />}
+                  />
                 );
               }
 
@@ -145,7 +142,7 @@ export default class SearchApp extends React.Component {
 }
 
 const SearchResultSection = ({ title, items }) => (
-  <Card>
+  <Box>
     {items.map(item => {
       let extraInfo;
       switch (item.model) {
@@ -197,5 +194,5 @@ const SearchResultSection = ({ title, items }) => (
         </Link>
       );
     })}
-  </Card>
+  </Box>
 );

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -11,23 +11,21 @@ import Database from "metabase/entities/databases";
 
 import EmptyState from "metabase/components/EmptyState";
 import EntityItem from "metabase/components/EntityItem";
-import Subhead from "metabase/components/Subhead";
+import PageHeading from "metabase/components/PageHeading";
 import { FILTERS } from "metabase/components/ItemTypeFilterBar";
 
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import NoResults from "assets/img/no_results.svg";
 
-const PAGE_PADDING = [1, 2, 4];
-
 export default class SearchApp extends React.Component {
   render() {
     const { location } = this.props;
     return (
-      <Box mx={PAGE_PADDING}>
+      <Box w={"80%"} mx="auto" pt={2}>
         {location.query.q && (
           <Flex align="center" py={[2, 3]}>
-            <Subhead>{jt`Results for "${location.query.q}"`}</Subhead>
+            <PageHeading>{jt`Results for "${location.query.q}"`}</PageHeading>
           </Flex>
         )}
         <Box>

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -22,7 +22,7 @@ export default class SearchApp extends React.Component {
   render() {
     const { location } = this.props;
     return (
-      <Box w={"80%"} mx="auto" pt={2}>
+      <Box>
         {location.query.q && (
           <Flex align="center" py={[2, 3]}>
             <PageHeading>{jt`Results for "${location.query.q}"`}</PageHeading>

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -87,11 +87,12 @@ import DashboardCopyModal from "metabase/dashboard/components/DashboardCopyModal
 import DashboardDetailsModal from "metabase/dashboard/components/DashboardDetailsModal";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 
-import CollectionLanding from "metabase/components/CollectionLanding";
+import CollectionContent from "metabase/collections/containers/CollectionContent";
 import Overworld from "metabase/containers/Overworld";
 
 import ArchiveApp from "metabase/home/containers/ArchiveApp";
 import SearchApp from "metabase/home/containers/SearchApp";
+import HomeLayout from "metabase/home/components/HomeLayout";
 
 const MetabaseIsSetup = UserAuthWrapper({
   predicate: authData => !authData.hasSetupToken,
@@ -194,19 +195,21 @@ export const getRoutes = store => (
         <Route path="/explore" component={PostSetupApp} />
         <Route path="/explore/:databaseId" component={PostSetupApp} />
 
-        <Route path="search" title={t`Search`} component={SearchApp} />
         <Route path="archive" title={t`Archive`} component={ArchiveApp} />
 
         <Route path="collection/users" component={IsAdmin}>
           <IndexRoute component={UserCollectionList} />
         </Route>
 
-        <Route path="collection/:collectionId" component={CollectionLanding}>
-          <ModalRoute path="edit" modal={CollectionEdit} />
-          <ModalRoute path="archive" modal={ArchiveCollectionModal} />
-          <ModalRoute path="new_collection" modal={CollectionCreate} />
-          <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
-          <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
+        <Route component={HomeLayout}>
+          <Route path="collection/:collectionId" component={CollectionContent}>
+            <ModalRoute path="edit" modal={CollectionEdit} />
+            <ModalRoute path="archive" modal={ArchiveCollectionModal} />
+            <ModalRoute path="new_collection" modal={CollectionCreate} />
+            <ModalRoute path="new_dashboard" modal={CreateDashboardModal} />
+            <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
+          </Route>
+          <Route path="search" title={t`Search`} component={SearchApp} />
         </Route>
 
         <Route path="activity" component={HomepageApp} />

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -195,8 +195,6 @@ export const getRoutes = store => (
         <Route path="/explore" component={PostSetupApp} />
         <Route path="/explore/:databaseId" component={PostSetupApp} />
 
-        <Route path="archive" title={t`Archive`} component={ArchiveApp} />
-
         <Route path="collection/users" component={IsAdmin}>
           <IndexRoute component={UserCollectionList} />
         </Route>
@@ -210,6 +208,7 @@ export const getRoutes = store => (
             <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
           </Route>
           <Route path="search" title={t`Search`} component={SearchApp} />
+          <Route path="archive" title={t`Archive`} component={ArchiveApp} />
         </Route>
 
         <Route path="activity" component={HomepageApp} />


### PR DESCRIPTION
## What this does
Moves `ArchiveApp` to live under the `HomeLayout` for more layout consistency when visiting the archive.  I also took this as an opportunity to move some shared layout widths and padding into `HomeLayout` so we don't have to set that in `SearchApp`, `CollectionContent`, etc each time.

~~For diff / momentum reasons I'm basing off of #13980, but I'll rebase onto `homepage-collection-integration` once that gets merged into the feature branch.~~

## How to test
1. Visit /archive
2. Archive content (or empty state) should be seen alongside the collection sidebar

![image](https://user-images.githubusercontent.com/5248953/101376643-d83f6480-387e-11eb-83be-26de1d915636.png)
