### PR TITLE
redirect to /collection/root on /

### DIFF
--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -190,7 +190,9 @@ export const getRoutes = store => (
               replace(page);
             }
           }}
-        />
+        >
+          <IndexRedirect to="/collection/root" />
+        </Route>
 
         <Route path="/explore" component={PostSetupApp} />
         <Route path="/explore/:databaseId" component={PostSetupApp} />


### PR DESCRIPTION
## What this does
Adds an `<IndexRedirect />` to `/` to send people to `/collection/root`. 

## How to test
1. Log out of Metabase or go to a non collection page and hit the logo in the top nav.
2. Log back in (if logged out in step 1)
3. You should see the "Our analytics" collection

## Todos 
- [ ] Fix up tests