### PR TITLE
Apply auto-bucketing to :joined-field clauses

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -110,7 +110,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("3621077291879").should("not.exist"); // one of the "Gizmo" EANs
   });
 
-  it.skip("'Between Dates' filter should behave consistently (metabase#12872)", () => {
+  it("'Between Dates' filter should behave consistently (metabase#12872)", () => {
     withSampleDataset(({ PRODUCTS }) => {
       cy.request("POST", "/api/card", {
         name: "12872",

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -97,7 +97,8 @@
                  ;; `:joined-field` clause itself
                  [:joined-field _ field]
                  (let [wrapped-field (wrap-fields field)]
-                   (when-not (= field wrapped-field)
+                   (if (= field wrapped-field)
+                     &match
                      [:datetime-field &match :day]))
 
                  ;; if it's a raw `:field-id` and `field-id->type-info` tells us it's a `:type/Temporal` (but not `:type/Time`),
@@ -105,7 +106,8 @@
                  [(_ :guard #{:field-id :field-literal}) (_ :guard datetime-but-not-time?) & _]
                  ;; don't wrap this if it is inside a `:joined-field` clause -- that should be covered by the pattern
                  ;; above
-                 (when-not (= (last &parents) :joined-field)
+                 (if (contains? (set &parents) :joined-field)
+                   &match
                    [:datetime-field &match :day])))]
        (m/update-existing-in query [:query clause-to-rewrite] wrap-fields)))))
 

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -2,7 +2,8 @@
   "Middleware for automatically bucketing unbucketed `:type/Temporal` (but not `:type/Time`) Fields with `:day`
   bucketing. Applies to any unbucketed Field in a breakout, or fields in a filter clause being compared against
   `yyyy-MM-dd` format datetime strings."
-  (:require [metabase.mbql
+  (:require [medley.core :as m]
+            [metabase.mbql
              [predicates :as mbql.preds]
              [schema :as mbql.s]
              [util :as mbql.u]]
@@ -28,7 +29,7 @@
 ;; which would save a bit of time when we do resolve them
 (s/defn ^:private unbucketed-fields->field-id->type-info :- FieldIDOrName->TypeInfo
   "Fetch a map of Field ID -> type information for the Fields referred to by the `unbucketed-fields`."
-  [unbucketed-fields :- (su/non-empty [(mbql.s.helpers/one-of mbql.s/field-id mbql.s/field-literal)])]
+  [unbucketed-fields :- (su/non-empty [(mbql.s.helpers/one-of mbql.s/field-id mbql.s/field-literal mbql.s/joined-field)])]
   (merge
    ;; build map of field-literal-name -> {:base_type base-type}
    (into {} (for [[clause field-name base-type] unbucketed-fields
@@ -66,7 +67,7 @@
    ;; do not autobucket field-ids that are already wrapped by another Field clause like `datetime-field` or
    ;; `binning-strategy`
    (and (mbql.preds/Field? x)
-        (not (mbql.u/is-clause? #{:field-id :field-literal} x)))))
+        (not (mbql.u/is-clause? #{:field-id :field-literal :joined-field} x)))))
 
 (defn- date-or-datetime-field? [{base-type :base_type, special-type :special_type}]
   (some (fn [field-type]
@@ -76,7 +77,7 @@
 
 (s/defn ^:private wrap-unbucketed-fields
   "Wrap Fields in breakouts and filters in a `:datetime-field` clause if appropriate; look at corresponing type
-  information in `field-id->type-inf` to see if we should do so."
+  information in `field-id->type-info` to see if we should do so."
   ;; we only want to wrap clauses in `:breakout` and `:filter` so just make a 3-arg version of this fn that takes the
   ;; name of the clause to rewrite and call that twice
   ([query field-id->type-info :- FieldIDOrName->TypeInfo]
@@ -86,15 +87,27 @@
 
   ([query field-id->type-info clause-to-rewrite]
    (let [datetime-but-not-time? (comp date-or-datetime-field? field-id->type-info)]
-     (mbql.u/replace-in query [:query clause-to-rewrite]
-       ;; don't replace anything that's already wrapping a `field-id`
-       (_ :guard should-not-be-autobucketed?)
-       &match
+     (letfn [(wrap-fields [x]
+               (mbql.u/replace x
+                 ;; don't replace anything that's already wrapping a `field-id` (other than `:joined-field`)
+                 (_ :guard should-not-be-autobucketed?)
+                 &match
 
-       ;; if it's a raw `:field-id` and `field-id->type-info` tells us it's a `:type/Temporal` (but not `:type/Time`),
-       ;; then go ahead and replace it
-       [(_ :guard #{:field-id :field-literal}) (_ :guard datetime-but-not-time?) & _]
-       [:datetime-field &match :day]))))
+                 ;; if wrapping the the field wrapped by `:joined-field` would have an effect, then wrap the entire
+                 ;; `:joined-field` clause itself
+                 [:joined-field _ field]
+                 (let [wrapped-field (wrap-fields field)]
+                   (when-not (= field wrapped-field)
+                     [:datetime-field &match :day]))
+
+                 ;; if it's a raw `:field-id` and `field-id->type-info` tells us it's a `:type/Temporal` (but not `:type/Time`),
+                 ;; then go ahead and replace it
+                 [(_ :guard #{:field-id :field-literal}) (_ :guard datetime-but-not-time?) & _]
+                 ;; don't wrap this if it is inside a `:joined-field` clause -- that should be covered by the pattern
+                 ;; above
+                 (when-not (= (last &parents) :joined-field)
+                   [:datetime-field &match :day])))]
+       (m/update-existing-in query [:query clause-to-rewrite] wrap-fields)))))
 
 (s/defn ^:private auto-bucket-datetimes*
   [{{breakouts :breakout, filter-clause :filter} :query, :as query}]

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -231,4 +231,14 @@
                  [:and
                   [:between [:datetime-field $date :day] "2019-11-01" "2019-11-01"]
                   [:between [:datetime-field [:joined-field "Checkins" $date] :day] "2019-11-01" "2019-11-01"]])
+               (get-in (auto-bucket query) [:query :filter])))))
+    (testing "Don't auto-bucket an already-bucketed joined-field"
+      (let [query (mt/mbql-query checkins
+                    {:filter [:between [:datetime-field [:joined-field "Checkins" $date] :month] "2019-11-01" "2019-11-01"]
+                     :joins  [{:alias        "Checkins"
+                               :condition    [:= $id [:joined-field "Checkins" $date]]
+                               :fields       :all
+                               :source-table $$checkins}]})]
+        (is (= (mt/$ids checkins
+                 [:between [:datetime-field [:joined-field "Checkins" $date] :month] "2019-11-01" "2019-11-01"])
                (get-in (auto-bucket query) [:query :filter])))))))

--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -1,200 +1,234 @@
 (ns metabase.query-processor.middleware.auto-bucket-datetimes-test
   (:require [clojure.test :refer :all]
-            [expectations :refer [expect]]
             [metabase
              [test :as mt]
              [util :as u]]
             [metabase.models.field :refer [Field]]
-            [metabase.query-processor.middleware.auto-bucket-datetimes :as auto-bucket-datetimes]
-            [metabase.test.data :as data]
-            [toucan.util.test :as tt]))
+            [metabase.query-processor.middleware.auto-bucket-datetimes :as auto-bucket-datetimes]))
 
 (defn- auto-bucket [query]
   (:pre (mt/test-qp-middleware auto-bucket-datetimes/auto-bucket-datetimes query)))
 
 (defn- auto-bucket-mbql [mbql-query]
-  (-> (auto-bucket {:database (data/id), :type :query, :query mbql-query})
+  (-> (auto-bucket {:database (mt/id), :type :query, :query mbql-query})
       :query))
 
-;; does a :type/DateTime Field get auto-bucketed when present in a breakout clause?
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :breakout     [[:datetime-field [:field-id (u/get-id field)] :day]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:field-id (u/get-id field)]]}))
+(deftest auto-bucket-in-breakout-test
+  (testing "does a :type/DateTime Field get auto-bucketed when present in a breakout clause?"
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :breakout     [[:datetime-field [:field-id (u/get-id field)] :day]]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:field-id (u/get-id field)]]}))))))
 
-;; does the Field get bucketed if present in the `:filter` clause? (#8932)
-;;
-;; e.g. `[:= <field> "2018-11-19"] should get rewritten as `[:= [:datetime-field <field> :day] "2018-11-19"]` if
-;; `<field>` is a `:type/DateTime` Field
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :filter       [:= [:datetime-field [:field-id (u/get-id field)] :day] "2018-11-19"]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :filter       [:= [:field-id (u/get-id field)] "2018-11-19"]}))
+(deftest auto-bucket-in-filter-test
+  (testing "does the Field get bucketed if present in the `:filter` clause? (#8932)"
+    ;;
+    ;;
+    ;; e.g. `[:= <field> "2018-11-19"] should get rewritten as `[:= [:datetime-field <field> :day] "2018-11-19"]` if
+    ;; `<field>` is a `:type/DateTime` Field
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :filter       [:= [:datetime-field [:field-id (u/get-id field)] :day] "2018-11-19"]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :filter       [:= [:field-id (u/get-id field)] "2018-11-19"]}))))))
 
