### PR TITLE
Add metadata sync for external DBs

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -290,4 +290,12 @@ function addQADatabase(engine, db_display_name, port) {
   }).then(({ status }) => {
     expect(status).to.equal(200);
   });
+
+  // Make sure we have all the metadata because we'll need to use it in tests
+  cy.request("POST", "/api/database/2/sync_schema").then(({ status }) => {
+    expect(status).to.equal(200);
+  });
+  cy.request("POST", "/api/database/2/rescan_values").then(({ status }) => {
+    expect(status).to.equal(200);
+  });
 }


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds a forced sync of external DBs schema and rescan of their values
- Asserts that the response status is `200`

### Why is this important?
- This gives us an opportunity to use `withDatabase()` function to extract metadata in Cypress tests without risking the empty tables response

```javascript
withDatabase(2, ({ PEOPLE, PEOPLE_ID }) => {
  cy.request("POST", "/api/card", {
    name: "12445",
    dataset_query: {
      type: "query",
      query: {
        "source-query": {
          "source-table": PEOPLE_ID,
          breakout: [["field-id", PEOPLE.SOURCE]],
        },
      ...
  });
});
```