### PR TITLE
Use report timezone for XLSX results

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -10,14 +10,16 @@
             [medley.core :as m]
             [metabase
              [config :as config]
+             [driver :as driver]
              [email :as email]
              [public-settings :as public-settings]
              [util :as u]]
+            [metabase.driver.util :as driver.u]
             [metabase.pulse.render :as render]
             [metabase.pulse.render
              [body :as render.body]
              [style :as render.style]]
-            [metabase.query-processor.streaming :as qp.streaming]
+            [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.streaming.interface :as qp.streaming.i]
             [metabase.util
              [i18n :refer [deferred-trs trs tru]]
@@ -27,7 +29,7 @@
              [core :as stencil]
              [loader :as stencil-loader]]
             [toucan.db :as db])
-  (:import [java.io File IOException]))
+  (:import [java.io File IOException OutputStream]))
 
 (defn- app-name-trs
   "Return the user configured application name, or Metabase translated
@@ -316,18 +318,42 @@
       :else
       (no "less than %d columns, %d rows in results" render.body/cols-limit render.body/rows-limit))))
 
+(defn- stream-api-results-to-export-format
+  "For legacy compatability. Takes QP results in the normal `:api` response format and streams them to a different
+  format.
+
+  TODO -- this function is provided mainly because rewriting all of the Pulse/Alert code to stream results directly
+  was a lot of work. I intend to rework that code so we can stream directly to the correct export format(s) at some
+  point in the future; for now, this function is a stopgap.
+
+  Results are streamed synchronosuly. Caller is responsible for closing `os` when this call is complete."
+  [export-format ^OutputStream os {{:keys [rows]} :data, database-id :database_id, :as results}]
+  ;; make sure Database/driver info is available for the streaming results writers -- they might need this in order to
+    ;; get timezone information when writing results
+  (driver/with-driver (driver.u/database->driver database-id)
+    (qp.store/with-store
+      (qp.store/fetch-and-store-database! database-id)
+      (let [w (qp.streaming.i/streaming-results-writer export-format os)]
+        (qp.streaming.i/begin! w results)
+        (dorun
+         (map-indexed
+          (fn [i row]
+            (qp.streaming.i/write-row! w row i))
+          rows))
+        (qp.streaming.i/finish! w results)))))
+
 (defn- result-attachment
   [{{card-name :name, :as card} :card, {{:keys [rows], :as result-data} :data, :as result} :result}]
   (when (seq rows)
     [(when-let [temp-file (and (include-csv-attachment? card result-data)
                                (create-temp-file-or-throw "csv"))]
        (with-open [os (io/output-stream temp-file)]
-         (qp.streaming/stream-api-results-to-export-format :csv os result))
+         (stream-api-results-to-export-format :csv os result))
        (create-result-attachment-map "csv" card-name temp-file))
      (when-let [temp-file (and (:include_xls card)
                                (create-temp-file-or-throw "xlsx"))]
        (with-open [os (io/output-stream temp-file)]
-         (qp.streaming/stream-api-results-to-export-format :xlsx os result))
+         (stream-api-results-to-export-format :xlsx os result))
        (create-result-attachment-map "xlsx" card-name temp-file))]))
 
 (defn- result-attachments [results]

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -7,7 +7,6 @@
             [metabase
              [public-settings :as public-settings]
              [util :as u]]
-            [metabase.email.messages :as email]
             [metabase.models
              [collection :as collection]
              [permissions :as perms]
@@ -20,7 +19,8 @@
             [schema.core :as s]
             [toucan
              [db :as db]
-             [models :as models]])
+             [models :as models]]
+            [metabase.plugins.classloader :as classloader])
   (:import java.util.UUID))
 
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
@@ -162,7 +162,8 @@
   (let [reset-token (set-password-reset-token! (u/get-id new-user))
         ;; the new user join url is just a password reset with an indicator that this is a first time user
         join-url    (str (form-password-reset-url reset-token) "#new")]
-    (email/send-new-user-email! new-user invitor join-url)))
+    (classloader/require 'metabase.email.messages)
+    ((resolve 'metabase.email.messages/send-new-user-email!) new-user invitor join-url)))
 
 (def LoginAttributes
   "Login attributes, currently not collected for LDAP or Google Auth. Will ultimately be stored as JSON."
@@ -204,7 +205,8 @@
   [new-user :- NewUser]
   (u/prog1 (insert-new-user! (assoc new-user :google_auth true))
     ;; send an email to everyone including the site admin if that's set
-    (email/send-user-joined-admin-notification-email! <>, :google-auth? true)))
+    (classloader/require 'metabase.email.messages)
+    ((resolve 'metabase.email.messages/send-user-joined-admin-notification-email!) <>, :google-auth? true)))
 
 (s/defn create-new-ldap-auth-user!
   "Convenience for creating a new user via LDAP. This account is considered active immediately; thus all active admins

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -13,14 +13,14 @@
              [permissions-group :as group]
              [permissions-group-membership :as perm-membership :refer [PermissionsGroupMembership]]
              [session :refer [Session]]]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util
              [i18n :as i18n :refer [deferred-tru trs]]
              [schema :as su]]
             [schema.core :as s]
             [toucan
              [db :as db]
-             [models :as models]]
-            [metabase.plugins.classloader :as classloader])
+             [models :as models]])
   (:import java.util.UUID))
 
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -157,6 +157,9 @@
     (not (are-all-cards-empty? results))
     true))
 