-;; Fields should still get auto-bucketed when present in compound filter clauses (#9127)
-(tt/expect-with-temp [Field [field-1 {:base_type :type/DateTime, :special_type nil}]
-                      Field [field-2 {:base_type :type/Text,     :special_type nil}]]
-  {:source-table 1
-   :filter       [:and
-                  [:= [:datetime-field [:field-id (u/get-id field-1)] :day] "2018-11-19"]
-                  [:= [:field-id (u/get-id field-2)] "ABC"]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :filter       [:and
-                   [:= [:field-id (u/get-id field-1)] "2018-11-19"]
-                   [:= [:field-id (u/get-id field-2)] "ABC"]]}))
+(deftest auto-bucket-in-compound-filter-clause-test
+  (testing "Fields should still get auto-bucketed when present in compound filter clauses (#9127)"
+    (mt/with-temp* [Field [field-1 {:base_type :type/DateTime, :special_type nil}]
+                    Field [field-2 {:base_type :type/Text, :special_type nil}]]
+      (is (= {:source-table 1
+              :filter       [:and
+                             [:= [:datetime-field [:field-id (u/get-id field-1)] :day] "2018-11-19"]
+                             [:= [:field-id (u/get-id field-2)] "ABC"]]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :filter       [:and
+                              [:= [:field-id (u/get-id field-1)] "2018-11-19"]
+                              [:= [:field-id (u/get-id field-2)] "ABC"]]}))))))
 
