### PR TITLE
[WIP]Fix #13894: Chained joins should use "Previous results"?

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -95,7 +95,7 @@ class JoinClause extends React.Component {
               />
             ) : (
               <NotebookCellItem color={color}>
-                {`Choose a join type`}
+                {t`Choose a join type`}
               </NotebookCellItem>
             )
           }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -72,12 +72,16 @@ class JoinClause extends React.Component {
       return null;
     }
 
+    // first join's lhs is always the parent table
+    // subsequent should always be a string "Previous results" as per:
+    // https://github.com/metabase/metabase/pull/13895#issuecomment-735933018
+    const lhsTable = join.index() === 0 ? join.parentTable() : null;
     const joinedTable = join.joinedTable();
     const strategyOption = join.strategyOption();
     return (
       <Flex align="center" flex="1 1 auto" {...props}>
         <NotebookCellItem color={color} icon="table2">
-          {t`Previous results`}
+          {(lhsTable && lhsTable.displayName()) || t`Previous results`}
         </NotebookCellItem>
 
         <PopoverWithTrigger

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -72,22 +72,12 @@ class JoinClause extends React.Component {
       return null;
     }
 
-    let lhsTable;
-    if (join.index() === 0) {
-      // first join's lhs is always the parent table
-      lhsTable = join.parentTable();
-    } else if (join.parentDimension()) {
-      // subsequent can be one of the previously joined tables
-      // NOTE: `lhsDimension` would probably be a better name for `parentDimension`
-      lhsTable = join.parentDimension().field().table;
-    }
-
     const joinedTable = join.joinedTable();
     const strategyOption = join.strategyOption();
     return (
       <Flex align="center" flex="1 1 auto" {...props}>
         <NotebookCellItem color={color} icon="table2">
-          {(lhsTable && lhsTable.displayName()) || `Previous results`}
+          {t`Previous results`}
         </NotebookCellItem>
 
         <PopoverWithTrigger

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -59,6 +59,40 @@ describe("scenarios > question > notebook", () => {
   });
 
   describe("joins", () => {
+    it("should always display 'Previous results' for subsequent joins (metabase#13894)", () => {
+      // Go straight to orders table in custom questions
+      cy.visit("/question/new?database=1&table=2&mode=notebook");
+
+      // Orders (parent table) join People
+      cy.findByText("Join data").click();
+      popover()
+        .contains("People")
+        .click();
+
+      cy.log("**First join should display the parent table name**");
+      cy.findAllByText("Orders").should("have.length", 2);
+
+      cy.get(".Button")
+        .contains("Join data")
+        .as("joinButton");
+
+      // Add subsequent joins and assert on the UI
+      cy.get("@joinButton").click();
+
+      cy.log(
+        "**All subsequent joins should always display 'Previous results'**",
+      );
+      cy.findByText("Previous results");
+      popover()
+        .contains(/Products?/i)
+        .click();
+      cy.get("@joinButton").click();
+      popover()
+        .contains("People")
+        .click();
+      cy.findAllByText("Previous results").should("have.length", 2);
+    });
+
     it("should allow joins", () => {
       // start a custom question with orders
       cy.visit("/question/new");


### PR DESCRIPTION
### Status
Open for discussion

### Context:
- This fix/proposal was originally merged into `release-x.37.x` branch (https://github.com/metabase/metabase/pull/13895)
- It was then decided it should be reverted (https://github.com/metabase/metabase/pull/13964) and opened up against the `master` to leave room for more discussion on what is the best solution.

This PR is doing exactly that.