+;; 'notification' used below means a map that has information needed to send a Pulse/Alert, including results of
+;; running the underlying query
+
 (defmulti ^:private notification
   "Polymorphoic function for creating notifications. This logic is different for pulse type (i.e. alert vs. pulse) and
   channel_type (i.e. email vs. slack)"
@@ -220,7 +223,9 @@
             :when   (contains? (set channel-ids) (:id channel))]
         (notification pulse results channel)))))
 
-(defn- pulse->notifications [{:keys [cards], pulse-id :id, :as pulse}]
+(defn- pulse->notifications
+  "Execute the underlying queries for a sequence of Pulses and return the results as 'notification' maps."
+  [{:keys [cards], pulse-id :id, :as pulse}]
   (let [results (for [card  cards
                       ;; Pulse ID may be `nil` if the Pulse isn't saved yet
                       :let  [result (execute-card pulse (u/get-id card), :pulse-id pulse-id)]

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -8,11 +8,63 @@
             [potemkin.types :as p.types])
   (:import [java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime ZoneId]))
 
+;; TODO -- consider moving this it `metabase.util.date2`
+(p.types/defprotocol+ WithTimeZoneSameInstant
+  "Protocol for converting a temporal value to an equivalent one in a given timezone."
+  (with-time-zone-same-instant [t ^ZoneId timezone-id]
+    "Convert a temporal value to an equivalent one in a given timezone. For local temporal values, this simply
+    converts it to the corresponding offset/zoned type; for offset/zoned types, this applies an appropriate timezone
+    shift."))
+
+(extend-protocol WithTimeZoneSameInstant
+  ;; convert to a OffsetTime with no offset (UTC); the OffsetTime method impl will apply the zone shift.
+  LocalTime
+  (with-time-zone-same-instant [t zone-id]
+    (with-time-zone-same-instant (t/offset-time t (t/zone-offset 0)) zone-id))
+
+  ;; We don't know what zone offset to shift this to, since the offset for a zone-id can vary depending on the date
+  ;; part of a temporal value (e.g. DST vs non-DST). So just adjust to the non-DST "standard" offset for the zone in
+  ;; question.
+  OffsetTime
+  (with-time-zone-same-instant [t ^ZoneId zone-id]
+    (let [offset (.. zone-id getRules (getStandardOffset (t/instant 0)))]
+      (t/with-offset-same-instant t offset)))
+
+  LocalDate
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time t (t/local-time 0) zone-id))
+
+  LocalDate
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time t (t/local-time 0) zone-id))
+
+  LocalDateTime
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time t zone-id))
+
+  Instant
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time t zone-id))
+
+  OffsetDateTime
+  (with-time-zone-same-instant [t ^ZoneId zone-id]
+    ;; calculate the zone offset applicable for the date in question
+    (if (or (= t OffsetDateTime/MAX)
+            (= t OffsetDateTime/MIN))
+      t
+      (let [rules  (.getRules zone-id)
+            offset (.getOffset rules (t/instant t))]
+        (t/with-offset-same-instant t offset))))
+
+  ZonedDateTime
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time (t/with-zone-same-instant t zone-id))))
+
 ;; TODO - consider moving to `metabase.util.date-2/format-with-timezone`
 (p.types/defprotocol+ FormatValue
   "Protocol for determining how QP results of various classes are serialized. Drivers can add implementations to support
   custom driver types as needed."
-  (format-value [v, ^ZoneId timezone-id]
+  (format-value [v ^ZoneId timezone-id]
     "Serialize a value in the QP results. You can add impementations for driver-specific types as needed."))
 
 (extend-protocol FormatValue
@@ -24,44 +76,33 @@
   (format-value [v _]
     v)
 
-  ;; TIMEZONE FIXME — not sure this makes sense at all...
   LocalTime
   (format-value [t timezone-id]
-    (t/format :iso-offset-time (t/offset-time t timezone-id)))
+    (t/format :iso-offset-time (with-time-zone-same-instant t timezone-id)))
 
-  ;; TODO - this is a little screwy, for `OffsetDateTime` and `ZonedDateTime` we convert them into the `timezone-id`
-  ;; (by adjusting offset as needed); because `OffsetTime` doesn't have a date (and adjusting offset can't be done
-  ;; with Zone ID alone), return it *without* adjusting it into `timezone-id`
   OffsetTime