-;; DateTime field literals should also get auto-bucketed (#9007)
-(expect
-  {:source-query {:source-table 1}
-   :filter       [:= [:datetime-field [:field-literal "timestamp" :type/DateTime] :day] "2018-11-19"]}
-  (auto-bucket-mbql
-   {:source-query {:source-table 1}
-    :filter       [:= [:field-literal "timestamp" :type/DateTime] "2018-11-19"]}))
+(deftest auto-bucket-field-literals-test
+  (testing "DateTime field literals should also get auto-bucketed (#9007)"
+    (is (= {:source-query {:source-table 1}
+            :filter       [:= [:datetime-field [:field-literal "timestamp" :type/DateTime] :day] "2018-11-19"]}
+           (auto-bucket-mbql
+            {:source-query {:source-table 1}
+             :filter       [:= [:field-literal "timestamp" :type/DateTime] "2018-11-19"]})))))
 
-;; On the other hand, we shouldn't auto-bucket Fields inside a filter clause if they are being compared against a
-;; datetime string that includes more than just yyyy-MM-dd:
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :filter       [:= [:field-id (u/get-id field)] "2018-11-19T14:11:00"]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :filter       [:= [:field-id (u/get-id field)] "2018-11-19T14:11:00"]}))
+(deftest do-not-autobucket-when-compared-to-non-yyyy-MM-dd-strings-test
+  (testing (str "On the other hand, we shouldn't auto-bucket Fields inside a filter clause if they are being compared "
+                "against a datetime string that includes more than just yyyy-MM-dd:")
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :filter       [:= [:field-id (u/get-id field)] "2018-11-19T14:11:00"]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :filter       [:= [:field-id (u/get-id field)] "2018-11-19T14:11:00"]}))))
 
-(expect
-  {:source-query {:source-table 1}
-   :filter       [:= [:field-literal "timestamp" :type/DateTime] "2018-11-19T14:11:00"]}
-  (auto-bucket-mbql
-   {:source-query {:source-table 1}
-    :filter       [:= [:field-literal "timestamp" :type/DateTime] "2018-11-19T14:11:00"]}))
+    (is (= {:source-query {:source-table 1}
+            :filter       [:= [:field-literal "timestamp" :type/DateTime] "2018-11-19T14:11:00"]}
+           (auto-bucket-mbql
+            {:source-query {:source-table 1}
+             :filter       [:= [:field-literal "timestamp" :type/DateTime] "2018-11-19T14:11:00"]})))
 
-;; for breakouts or other filters with multiple args, all args must be yyyy-MM-dd
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :filter       [:between [:datetime-field [:field-id (u/get-id field)] :day] "2018-11-19" "2018-11-20"]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :filter       [:between [:field-id (u/get-id field)] "2018-11-19" "2018-11-20"]}))
+    (testing "for breakouts or other filters with multiple args, all args must be yyyy-MM-dd"
+      (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+        (is (= {:source-table 1
+                :filter       [:between [:datetime-field [:field-id (u/get-id field)] :day] "2018-11-19" "2018-11-20"]}
+               (auto-bucket-mbql
+                {:source-table 1
+                 :filter       [:between [:field-id (u/get-id field)] "2018-11-19" "2018-11-20"]}))))
 
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :filter       [:between [:field-id (u/get-id field)] "2018-11-19" "2018-11-20T14:20:00.000Z"]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :filter       [:between [:field-id (u/get-id field)] "2018-11-19" "2018-11-20T14:20:00.000Z"]}))
+      (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+        (is (= {:source-table 1
+                :filter       [:between [:field-id (u/get-id field)] "2018-11-19" "2018-11-20T14:20:00.000Z"]}
+               (auto-bucket-mbql
+                {:source-table 1
+                 :filter       [:between [:field-id (u/get-id field)] "2018-11-19" "2018-11-20T14:20:00.000Z"]})))))))
 
