### PR TITLE
Check Uberjar by launching it and testing /api/health [ci skip]

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - 'release-**'
+    tags:
+      - '**'
     paths-ignore:
     - 'docs/**'
     - 'frontend/test/**'
@@ -73,3 +75,64 @@ jobs:
           ./target/uberjar/metabase.jar
           ./COMMIT-ID
           ./SHA256.sum
+
+  check:
+    runs-on: ubuntu-20.04
+    name: check ${{ matrix.edition }} (java ${{ matrix.java-version }})
+    needs: build
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        edition: [ee, oss]
+        java-version: [8, 11, 13]
+    steps:
+    - name: Prepare JRE (Java Run-time Environment)
+      uses: actions/setup-java@v1
+      with:
+        java-package: jre
+        java-version: ${{ matrix.java-version }}
+    - run: java -version
+
+    - uses: actions/download-artifact@v2
+      name: Retrieve uberjar artifact
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+
+    - name: Launch uberjar
+      run: |
+        java -jar ./target/uberjar/metabase.jar &
+        sleep 180
+      timeout-minutes: 5
+
+    - name: Check API health
+      run: curl -s localhost:3000/api/health
+
+  known-issue-java15:
+    runs-on: ubuntu-20.04
+    needs: build
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        edition: [ee, oss]
+    steps:
+    - name: Prepare JRE 15
+      uses: actions/setup-java@v1
+      with:
+        java-package: jre
+        java-version: 15
+    - run: java -version
+
+    - uses: actions/download-artifact@v2
+      name: Retrieve uberjar artifact
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+
+    - name: Launch uberjar
+      run: |
+        java -jar ./target/uberjar/metabase.jar &
+        sleep 180
+      timeout-minutes: 5
+
+    - name: Check API health
+      run: curl -s localhost:3000/api/health
+      continue-on-error: true


### PR DESCRIPTION
This is the follow-up to previous PR #13996 (please read it for more context). Again, no current existing development workflow should be affected.

To simulate a regular end user (with just JRE, not JDK), the launch is varied across different Java versions.

Since Metabase doesn't work with Java 15 yet, it is explicitly marked as a known issue (without marking the whole build as a failure, thanks to `continue-on-error` flag).

![image](https://user-images.githubusercontent.com/7288/101923511-51db9900-3b84-11eb-81d8-055f914e7eff.png)