-  (format-value [t _]
-    (t/format :iso-offset-time t))
+  (format-value [t timezone-id]
+    (t/format :iso-offset-time (with-time-zone-same-instant t timezone-id)))
 
   LocalDate
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time (t/offset-date-time t (t/local-time 0) timezone-id)))
+    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
 
   LocalDateTime
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time (t/offset-date-time t timezone-id)))
+    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
 
   Instant
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time (t/offset-date-time t timezone-id)))
+    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
 
   OffsetDateTime
   (format-value [t, ^ZoneId timezone-id]
-    (t/format :iso-offset-date-time
-              (if (or (= t OffsetDateTime/MAX)
-                      (= t OffsetDateTime/MIN))
-                t
-                (let [rules  (.getRules timezone-id)
-                      offset (.getOffset rules (t/instant t))]
-                  (t/with-offset-same-instant t offset)))))
+    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
 
   ZonedDateTime
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time
-              (t/offset-date-time (t/with-zone-same-instant t timezone-id)))))
+    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id))))
 
 (defn- format-rows-xform [rf]
   {:pre [(fn? rf)]}

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -4,63 +4,12 @@
   (:require [clojure.tools.logging :as log]
             [java-time :as t]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.util.i18n :refer [tru]]
+            [metabase.util
+             [date-2 :as u.date]
+             [i18n :refer [tru]]]
             [potemkin.types :as p.types])
   (:import [java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime ZoneId]))
 
-;; TODO -- consider moving this it `metabase.util.date2`
-(p.types/defprotocol+ WithTimeZoneSameInstant
-  "Protocol for converting a temporal value to an equivalent one in a given timezone."
-  (with-time-zone-same-instant [t ^ZoneId timezone-id]
-    "Convert a temporal value to an equivalent one in a given timezone. For local temporal values, this simply
-    converts it to the corresponding offset/zoned type; for offset/zoned types, this applies an appropriate timezone
-    shift."))
-
-(extend-protocol WithTimeZoneSameInstant
-  ;; convert to a OffsetTime with no offset (UTC); the OffsetTime method impl will apply the zone shift.
-  LocalTime
-  (with-time-zone-same-instant [t zone-id]
-    (with-time-zone-same-instant (t/offset-time t (t/zone-offset 0)) zone-id))
-
-  ;; We don't know what zone offset to shift this to, since the offset for a zone-id can vary depending on the date
-  ;; part of a temporal value (e.g. DST vs non-DST). So just adjust to the non-DST "standard" offset for the zone in
-  ;; question.
-  OffsetTime
-  (with-time-zone-same-instant [t ^ZoneId zone-id]
-    (let [offset (.. zone-id getRules (getStandardOffset (t/instant 0)))]
-      (t/with-offset-same-instant t offset)))
-
-  LocalDate
-  (with-time-zone-same-instant [t zone-id]
-    (t/offset-date-time t (t/local-time 0) zone-id))
-
-  LocalDate
-  (with-time-zone-same-instant [t zone-id]
-    (t/offset-date-time t (t/local-time 0) zone-id))
-
-  LocalDateTime
-  (with-time-zone-same-instant [t zone-id]
-    (t/offset-date-time t zone-id))
-
-  Instant
-  (with-time-zone-same-instant [t zone-id]
-    (t/offset-date-time t zone-id))
-
-  OffsetDateTime
-  (with-time-zone-same-instant [t ^ZoneId zone-id]
-    ;; calculate the zone offset applicable for the date in question
-    (if (or (= t OffsetDateTime/MAX)
-            (= t OffsetDateTime/MIN))
-      t
-      (let [rules  (.getRules zone-id)
-            offset (.getOffset rules (t/instant t))]
-        (t/with-offset-same-instant t offset))))
-
-  ZonedDateTime
-  (with-time-zone-same-instant [t zone-id]
-    (t/offset-date-time (t/with-zone-same-instant t zone-id))))
-
-;; TODO - consider moving to `metabase.util.date-2/format-with-timezone`
 (p.types/defprotocol+ FormatValue
   "Protocol for determining how QP results of various classes are serialized. Drivers can add implementations to support
   custom driver types as needed."
@@ -78,31 +27,32 @@
 
   LocalTime
   (format-value [t timezone-id]
-    (t/format :iso-offset-time (with-time-zone-same-instant t timezone-id)))
+    (t/format :iso-offset-time (u.date/with-time-zone-same-instant t timezone-id)))
 
   OffsetTime
   (format-value [t timezone-id]
-    (t/format :iso-offset-time (with-time-zone-same-instant t timezone-id)))
+    (t/format :iso-offset-time (u.date/with-time-zone-same-instant t timezone-id)))
 
   LocalDate
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
+    (t/format :iso-offset-date-time (u.date/with-time-zone-same-instant t timezone-id)))
 
   LocalDateTime
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
+    (t/format :iso-offset-date-time (u.date/with-time-zone-same-instant t timezone-id)))
 