-;; if a Field occurs more than once we should only rewrite the instances that should be rebucketed
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :breakout     [[:datetime-field [:field-id (u/get-id field)] :day]]
-   :filter       [:= [:field-id (u/get-id field)] "2018-11-20T14:20:00.000Z"]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:field-id (u/get-id field)]]
-    :filter       [:= [:field-id (u/get-id field)] "2018-11-20T14:20:00.000Z"]}))
+(deftest only-auto-bucket-appropriate-instances-test
+  (testing "if a Field occurs more than once we should only rewrite the instances that should be rebucketed"
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :breakout     [[:datetime-field [:field-id (u/get-id field)] :day]]
+              :filter       [:= [:field-id (u/get-id field)] "2018-11-20T14:20:00.000Z"]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:field-id (u/get-id field)]]
+               :filter       [:= [:field-id (u/get-id field)] "2018-11-20T14:20:00.000Z"]}))))
 
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :breakout       [[:datetime-field [:field-id (u/get-id field)] :month]]
-   :filter         [:= [:datetime-field [:field-id (u/get-id field)] :day] "2018-11-20"]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:datetime-field [:field-id (u/get-id field)] :month]]
-    :filter       [:= [:field-id (u/get-id field)] "2018-11-20"]}))
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :breakout     [[:datetime-field [:field-id (u/get-id field)] :month]]
+              :filter       [:= [:datetime-field [:field-id (u/get-id field)] :day] "2018-11-20"]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:datetime-field [:field-id (u/get-id field)] :month]]
+               :filter       [:= [:field-id (u/get-id field)] "2018-11-20"]}))))))
 
-;; or if they are used in a non-equality or non-comparison filter clause, for example `:is-null`:
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :filter       [:is-null [:field-id (u/get-id field)]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :filter       [:is-null [:field-id (u/get-id field)]]}))
+(deftest do-not-auto-bucket-inside-time-interval-test
+  (testing "We should not try to bucket Fields inside a `time-interval` clause as that would be invalid"
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :filter       [:time-interval [:field-id (u/get-id field)] -30 :day]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :filter       [:time-interval [:field-id (u/get-id field)] -30 :day]}))))))
 
-;; however, we should not try to bucket Fields inside a `time-interval` clause as that would be invalid
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :filter       [:time-interval [:field-id (u/get-id field)] -30 :day]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :filter       [:time-interval [:field-id (u/get-id field)] -30 :day]}))
+(deftest do-not-auto-bucket-inappropriate-filter-clauses-test
+  (testing "Don't auto-bucket fields in non-equality or non-comparison filter clauses, for example `:is-null`:"
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :filter       [:is-null [:field-id (u/get-id field)]]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :filter       [:is-null [:field-id (u/get-id field)]]}))))))
 
-;; we also should not auto-bucket Fields that are `:type/Time`, because grouping a Time Field by day makes ZERO SENSE.
-(tt/expect-with-temp [Field [field {:base_type :type/Time, :special_type nil}]]
-  {:source-table 1
-   :breakout     [[:field-id (u/get-id field)]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:field-id (u/get-id field)]]}))
+(deftest do-not-auto-bucket-time-fields-test
+  (testing (str "we also should not auto-bucket Fields that are `:type/Time`, because grouping a Time Field by day "
+                "makes ZERO SENSE.")
+    (mt/with-temp Field [field {:base_type :type/Time, :special_type nil}]
+      (is (= {:source-table 1
+              :breakout     [[:field-id (u/get-id field)]]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:field-id (u/get-id field)]]}))))))
 
-;; should be considered to be :type/DateTime based on `special_type` as well
-(tt/expect-with-temp [Field [field {:base_type :type/Integer, :special_type :type/DateTime}]]
-  {:source-table 1
-   :breakout     [[:datetime-field [:field-id (u/get-id field)] :day]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:field-id (u/get-id field)]]}))
+(deftest auto-bucket-by-special-type-test
+  (testing "should be considered to be :type/DateTime based on `special_type` as well"
+    (mt/with-temp Field [field {:base_type :type/Integer, :special_type :type/DateTime}]
+      (is (= {:source-table 1
+              :breakout     [[:datetime-field [:field-id (u/get-id field)] :day]]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:field-id (u/get-id field)]]}))))))
 
-;; do native queries pass thru unchanged?
-(let [native-query {:database 1, :type :native, :native {:query "SELECT COUNT(cans) FROM birds;"}}]
-  (expect
-    native-query
-    (auto-bucket native-query)))
+(deftest ignore-native-queries-test
+  (testing "do native queries pass thru unchanged?"
+    (let [native-query {:database 1, :type :native, :native {:query "SELECT COUNT(cans) FROM birds;"}}]
+      (is (= native-query
+             (auto-bucket native-query))))))
 
-;; do MBQL queries w/o breakouts pass thru unchanged?
-(expect
-  {:source-table 1}
-  (auto-bucket-mbql
-   {:source-table 1}))
+(deftest ignore-queries-with-no-breakouts-test
+  (testing "do MBQL queries w/o breakouts pass thru unchanged?"
+    (is (= {:source-table 1}
+           (auto-bucket-mbql
+            {:source-table 1})))))
 
