### PR TITLE
Pivot tables - fix some layout bugs

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -4,8 +4,8 @@ import { getIn } from "icepick";
 import { formatValue } from "metabase/lib/formatting";
 
 export function multiLevelPivot(
-  data,
-  subtotals,
+  pivotData,
+  columns,
   columnColumnIndexes,
   rowColumnIndexes,
   valueColumnIndexes,
@@ -18,7 +18,11 @@ export function multiLevelPivot(
   const valuesByKey = {};
 
   // loop over the primary rows to build trees of column/row header data
-  for (const row of data.rows) {
+  for (const row of pivotData[
+    JSON.stringify(
+      _.range(columnColumnIndexes.length + rowColumnIndexes.length),
+    )
+  ]) {
     // mutate the trees to add the tuple from the current row
     updateValueObject(row, columnColumnIndexes, columnColumnTree);
     updateValueObject(row, rowColumnIndexes, rowColumnTree);
@@ -32,10 +36,10 @@ export function multiLevelPivot(
 
   // build objects to look up subtotal values
   const subtotalValues = {};
-  for (const [subtotalName, subtotal] of Object.entries(subtotals)) {
+  for (const [subtotalName, subtotal] of Object.entries(pivotData)) {
     const indexes = JSON.parse(subtotalName);
     subtotalValues[subtotalName] = {};
-    for (const row of subtotal.rows) {
+    for (const row of subtotal) {
       const valueKey = JSON.stringify(indexes.map(index => row[index]));
       subtotalValues[subtotalName][valueKey] = valueColumnIndexes.map(
         index => row[index],
@@ -44,18 +48,22 @@ export function multiLevelPivot(
   }
 
   const valueFormatters = valueColumnIndexes.map(index => value =>
-    formatValue(value, { column: data.cols[index] }),
+    formatValue(value, { column: columns[index] }),
   );
 
-  const valueColumns = valueColumnIndexes.map(index => data.cols[index]);
+  const valueColumns = valueColumnIndexes.map(index => columns[index]);
   const topIndex = getIndex(columnColumnTree, { valueColumns });
   const leftIndex = getIndex(rowColumnTree, {});
 
+  const columnCount =
+    topIndex.length + (topIndex.length > 1 && leftIndex.length > 0 ? 1 : 0);
+  const rowCount =
+    leftIndex.length + (leftIndex.length > 1 && topIndex.length > 0 ? 1 : 0);
   return {
     topIndex,
     leftIndex,
-    columnCount: topIndex.length + (leftIndex.length > 0 ? 1 : 0),
-    rowCount: leftIndex.length + (topIndex.length > 0 ? 1 : 0),
+    columnCount,
+    rowCount,
     getRowSection: createRowSectionGetter({
       valuesByKey,
       columnColumnTree,
@@ -83,34 +91,42 @@ function createRowSectionGetter({
       : values.map((v, i) => valueFormatters[i](v));
   const getSubtotals = (breakoutIndexes, values) =>
     formatValues(
-      getIn(subtotalValues, [breakoutIndexes, values].map(JSON.stringify)),
+      getIn(
+        subtotalValues,
+        [breakoutIndexes, values].map(a =>
+          JSON.stringify(
+            _.sortBy(a, (_value, index) => breakoutIndexes[index]),
+          ),
+        ),
+      ),
     );
 
   return (columnIndex, rowIndex) => {
     const rows =
-      rowIndex === rowColumnTree.length
+      rowIndex >= rowColumnTree.length
         ? [[]]
         : enumerate(rowColumnTree[rowIndex]);
     const columns =
-      columnIndex === columnColumnTree.length
+      columnIndex >= columnColumnTree.length
         ? [[]]
         : enumerate(columnColumnTree[columnIndex]);
 
+    const bottomRow =
+      rowIndex === rowColumnTree.length && rowColumnTree.length > 0;
+    const rightColumn =
+      columnIndex === columnColumnTree.length && columnColumnTree.length > 0;
     // totals in the bottom right
-    if (
-      rowIndex === rowColumnTree.length &&
-      columnIndex === columnColumnTree.length
-    ) {
+    if (bottomRow && rightColumn) {
       return [getSubtotals([], [])];
     }
 
     // "grand totals" on the bottom
-    if (rowIndex === rowColumnTree.length) {
+    if (bottomRow) {
       return [columns.flatMap(col => getSubtotals(columnColumnIndexes, col))];
     }
 
     // "row totals" on the right
-    if (columnIndex === columnColumnTree.length) {
+    if (rightColumn) {
       const subtotalRows =
         rowColumnIndexes.length > 1
           ? [
@@ -156,9 +172,9 @@ function enumerate({ value, children }, path = []) {
   return children.flatMap(child => enumerate(child, pathWithValue));
 }
 
-function getIndex(values, { valueColumns = [] } = {}) {
+function getIndex(values, { valueColumns = [], depth = 0 } = {}) {
   if (values.length === 0) {
-    if (valueColumns.length > 1) {
+    if (valueColumns.length > 1 || depth === 0) {
       // if we have multiple value columns include their column names
       const colNames = valueColumns.map(col => ({
         value: col.display_name,
@@ -169,9 +185,9 @@ function getIndex(values, { valueColumns = [] } = {}) {
     return [];
   }
   return values.map(({ value, children }) => {
-    const foo = _.zip(...getIndex(children, { valueColumns })).map(a =>
-      a.flat(),
-    );
+    const foo = _.zip(
+      ...getIndex(children, { valueColumns, depth: depth + 1 }),
+    ).map(a => a.flat());
     const span = foo.length === 0 ? 1 : foo[foo.length - 1].length;
     return [[{ value, span }], ...foo];
   });

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -359,7 +359,6 @@ export default class PivotTable extends Component {
                       </div>
                     );
                   }}
-                  onRowsRendered={() => {}}
                   onScroll={({ scrollLeft, scrollTop }) =>
                     onScroll({ scrollLeft, scrollTop })
                   }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -108,6 +108,12 @@ export default class PivotTable extends Component {
     },
   };
 
+  componentDidUpdate() {
+    this.bodyGrid && this.bodyGrid.recomputeGridSize();
+    this.leftList && this.leftList.recomputeGridSize();
+    this.topGrid && this.topGrid.recomputeGridSize();
+  }
+
   render() {
     const { settings, data, width, height } = this.props;
     if (data == null || !data.cols.some(isPivotGroupColumn)) {
@@ -125,28 +131,34 @@ export default class PivotTable extends Component {
       rows: rowIndexes,
       columns: columnIndexes,
       values: valueIndexes,
-    } = _.mapObject(setting, columns => {
-      return columns
+    } = _.mapObject(setting, columns =>
+      columns
         .map(field_ref =>
           columnsWithoutPivotGroup.findIndex(col =>
             _.isEqual(col.field_ref, field_ref),
           ),
         )
-        .filter(index => index !== -1);
+        .filter(index => index !== -1),
+    );
+    const { pivotData, columns } = splitPivotData(
+      data,
+      rowIndexes,
+      columnIndexes,
+    );
+    console.log({
+      data,
+      pivotData,
+      columns,
+      rowIndexes,
+      columnIndexes,
+      valueIndexes,
     });
-    const pivotData = splitPivotData(data, rowIndexes, columnIndexes);
-    const {
-      [JSON.stringify(
-        _.range(columnIndexes.length + rowIndexes.length),
-      )]: primary,
-      ...subtotals
-    } = pivotData;
 
     let pivoted;
     try {
       pivoted = multiLevelPivot(
-        primary,
-        subtotals,
+        pivotData,
+        columns,
         columnIndexes,
         rowIndexes,
         valueIndexes,
@@ -206,14 +218,13 @@ export default class PivotTable extends Component {
                       style={{ height: cellHeight, width: cellWidth }}
                       className="px1"
                     >
-                      <Ellipsified>
-                        {formatColumn(primary.cols[index])}
-                      </Ellipsified>
+                      <Ellipsified>{formatColumn(columns[index])}</Ellipsified>
                     </div>
                   ))}
                 </div>
                 {/* top header */}
                 <Grid
+                  ref={e => (this.topGrid = e)}
                   className="border-bottom border-medium scroll-hide-all text-medium"
                   width={width - leftHeaderWidth}
                   height={topHeaderHeight}
@@ -253,7 +264,7 @@ export default class PivotTable extends Component {
                               >
                                 <Ellipsified>
                                   {formatValue(value, {
-                                    column: primary.cols[columnIndexes[index]],
+                                    column: columns[columnIndexes[index]],
                                   })}
                                 </Ellipsified>
                               </div>
@@ -268,6 +279,7 @@ export default class PivotTable extends Component {
                 />
                 {/* left header */}
                 <List
+                  ref={e => (this.leftList = e)}
                   width={leftHeaderWidth}
                   height={height - topHeaderHeight}
                   className="scroll-hide-all text-dark border-right border-medium"
@@ -306,7 +318,7 @@ export default class PivotTable extends Component {
                                 >
                                   <Ellipsified>
                                     {formatValue(value, {
-                                      column: primary.cols[rowIndexes[index]],
+                                      column: columns[rowIndexes[index]],
                                     })}
                                   </Ellipsified>
                                 </div>
@@ -328,6 +340,7 @@ export default class PivotTable extends Component {
                 />
                 {/* pivot table body */}
                 <Grid
+                  ref={e => (this.bodyGrid = e)}
                   width={width - leftHeaderWidth}
                   height={height - topHeaderHeight}
                   className="text-dark"
@@ -354,6 +367,7 @@ export default class PivotTable extends Component {
                       </div>
                     );
                   }}
+                  onRowsRendered={() => {}}
                   onScroll={({ scrollLeft, scrollTop }) =>
                     onScroll({ scrollLeft, scrollTop })
                   }
@@ -385,7 +399,7 @@ function updateValueWithCurrentColumns(storedValue, columns) {
   );
   // add toAdd to first partitions where it matches the filter
   for (const fieldRef of toAdd) {
-    for (const { filter, name } of partitions) {
+    for (const { columnFilter: filter, name } of partitions) {
       const column = columns.find(
         c => JSON.stringify(c.field_ref) === fieldRef,
       );
@@ -412,25 +426,23 @@ function isColumnValid(col) {
 
 function splitPivotData(data, rowIndexes, columnIndexes) {
   const groupIndex = data.cols.findIndex(isPivotGroupColumn);
-  const remainingColumns = data.cols.filter(col => !isPivotGroupColumn(col));
-  return _.chain(data.rows)
+  const columns = data.cols.filter(col => !isPivotGroupColumn(col));
+  const pivotData = _.chain(data.rows)
     .groupBy(row => row[groupIndex])
     .pairs()
     .map(([key, rows]) => {
       const indexes = JSON.parse(key).map(breakout =>
-        remainingColumns.findIndex(col => _.isEqual(col.field_ref, breakout)),
+        columns.findIndex(col => _.isEqual(col.field_ref, breakout)),
       );
 
       return [
         JSON.stringify(indexes),
-        {
-          cols: remainingColumns,
-          rows: rows.map(row =>
-            row.slice(0, groupIndex).concat(row.slice(groupIndex + 1)),
-          ),
-        },
+        rows.map(row =>
+          row.slice(0, groupIndex).concat(row.slice(groupIndex + 1)),
+        ),
       ];
     })
     .object()
     .value();
+  return { pivotData, columns };
 }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -145,14 +145,6 @@ export default class PivotTable extends Component {
       rowIndexes,
       columnIndexes,
     );
-    console.log({
-      data,
-      pivotData,
-      columns,
-      rowIndexes,
-      columnIndexes,
-      valueIndexes,
-    });
 
     let pivoted;
     try {


### PR DESCRIPTION
Part of #13662

Misc fixes:
- Prevents added metrics from being pivoted (e.g. if you add `Sum` it should go into "values")
- Forces a Grid rerender when there's new data
- Patches up some edge cases around putting all the pivot dimensions on one side