### PR TITLE
Update Cypress tests with new metadata retrieval method

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -5,9 +5,12 @@ import {
   signInAsAdmin,
   USERS,
   signInAsNormalUser,
-  withSampleDataset,
   describeWithToken,
-} from "../../../../../frontend/test/__support__/cypress";
+} from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
 
 const year = new Date().getFullYear();
 
@@ -15,34 +18,32 @@ export function generateQuestions(users) {
   users.forEach(user => {
     signIn(user);
 
-    withSampleDataset(({ PRODUCTS }) => {
-      cy.request("POST", `/api/card`, {
-        name: `${user} test q`,
-        dataset_query: {
-          type: "native",
-          native: {
-            query: "SELECT * FROM products WHERE {{ID}}",
-            "template-tags": {
-              ID: {
-                id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-                name: "ID",
-                display_name: "ID",
-                type: "dimension",
-                dimension: ["field-id", PRODUCTS.ID],
-                "widget-type": "category",
-                default: null,
-              },
+    cy.request("POST", `/api/card`, {
+      name: `${user} test q`,
+      dataset_query: {
+        type: "native",
+        native: {
+          query: "SELECT * FROM products WHERE {{ID}}",
+          "template-tags": {
+            ID: {
+              id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+              name: "ID",
+              display_name: "ID",
+              type: "dimension",
+              dimension: ["field-id", PRODUCTS.ID],
+              "widget-type": "category",
+              default: null,
             },
           },
-          database: 1,
         },
-        display: "scalar",
-        description: null,
-        visualization_settings: {},
-        collection_id: null,
-        result_metadata: null,
-        metadata_checksum: null,
-      });
+        database: 1,
+      },
+      display: "scalar",
+      description: null,
+      visualization_settings: {},
+      collection_id: null,
+      result_metadata: null,
+      metadata_checksum: null,
     });
   });
 }

--- a/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
@@ -3,8 +3,11 @@ import {
   restore,
   popover,
   visitAlias,
-  withSampleDataset,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS_ID } = SAMPLE_DATASET;
 
 const SAMPLE_DB_URL = "/admin/datamodel/database/1";
 
@@ -16,9 +19,7 @@ describe.skip("scenarios > admin > datamodel > editor", () => {
     cy.server();
     cy.route("PUT", "/api/table/*").as("tableUpdate");
     cy.route("PUT", "/api/field/*").as("fieldUpdate");
-    withSampleDataset(({ ORDERS_ID }) => {
-      cy.wrap(`${SAMPLE_DB_URL}/table/${ORDERS_ID}`).as(`ORDERS_URL`);
-    });
+    cy.wrap(`${SAMPLE_DB_URL}/table/${ORDERS_ID}`).as(`ORDERS_URL`);
   });
 
   it("should allow editing of the name and description", () => {
@@ -174,7 +175,7 @@ describe.skip("scenarios > admin > datamodel > editor", () => {
     // check that new order is obeyed in queries
     cy.request("POST", "/api/dataset", {
       database: 1,
-      query: { "source-table": 2 },
+      query: { "source-table": ORDERS_ID },
       type: "query",
     }).then(resp => {
       expect(resp.body.data.cols[0].name).to.eq("PRODUCT_ID");

--- a/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
@@ -1,23 +1,26 @@
 import {
   signInAsAdmin,
   restore,
-  withSampleDataset,
   withDatabase,
   visitAlias,
   popover,
 } from "__support__/cypress";
 
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+
 // [quarantine] - intermittently failing, possibly due to a "flickering" element (re-rendering)
 describe.skip("scenarios > admin > datamodel > field", () => {
   beforeEach(() => {
     signInAsAdmin();
-    withSampleDataset(({ ORDERS, ORDERS_ID }) => {
-      ["CREATED_AT", "PRODUCT_ID", "QUANTITY"].forEach(name => {
-        cy.wrap(
-          `/admin/datamodel/database/1/table/${ORDERS_ID}/${ORDERS[name]}/general`,
-        ).as(`ORDERS_${name}_URL`);
-      });
+
+    ["CREATED_AT", "PRODUCT_ID", "QUANTITY"].forEach(name => {
+      cy.wrap(
+        `/admin/datamodel/database/1/table/${ORDERS_ID}/${ORDERS[name]}/general`,
+      ).as(`ORDERS_${name}_URL`);
     });
+
     cy.server();
     cy.route("PUT", "/api/field/*").as("fieldUpdate");
     cy.route("POST", "/api/field/*/dimension").as("fieldDimensionUpdate");

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -1,4 +1,7 @@
 import { restore, signInAsAdmin, popover, modal } from "__support__/cypress";
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > admin > datamodel > metrics", () => {
   before(restore);
@@ -187,9 +190,9 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.request("POST", "/api/metric", {
         name: "13022_Metric",
         desription: "desc",
-        table_id: 2,
+        table_id: ORDERS_ID,
         definition: {
-          "source-table": 2,
+          "source-table": ORDERS_ID,
           aggregation: [
             [
               "aggregation-options",

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -1,12 +1,15 @@
+// Ported from `segments.e2e.spec.js`
 import {
   restore,
   signInAsAdmin,
   popover,
   modal,
   sidebar,
-  withSampleDataset,
 } from "__support__/cypress";
-// Ported from `segments.e2e.spec.js`
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > admin > datamodel > segments", () => {
   before(restore);
@@ -53,17 +56,15 @@ describe("scenarios > admin > datamodel > segments", () => {
       signInAsAdmin();
 
       // Create a segment through API
-      withSampleDataset(({ ORDERS }) => {
-        cy.request("POST", "/api/segment", {
-          name: SEGMENT_NAME,
-          description: "All orders with a total under $100.",
-          table_id: 2,
-          definition: {
-            "source-table": 2,
-            aggregation: [["count"]],
-            filter: ["<", ["field-id", ORDERS.TOTAL], 100],
-          },
-        });
+      cy.request("POST", "/api/segment", {
+        name: SEGMENT_NAME,
+        description: "All orders with a total under $100.",
+        table_id: ORDERS_ID,
+        definition: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          filter: ["<", ["field-id", ORDERS.TOTAL], 100],
+        },
       });
     });
 

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -1,9 +1,7 @@
-import {
-  signIn,
-  restore,
-  popover,
-  withSampleDataset,
-} from "__support__/cypress";
+import { signIn, restore, popover } from "__support__/cypress";
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { PEOPLE } = SAMPLE_DATASET;
 
 describe("scenarios > dashboard > chained filter", () => {
   beforeEach(() => {
@@ -13,10 +11,8 @@ describe("scenarios > dashboard > chained filter", () => {
 
   for (const has_field_values of ["search", "list"]) {
     it(`limit ${has_field_values} options based on linked filter`, () => {
-      withSampleDataset(({ PEOPLE }) =>
-        cy.request("PUT", `/api/field/${PEOPLE.CITY}`, { has_field_values }),
-      );
-      cy.visit("/dashboard/1");
+      cy.request("PUT", `/api/field/${PEOPLE.CITY}`, { has_field_values }),
+        cy.visit("/dashboard/1");
       // start editing
       cy.get(".Icon-pencil").click();
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -3,9 +3,12 @@ import {
   restore,
   modal,
   popover,
-  withSampleDataset,
   createNativeQuestion,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { REVIEWS, REVIEWS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > dashboard > dashboard drill", () => {
   before(restore);
@@ -249,89 +252,88 @@ describe("scenarios > dashboard > dashboard drill", () => {
   it("should pass multiple filters for numeric column on drill-through (metabase#13062)", () => {
     // Preparation for the test: "Arrange and Act phase" - see repro steps in #13062
     // 1. set "Rating" Field type to: "Category"
-    withSampleDataset(({ REVIEWS }) => {
-      cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
-        special_type: "type/Category",
-      });
-      // 2. create a question based on Reviews
-      cy.request("POST", `/api/card`, {
-        name: "13062Q",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": 4,
-          },
-          type: "query",
+
+    cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
+      special_type: "type/Category",
+    });
+    // 2. create a question based on Reviews
+    cy.request("POST", `/api/card`, {
+      name: "13062Q",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": REVIEWS_ID,
         },
-        display: "table",
-        visualization_settings: {},
-      }).then(({ body: { id: questionId } }) => {
-        // 3. create a dashboard
-        cy.request("POST", "/api/dashboard", {
-          name: "13062D",
-        }).then(({ body: { id: dashboardId } }) => {
-          // add filter to the dashboard
-          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-            parameters: [
+        type: "query",
+      },
+      display: "table",
+      visualization_settings: {},
+    }).then(({ body: { id: questionId } }) => {
+      // 3. create a dashboard
+      cy.request("POST", "/api/dashboard", {
+        name: "13062D",
+      }).then(({ body: { id: dashboardId } }) => {
+        // add filter to the dashboard
+        cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+          parameters: [
+            {
+              id: "18024e69",
+              name: "Category",
+              slug: "category",
+              type: "category",
+            },
+          ],
+        });
+
+        // add previously created question to the dashboard
+        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+          cardId: questionId,
+        }).then(({ body: { id: dashCardId } }) => {
+          // connect filter to that question
+          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+            cards: [
               {
-                id: "18024e69",
-                name: "Category",
-                slug: "category",
-                type: "category",
+                id: dashCardId,
+                card_id: questionId,
+                row: 0,
+                col: 0,
+                sizeX: 8,
+                sizeY: 6,
+                parameter_mappings: [
+                  {
+                    parameter_id: "18024e69",
+                    card_id: questionId,
+                    target: ["dimension", ["field-id", REVIEWS.RATING]],
+                  },
+                ],
               },
             ],
           });
-
-          // add previously created question to the dashboard
-          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-            cardId: questionId,
-          }).then(({ body: { id: dashCardId } }) => {
-            // connect filter to that question
-            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-              cards: [
-                {
-                  id: dashCardId,
-                  card_id: questionId,
-                  row: 0,
-                  col: 0,
-                  sizeX: 8,
-                  sizeY: 6,
-                  parameter_mappings: [
-                    {
-                      parameter_id: "18024e69",
-                      card_id: questionId,
-                      target: ["dimension", ["field-id", REVIEWS.RATING]],
-                    },
-                  ],
-                },
-              ],
-            });
-          });
-
-          // NOTE: The actual "Assertion" phase begins here
-          cy.log("**Reported failing on Metabase 1.34.3 and 0.36.2**");
-
-          cy.log("**The first case**");
-          // set filter values (ratings 5 and 4) directly through the URL
-          cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
-
-          // drill-through
-          cy.findByText("xavier").click();
-          cy.findByText("=").click();
-
-          cy.findByText("Reviewer is xavier");
-          cy.findByText("Rating is equal to 2 selections");
-          cy.contains("Reprehenderit non error"); // xavier's review
-
-          cy.log("**The second case**");
-          // go back to the dashboard
-          cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
-          cy.findByText("2 selections");
-
-          cy.findByText("13062Q").click(); // the card title
-          cy.findByText("Rating is equal to 2 selections");
-          cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
         });
+
+        // NOTE: The actual "Assertion" phase begins here
+        cy.log("**Reported failing on Metabase 1.34.3 and 0.36.2**");
+
+        cy.log("**The first case**");
+        // set filter values (ratings 5 and 4) directly through the URL
+        cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
+
+        // drill-through
+        cy.findByText("xavier").click();
+        cy.findByText("=").click();
+
+        cy.findByText("Reviewer is xavier");
+        cy.findByText("Rating is equal to 2 selections");
+        cy.contains("Reprehenderit non error"); // xavier's review
+
+        cy.log("**The second case**");
+        // go back to the dashboard
+        cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
+        cy.findByText("2 selections");
+
+        cy.findByText("13062Q").click(); // the card title
+        cy.findByText("Rating is equal to 2 selections");
+        cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
       });
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -1,12 +1,15 @@
+// Mostly ported from `dashboard.e2e.spec.js`
+// *** Haven't ported: should add the parameter values to state tree for public dashboards
 import {
   popover,
   restore,
   signInAsAdmin,
-  withSampleDataset,
   selectDashboardFilter,
 } from "__support__/cypress";
-// Mostly ported from `dashboard.e2e.spec.js`
-// *** Haven't ported: should add the parameter values to state tree for public dashboards
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
 
 function saveDashboard() {
   cy.findByText("Save").click();
@@ -108,35 +111,33 @@ describe("scenarios > dashboard", () => {
 
   it("should link filters to custom question with filtered aggregate data (metabase#11007)", () => {
     // programatically create and save a question as per repro instructions in #11007
-    withSampleDataset(({ ORDERS, PRODUCTS }) => {
-      cy.request("POST", "/api/card", {
-        name: "11007",
-        dataset_query: {
-          database: 1,
-          filter: [">", ["field-literal", "sum", "type/Float"], 100],
-          query: {
-            "source-table": 2,
-            aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "day"],
-              [
-                "fk->",
-                ["field-id", ORDERS.PRODUCT_ID],
-                ["field-id", PRODUCTS.ID],
-              ],
-              [
-                "fk->",
-                ["field-id", ORDERS.PRODUCT_ID],
-                ["field-id", PRODUCTS.CATEGORY],
-              ],
+    cy.request("POST", "/api/card", {
+      name: "11007",
+      dataset_query: {
+        database: 1,
+        filter: [">", ["field-literal", "sum", "type/Float"], 100],
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "day"],
+            [
+              "fk->",
+              ["field-id", ORDERS.PRODUCT_ID],
+              ["field-id", PRODUCTS.ID],
             ],
-            filter: ["=", ["field-id", ORDERS.USER_ID], 1],
-          },
-          type: "query",
+            [
+              "fk->",
+              ["field-id", ORDERS.PRODUCT_ID],
+              ["field-id", PRODUCTS.CATEGORY],
+            ],
+          ],
+          filter: ["=", ["field-id", ORDERS.USER_ID], 1],
         },
-        display: "table",
-        visualization_settings: {},
-      });
+        type: "query",
+      },
+      display: "table",
+      visualization_settings: {},
     });
 
     // create a dashboard
@@ -186,83 +187,81 @@ describe("scenarios > dashboard", () => {
 
   it.skip("should update a dashboard filter by clicking on a map pin (metabase#13597)", () => {
     // 1. create a question based on repro steps in #13597
-    withSampleDataset(({ PEOPLE }) => {
-      cy.request("POST", "/api/card", {
-        name: "13597",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": 3,
-            limit: 2,
-          },
-          type: "query",
+    cy.request("POST", "/api/card", {
+      name: "13597",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": PEOPLE_ID,
+          limit: 2,
         },
-        display: "map",
-        visualization_settings: {},
-      }).then(({ body: { id: questionId } }) => {
-        // 2. create a dashboard
-        cy.request("POST", "/api/dashboard", {
-          name: "13597D",
-        }).then(({ body: { id: dashboardId } }) => {
-          // add filter (ID) to the dashboard
-          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-            parameters: [
-              {
-                id: "92eb69ea",
-                name: "ID",
-                slug: "id",
-                type: "id",
-              },
-            ],
-          });
+        type: "query",
+      },
+      display: "map",
+      visualization_settings: {},
+    }).then(({ body: { id: questionId } }) => {
+      // 2. create a dashboard
+      cy.request("POST", "/api/dashboard", {
+        name: "13597D",
+      }).then(({ body: { id: dashboardId } }) => {
+        // add filter (ID) to the dashboard
+        cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+          parameters: [
+            {
+              id: "92eb69ea",
+              name: "ID",
+              slug: "id",
+              type: "id",
+            },
+          ],
+        });
 
-          // add previously created question to the dashboard
-          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-            cardId: questionId,
-          }).then(({ body: { id: dashCardId } }) => {
-            // connect filter to that question
-            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-              cards: [
-                {
-                  id: dashCardId,
-                  card_id: questionId,
-                  row: 0,
-                  col: 0,
-                  sizeX: 10,
-                  sizeY: 8,
-                  parameter_mappings: [
-                    {
-                      parameter_id: "92eb69ea",
-                      card_id: questionId,
-                      target: ["dimension", ["field-id", PEOPLE.ID]],
-                    },
-                  ],
-                  visualization_settings: {
-                    // set click behavior to update filter (ID)
-                    click_behavior: {
-                      type: "crossfilter",
-                      parameterMapping: {
+        // add previously created question to the dashboard
+        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+          cardId: questionId,
+        }).then(({ body: { id: dashCardId } }) => {
+          // connect filter to that question
+          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+            cards: [
+              {
+                id: dashCardId,
+                card_id: questionId,
+                row: 0,
+                col: 0,
+                sizeX: 10,
+                sizeY: 8,
+                parameter_mappings: [
+                  {
+                    parameter_id: "92eb69ea",
+                    card_id: questionId,
+                    target: ["dimension", ["field-id", PEOPLE.ID]],
+                  },
+                ],
+                visualization_settings: {
+                  // set click behavior to update filter (ID)
+                  click_behavior: {
+                    type: "crossfilter",
+                    parameterMapping: {
+                      id: "92eb69ea",
+                      source: { id: "ID", name: "ID", type: "column" },
+                      target: {
                         id: "92eb69ea",
-                        source: { id: "ID", name: "ID", type: "column" },
-                        target: {
-                          id: "92eb69ea",
-                          type: "parameter",
-                        },
+                        type: "parameter",
                       },
                     },
                   },
                 },
-              ],
-            });
+              },
+            ],
           });
-
-          cy.visit(`/dashboard/${dashboardId}`);
-          cy.get(".leaflet-marker-icon") // pin icon
-            .eq(0)
-            .click({ force: true });
-          cy.url().should("include", `/dashboard/${dashboardId}?id=1`);
-          cy.contains("Hudson Borer - 1");
         });
+
+        cy.visit(`/dashboard/${dashboardId}`);
+        cy.get(".leaflet-marker-icon") // pin icon
+          .eq(0)
+          .click({ force: true });
+        cy.url().should("include", `/dashboard/${dashboardId}?id=1`);
+        cy.contains("Hudson Borer - 1");
       });
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
@@ -1,10 +1,8 @@
-import {
-  signInAsAdmin,
-  signOut,
-  restore,
-  popover,
-  withSampleDataset,
-} from "__support__/cypress";
+import { signInAsAdmin, signOut, restore, popover } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, PEOPLE } = SAMPLE_DATASET;
 
 const METABASE_SECRET_KEY =
   "24134bd93e081773fb178e8e1abb4e8a973822f7e19c872bd92c8d5a122ef63f";
@@ -25,27 +23,23 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     restore();
     signInAsAdmin();
 
-    withSampleDataset(SAMPLE_DATASET => {
-      cy.log(SAMPLE_DATASET);
-      const { ORDERS, PEOPLE } = SAMPLE_DATASET;
-      cy.request("POST", `/api/field/${ORDERS.USER_ID}/dimension`, {
-        type: "external",
-        name: "User ID",
-        human_readable_field_id: PEOPLE.NAME,
-      });
+    cy.request("POST", `/api/field/${ORDERS.USER_ID}/dimension`, {
+      type: "external",
+      name: "User ID",
+      human_readable_field_id: PEOPLE.NAME,
+    });
 
-      [ORDERS.USER_ID, PEOPLE.NAME, PEOPLE.ID].forEach(id =>
-        cy.request("PUT", `/api/field/${id}`, { has_field_values: "search" }),
-      );
+    [ORDERS.USER_ID, PEOPLE.NAME, PEOPLE.ID].forEach(id =>
+      cy.request("PUT", `/api/field/${id}`, { has_field_values: "search" }),
+    );
 
-      createQuestion(SAMPLE_DATASET).then(res => {
-        questionId = res.body.id;
-        createDashboard().then(res => {
-          dashboardId = res.body.id;
-          addCardToDashboard({ dashboardId, questionId }).then(res => {
-            dashcardId = res.body.id;
-            mapParameters({ dashboardId, questionId, dashcardId });
-          });
+    createQuestion().then(res => {
+      questionId = res.body.id;
+      createDashboard().then(res => {
+        dashboardId = res.body.id;
+        addCardToDashboard({ dashboardId, questionId }).then(res => {
+          dashcardId = res.body.id;
+          mapParameters({ dashboardId, questionId, dashcardId });
         });
       });
     });
@@ -226,7 +220,7 @@ function sharedParametersTests(visitUrl) {
   });
 }
 
-const createQuestion = ({ ORDERS, PEOPLE }) =>
+const createQuestion = () =>
   cy.request("PUT", "/api/card/3", {
     name: "Test Question",
     dataset_query: {

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  signInAsAdmin,
-  signIn,
-  withSampleDataset,
-  restore,
-} from "__support__/cypress";
+import { signInAsAdmin, signIn, restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > permissions", () => {
   before(restore);
@@ -16,48 +11,47 @@ describe("scenarios > dashboard > permissions", () => {
 
     // The setup is a bunch of nested API calls to create the questions, dashboard, dashcards, collections and link them all up together.
     let firstQuestionId, secondQuestionId;
-    withSampleDataset(({ ORDERS_ID }) => {
-      cy.request("POST", "/api/collection", {
-        name: "locked down collection",
-        color: "#509EE3",
-        parent_id: null,
-      }).then(({ body: { id: collection_id } }) => {
-        // TODO - This will break if the default snapshot updates collections or groups.
-        // We should first request the current graph and then modify it.
-        cy.request("PUT", "/api/collection/graph", {
-          revision: 1,
-          groups: {
-            "1": { "6": "none", root: "none" },
-            "2": { "6": "write", root: "write" },
-            "3": { "6": "write", root: "write" },
-            "4": { "6": "none", root: "write" },
-            "5": { "6": "none", root: "none" },
-          },
-        });
-        cy.request("POST", "/api/card", {
-          dataset_query: {
-            database: 1,
-            type: "native",
-            native: { query: "select 'foo'" },
-          },
-          display: "table",
-          visualization_settings: {},
-          name: "First Question",
-          collection_id,
-        }).then(({ body: { id } }) => (firstQuestionId = id));
+
+    cy.request("POST", "/api/collection", {
+      name: "locked down collection",
+      color: "#509EE3",
+      parent_id: null,
+    }).then(({ body: { id: collection_id } }) => {
+      // TODO - This will break if the default snapshot updates collections or groups.
+      // We should first request the current graph and then modify it.
+      cy.request("PUT", "/api/collection/graph", {
+        revision: 1,
+        groups: {
+          "1": { "6": "none", root: "none" },
+          "2": { "6": "write", root: "write" },
+          "3": { "6": "write", root: "write" },
+          "4": { "6": "none", root: "write" },
+          "5": { "6": "none", root: "none" },
+        },
       });
       cy.request("POST", "/api/card", {
         dataset_query: {
           database: 1,
           type: "native",
-          native: { query: "select 'bar'" },
+          native: { query: "select 'foo'" },
         },
         display: "table",
         visualization_settings: {},
-        name: "Second Question",
-        collection_id: null,
-      }).then(({ body: { id } }) => (secondQuestionId = id));
+        name: "First Question",
+        collection_id,
+      }).then(({ body: { id } }) => (firstQuestionId = id));
     });
+    cy.request("POST", "/api/card", {
+      dataset_query: {
+        database: 1,
+        type: "native",
+        native: { query: "select 'bar'" },
+      },
+      display: "table",
+      visualization_settings: {},
+      name: "Second Question",
+      collection_id: null,
+    }).then(({ body: { id } }) => (secondQuestionId = id));
 
     cy.request("POST", "/api/dashboard", { name: "dashboard" }).then(
       ({ body: { id: dashId } }) => {

--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -5,8 +5,11 @@ import {
   restore,
   popover,
   modal,
-  withSampleDataset,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
 
 const COUNT_ALL = "200";
 const COUNT_DOOHICKEY = "42";
@@ -29,35 +32,31 @@ describe.skip("scenarios > public", () => {
     signInAsAdmin();
 
     // setup parameterized question
-    withSampleDataset(({ PRODUCTS }) =>
-      cy
-        .request("POST", "/api/card", {
-          name: "sql param",
-          dataset_query: {
-            type: "native",
-            native: {
-              query: "select count(*) from products where {{c}}",
-              "template-tags": {
-                c: {
-                  id: "e126f242-fbaa-1feb-7331-21ac59f021cc",
-                  name: "c",
-                  "display-name": "Category",
-                  type: "dimension",
-                  dimension: ["field-id", PRODUCTS.CATEGORY],
-                  default: null,
-                  "widget-type": "category",
-                },
-              },
+    cy.request("POST", "/api/card", {
+      name: "sql param",
+      dataset_query: {
+        type: "native",
+        native: {
+          query: "select count(*) from products where {{c}}",
+          "template-tags": {
+            c: {
+              id: "e126f242-fbaa-1feb-7331-21ac59f021cc",
+              name: "c",
+              "display-name": "Category",
+              type: "dimension",
+              dimension: ["field-id", PRODUCTS.CATEGORY],
+              default: null,
+              "widget-type": "category",
             },
-            database: 1,
           },
-          display: "scalar",
-          visualization_settings: {},
-        })
-        .then(({ body }) => {
-          questionId = body.id;
-        }),
-    );
+        },
+        database: 1,
+      },
+      display: "scalar",
+      visualization_settings: {},
+    }).then(({ body }) => {
+      questionId = body.id;
+    });
   });
 
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -4,8 +4,11 @@ import {
   openOrdersTable,
   openProductsTable,
   popover,
-  withSampleDataset,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > question > filter", () => {
   before(restore);
@@ -111,123 +114,113 @@ describe("scenarios > question > filter", () => {
   });
 
   it("'Between Dates' filter should behave consistently (metabase#12872)", () => {
-    withSampleDataset(({ PRODUCTS }) => {
-      cy.request("POST", "/api/card", {
-        name: "12872",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": 1,
-            aggregation: [["count"]],
-            filter: [
-              "and",
-              [
-                "between",
-                ["field-id", PRODUCTS.CREATED_AT],
-                "2019-04-15",
-                "2019-04-15",
-              ],
-              [
-                "between",
-                ["joined-field", "Products", ["field-id", PRODUCTS.CREATED_AT]],
-                "2019-04-15",
-                "2019-04-15",
-              ],
+    cy.request("POST", "/api/card", {
+      name: "12872",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          filter: [
+            "and",
+            [
+              "between",
+              ["field-id", PRODUCTS.CREATED_AT],
+              "2019-04-15",
+              "2019-04-15",
             ],
-            joins: [
-              {
-                alias: "Products",
-                condition: [
-                  "=",
-                  ["field-id", PRODUCTS.ID],
-                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-                ],
-                fields: "all",
-                "source-table": 1,
-              },
+            [
+              "between",
+              ["joined-field", "Products", ["field-id", PRODUCTS.CREATED_AT]],
+              "2019-04-15",
+              "2019-04-15",
             ],
-          },
-          type: "query",
+          ],
+          joins: [
+            {
+              alias: "Products",
+              condition: [
+                "=",
+                ["field-id", PRODUCTS.ID],
+                ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+              ],
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+            },
+          ],
         },
-        display: "scalar",
-        visualization_settings: {},
-      }).then(({ body: { id: questionId } }) => {
-        cy.visit(`/question/${questionId}`);
-        cy.findByText("12872");
-        cy.log("**At the moment of unfixed issue, it's showing '0'**");
-        cy.get(".ScalarValue").contains("1");
-      });
+        type: "query",
+      },
+      display: "scalar",
+      visualization_settings: {},
+    }).then(({ body: { id: questionId } }) => {
+      cy.visit(`/question/${questionId}`);
+      cy.findByText("12872");
+      cy.log("**At the moment of unfixed issue, it's showing '0'**");
+      cy.get(".ScalarValue").contains("1");
     });
   });
 
   it.skip("should filter based on remapped values (metabase#13235)", () => {
-    withSampleDataset(({ ORDERS, PRODUCTS }) => {
-      // set "Filtering on this field" = "A list of all values"
-      cy.request("PUT", `/api/field/${ORDERS.PRODUCT_ID}`, {
-        has_field_values: "list",
-      });
-      // "Display values" = "Use foreign key" as `Product.Title`
-      cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
-        name: "Product ID",
-        type: "external",
-        human_readable_field_id: PRODUCTS.TITLE,
-      });
-
-      // Add filter as remapped Product ID (Product name)
-      openOrdersTable();
-      cy.findByText("Filter").click();
-      cy.get(".List-item-title")
-        .contains("Product ID")
-        .click();
-      cy.get(".scroll-y")
-        .contains("Aerodynamic Linen Coat")
-        .click();
-      cy.findByText("Add filter").click();
-
-      cy.log("**Reported failing on v0.36.4 and v0.36.5.1**");
-      cy.get(".LoadingSpinner").should("not.exist");
-      cy.findAllByText("148.23"); // one of the subtotals for this product
-      cy.findAllByText("Fantastic Wool Shirt").should("not.exist");
+    // set "Filtering on this field" = "A list of all values"
+    cy.request("PUT", `/api/field/${ORDERS.PRODUCT_ID}`, {
+      has_field_values: "list",
     });
+    // "Display values" = "Use foreign key" as `Product.Title`
+    cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
+      name: "Product ID",
+      type: "external",
+      human_readable_field_id: PRODUCTS.TITLE,
+    });
+
+    // Add filter as remapped Product ID (Product name)
+    openOrdersTable();
+    cy.findByText("Filter").click();
+    cy.get(".List-item-title")
+      .contains("Product ID")
+      .click();
+    cy.get(".scroll-y")
+      .contains("Aerodynamic Linen Coat")
+      .click();
+    cy.findByText("Add filter").click();
+
+    cy.log("**Reported failing on v0.36.4 and v0.36.5.1**");
+    cy.get(".LoadingSpinner").should("not.exist");
+    cy.findAllByText("148.23"); // one of the subtotals for this product
+    cy.findAllByText("Fantastic Wool Shirt").should("not.exist");
   });
 
   it.skip("should filter using Custom Expression from aggregated results (metabase#12839)", () => {
     const CE_NAME = "Simple Math";
 
-    withSampleDataset(({ PRODUCTS }) => {
-      cy.request("POST", "/api/card", {
-        name: "12839",
-        dataset_query: {
-          database: 1,
-          query: {
-            filter: [">", ["field-literal", CE_NAME, "type/Float"], 0],
-            "source-query": {
-              aggregation: [
-                [
-                  "aggregation-options",
-                  ["+", 1, 1],
-                  { "display-name": CE_NAME },
-                ],
-              ],
-              breakout: [["field-id", PRODUCTS.CATEGORY]],
-              "source-table": 1,
-            },
+    cy.request("POST", "/api/card", {
+      name: "12839",
+      dataset_query: {
+        database: 1,
+        query: {
+          filter: [">", ["field-literal", CE_NAME, "type/Float"], 0],
+          "source-query": {
+            aggregation: [
+              ["aggregation-options", ["+", 1, 1], { "display-name": CE_NAME }],
+            ],
+            breakout: [["field-id", PRODUCTS.CATEGORY]],
+            "source-table": PRODUCTS_ID,
           },
-          type: "query",
         },
-        display: "table",
-        visualization_settings: {},
-      }).then(({ body: { id: questionId } }) => {
-        cy.server();
-        cy.route("POST", `/api/card/${questionId}/query`).as("cardQuery");
+        type: "query",
+      },
+      display: "table",
+      visualization_settings: {},
+    }).then(({ body: { id: questionId } }) => {
+      cy.server();
+      cy.route("POST", `/api/card/${questionId}/query`).as("cardQuery");
 
-        cy.visit(`/question/${questionId}`);
-        cy.wait("@cardQuery");
+      cy.visit(`/question/${questionId}`);
+      cy.wait("@cardQuery");
 
-        cy.log("**Reported failing on v0.35.4**");
-        cy.log(`Error message: **Column 'source.${CE_NAME}' not found;**`);
-        cy.findAllByText("Gizmo");
-      });
+      cy.log("**Reported failing on v0.35.4**");
+      cy.log(`Error message: **Column 'source.${CE_NAME}' not found;**`);
+      cy.findAllByText("Gizmo");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -3,8 +3,11 @@ import {
   restore,
   popover,
   modal,
-  withSampleDataset,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS } = SAMPLE_DATASET;
 
 describe("scenarios > question > native", () => {
   before(restore);
@@ -158,36 +161,34 @@ describe("scenarios > question > native", () => {
   });
 
   it("can load a question with a date filter (from issue metabase#12228)", () => {
-    withSampleDataset(({ ORDERS }) => {
-      cy.request("POST", "/api/card", {
-        name: "Test Question",
-        dataset_query: {
-          type: "native",
-          native: {
-            query: "select count(*) from orders where {{created_at}}",
-            "template-tags": {
-              created_at: {
-                id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-                name: "created_at",
-                "display-name": "Created at",
-                type: "dimension",
-                dimension: ["field-id", ORDERS.CREATED_AT],
-                "widget-type": "date/month-year",
-              },
+    cy.request("POST", "/api/card", {
+      name: "Test Question",
+      dataset_query: {
+        type: "native",
+        native: {
+          query: "select count(*) from orders where {{created_at}}",
+          "template-tags": {
+            created_at: {
+              id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+              name: "created_at",
+              "display-name": "Created at",
+              type: "dimension",
+              dimension: ["field-id", ORDERS.CREATED_AT],
+              "widget-type": "date/month-year",
             },
           },
-          database: 1,
         },
-        display: "scalar",
-        description: null,
-        visualization_settings: {},
-        collection_id: null,
-        result_metadata: null,
-        metadata_checksum: null,
-      }).then(response => {
-        cy.visit(`/question/${response.body.id}?created_at=2020-01`);
-        cy.contains("580");
-      });
+        database: 1,
+      },
+      display: "scalar",
+      description: null,
+      visualization_settings: {},
+      collection_id: null,
+      result_metadata: null,
+      metadata_checksum: null,
+    }).then(response => {
+      cy.visit(`/question/${response.body.id}?created_at=2020-01`);
+      cy.contains("580");
     });
   });
 

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -1,11 +1,14 @@
 import {
   signInAsAdmin,
-  withSampleDataset,
   restore,
   popover,
   createNativeQuestion,
   openOrdersTable,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
 
 describe("scenarios > question > nested (metabase#12568)", () => {
   before(() => {
@@ -13,23 +16,21 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     signInAsAdmin();
 
     // Create a simple question of orders by week
-    withSampleDataset(({ ORDERS }) => {
-      cy.request("POST", "/api/card", {
-        name: "GH_12568: Simple",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": 2,
-            aggregation: [["count"]],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"],
-            ],
-          },
-          type: "query",
+    cy.request("POST", "/api/card", {
+      name: "GH_12568: Simple",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"],
+          ],
         },
-        display: "line",
-        visualization_settings: {},
-      });
+        type: "query",
+      },
+      display: "line",
+      visualization_settings: {},
     });
 
     // Create a native question of orders by day
@@ -159,40 +160,38 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should handle duplicate column names in nested queries (metabase#10511)", () => {
-    withSampleDataset(({ ORDERS, PRODUCTS }) => {
-      cy.request("POST", "/api/card", {
-        name: "10511",
-        dataset_query: {
-          database: 1,
-          query: {
-            filter: [">", ["field-literal", "count", "type/Integer"], 5],
-            "source-query": {
-              "source-table": 2,
-              aggregation: [["count"]],
-              breakout: [
-                ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+    cy.request("POST", "/api/card", {
+      name: "10511",
+      dataset_query: {
+        database: 1,
+        query: {
+          filter: [">", ["field-literal", "count", "type/Integer"], 5],
+          "source-query": {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+              [
+                "datetime-field",
                 [
-                  "datetime-field",
-                  [
-                    "fk->",
-                    ["field-id", ORDERS.PRODUCT_ID],
-                    ["field-id", PRODUCTS.CREATED_AT],
-                  ],
-                  "month",
+                  "fk->",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["field-id", PRODUCTS.CREATED_AT],
                 ],
+                "month",
               ],
-            },
+            ],
           },
-          type: "query",
         },
-        display: "table",
-        visualization_settings: {},
-      }).then(({ body: { id: questionId } }) => {
-        cy.visit(`/question/${questionId}`);
-        cy.findByText("10511");
-        cy.findAllByText("June, 2016");
-        cy.findAllByText("13");
-      });
+        type: "query",
+      },
+      display: "table",
+      visualization_settings: {},
+    }).then(({ body: { id: questionId } }) => {
+      cy.visit(`/question/${questionId}`);
+      cy.findByText("10511");
+      cy.findAllByText("June, 2016");
+      cy.findAllByText("13");
     });
   });
 
@@ -271,72 +270,68 @@ describe("scenarios > question > nested", () => {
   it.skip("should apply metrics including filter to the nested question (metabase#12507)", () => {
     const METRIC_NAME = "Discount Applied";
 
-    withSampleDataset(({ ORDERS }) => {
-      cy.log("**-- 1. Create a metric with a filter --**");
+    cy.log("**-- 1. Create a metric with a filter --**");
 
-      cy.request("POST", "/api/metric", {
-        name: METRIC_NAME,
-        description: "Discounted orders.",
-        definition: {
-          aggregation: [["count"]],
-          filter: ["not-null", ["field-id", ORDERS.DISCOUNT]],
-          "source-table": 2,
+    cy.request("POST", "/api/metric", {
+      name: METRIC_NAME,
+      description: "Discounted orders.",
+      definition: {
+        aggregation: [["count"]],
+        filter: ["not-null", ["field-id", ORDERS.DISCOUNT]],
+        "source-table": ORDERS_ID,
+      },
+      table_id: ORDERS_ID,
+    }).then(({ body: { id: METRIC_ID } }) => {
+      // "capture" the original query because we will need to re-use it later in a nested question as "source-query"
+      const ORIGINAL_QUERY = {
+        aggregation: ["metric", METRIC_ID],
+        breakout: [["binning-strategy", ["field-id", ORDERS.TOTAL], "default"]],
+        "source-table": ORDERS_ID,
+      };
+
+      cy.log(
+        "**-- 2. Create new question which uses previously defined metric --**",
+      );
+
+      cy.request("POST", "/api/card", {
+        name: "Orders with discount applied",
+        dataset_query: {
+          database: 1,
+          query: ORIGINAL_QUERY,
+          type: "query",
         },
-        table_id: 2,
-      }).then(({ body: { id: METRIC_ID } }) => {
-        // "capture" the original query because we will need to re-use it later in a nested question as "source-query"
-        const ORIGINAL_QUERY = {
-          aggregation: ["metric", METRIC_ID],
-          breakout: [
-            ["binning-strategy", ["field-id", ORDERS.TOTAL], "default"],
-          ],
-          "source-table": 2,
-        };
+        display: "bar",
+        visualization_settings: {
+          "graph.dimension": ["TOTAL"],
+          "graph.metrics": [METRIC_NAME],
+        },
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.server();
+        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
 
         cy.log(
-          "**-- 2. Create new question which uses previously defined metric --**",
+          "**-- 3. Create a nested question based on the previous one --**",
         );
 
-        cy.request("POST", "/api/card", {
-          name: "Orders with discount applied",
+        // we're adding filter and saving/overwriting the original question, keeping the same ID
+        cy.request("PUT", `/api/card/${QUESTION_ID}`, {
           dataset_query: {
             database: 1,
-            query: ORIGINAL_QUERY,
+            query: {
+              filter: [">", ["field-literal", "TOTAL", "type/Float"], 50],
+              "source-query": ORIGINAL_QUERY,
+            },
             type: "query",
           },
-          display: "bar",
-          visualization_settings: {
-            "graph.dimension": ["TOTAL"],
-            "graph.metrics": [METRIC_NAME],
-          },
-        }).then(({ body: { id: QUESTION_ID } }) => {
-          cy.server();
-          cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
-
-          cy.log(
-            "**-- 3. Create a nested question based on the previous one --**",
-          );
-
-          // we're adding filter and saving/overwriting the original question, keeping the same ID
-          cy.request("PUT", `/api/card/${QUESTION_ID}`, {
-            dataset_query: {
-              database: 1,
-              query: {
-                filter: [">", ["field-literal", "TOTAL", "type/Float"], 50],
-                "source-query": ORIGINAL_QUERY,
-              },
-              type: "query",
-            },
-          });
-
-          cy.log("**Reported failing since v0.35.2**");
-          cy.visit(`/question/${QUESTION_ID}`);
-          cy.wait("@cardQuery").then(xhr => {
-            expect(xhr.response.body.error).not.to.exist;
-          });
-          cy.findByText(METRIC_NAME);
-          cy.get(".bar");
         });
+
+        cy.log("**Reported failing since v0.35.2**");
+        cy.visit(`/question/${QUESTION_ID}`);
+        cy.wait("@cardQuery").then(xhr => {
+          expect(xhr.response.body.error).not.to.exist;
+        });
+        cy.findByText(METRIC_NAME);
+        cy.get(".bar");
       });
     });
   });

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -7,6 +7,10 @@ import {
   withSampleDataset,
 } from "__support__/cypress";
 
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS_ID } = SAMPLE_DATASET;
+
 // test various entry points into the query builder
 
 describe("scenarios > question > new", () => {
@@ -117,7 +121,7 @@ describe("scenarios > question > new", () => {
         name: "11439",
         dataset_query: {
           database: 1,
-          query: { "source-table": 2 },
+          query: { "source-table": ORDERS_ID },
           type: "query",
         },
         type: "query",

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -4,8 +4,11 @@ import {
   openOrdersTable,
   popover,
   signIn,
-  withSampleDataset,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
 
 describe("scenarios > question > view", () => {
   before(restore);
@@ -105,41 +108,40 @@ describe("scenarios > question > view", () => {
       cy.request("POST", "/api/dashboard", {
         name: "Dashboard",
       });
-      withSampleDataset(({ PRODUCTS }) => {
-        cy.request("POST", "/api/card", {
-          name: "Question",
-          dataset_query: {
-            type: "native",
-            native: {
-              query: "select * from products where {{category}} and {{vendor}}",
-              "template-tags": {
-                category: {
-                  id: "6b8b10ef-0104-1047-1e5v-2492d5954555",
-                  name: "category",
-                  "display-name": "CATEGORY",
-                  type: "dimension",
-                  dimension: ["field-id", PRODUCTS.CATEGORY],
-                  "widget-type": "id",
-                },
-                vendor: {
-                  id: "6b8b10ef-0104-1047-1e5v-2492d5964545",
-                  name: "vendor",
-                  "display-name": "VENDOR",
-                  type: "dimension",
-                  dimension: ["field-id", PRODUCTS.VENDOR],
-                  "widget-type": "id",
-                },
+
+      cy.request("POST", "/api/card", {
+        name: "Question",
+        dataset_query: {
+          type: "native",
+          native: {
+            query: "select * from products where {{category}} and {{vendor}}",
+            "template-tags": {
+              category: {
+                id: "6b8b10ef-0104-1047-1e5v-2492d5954555",
+                name: "category",
+                "display-name": "CATEGORY",
+                type: "dimension",
+                dimension: ["field-id", PRODUCTS.CATEGORY],
+                "widget-type": "id",
+              },
+              vendor: {
+                id: "6b8b10ef-0104-1047-1e5v-2492d5964545",
+                name: "vendor",
+                "display-name": "VENDOR",
+                type: "dimension",
+                dimension: ["field-id", PRODUCTS.VENDOR],
+                "widget-type": "id",
               },
             },
-            database: 1,
           },
-          display: "table",
-          visualization_settings: {},
-        });
-        cy.request("POST", "/api/dashboard/2/cards", {
-          id: 2,
-          cardId: 4,
-        });
+          database: 1,
+        },
+        display: "table",
+        visualization_settings: {},
+      });
+      cy.request("POST", "/api/dashboard/2/cards", {
+        id: 2,
+        cardId: 4,
       });
     });
 

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -1,12 +1,15 @@
 import {
   signInAsAdmin,
   restore,
-  withSampleDataset,
   openProductsTable,
   openOrdersTable,
   popover,
   sidebar,
 } from "__support__/cypress";
+
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE_ID } = SAMPLE_DATASET;
 
 describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   beforeEach(() => {
@@ -15,74 +18,92 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it("should allow brush date filter", () => {
-    withSampleDataset(({ ORDERS, PRODUCTS }) => {
-      cy.request("POST", "/api/card", {
-        name: "Orders by Product → Created At (month) and Product → Category",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": 2,
-            aggregation: [["count"]],
-            breakout: [
-              [
-                "datetime-field",
-                [
-                  "fk->",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["field-id", PRODUCTS.CREATED_AT],
-                ],
-                "month",
-              ],
+    cy.request("POST", "/api/card", {
+      name: "Orders by Product → Created At (month) and Product → Category",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "datetime-field",
               [
                 "fk->",
                 ["field-id", ORDERS.PRODUCT_ID],
-                ["field-id", PRODUCTS.CATEGORY],
+                ["field-id", PRODUCTS.CREATED_AT],
               ],
+              "month",
             ],
-          },
-          type: "query",
+            [
+              "fk->",
+              ["field-id", ORDERS.PRODUCT_ID],
+              ["field-id", PRODUCTS.CATEGORY],
+            ],
+          ],
         },
-        display: "line",
-        visualization_settings: {},
-      }).then(response => {
-        cy.visit(`/question/${response.body.id}`);
+        type: "query",
+      },
+      display: "line",
+      visualization_settings: {},
+    }).then(response => {
+      cy.visit(`/question/${response.body.id}`);
 
-        // wait for chart to expand and display legend/labels
-        cy.contains("Loading..."); // this gives more time to load
-        cy.contains("Gadget");
-        cy.contains("January, 2017");
-        cy.wait(100); // wait longer to avoid grabbing the svg before a chart redraw
+      // wait for chart to expand and display legend/labels
+      cy.contains("Loading..."); // this gives more time to load
+      cy.contains("Gadget");
+      cy.contains("January, 2017");
+      cy.wait(100); // wait longer to avoid grabbing the svg before a chart redraw
 
-        // drag across to filter
-        cy.get(".dc-chart svg")
-          .trigger("mousedown", 100, 200)
-          .trigger("mousemove", 200, 200)
-          .trigger("mouseup", 200, 200);
+      // drag across to filter
+      cy.get(".dc-chart svg")
+        .trigger("mousedown", 100, 200)
+        .trigger("mousemove", 200, 200)
+        .trigger("mouseup", 200, 200);
 
-        // new filter applied
-        cy.contains("Created At between May, 2016 July, 2016");
-        // more granular axis labels
-        cy.contains("June, 2016");
-        // confirm that product category is still broken out
-        cy.contains("Gadget");
-        cy.contains("Doohickey");
-        cy.contains("Gizmo");
-        cy.contains("Widget");
-      });
+      // new filter applied
+      cy.contains("Created At between May, 2016 July, 2016");
+      // more granular axis labels
+      cy.contains("June, 2016");
+      // confirm that product category is still broken out
+      cy.contains("Gadget");
+      cy.contains("Doohickey");
+      cy.contains("Gizmo");
+      cy.contains("Widget");
     });
   });
 
   it.skip("should allow drill-through on combined cards with different amount of series (metabase#13457)", () => {
-    withSampleDataset(({ ORDERS, ORDERS_ID }) => {
-      cy.log("**--1. Create the first question--**");
+    cy.log("**--1. Create the first question--**");
+
+    cy.request("POST", "/api/card", {
+      name: "13457_Q1",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+          ],
+        },
+        type: "query",
+      },
+      display: "line",
+      visualization_settings: {},
+    }).then(({ body: { id: Q1_ID } }) => {
+      cy.log("**--2. Create the second question--**");
 
       cy.request("POST", "/api/card", {
-        name: "13457_Q1",
+        name: "13457_Q2",
         dataset_query: {
           database: 1,
           query: {
             "source-table": ORDERS_ID,
-            aggregation: [["count"]],
+            aggregation: [
+              ["avg", ["field-id", ORDERS.DISCOUNT]],
+              ["avg", ["field-id", ORDERS.QUANTITY]],
+            ],
             breakout: [
               ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
             ],
@@ -91,86 +112,64 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         },
         display: "line",
         visualization_settings: {},
-      }).then(({ body: { id: Q1_ID } }) => {
-        cy.log("**--2. Create the second question--**");
+      }).then(({ body: { id: Q2_ID } }) => {
+        cy.log("**--3. Create a dashboard--**");
 
-        cy.request("POST", "/api/card", {
-          name: "13457_Q2",
-          dataset_query: {
-            database: 1,
-            query: {
-              "source-table": ORDERS_ID,
-              aggregation: [
-                ["avg", ["field-id", ORDERS.DISCOUNT]],
-                ["avg", ["field-id", ORDERS.QUANTITY]],
+        cy.request("POST", "/api/dashboard", {
+          name: "13457D",
+        }).then(({ body: { id: DASHBOARD_ID } }) => {
+          cy.log("**--4. Add the first question to the dashboard--**");
+
+          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cardId: Q1_ID,
+          }).then(({ body: { id: DASH_CARD_ID } }) => {
+            cy.log(
+              "**--5. Add additional series combining it with the second question--**",
+            );
+
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cards: [
+                {
+                  id: DASH_CARD_ID,
+                  card_id: Q1_ID,
+                  row: 0,
+                  col: 0,
+                  sizeX: 16,
+                  sizeY: 12,
+                  series: [
+                    {
+                      id: Q2_ID,
+                      model: "card",
+                    },
+                  ],
+                  visualization_settings: {},
+                  parameter_mappings: [],
+                },
               ],
-              breakout: [
-                ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-              ],
-            },
-            type: "query",
-          },
-          display: "line",
-          visualization_settings: {},
-        }).then(({ body: { id: Q2_ID } }) => {
-          cy.log("**--3. Create a dashboard--**");
-
-          cy.request("POST", "/api/dashboard", {
-            name: "13457D",
-          }).then(({ body: { id: DASHBOARD_ID } }) => {
-            cy.log("**--4. Add the first question to the dashboard--**");
-
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: Q1_ID,
-            }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log(
-                "**--5. Add additional series combining it with the second question--**",
-              );
-
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
-                  {
-                    id: DASH_CARD_ID,
-                    card_id: Q1_ID,
-                    row: 0,
-                    col: 0,
-                    sizeX: 16,
-                    sizeY: 12,
-                    series: [
-                      {
-                        id: Q2_ID,
-                        model: "card",
-                      },
-                    ],
-                    visualization_settings: {},
-                    parameter_mappings: [],
-                  },
-                ],
-              });
             });
-
-            cy.visit(`/dashboard/${DASHBOARD_ID}`);
-
-            cy.log("**The first series line**");
-            cy.get(".sub.enable-dots._0")
-              .find(".dot")
-              .eq(0)
-              .click({ force: true });
-            cy.findByText(/Zoom in/i);
-            cy.findByText(/View these Orders/i);
-
-            // Click anywhere else to close the first action panel
-            cy.findByText("13457D").click();
-
-            // Second line from the second question
-            cy.log("**The third series line**");
-            cy.get(".sub.enable-dots._2")
-              .find(".dot")
-              .eq(0)
-              .click({ force: true });
-            cy.findByText(/Zoom in/i);
-            cy.findByText(/View these Orders/i);
           });
+
+          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+
+          cy.log("**The first series line**");
+          cy.get(".sub.enable-dots._0")
+            .find(".dot")
+            .eq(0)
+            .click({ force: true });
+          cy.findByText(/Zoom in/i);
+          cy.findByText(/View these Orders/i);
+
+          // Click anywhere else to close the first action panel
+          cy.findByText("13457D").click();
+
+          // Second line from the second question
+          cy.log("**The third series line**");
+          cy.get(".sub.enable-dots._2")
+            .find(".dot")
+            .eq(0)
+            .click({ force: true });
+          cy.findByText(/Zoom in/i);
+          cy.findByText(/View these Orders/i);
         });
       });
     });
@@ -191,7 +190,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       visualization_settings: {},
       dataset_query: {
         database: 1,
-        query: { "source-table": 3, limit: 5 },
+        query: { "source-table": PEOPLE_ID, limit: 5 },
         type: "query",
       },
     });
@@ -225,21 +224,19 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
   it.skip("should drill through a with date filter (metabase#12496)", () => {
     // save a question of orders by week
-    withSampleDataset(({ ORDERS }) => {
-      cy.request("POST", "/api/card", {
-        name: "Orders by Created At: Week",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": 2,
-            aggregation: [["count"]],
-            breakout: [["datetime-field", ORDERS.CREATED_AT, "week"]],
-          },
-          type: "query",
+    cy.request("POST", "/api/card", {
+      name: "Orders by Created At: Week",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [["datetime-field", ORDERS.CREATED_AT, "week"]],
         },
-        display: "line",
-        visualization_settings: {},
-      });
+        type: "query",
+      },
+      display: "line",
+      visualization_settings: {},
     });
 
     // Load the question up


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Uses [newly available](https://github.com/metabase/metabase/pull/13994) `SAMPLE_DATASET` and removes the need to wrap every single test that needs access to table and/or field ids in `withSampleDataset()`
- It also updates _every_ instance of hard coded table id with the appropriate constant

```javascript
// before
{ "source-table": 2 }

// now
{ "source-table": ORDERS_ID }
```