-;; does a breakout Field that isn't :type/DateTime pass thru unchnaged?
-(tt/expect-with-temp [Field [field {:base_type :type/Integer, :special_type nil}]]
-  {:source-table 1
-   :breakout     [[:field-id (u/get-id field)]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:field-id (u/get-id field)]]}))
+(deftest ignore-non-temporal-breakouts-test
+  (testing "does a breakout Field that isn't temporal pass thru unchnaged?"
+    (mt/with-temp Field [field {:base_type :type/Integer, :special_type nil}]
+      (is (= {:source-table 1
+              :breakout     [[:field-id (u/get-id field)]]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:field-id (u/get-id field)]]}))))))
 
-;; does a :type/DateTime breakout Field that is already bucketed pass thru unchanged?
-(tt/expect-with-temp [Field [field {:base_type :type/DateTime, :special_type nil}]]
-  {:source-table 1
-   :breakout     [[:datetime-field [:field-id (u/get-id field)] :month]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:datetime-field [:field-id (u/get-id field)] :month]]}))
+(deftest do-not-auto-bucket-already-bucketed-test
+  (testing "does a :type/DateTime breakout Field that is already bucketed pass thru unchanged?"
+    (mt/with-temp Field [field {:base_type :type/DateTime, :special_type nil}]
+      (is (= {:source-table 1
+              :breakout     [[:datetime-field [:field-id (u/get-id field)] :month]]}
+             (auto-bucket-mbql
+              {:source-table 1
+               :breakout     [[:datetime-field [:field-id (u/get-id field)] :month]]}))))))
 
-;; does the middleware avoid barfing if for some reason the Field could not be resolved in the DB? (That is the job of
-;; the resolve middleware to worry about that stuff.)
-(expect
-  {:source-table 1
-   :breakout     [[:field-id Integer/MAX_VALUE]]}
-  (auto-bucket-mbql
-   {:source-table 1
-    :breakout     [[:field-id Integer/MAX_VALUE]]}))
+(deftest do-not-fail-on-invalid-field-test
+  (testing "does the middleware avoid barfing if for some reason the Field could not be resolved in the DB?"
+    ;; (That is the job of the resolve middleware to worry about that stuff.)
+    (is (= {:source-table 1
+            :breakout     [[:field-id Integer/MAX_VALUE]]}
+           (auto-bucket-mbql
+            {:source-table 1
+             :breakout     [[:field-id Integer/MAX_VALUE]]})))))
 
-;; do UNIX TIMESTAMP datetime fields get auto-bucketed?
-(expect
-  (data/dataset sad-toucan-incidents
-    (data/$ids incidents
-      {:source-table $$incidents
-       :breakout     [!day.timestamp]}))
-  (data/dataset sad-toucan-incidents
-    (data/$ids incidents
-      (auto-bucket-mbql
-       {:source-table $$incidents
-        :breakout     [$timestamp]}))))
+(deftest auto-bucket-unix-timestamp-fields-test
+  (testing "do UNIX TIMESTAMP fields get auto-bucketed?"
+    (mt/dataset sad-toucan-incidents
+      (mt/$ids incidents
+        (is (= {:source-table $$incidents
+                :breakout     [!day.timestamp]}
+               (auto-bucket-mbql
+                {:source-table $$incidents
+                 :breakout     [$timestamp]})))))))
 
 (deftest relative-datetime-test
-  (is (= (->
-          (data/mbql-query checkins
-            {:filter [:= [:datetime-field $date :day] [:relative-datetime :current]]})
-          :query :filter)
-         (->
-          (auto-bucket
-           (data/mbql-query checkins
-             {:filter [:= $date [:relative-datetime :current]]}))
-          :query :filter))
-      "Fields being compared against `:relative-datetime`s should be subject to auto-bucketing. (#9014)"))
+  (testing "Fields being compared against `:relative-datetime`s should be subject to auto-bucketing. (#9014)"
+    (is (= (->
+            (mt/mbql-query checkins
+              {:filter [:= [:datetime-field $date :day] [:relative-datetime :current]]})
+            :query :filter)
+           (->
+            (auto-bucket
+             (mt/mbql-query checkins
+               {:filter [:= $date [:relative-datetime :current]]}))
+            :query :filter)))))
+
+(deftest auto-bucket-joined-fields-test
+  (testing "Joined fields should get auto-bucketed (#12872)"
+    (testing "only joined-field reference to Field"
+      (let [query (mt/mbql-query checkins
+                    {:filter [:between [:joined-field "Checkins" $date] "2019-11-01" "2019-11-01"]
+                     :joins  [{:alias        "Checkins"
+                               :condition    [:= $id [:joined-field "Checkins" $date]]
+                               :fields       :all
+                               :source-table $$checkins}]})]
+        (is (= (mt/$ids checkins
+                 [:between [:datetime-field [:joined-field "Checkins" $date] :day] "2019-11-01" "2019-11-01"])
+               (get-in (auto-bucket query) [:query :filter])))))
+    (testing "joined-field and normal reference to same Field"
+      (let [query (mt/mbql-query checkins
+                    {:filter [:and
+                              [:between $date "2019-11-01" "2019-11-01"]
+                              [:between [:joined-field "Checkins" $date] "2019-11-01" "2019-11-01"]]
+                     :joins  [{:alias        "Checkins"
+                               :condition    [:= $id [:joined-field "Checkins" $date]]
+                               :fields       :all
+                               :source-table $$checkins}]})]
+        (is (= (mt/$ids checkins
+                 [:and
+                  [:between [:datetime-field $date :day] "2019-11-01" "2019-11-01"]
+                  [:between [:datetime-field [:joined-field "Checkins" $date] :day] "2019-11-01" "2019-11-01"]])
+               (get-in (auto-bucket query) [:query :filter])))))))