+  ;; convert to a ZonedDateTime
   Instant
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
+    (format-value (t/zoned-date-time t (t/zone-id "UTC")) timezone-id))
 
   OffsetDateTime
   (format-value [t, ^ZoneId timezone-id]
-    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id)))
+    (t/format :iso-offset-date-time (u.date/with-time-zone-same-instant t timezone-id)))
 
   ZonedDateTime
   (format-value [t timezone-id]
-    (t/format :iso-offset-date-time (with-time-zone-same-instant t timezone-id))))
+    (t/format :iso-offset-date-time (u.date/with-time-zone-same-instant t timezone-id))))
 
 (defn- format-rows-xform [rf]
   {:pre [(fn? rf)]}

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -102,22 +102,3 @@
   with extra metadata), but other types may be available if plugins are installed. (The interface is extensible.)"
   []
   (set (keys (methods i/stream-options))))
-
-(defn ^:deprecated stream-api-results-to-export-format
-  "For legacy compatability. Takes QP results in the normal `:api` response format and streams them to a different
-  format.
-
-  TODO -- this function is provided mainly because rewriting all of the Pulse/Alert code to stream results directly
-  was a lot of work. I intend to rework that code so we can stream directly to the correct export format(s) at some
-  point in the future; for now, this function is a stopgap.
-
-  Results are streamed synchronosuly. Caller is responsible for closing `os` when this call is complete."
-  [export-format ^OutputStream os {{:keys [rows]} :data, :as results}]
-  (let [w (i/streaming-results-writer export-format os)]
-    (i/begin! w results)
-    (dorun
-     (map-indexed
-      (fn [i row]
-        (i/write-row! w row i))
-      rows))
-    (i/finish! w results)))

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -2,15 +2,18 @@
   (:require [cheshire.core :as json]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [java-time :as t]
+            [metabase.query-processor.middleware.format-rows :as qp.format-rows]
             [metabase.query-processor.streaming.interface :as i]
+            [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util
              [date-2 :as u.date]
              [i18n :refer [tru]]])
   (:import java.io.OutputStream
            [java.time LocalDate LocalDateTime OffsetDateTime ZonedDateTime]
-           java.util.Date
            [org.apache.poi.ss.usermodel Cell CellType Workbook]
            org.apache.poi.xssf.streaming.SXSSFWorkbook))
+
+(def ^:private ^:dynamic *results-timezone-id* "UTC")
 
 (defmethod i/stream-options :xlsx
   [_]
@@ -61,28 +64,36 @@
   (.setCellValue cell ^Date date)
   (.setCellStyle cell (create-or-get-date-format (.. cell getSheet getWorkbook) format-string)))
 
-(defmethod spreadsheet/set-cell! LocalDate [^Cell cell val]
-  ;; this truncates the time to midnight UTC on the given date
-  (set-cell! cell date-format (t/java-date (t/zoned-date-time val (t/local-time 00 00) (t/zone-id)))))
+(defn- apply-timezone [t]
+  (qp.format-rows/with-time-zone-same-instant t (t/zone-id *results-timezone-id*)))
 
-(defmethod spreadsheet/set-cell! LocalDateTime [^Cell cell val]
-  (set-cell! cell datetime-format (t/java-date (t/zoned-date-time val (t/zone-id)))))
+(defmethod spreadsheet/set-cell! LocalDate
+  [^Cell cell t]
+  (set-cell! cell date-format (t/java-date (apply-timezone t))))
 
-(defmethod spreadsheet/set-cell! ZonedDateTime [^Cell cell val]
-  (set-cell! cell datetime-format (t/java-date val)))
+(defmethod spreadsheet/set-cell! LocalDateTime
+  [^Cell cell t]
+  (spreadsheet/set-cell! cell (t/java-date (apply-timezone t))))
 
-(defmethod spreadsheet/set-cell! OffsetDateTime [^Cell cell val]
-  (set-cell! cell datetime-format (t/java-date val)))
+(defmethod spreadsheet/set-cell! ZonedDateTime
+  [^Cell cell t]
+  (set-cell! cell datetime-format (t/java-date (apply-timezone t))))
+
+(defmethod spreadsheet/set-cell! OffsetDateTime
+  [^Cell cell t]
+  (set-cell! cell datetime-format (t/java-date (apply-timezone t))))
 
 ;; overrides the default implementation from docjure, so that a plain Date object
 ;; carries its time too
-(defmethod spreadsheet/set-cell! Date [^Cell cell val]
+(defmethod spreadsheet/set-cell! java.util.Date
+  [^Cell cell val]
   (set-cell! cell datetime-format val))
 
 ;; add a generic implementation for the method that writes values to XLSX cells that just piggybacks off the
 ;; implementations we've already defined for encoding things as JSON. These implementations live in
 ;; `metabase.middleware`.
-(defmethod spreadsheet/set-cell! Object [^Cell cell, value]
+(defmethod spreadsheet/set-cell! Object
+  [^Cell cell, value]
   (when (= (.getCellType cell) CellType/FORMULA)
     (.setCellType cell CellType/STRING))
   ;; stick the object in a JSON map and encode it, which will force conversion to a string. Then unparse that JSON and
@@ -92,18 +103,20 @@
                                (json/parse-string keyword)
                                :v))))
 
