### PR TITLE
More dash subscription styling tweaks

### DIFF
--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -470,21 +470,23 @@ class SharingSidebar extends React.Component {
 
     if (pulse.id != null && !pulse.archived) {
       return (
-        <ModalWithTrigger
-          triggerClasses="Button Button--danger flex-align-right flex-no-shrink"
-          triggerElement={t`Delete this subscription`}
-        >
-          {({ onClose }) => (
-            <DeleteModalWithConfirm
-              objectType="pulse"
-              title={t`Archive` + ' "' + pulse.name + '"?'}
-              buttonText={t`Archive`}
-              confirmItems={this.getConfirmItems()}
-              onClose={onClose}
-              onDelete={this.handleArchive}
-            />
-          )}
-        </ModalWithTrigger>
+        <div className="border-top pt1 pb3 flex justify-end">
+          <ModalWithTrigger
+            triggerClasses="Button Button--borderless text-light text-error-hover flex-align-right flex-no-shrink"
+            triggerElement={t`Delete this subscription`}
+          >
+            {({ onClose }) => (
+              <DeleteModalWithConfirm
+                objectType="pulse"
+                title={t`Archive` + ' "' + pulse.name + '"?'}
+                buttonText={t`Archive`}
+                confirmItems={this.getConfirmItems()}
+                onClose={onClose}
+                onDelete={this.handleArchive}
+              />
+            )}
+          </ModalWithTrigger>
+        </div>
       );
     }
 

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -573,9 +573,9 @@ class SharingSidebar extends React.Component {
           <div className="my1 mx4">
             <Card
               flat
-              hoverable={emailSpec.configured}
               className={cx("mt1 mb3", {
-                "cursor-pointer": slackSpec.configured,
+                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
+                  emailSpec.configured,
               })}
               onClick={() => {
                 if (emailSpec.configured) {
@@ -590,7 +590,10 @@ class SharingSidebar extends React.Component {
                     name="mail"
                     className={cx(
                       "mr1",
-                      { "text-brand": emailSpec.configured },
+                      {
+                        "text-brand hover-child hover--inherit":
+                          emailSpec.configured,
+                      },
                       { "text-light": !emailSpec.configured },
                     )}
                   />
@@ -598,7 +601,11 @@ class SharingSidebar extends React.Component {
                     className={cx({ "text-light": !emailSpec.configured })}
                   >{t`Email it`}</h3>
                 </div>
-                <div className="text-medium">
+                <div
+                  className={cx("text-medium", {
+                    "hover-child hover--inherit": emailSpec.configured,
+                  })}
+                >
                   {!emailSpec.configured &&
                     jt`You'll need to ${(
                       <Link to="/admin/settings/email" className="link">
@@ -612,8 +619,10 @@ class SharingSidebar extends React.Component {
             </Card>
             <Card
               flat
-              hoverable={slackSpec.configured}
-              className={cx({ "cursor-pointer": slackSpec.configured })}
+              className={cx({
+                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
+                  slackSpec.configured,
+              })}
               onClick={() => {
                 if (slackSpec.configured) {
                   this.setState({ editingMode: "add-edit-slack" });
@@ -628,13 +637,18 @@ class SharingSidebar extends React.Component {
                     size={24}
                     className={cx("mr1", {
                       "text-light": !slackSpec.configured,
+                      "hover-child hover--inherit": slackSpec.configured,
                     })}
                   />
                   <h3
                     className={cx({ "text-light": !slackSpec.configured })}
                   >{t`Send it to Slack`}</h3>
                 </div>
-                <div className="text-medium">
+                <div
+                  className={cx("text-medium", {
+                    "hover-child hover--inherit": slackSpec.configured,
+                  })}
+                >
                   {!slackSpec.configured &&
                     jt`First, you'll have to ${(
                       <Link to="/admin/settings/slack" className="link">

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -729,7 +729,7 @@ class SharingSidebar extends React.Component {
               ] || t`Messages`} will be sent at`}
               onScheduleChange={this.onChannelScheduleChange.bind(this, index)}
             />
-            <div className="pt2">
+            <div className="pt2 pb1">
               <SendTestEmail
                 channel={channel}
                 pulse={pulse}
@@ -737,7 +737,7 @@ class SharingSidebar extends React.Component {
               />
             </div>
 
-            <div className="text-bold py2 mt2 flex justify-between align-center border-top">
+            <div className="text-bold py3 mt2 flex justify-between align-center border-top">
               <Heading>{t`Don't send if there aren't results`}</Heading>
               <Toggle
                 value={pulse.skip_if_empty || false}

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -8,7 +8,7 @@ import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import Radio from "metabase/components/Radio";
+import ButtonGroup from "metabase/components/ButtonGroup";
 import RecipientPicker from "metabase/pulse/components/RecipientPicker";
 import SchedulePicker from "metabase/components/SchedulePicker";
 import Select, { Option } from "metabase/components/Select";
@@ -760,11 +760,11 @@ class SharingSidebar extends React.Component {
               />
             </div>
             {this.attachmentTypeValue() != null && (
-              <div className="text-bold py2 flex justify-between align-center">
-                <Radio
+              <div className="pb3 flex">
+                <ButtonGroup
                   options={[
-                    { name: "CSV", value: "csv" },
-                    { name: "XLSX", value: "xls" },
+                    { name: ".csv", value: "csv" },
+                    { name: ".xlsx", value: "xls" },
                   ]}
                   onChange={value => this.setAttachmentType(value)}
                   value={this.attachmentTypeValue()}


### PR DESCRIPTION
Couple more styling changes to the delivery mechanism sidebar and the settings.

## New hover state here:

![delivery-hover](https://user-images.githubusercontent.com/2223916/101561701-a3b0d300-397a-11eb-9088-1c8057bcc5dd.gif)

## Updated delete, attachments, and spacing:

<img width="388" alt="image" src="https://user-images.githubusercontent.com/2223916/101561614-7fed8d00-397a-11eb-9e08-5b84ceb23c50.png">