--- a/test/metabase/query_processor/middleware/optimize_datetime_filters_test.clj
+++ b/test/metabase/query_processor/middleware/optimize_datetime_filters_test.clj
@@ -144,15 +144,14 @@
                      [:absolute-datetime filter-value unit]
                      [:absolute-datetime filter-value unit]])))))))))
 
-(defn- optimize-with-timezone [t]
+(defn- optimize-filter-clauses [t]
   (let [query {:database 1
                :type     :query
                :query    {:filter [:=
                                    [:datetime-field [:field-id 1] :day]
                                    [:absolute-datetime t :day]]}}]
     (-> (mt/test-qp-middleware optimize-datetime-filters/optimize-datetime-filters query)
-        :pre
-        (get-in [:query :filter]))))
+        (get-in [:pre :query :filter]))))
 
 (deftest timezones-test
   (driver/with-driver ::timezone-driver
@@ -174,7 +173,7 @@
                               [:>= [:datetime-field [:field-id 1] :default] [:absolute-datetime lower :default]]
                               [:<  [:datetime-field [:field-id 1] :default] [:absolute-datetime upper :default]]]]
                 (is (= expected
-                       (optimize-with-timezone t))
+                       (optimize-filter-clauses t))
                     (format "= %s in the %s timezone should be optimized to range %s -> %s"
                             t timezone-id lower upper))))))))))
 

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -4,9 +4,10 @@
              [test :refer :all]]
             [metabase
              [driver :as driver]
+             [models :refer [Card]]
              [query-processor :as qp]
              [test :as mt]]
-            [metabase.models.card :refer [Card]]
+            [metabase.query-processor-test.timezones-test :as timezones-test]
             [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test.data.interface :as tx]))
 
@@ -483,7 +484,7 @@
   ;; currently work. We should use the closest equivalent types (e.g. `DATETIME` or `TIMESTAMP` so we can still load
   ;; the dataset and run tests using this dataset such as these, which doesn't even use the TIME type.
   (mt/test-drivers (set/difference (mt/normal-drivers-with-feature :nested-queries :left-join)
-                                   metabase.query-processor-test.timezones-test/broken-drivers)
+                                   timezones-test/broken-drivers)
     (testing "Date filter should behave the same for joined columns"
       (mt/dataset attempted-murders
         (is (= [["2019-11-01T07:23:18.331Z" "2019-11-01T07:23:18.331Z"]]

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -483,7 +483,7 @@
   ;; currently work. We should use the closest equivalent types (e.g. `DATETIME` or `TIMESTAMP` so we can still load
   ;; the dataset and run tests using this dataset such as these, which doesn't even use the TIME type.
   (mt/test-drivers (set/difference (mt/normal-drivers-with-feature :nested-queries :left-join)
-                                   #{:oracle :presto :redshift :sparksql :snowflake})
+                                   metabase.query-processor-test.timezones-test/broken-drivers)
     (testing "Date filter should behave the same for joined columns"
       (mt/dataset attempted-murders
         (is (= [["2019-11-01T07:23:18.331Z" "2019-11-01T07:23:18.331Z"]]

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -492,8 +492,8 @@
                   {:fields [$datetime_tz]
                    :filter [:and
                             [:between $datetime_tz "2019-11-01" "2019-11-01"]
-                            [:between &Attempts.datetime_tz "2019-11-01" "2019-11-01"]]
-                   :joins  [{:alias        "Attempts"
-                             :condition    [:= $id &Attempts.id]
-                             :fields       [&Attempts.datetime_tz]
+                            [:between &attempts_joined.datetime_tz "2019-11-01" "2019-11-01"]]
+                   :joins  [{:alias        "attempts_joined"
+                             :condition    [:= $id &attempts_joined.id]
+                             :fields       [&attempts_joined.datetime_tz]
                              :source-table $$attempts}]}))))))))

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -6,23 +6,16 @@
             [java-time :as t]
             [metabase
              [driver :as driver]
+             [models :refer [Field Table]]
              [query-processor :as qp]
-             [query-processor-test :as qp.test]]
+             [test :as mt]]
             [metabase.driver.sql.query-processor :as sql.qp]
-            [metabase.models
-             [field :refer [Field]]
-             [table :refer [Table]]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
-            [metabase.test.data
-             [datasets :as datasets]
-             [sql :as sql.tx]]
+            [metabase.test.data.sql :as sql.tx]
             [metabase.util.honeysql-extensions :as hx]
-            [toucan.db :as db]) )
+            [toucan.db :as db]))
 
 ;; TIMEZONE FIXME
