### PR TITLE
GitHub Actions CI to build and archive Uberjar

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -18,6 +18,7 @@ jobs:
         edition: [ee, oss]
     env:
       MB_EDITION: ${{ matrix.edition }}
+      INTERACTIVE: false
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -24,10 +24,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
-    - name: Prepare JDK 8
+    - name: Prepare JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
     - name: Install gettext
       run: sudo apt install gettext
     - name: Install Clojure CLI
@@ -57,11 +57,7 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}-${{ hashFiles('**/deps.edn') }}
     - run: lein with-profile +include-all-drivers,+cloverage,+junit,+oss deps
 
-    - run: ./bin/build version
-    - run: ./bin/build translations
-    - run: ./bin/build frontend
-    - run: ./bin/build drivers
-    - run: ./bin/build uberjar
+    - run: ./bin/build
 
     - name: Mark with the commit hash
       run:  git rev-parse --short HEAD > COMMIT-ID

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -7,6 +7,8 @@ on:
       - 'release-**'
     paths-ignore:
     - 'docs/**'
+    - 'frontend/test/**'
+    - 'enterprise/frontend/test/**'
 
 jobs:
 

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -49,15 +49,14 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --lockfile
-
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}-${{ hashFiles('**/deps.edn') }}
-    - run: lein with-profile +include-all-drivers,+cloverage,+junit,+oss deps
 
+    - run: yarn install --lockfile
+    - run: lein with-profile +include-all-drivers,+cloverage,+junit,+${{ matrix.edition }} deps
     - run: ./bin/build
 
     - name: Mark with the commit hash

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -1,0 +1,77 @@
+name: Uberjar
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-**'
+    paths-ignore:
+    - 'docs/**'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        edition: [ee, oss]
+    env:
+      MB_EDITION: ${{ matrix.edition }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Prepare JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Install gettext
+      run: sudo apt install gettext
+    - name: Install Clojure CLI
+      run: |
+        curl -O https://download.clojure.org/install/linux-install-1.10.1.708.sh &&
+        sudo bash ./linux-install-1.10.1.708.sh
+    - name: Check versions
+      run: |
+        echo "Node.js `node --version`"
+        echo "yarn `yarn --version`"
+        java -version
+        echo "Clojure `clojure -e "(println (clojure-version))"`"
+        lein --version
+        msgfmt --version
+
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --lockfile
+
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}-${{ hashFiles('**/deps.edn') }}
+    - run: lein with-profile +include-all-drivers,+cloverage,+junit,+oss deps
+
+    - run: ./bin/build version
+    - run: ./bin/build translations
+    - run: ./bin/build frontend
+    - run: ./bin/build drivers
+    - run: ./bin/build uberjar
+
+    - name: Mark with the commit hash
+      run:  git rev-parse --short HEAD > COMMIT-ID
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
+    - name: Upload JARs as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+        path: |
+          ./target/uberjar/metabase.jar
+          ./COMMIT-ID
+          ./SHA256.sum

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -25,10 +25,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
-    - name: Prepare JDK 11
+    - name: Prepare JDK 8
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 8
     - name: Install gettext
       run: sudo apt install gettext
     - name: Install Clojure CLI


### PR DESCRIPTION
This happens behind the scene, asynchronously (only for master and release branches) so that it won't block any pull requests at all. No current existing development workflow should be affected.

The reasons it was done with GitHub Actions instead of Circle CI are so that: 

* We don't use the Circle CI minutes (which are better spent on  higher priority tasks such as running the tests). This doesn't necessarily apply here for the simple case of building Uberjar, but it becomes important as we expand the tests (grab the JAR, run it with different JDKs, OS & distributions, etc).

* Any person with a GitHub account or any tool via the [REST API](https://developer.github.com/v3/actions/artifacts/) can retrieve the archived JARs without the need to authenticate to another service (Circle CI).

![image](https://user-images.githubusercontent.com/7288/101513895-8acfff80-3931-11eb-8e2c-ab38ea15cea1.png)
