### PR TITLE
Peek at metadata for native SQL sandboxing queries :eyes:

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -1,8 +1,5 @@
 (ns metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions
   (:require [clojure.tools.logging :as log]
-            [metabase
-             [query-processor :as qp]
-             [util :as u]]
             [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase.api.common :as api :refer [*current-user* *current-user-id* *current-user-permissions-set*]]
             [metabase.mbql
@@ -21,6 +18,7 @@
             [metabase.query-processor.middleware
              [annotate :as annotate]
              [fetch-source-query :as fetch-source-query]]
+            [metabase.util :as u]
             [metabase.util
              [i18n :refer [tru]]
              [schema :as su]]
@@ -167,7 +165,7 @@
                :type     :query
                :query    source-query}
         cols  (binding [api/*current-user-permissions-set* (atom #{"/"})]
-                (-> (qp/process-query (assoc query :limit 0))
+                (-> ((resolve 'metabase.query-processor/process-query) (assoc query :limit 0))
                     :data :cols))]
     (u/prog1 (for [col cols]
                (select-keys col [:name :base_type :display_name :special_type]))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -1,5 +1,8 @@
 (ns metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions
   (:require [clojure.tools.logging :as log]
+            [metabase
+             [query-processor :as qp]
+             [util :as u]]
             [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase.api.common :as api :refer [*current-user* *current-user-id* *current-user-permissions-set*]]
             [metabase.mbql
@@ -16,10 +19,8 @@
              [error-type :as qp.error-type]
              [store :as qp.store]]
             [metabase.query-processor.middleware
-             [add-source-metadata :as add-source-metadata]
              [annotate :as annotate]
              [fetch-source-query :as fetch-source-query]]
-            [metabase.util :as u]
             [metabase.util
              [i18n :refer [tru]]
              [schema :as su]]
@@ -151,34 +152,64 @@
 (defn- table-gtap->source [{table-id :table_id, :as gtap}]
   {:source-query {:source-table table-id, :parameters (gtap->parameters gtap)}})
 
-;; If a GTAP source query doesn't have results metadata for whatever reason, we can infer the results metadata if we
-;; assume the results will match the shape of the Table we're GTAPping; figure out what the results metadata for that
-;; Table would be and return that. In practice, this is hopefully a safe assumption to make, but we never explictly
-;; enforce a constraint that a GTAP must return the exact same columns as the Table it replaces. (We probably SHOULD
-;; enforce this constraint.)
+;; If a GTAP source query doesn't have results metadata for whatever reason, we can infer the results metadata by
+;; running the query on its own for the User in question. We'll run the query with a `LIMIT 0`, so it doesn't return
+;; any rows, but it should be enough to give us the relevant metadata for the result columns.
+;;
+;; Note that we only need to infer metadata in this fashion for situations where we're applying GTAPs to joined tables
+;; and using `:fields :all` for that join -- we need to know the columns that are produced in order to build the
+;; surrounding query correctly. (We probably could use `SELECT *`, but at this time we're always selecting every Field
+;; individually)
 
-(s/defn ^:private source-metadata-for-table :- [mbql.s/SourceQueryMetadata]
-  "Determine the source metadata that would normally come back for a Table with `table-id`."
-  [table-id :- su/IntGreaterThanZero]
-  (log/tracef "GTAP source query has no results Metadata. Inferring metdata from Table %d %s.%s"
-              table-id
-              (pr-str (:schema (qp.store/table table-id)))
-              (pr-str (:name (qp.store/table table-id))))
-  (let [cols (add-source-metadata/mbql-source-query->metadata {:source-table table-id})]
+(s/defn ^:private run-gtap-source-query-for-metadata :- [mbql.s/SourceQueryMetadata]
+  [source-query :- mbql.s/SourceQuery]
+  (let [query {:database (:id (qp.store/database))
+               :type     :query
+               :query    source-query}
+        cols  (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                (-> (qp/process-query (assoc query :limit 0))
+                    :data :cols))]
     (u/prog1 (for [col cols]
                (select-keys col [:name :base_type :display_name :special_type]))
       (log/tracef "Inferred source query metadata:\n%s" (u/pprint-to-str 'magenta <>)))))
 
+;; This metadata will be the same regardless of what user runs the query in question, so we only need to run it once
+;; for each GTAP Card; we can save it and reuse it after that point. `update-metadata-for-gtap!` takes care of that.
+
+(defn- update-metadata-for-gtap!
+  "Callback that saves results metadata for the Card associated with a GTAP if it does not already have it."
+  [{card-id :card_id, gtap-id :id} new-metadata]
+  (cond
+    (not card-id)
+    (log/tracef "Not updating metadata for GTAP {0}: GTAP has no associated Card ID" gtap-id)
+
+    (db/exists? Card :id card-id, :result_metadata [:not= nil])
+    (log/trace "Not updating metadata for GTAP {0} Card {1}: Card already has result metadata" gtap-id card-id)
+
+    :else
+    (do
+      (log/trace "Saving results metadata for GTAP {0} Card {1}" gtap-id card-id)
+      (db/update! Card card-id :result_metadata new-metadata))))
+
 (s/defn ^:private gtap->source :- {:source-query                     s/Any
                                    (s/optional-key :source-metadata) [mbql.s/SourceQueryMetadata]
                                    s/Keyword                         s/Any}
-  "Get the source query associated with a `gtap`."
-  [{card-id :card_id, table-id :table_id, :as gtap} infer-source-metadata?]
-  {:pre [gtap]}
-  (let [source-query (preprocess-source-query ((if card-id card-gtap->source table-gtap->source) gtap))]
-    (cond-> source-query
-      (and infer-source-metadata? (empty? (:source-metadata source-query)))
-      (assoc :source-metadata (source-metadata-for-table table-id)))))
+  "Get the source query associated with a `gtap`.
+
+  `save-metadata!` is a callback function with the signature
+
+    (save-metadata! result-metadata)
+
+  that will be called if we end up running the GTAP source query in question to infer the metadata. This callback
+  should save the metadata so we don't have to run the query again in the future."
+  [{card-id :card_id, table-id :table_id, :as gtap} :- su/Map run-gtap-source-query-for-metadata?]
+  (let [source-query            (preprocess-source-query ((if card-id card-gtap->source table-gtap->source) gtap))
+        run-query-for-metadata? (and run-gtap-source-query-for-metadata? (empty? (:source-metadata source-query)))]
+    (if-not run-query-for-metadata?
+      source-query
+      (let [metadata (run-gtap-source-query-for-metadata source-query)]
+        (update-metadata-for-gtap! gtap metadata)
+        (assoc source-query :source-metadata metadata)))))
 
 (s/defn ^:private gtap->perms-set :- #{perms/ObjectPath}
   "Calculate the set of permissions needed to run the query associated with a GTAP; this set of permissions is excluded
@@ -217,10 +248,10 @@
   ;; columns as the Table it replaces, but this constraint is not enforced anywhere. If we infer metadata and the GTAP
   ;; turns out *not* to match exactly, the query could break. So only infer it in cases where the query would
   ;; definitely break otherwise.
-  (let [infer-source-metadata? (= (:fields m) :all)]
+  (let [run-gtap-source-query-for-metadata? (= (:fields m) :all)]
     (u/prog1 (merge
               (dissoc m :source-table :source-query)
-              (gtap->source gtap infer-source-metadata?))
+              (gtap->source gtap run-gtap-source-query-for-metadata?))
       (log/tracef "Applied GTAP: replaced\n%swith\n%s"
                   (u/pprint-to-str 'yellow m)
                   (u/pprint-to-str 'green <>)))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -182,11 +182,11 @@
     (log/tracef "Not updating metadata for GTAP {0}: GTAP has no associated Card ID" gtap-id)
 
     (db/exists? Card :id card-id, :result_metadata [:not= nil])
-    (log/trace "Not updating metadata for GTAP {0} Card {1}: Card already has result metadata" gtap-id card-id)
+    (log/tracef "Not updating metadata for GTAP {0} Card {1}: Card already has result metadata" gtap-id card-id)
 
     :else
     (do
-      (log/trace "Saving results metadata for GTAP {0} Card {1}" gtap-id card-id)
+      (log/tracef "Saving results metadata for GTAP {0} Card {1}" gtap-id card-id)
       (db/update! Card card-id :result_metadata new-metadata))))
 
 (s/defn ^:private gtap->source :- {:source-query                     s/Any

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -179,14 +179,14 @@
   [{card-id :card_id, gtap-id :id} new-metadata]
   (cond
     (not card-id)
-    (log/tracef "Not updating metadata for GTAP {0}: GTAP has no associated Card ID" gtap-id)
+    (log/tracef "Not updating metadata for GTAP %s: GTAP has no associated Card ID" gtap-id)
 
     (db/exists? Card :id card-id, :result_metadata [:not= nil])
-    (log/tracef "Not updating metadata for GTAP {0} Card {1}: Card already has result metadata" gtap-id card-id)
+    (log/tracef "Not updating metadata for GTAP %s Card %s: Card already has result metadata" gtap-id card-id)
 
     :else
     (do
-      (log/tracef "Saving results metadata for GTAP {0} Card {1}" gtap-id card-id)
+      (log/tracef "Saving results metadata for GTAP %s Card %s" gtap-id card-id)
       (db/update! Card card-id :result_metadata new-metadata))))
 
 (s/defn ^:private gtap->source :- {:source-query                     s/Any

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -16,7 +16,9 @@
             [metabase.mbql
              [normalize :as normalize]
              [util :as mbql.u]]
-            [metabase.models.permissions :as perms]
+            [metabase.models
+             [permissions :as perms]
+             [permissions-group :as perms-group]]
             [metabase.query-processor.util :as qputil]
             [metabase.test.data.env :as tx.env]
             [metabase.test.util :as tu]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -9,19 +9,19 @@
              [query-processor :as qp]
              [test :as mt]
              [util :as u]]
+            [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions :as row-level-restrictions]
             [metabase-enterprise.sandbox.test-util :as mt.tu]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.mbql
              [normalize :as normalize]
              [util :as mbql.u]]
-            [metabase.models
-             [permissions :as perms]
-             [permissions-group :as perms-group]]
+            [metabase.models.permissions :as perms]
             [metabase.query-processor.util :as qputil]
             [metabase.test.data.env :as tx.env]
             [metabase.test.util :as tu]
-            [metabase.util.honeysql-extensions :as hx]))
+            [metabase.util.honeysql-extensions :as hx]
+            [toucan.db :as db]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                      SHARED GTAP DEFINITIONS & HELPER FNS                                      |
@@ -551,3 +551,41 @@
                               :alias        "Venue"}]
                   :order-by [[:asc $id]]
                   :limit    3})))))))
+
+(deftest sandboxing-run-sql-queries-to-infer-columns-test
+  (testing "Run SQL queries to infer the columns when used as GTAPS (#13716)\n"
+    (testing "Should work with SQL queries that return less columns than there were in the original Table\n"
+      (mt/with-gtaps (mt/$ids
+                       {:gtaps      {:venues   {:query      (mt/native-query
+                                                              {:query         (str "SELECT DISTINCT VENUES.ID, VENUES.NAME "
+                                                                                   "FROM VENUES "
+                                                                                   "WHERE VENUES.ID IN ({{sandbox}})")
+                                                               :template-tags {"sandbox"
+                                                                               {:name         "sandbox"
+                                                                                :display-name "Sandbox"
+                                                                                :type         :text}}})
+                                                :remappings {"venue_id" [:variable [:template-tag "sandbox"]]}}
+                                     :checkins {}}
+                        :attributes {"venue_id" 1}})
+        (let [venues-gtap-card-id (db/select-one-field :card_id GroupTableAccessPolicy
+                                    :group_id (:id &group)
+                                    :table_id (mt/id :venues))]
+          (assert (integer? venues-gtap-card-id))
+          (testing "GTAP Card should not yet current have result_metadata"
+            (is (= nil
+                   (db/select-one-field :result_metadata Card :id venues-gtap-card-id))))
+          (testing "Should be able to run the query"
+            (is (= [[1 "Red Medicine" 1 "Red Medicine"]]
+                   (mt/rows
+                     (mt/run-mbql-query venues
+                       {:fields   [$id $name] ; joined fields get appended automatically because we specify :all :below
+                        :joins    [{:fields       :all
+                                    :source-table $$venues
+                                    :condition    [:= $id [:joined-field "Venue" $id]]
+                                    :alias        "Venue"}]
+                        :order-by [[:asc $id]]
+                        :limit    3})))))
+          (testing "After running the query the first time, result_metadata should have been saved for the GTAP Card"
+            (is (= [{:name "ID", :base_type "type/BigInteger", :display_name "ID"}
+                    {:name "NAME", :base_type "type/Text", :display_name "NAME"}]
+                   (db/select-one-field :result_metadata Card :id venues-gtap-card-id)))))))))


### PR DESCRIPTION
Implements #13716

The basic idea here is that if the source query in question used in a GTAP doesn't have source metadata, we run just the source query with `LIMIT 0` to get the metadata and save it for future use, and then go from there. I added some extra tests to make sure this works as expected, and that we can now support GTAPs whose columns differ from the column of the Table they are replacing (which previously didn't work when the GTAPs were applies to Tables used in joins with `:fields :all`)

We didn't need to run these queries as a "test user" -- running them with the current user is sufficient, since the metadata isn't going to change between users