-;; TODO -- this is obviously not streaming! SAD!
 (defmethod i/streaming-results-writer :xlsx
   [_ ^OutputStream os]
-  (let [workbook    (SXSSFWorkbook.)
-        cell-styles (atom {})
-        sheet       (spreadsheet/add-sheet! workbook (tru "Query result"))]
+  (let [workbook         (SXSSFWorkbook.)
+        cell-styles      (atom {})
+        sheet            (spreadsheet/add-sheet! workbook (tru "Query result"))
+        results-timezone (atom nil)]
     (reify i/StreamingResultsWriter
       (begin! [_ {{:keys [cols]} :data}]
+        (reset! results-timezone (qp.timezone/results-timezone-id))
         (spreadsheet/add-row! sheet (map (some-fn :display_name :name) cols)))
 
       (write-row! [_ row _]
-        (binding [*cell-styles* cell-styles]
+        (binding [*cell-styles*      cell-styles
+                  *results-timezone-id* @results-timezone]
           (spreadsheet/add-row! sheet row)))
 
       (finish! [_ _]

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -6,11 +6,11 @@
             [clojure.tools.logging :as log]
             [java-time :as t]
             [java-time.core :as t.core]
-            [metabase.config :as config]
             [metabase.util.date-2
              [common :as common]
              [parse :as parse]]
             [metabase.util.i18n :refer [tru]]
+            [potemkin.types :as p.types]
             [schema.core :as s])
   (:import [java.time Duration Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime Period ZonedDateTime]
            [java.time.temporal Temporal TemporalAdjuster WeekFields]
@@ -406,6 +406,63 @@
    (period-duration t (now-of-same-class t))
    duration))
 
+(p.types/defprotocol+ WithTimeZoneSameInstant
+  "Protocol for converting a temporal value to an equivalent one in a given timezone."
+  (with-time-zone-same-instant [t ^java.time.ZoneId zone-id]
+    "Convert a temporal value to an equivalent one in a given timezone. For local temporal values, this simply
+    converts it to the corresponding offset/zoned type; for offset/zoned types, this applies an appropriate timezone
+    shift."))
+
+;; We don't know what zone offset to shift this to, since the offset for a zone-id can vary depending on the date
+;; part of a temporal value (e.g. DST vs non-DST). So just adjust to the non-DST "standard" offset for the zone in
+;; question.
+(defn- standard-offset
+  "Standard (non-DST) offset for a time zone, for cases when we don't have date information."
+  ^java.time.ZoneOffset [^java.time.ZoneId zone-id]
+  (.. zone-id getRules (getStandardOffset (t/instant 0))))
+
+(extend-protocol WithTimeZoneSameInstant
+  ;; convert to a OffsetTime with no offset (UTC); the OffsetTime method impl will apply the zone shift.
+  LocalTime
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-time t (standard-offset zone-id)))
+
+  OffsetTime
+  (with-time-zone-same-instant [t ^java.time.ZoneId zone-id]
+    (t/with-offset-same-instant t (standard-offset zone-id)))
+
+  LocalDate
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time t (t/local-time 0) zone-id))
+
+  LocalDate
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time t (t/local-time 0) zone-id))
+
+  LocalDateTime
+  (with-time-zone-same-instant [t zone-id]
+    (t/offset-date-time t zone-id))
+
+  ;; instants are always normalized to UTC, so don't make any changes here. If you want to format in a different zone,
+  ;; convert to an OffsetDateTime or ZonedDateTime first.
+  Instant
+  (with-time-zone-same-instant [t _]
+    t)
+
+  OffsetDateTime
+  (with-time-zone-same-instant [t ^java.time.ZoneId zone-id]
+    ;; calculate the zone offset applicable for the date in question
+    (if (or (= t OffsetDateTime/MAX)
+            (= t OffsetDateTime/MIN))
+      t
+      (let [rules  (.getRules zone-id)
+            offset (.getOffset rules (t/instant t))]
+        (t/with-offset-same-instant t offset))))
+
+  ZonedDateTime
+  (with-time-zone-same-instant [t zone-id]
+    (t/with-zone-same-instant t zone-id)))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                      Etc                                                       |
@@ -442,13 +499,3 @@
 (defmethod print-method Duration
   [d writer]
   (print-method (list 't/duration (str d)) writer))
-
-;; mark everything in the `clj-time` namespaces as `:deprecated`, if they're loaded. If not, we don't care
-(when config/is-dev?
-  (doseq [a-namespace '[clj-time.core clj-time.coerce clj-time.format]]
-    (try
-      (let [a-namespace (the-ns a-namespace)]
-        (alter-meta! a-namespace assoc :deprecated true)
-        (doseq [[_ varr] (ns-publics a-namespace)]
-          (alter-meta! varr assoc :deprecated true)))
-      (catch Throwable _))))

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -68,6 +68,8 @@
                       :limit    5})))))))))
 
 (deftest format-value-test
+  ;; `t` = original value
+  ;; `expected` = the same value when shifted to `zone`
   (doseq [[t expected zone]
           [[(t/zoned-date-time 2011 4 18 0 0 0 0 (t/zone-id "Asia/Tokyo"))
             "2011-04-17T15:00:00Z"
@@ -125,10 +127,8 @@
             "2011-04-18T00:00:00Z"
             "UTC"]
 
-           ;; formatting `OffsetTime` currently doesn't adjust the time into the results timezone, because that can't
-           ;; be done without knowing the date (e.g., because of DST boundaries)
            [(t/offset-time 19 55 0 0 (t/zone-offset 9))
-            "19:55:00+09:00"
+            "10:55:00Z"
             "UTC"]
 
            [(t/offset-time 19 55 0 0 (t/zone-offset 9))
@@ -140,7 +140,7 @@
             "UTC"]
 
            [(t/offset-time 19 55 0 0 (t/zone-offset 0))
-            "19:55:00Z"
+            "04:55:00+09:00"
             "Asia/Tokyo"]
 
            [(t/local-time 19 55)
@@ -158,9 +158,9 @@
                                         ["2019-07-01T13:14:15Z" "US/Pacific"]]]
       (testing (format "system clock = %s; system timezone = %s" clock-instant clock-zone)
         (mt/with-clock (t/mock-clock (t/instant clock-instant) clock-zone)
-          (is (= expected
-                 (format-rows/format-value t (t/zone-id zone)))
-              (format "format %s '%s' with results timezone ID '%s'" (.getName (class t)) t zone))))))
+          (testing (format "\nformat %s '%s' with results timezone ID '%s'" (.getName (class t)) t zone)
+            (is (= expected
+                   (format-rows/format-value t (t/zone-id zone)))))))))
   (testing "can handle infinity dates (#12761)"
     (is (format-rows/format-value java.time.OffsetDateTime/MAX (t/zone-id "UTC")))
     (is (format-rows/format-value java.time.OffsetDateTime/MIN (t/zone-id "UTC")))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :refer :all]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [metabase
+             [driver :as driver]
              [query-processor :as qp]
              [test :as mt]]
             [metabase.query-processor
@@ -36,25 +37,40 @@
            second))))
 
 (deftest report-timezone-test
-  (testing "XLSX downloads should format stuff with the report timezone rather than UTC (#13677)\n"
-    (testing "Should be in UTC by default"
-      (is (= {:date           "2019-11-01T00:00:00Z"
-              :datetime       "2019-11-01T00:23:18.331Z"
-              :datetime-ltz   "2019-11-01T07:23:18.331Z"
-              :datetime-tz    "2019-11-01T07:23:18.331Z"
-              :datetime-tz-id "2019-11-01T07:23:18.331Z"
-              :time           "00:23:18Z"
-              :time-ltz       "07:23:18Z"
-              :time-tz        "07:23:18Z"}
-             (timestamps-in-xlsx-results))))
-    (testing "If report timezone is set, results should be in that timezone"
-      (binding [qp.timezone/*results-timezone-id-override* "US/Pacific"]
-        (is (= {:date           "2019-11-01T00:00:00-07:00"
-                :datetime       "2019-11-01T00:23:18.331-07:00"
-                :datetime-ltz   "2019-11-01T00:23:18.331-07:00"
-                :datetime-tz    "2019-11-01T00:23:18.331-07:00"
-                :datetime-tz-id "2019-11-01T00:23:18.331-07:00"
-                :time           "16:23:18-08:00"
-                :time-ltz       "23:23:18-08:00"
-                :time-tz        "23:23:18-08:00"}
-               (timestamps-in-xlsx-results)))))))
+  ;; H2 has limited timezone support so we run these tests with both H2 and Postgres
+  (mt/test-drivers #{:h2 :postgres}
+    (testing "XLSX downloads should format stuff with the report timezone rather than UTC (#13677)\n"
+      (testing "Should be in UTC by default"
+        (is (= (merge
+                {:date           "2019-11-01T00:00:00Z"
+                 :datetime       "2019-11-01T00:23:18.331Z"
+                 :datetime-ltz   "2019-11-01T07:23:18.331Z"
+                 :datetime-tz    "2019-11-01T07:23:18.331Z"
+                 :datetime-tz-id "2019-11-01T07:23:18.331Z"}
+                (case driver/*driver*
+                  :postgres {:time     "00:23:18.331Z"
+                             :time-ltz "07:23:18.331Z"
+                             :time-tz  "07:23:18.331Z"}
+                  :h2       {:time     "00:23:18Z"
+                             :time-ltz "07:23:18Z"
+                             :time-tz  "07:23:18Z"}))
+               (timestamps-in-xlsx-results))))
+      (testing "If report timezone is set, results should be in that timezone"
+        ;; by overriding this we can force the code that applies timezone shifts to act like H2 has full timezone
+        ;; support
+        (binding [qp.timezone/*results-timezone-id-override* "US/Pacific"]
+          (is (= (merge
+                  {:date           "2019-11-01T00:00:00-07:00"
+                   :datetime       "2019-11-01T00:23:18.331-07:00"
+                   :datetime-ltz   "2019-11-01T00:23:18.331-07:00"
+                   :datetime-tz    "2019-11-01T00:23:18.331-07:00"
+                   :datetime-tz-id "2019-11-01T00:23:18.331-07:00"}
+                  (case driver/*driver*
+                    :postgres {:time     "00:23:18.331-08:00"
+                               :time-ltz "23:23:18.331-08:00"
+                               :time-tz  "23:23:18.331-08:00"}
+                    ;; H2 doesn't have a TIME WITH TIME ZONE type so these columns are actually all LocalTimes.
+                    :h2       {:time     "00:23:18-08:00"
+                               :time-ltz "07:23:18-08:00"
+                               :time-tz  "07:23:18-08:00"}))
+                 (timestamps-in-xlsx-results))))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -1,0 +1,60 @@
+(ns metabase.query-processor.streaming.xlsx-test
+  "Additional tests for downloads (including XLSX) are in places like `metabase.query-processor.streaming-test`."
+  (:require [clojure.test :refer :all]
+            [dk.ative.docjure.spreadsheet :as spreadsheet]
+            [metabase
+             [query-processor :as qp]
+             [test :as mt]]
+            [metabase.query-processor
+             [streaming :as qp.streaming]
+             [timezone :as qp.timezone]]
+            [metabase.util.files :as u.files]))
+
+(defn- timestamps-in-xlsx-results
+  "Run a query that "
+  []
+  (mt/dataset attempted-murders
+    (let [filename (str (u.files/get-path (System/getProperty "java.io.tmpdir") "out.xlsx"))
+          query    (mt/mbql-query attempts
+                     {:fields   [$date $datetime $datetime_ltz $datetime_tz $datetime_tz_id $time $time_ltz $time_tz]
+                      :order-by [[:asc $id]]
+                      :limit    1})]
+      (with-open [os (java.io.FileOutputStream. filename)]
+        (is (= :completed
+               (:status (qp/process-query query
+                                          (qp.streaming/streaming-context :xlsx os))))))
+      (->> (spreadsheet/load-workbook filename)
+           (spreadsheet/select-sheet "Query result")
+           (spreadsheet/select-columns {:A :date
+                                        :B :datetime
+                                        :C :datetime-ltz
+                                        :D :datetime-tz
+                                        :E :datetime-tz-id
+                                        :F :time
+                                        :G :time-ltz
+                                        :H :time-tz})
+           second))))
+
+(deftest report-timezone-test
+  (testing "XLSX downloads should format stuff with the report timezone rather than UTC (#13677)\n"
+    (testing "Should be in UTC by default"
+      (is (= {:date           "2019-11-01T00:00:00Z"
+              :datetime       "2019-11-01T00:23:18.331Z"
+              :datetime-ltz   "2019-11-01T07:23:18.331Z"
+              :datetime-tz    "2019-11-01T07:23:18.331Z"
+              :datetime-tz-id "2019-11-01T07:23:18.331Z"
+              :time           "00:23:18Z"
+              :time-ltz       "07:23:18Z"
+              :time-tz        "07:23:18Z"}
+             (timestamps-in-xlsx-results))))
+    (testing "If report timezone is set, results should be in that timezone"
+      (binding [qp.timezone/*results-timezone-id-override* "US/Pacific"]
+        (is (= {:date           "2019-11-01T00:00:00-07:00"
+                :datetime       "2019-11-01T00:23:18.331-07:00"
+                :datetime-ltz   "2019-11-01T00:23:18.331-07:00"
+                :datetime-tz    "2019-11-01T00:23:18.331-07:00"
+                :datetime-tz-id "2019-11-01T00:23:18.331-07:00"
+                :time           "16:23:18-08:00"
+                :time-ltz       "23:23:18-08:00"
+                :time-tz        "23:23:18-08:00"}
+               (timestamps-in-xlsx-results)))))))

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -408,3 +408,102 @@
   (testing "in the Turkish locale, :minute-of-hour can be found"
     (mt/with-locale "tr"
       (is (some? (:minute-of-hour (u.date.common/static-instances ChronoField)))))))
+
+(deftest with-time-zone-same-instant-test
+  ;; `t` = original value
+  ;; `expected` = the same value when shifted to `zone`
+  (doseq [[t expected zone]
+          [[(t/zoned-date-time 2011 4 18 0 0 0 0 (t/zone-id "Asia/Tokyo"))
+            (t/zoned-date-time "2011-04-17T15:00:00Z[UTC]")
+            "UTC"]
+
+           [(t/zoned-date-time 2011 4 18 0 0 0 0 (t/zone-id "Asia/Tokyo"))
+            (t/zoned-date-time "2011-04-18T00:00:00+09:00[Asia/Tokyo]")
+            "Asia/Tokyo"]
+
+           [(t/zoned-date-time 2011 4 18 0 0 0 0 (t/zone-id "UTC"))
+            (t/zoned-date-time "2011-04-18T09:00:00+09:00[Asia/Tokyo]")
+            "Asia/Tokyo"]
+
+           [(t/zoned-date-time 2011 4 18 0 0 0 0 (t/zone-id "UTC"))
+            (t/zoned-date-time "2011-04-18T00:00:00Z[UTC]")
+            "UTC"]
+
+           [(t/offset-date-time 2011 4 18 0 0 0 0 (t/zone-offset 9))
+            (t/offset-date-time "2011-04-17T15:00:00Z")
+            "UTC"]
+
+           [(t/offset-date-time 2011 4 18 0 0 0 0 (t/zone-offset 9))
+            (t/offset-date-time "2011-04-18T00:00:00+09:00")
+            "Asia/Tokyo"]
+
+           [(t/offset-date-time 2011 4 18 0 0 0 0 (t/zone-offset 0))
+            (t/offset-date-time "2011-04-18T09:00:00+09:00")
+            "Asia/Tokyo"]
+
+           ;; instants should return arg as-is since they're always normalized to UTC
+           [(t/instant (t/offset-date-time 2011 4 18 0 0 0 0 (t/zone-offset 0)))
+            (t/instant "2011-04-18T00:00:00Z")
+            "UTC"]
+
+           [(t/instant (t/offset-date-time 2011 4 18 0 0 0 0 (t/zone-offset 0)))
+            (t/instant "2011-04-18T00:00:00Z")
+            "Asia/Tokyo"]
+
+           [(t/instant (t/offset-date-time 2011 4 18 0 0 0 0 (t/zone-offset 0)))
+            (t/instant "2011-04-18T00:00:00Z")
+            "UTC"]
+
+           [(t/local-date-time 2011 4 18 0 0 0 0)
+            (t/offset-date-time "2011-04-18T00:00:00+09:00")
+            "Asia/Tokyo"]
+
+           [(t/local-date-time 2011 4 18 0 0 0 0)
+            (t/offset-date-time "2011-04-18T00:00:00Z")
+            "UTC"]
+
+           [(t/local-date 2011 4 18)
+            (t/offset-date-time "2011-04-18T00:00:00+09:00")
+            "Asia/Tokyo"]
+
+           [(t/local-date 2011 4 18)
+            (t/offset-date-time "2011-04-18T00:00:00Z")
+            "UTC"]
+
+           [(t/offset-time 19 55 0 0 (t/zone-offset 9))
+            (t/offset-time "10:55:00Z")
+            "UTC"]
+
+           [(t/offset-time 19 55 0 0 (t/zone-offset 9))
+            (t/offset-time "19:55:00+09:00")
+            "Asia/Tokyo"]
+
+           [(t/offset-time 19 55 0 0 (t/zone-offset 0))
+            (t/offset-time "19:55:00Z")
+            "UTC"]
+
+           [(t/offset-time 19 55 0 0 (t/zone-offset 0))
+            (t/offset-time "04:55:00+09:00")
+            "Asia/Tokyo"]
+
+           [(t/local-time 19 55)
+            (t/offset-time "19:55:00Z")
+            "UTC"]
+
+           [(t/local-time 19 55)
+            (t/offset-time "19:55:00+09:00")
+            "Asia/Tokyo"]]]
+    ;; results should be completely independent of the system clock
+    (doseq [[clock-instant clock-zone] [["2019-07-01T00:00:00Z" "UTC"]
+                                        ["2019-01-01T00:00:00Z" "US/Pacific"]
+                                        ["2019-07-01T00:00:00Z" "US/Pacific"]
+                                        ["2019-07-01T13:14:15Z" "UTC"]
+                                        ["2019-07-01T13:14:15Z" "US/Pacific"]]]
+      (testing (format "system clock = %s; system timezone = %s" clock-instant clock-zone)
+        (mt/with-clock (t/mock-clock (t/instant clock-instant) clock-zone)
+          (testing (format "\nshift %s '%s' to timezone ID '%s'" (.getName (class t)) t zone)
+            (is (= expected
+                   (u.date/with-time-zone-same-instant t (t/zone-id zone)))))))))
+  (testing "can handle infinity dates (#12761)"
+    (is (u.date/with-time-zone-same-instant java.time.OffsetDateTime/MAX (t/zone-id "UTC")))
+    (is (u.date/with-time-zone-same-instant java.time.OffsetDateTime/MIN (t/zone-id "UTC")))))


### PR DESCRIPTION
Use the report-timezone when writing rows to Excel

Fixes #13677

As part of this I also tweaked the way we apply timezone shifts to OffsetTimes. Previously, we ignoring the report timezone altogether (i.e., not shifting anything) because the actual offset to use for a timezone ID requires date information (i.e. the offset is different depending on whether or not DST is in effect). I changed this to just apply the "standard offset" (non-DST offset) for a timezone which we were already doing for LocalTimes.