### PR TITLE
Smoketest: no need for version file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1008,9 +1008,6 @@ jobs:
             - restore_cache:
                 name: Restore cached uberjar built in previous step
                 <<: *CacheKeyUberjar
-            - run:
-                name: Generate version file
-                command: ./bin/build version
       - store_artifacts:
           path: /home/circleci/metabase/metabase/cypress
       - store_test_results:


### PR DESCRIPTION
As this is already taken care by the cached uberjar step.

Previous build failure:
https://app.circleci.com/pipelines/github/metabase/metabase/11033/workflows/5b76ab02-6dcf-4325-8037-a9cd3f7e5ee1

Successful CI run with this change:
https://app.circleci.com/pipelines/github/metabase/metabase/11051/workflows/d6826ed1-f87a-47e4-b13b-e0b76a4caf56/jobs/398017