### PR TITLE
Time-series waterfall: position the total value label correctly

### DIFF
--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -1,9 +1,8 @@
 import _ from "underscore";
 
-import { t } from "ttag";
 import { COMPACT_CURRENCY_OPTIONS } from "metabase/lib/formatting";
 import { moveToFront } from "metabase/lib/dom";
-import { isHistogramBar } from "./renderer_utils";
+import { isHistogramBar, xValueForWaterfallTotal } from "./renderer_utils";
 
 /*
 There's a lot of messy logic in this function. Its purpose is to place text labels at the appropriate place over a chart.
@@ -111,7 +110,15 @@ export function onRenderValueLabels(
       if (chart.settings["waterfall.show_total"]) {
         data = [
           ...data,
-          { ...data[0], x: t`Total`, y: total, cumulativeY: total },
+          {
+            ...data[0],
+            x: xValueForWaterfallTotal({
+              settings: chart.settings,
+              series: chart.series,
+            }),
+            y: total,
+            cumulativeY: total,
+          },
         ];
       }
     }


### PR DESCRIPTION
**Steps to test**:

1. Ask a question, Simple question
2. Choose Sample Dataset, Orders table
3. Summarize, Group by Created At
4. Filter, Created At, Previous 10 Months
5. Visualization, Waterfall
6. Settings, Display, Show total
7. Settings, Display, Show values on data points

**Before this fix**: The label for the total value (in this example, `1,414`) is position incorrectly (internally, the X value is `NaN`).


**With this fix**: The label for the total value (in this example, `1,414`) is position exactly where it is supposed to be, i.e. near the top of the bar.


![image](https://user-images.githubusercontent.com/7288/101400596-fceb0a80-3885-11eb-9668-b7d6c7a1f716.png)
