### PR TITLE
Waterfall chart: adjust value label position

### DIFF
--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -211,7 +211,7 @@ export function onRenderValueLabels(
     const yScale = yScaleForSeries(seriesIndex);
     const xPos = xShifts[seriesIndex] + xScale(x);
     let yPos = yScale(yy) + (showLabelBelow ? 18 : -8);
-    if (y >= 0 && display === "waterfall") {
+    if (y < 0 && display === "waterfall") {
       yPos += 25;
     }
     // if the yPos is below the x axis, move it to be above the data point


### PR DESCRIPTION
Steps to try:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'Apples' as product, 10 as profit
union all
select 'Bananas' as product, 4 as profit
union all
select 'Oranges' as product, 5 as profit
union all
select 'Peaches' as product, -7 as profit
union all
select 'Mangos' as product, 2 as profit
```

4. Visualization, Waterfall
5. Settings, Display, Show value on data points

**Expected**: The value labels for each bar are position either above or below bar (**not** inside the bar).

![image](https://user-images.githubusercontent.com/7288/101528613-63cef900-3944-11eb-996f-09e2058eb14c.png)

