### PR TITLE
Change back to manual navigation in smoke tests [ci skip]

### DIFF
--- a/frontend/test/metabase-smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin.cy.spec.js
@@ -157,7 +157,7 @@ describe("metabase-smoketest > admin", () => {
     });
 
     it.skip("should add a simple JOINed question as admin", () => {
-      cy.visit("/question/new");
+      cy.visit("/");
       cy.findByText("Ask a question");
 
       cy.findByText("Ask a question").click();

--- a/frontend/test/metabase-smoketest/user.cy.spec.js
+++ b/frontend/test/metabase-smoketest/user.cy.spec.js
@@ -6,8 +6,8 @@ describe("smoketest > user", () => {
   beforeEach(signInAsNormalUser);
 
   it("should be able to ask a custom questions", () => {
-    cy.visit("/question/new");
-
+    cy.visit("/");
+    cy.findByText("Ask a question").click();
     cy.findByText("Custom question").click();
     cy.findByText("Sample Dataset").click();
     cy.findByText("Products").click();


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Changes back a few lines of smoketests to a manual navigation instead of navigating through URL `/question/new`
@flamber pointed out that we shouldn't use shortcuts in Smoke tests. This quick PR fixes that.