-(def ^:private broken-drivers
+(def broken-drivers
   "The following drivers are broken to some extent -- details listed in the Google Doc, or can be see here:
   https://circleci.com/workflow-run/856f6dd0-3d95-4732-a56e-1af59e3ae4ba. The goal is to gradually remove these
   one-by-one as they are fixed."
@@ -37,7 +30,7 @@
   "Drivers that support setting a Session timezone."
   []
   (set/difference
-   (set (qp.test/normal-drivers-with-feature :set-timezone))
+   (set (mt/normal-drivers-with-feature :set-timezone))
    broken-drivers))
 
 (defn- timezone-aware-column-drivers
@@ -47,69 +40,69 @@
 
 ;; TODO - we should also do similar tests for timezone-unaware columns
 (deftest result-rows-test
-  (data/dataset test-data-with-timezones
-    (datasets/test-drivers (timezone-aware-column-drivers)
+  (mt/dataset test-data-with-timezones
+    (mt/test-drivers (timezone-aware-column-drivers)
       (is (= [[12 "2014-07-03T01:30:00Z"]
               [10 "2014-07-03T19:30:00Z"]]
-             (qp.test/formatted-rows [int identity]
-               (data/run-mbql-query users
+             (mt/formatted-rows [int identity]
+               (mt/run-mbql-query users
                  {:fields   [$id $last_login]
                   :filter   [:= $id 10 12]
                   :order-by [[:asc $last_login]]})))
           "Basic sanity check: make sure the rows come back with the values we'd expect without setting report-timezone"))
-    (datasets/test-drivers (set-timezone-drivers)
+    (mt/test-drivers (set-timezone-drivers)
       (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00Z"]
                                                       [10 "2014-07-03T19:30:00Z"]]
                                         "US/Pacific" [[10 "2014-07-03T12:30:00-07:00"]]}]
-        (tu/with-temporary-setting-values [report-timezone timezone]
+        (mt/with-temporary-setting-values [report-timezone timezone]
           (is (= expected-rows
-                 (qp.test/formatted-rows [int identity]
-                   (data/run-mbql-query users
+                 (mt/formatted-rows [int identity]
+                   (mt/run-mbql-query users
                      {:fields   [$id $last_login]
                       :filter   [:= $last_login "2014-07-03"]
                       :order-by [[:asc $last_login]]})))
               (format "There should be %d checkins on July 3rd in the %s timezone" (count expected-rows) timezone)))))))
 
 (deftest filter-test
-  (data/dataset test-data-with-timezones
-    (datasets/test-drivers (set-timezone-drivers)
-      (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+  (mt/dataset test-data-with-timezones
+    (mt/test-drivers (set-timezone-drivers)
+      (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
         (is (= [[6 "Shad Ferdynand" "2014-08-02T05:30:00-07:00"]]
-               (qp.test/formatted-rows [int identity identity]
-                 (data/run-mbql-query users
+               (mt/formatted-rows [int identity identity]
+                 (mt/run-mbql-query users
                    {:filter [:between $last_login "2014-08-02T03:00:00.000000" "2014-08-02T06:00:00.000000"]})))
             (str "If MBQL datetime literal strings do not explicitly specify a timezone, they should be parsed as if "
                  "in the current reporting timezone (Pacific in this case)"))
         (is (= [[6 "Shad Ferdynand" "2014-08-02T05:30:00-07:00"]]
-               (qp.test/formatted-rows [int identity identity]
-                 (data/run-mbql-query users
+               (mt/formatted-rows [int identity identity]
+                 (mt/run-mbql-query users
                    {:filter [:between $last_login "2014-08-02T10:00:00.000000Z" "2014-08-02T13:00:00.000000Z"]})))
             "MBQL datetime literal strings that include timezone should be parsed in it regardless of report timezone")))
     (testing "UTC timezone"
       (let [run-query   (fn []
-                          (qp.test/formatted-rows [int identity identity]
-                            (data/run-mbql-query users
+                          (mt/formatted-rows [int identity identity]
+                            (mt/run-mbql-query users
                               {:filter [:between $last_login "2014-08-02T10:00:00.000000" "2014-08-02T13:00:00.000000"]})))
             utc-results [[6 "Shad Ferdynand" "2014-08-02T12:30:00Z"]]]
-        (datasets/test-drivers (set-timezone-drivers)
+        (mt/test-drivers (set-timezone-drivers)
           (is (= utc-results
-                 (tu/with-temporary-setting-values [report-timezone "UTC"]
+                 (mt/with-temporary-setting-values [report-timezone "UTC"]
                    (run-query)))
               "Checking UTC report timezone filtering and responses"))
-        (datasets/test-drivers (timezone-aware-column-drivers)
+        (mt/test-drivers (timezone-aware-column-drivers)
           (is (= utc-results
                  (run-query))
               (str "With no report timezone, the JVM timezone is used. For our tests this is UTC so this should be the "
                    "same as specifying UTC for a report timezone")))))))
 
 (defn- table-identifier [table-key]
-  (let [table-name (db/select-one-field :name Table, :id (data/id table-key))]
-    (apply hx/identifier :table (sql.tx/qualified-name-components driver/*driver* (:name (data/db)) table-name))))
+  (let [table-name (db/select-one-field :name Table, :id (mt/id table-key))]
+    (apply hx/identifier :table (sql.tx/qualified-name-components driver/*driver* (:name (mt/db)) table-name))))
 
 (defn- field-identifier [table-key field-key]
-  (let [table-name (db/select-one-field :name Table, :id (data/id table-key))
-        field-name (db/select-one-field :name Field, :id (data/id table-key field-key))]
-    (apply hx/identifier :field (sql.tx/qualified-name-components driver/*driver* (:name (data/db)) table-name field-name))))
+  (let [table-name (db/select-one-field :name Table, :id (mt/id table-key))
+        field-name (db/select-one-field :name Field, :id (mt/id table-key field-key))]
+    (apply hx/identifier :field (sql.tx/qualified-name-components driver/*driver* (:name (mt/db)) table-name field-name))))
 
 (defn- honeysql->sql [honeysql]
   (first (sql.qp/format-honeysql driver/*driver* honeysql)))
@@ -147,7 +140,7 @@
                  :template-tags {:ts_range {:name         "ts_range"
                                             :display_name "Timestamp Range"
                                             :type         "dimension"
-                                            :dimension    [:field-id (data/id :users :last_login)]}}}
+                                            :dimension    [:field-id (mt/id :users :last_login)]}}}
     :parameters [{:type   "date/range"
                   :target ["dimension" ["template-tag" "ts_range"]]
                   :value  "2014-08-02~2014-08-03"}]}
@@ -162,7 +155,7 @@
                  :template-tags {:just_a_date {:name         "just_a_date"
                                                :display_name "Just A Date"
                                                :type         "dimension",
-                                               :dimension    [:field-id (data/id :users :last_login)]}}}
+                                               :dimension    [:field-id (mt/id :users :last_login)]}}}
     :parameters [{:type   "date/single"
                   :target ["dimension" ["template-tag" "just_a_date"]]
                   :value  "2014-08-02"}]}})
@@ -170,21 +163,21 @@
 (deftest native-params-filter-test
   ;; parameters always get `date` bucketing so doing something the between stuff we do below is basically just going
   ;; to match anything with a `2014-08-02` date
-  (datasets/test-drivers (set-timezone-drivers)
+  (mt/test-drivers (set-timezone-drivers)
     (when (driver/supports? driver/*driver* :native-parameters)
-      (data/dataset test-data-with-timezones
-        (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
+      (mt/dataset test-data-with-timezones
+        (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
           (testing "Native dates should be parsed with the report timezone"
             (doseq [[params-description query] (native-params-queries)]
               (testing (format "Query with %s" params-description)
                 (is (= [[6 "Shad Ferdynand"  "2014-08-02T05:30:00-07:00"]
                         [7 "Conchúr Tihomir" "2014-08-02T02:30:00-07:00"]]
-                       (qp.test/formatted-rows [int identity identity]
+                       (mt/formatted-rows [int identity identity]
                          (qp/process-query
-                           (merge
-                            {:database (data/id)
-                             :type     :native}
-                            query)))))))))))))
+                          (merge
+                           {:database (mt/id)
+                            :type     :native}
+                           query)))))))))))))
 
 
 
@@ -192,9 +185,9 @@
 (defn- attempts []
   (zipmap
    [:date :time :datetime :time_ltz :time_tz :datetime_ltz :datetime_tz :datetime_tz_id]
-   (qp.test/first-row
+   (mt/first-row
      (qp/process-query
-       (data/query attempts
+       (mt/query attempts
          {:query      {:fields [$date $time $datetime $time_ltz $time_tz $datetime_ltz $datetime_tz $datetime_tz_id]
                        :filter [:= $id 1]}
           :middleware {:format-rows? false}})))))
@@ -229,10 +222,10 @@
 (deftest time-timezone-handling-test
   ;; Actual value : "2019-11-01T00:23:18.331-07:00[America/Los_Angeles]"
   ;; Oracle doesn't have a time type
-  (datasets/test-drivers (set-timezone-drivers)
-    (data/dataset attempted-murders
+  (mt/test-drivers (set-timezone-drivers)
+    (mt/dataset attempted-murders
       (doseq [timezone [nil "US/Pacific" "US/Eastern" "Asia/Hong_Kong"]]
-        (tu/with-temporary-setting-values [report-timezone timezone]
+        (mt/with-temporary-setting-values [report-timezone timezone]
           (let [expected (expected-attempts)]
             (is (= expected
                    (select-keys (attempts) (keys expected))))))))))


### PR DESCRIPTION
Using a `:joined-field` version of a temporal column would work differently than using the same non-joined version because we weren't applying the same "auto-bucketing" logic we normally apply. This PR fixes that to make sure those Fields are auto-bucketed the same way.

Fixes #12872

#12872 is mentioned in #13702, but I think this fix is ultimately unrelated to the larger fixes happening in that PR