### PR TITLE
#12445 Repro: Substring in custom column returns empty value

### DIFF
--- a/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
@@ -1,0 +1,60 @@
+import {
+  restore,
+  signInAsAdmin,
+  addMySQLDatabase,
+  withDatabase,
+} from "__support__/cypress";
+
+const MYSQL_DB_NAME = "QA MySQL8";
+
+// NOTE: skipping the whole describe block because #12445 is the only test so far
+describe.skip("mysql > user > question > custom column", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+    addMySQLDatabase(MYSQL_DB_NAME);
+  });
+
+  // TODO: When you unskip this test, unskip the describe block as well
+  it.skip("should correctly apply substring for a custom column (metabase#12445)", () => {
+    const CC_NAME = "Abbr";
+
+    withDatabase(2, ({ PEOPLE, PEOPLE_ID }) => {
+      cy.log(
+        "**--1. Create a question with `Source` column and abbreviated CC--**",
+      );
+      cy.request("POST", "/api/card", {
+        name: "12445",
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-query": {
+              "source-table": PEOPLE_ID,
+              breakout: [["field-id", PEOPLE.SOURCE]],
+            },
+            expressions: {
+              [CC_NAME]: [
+                "substring",
+                ["field-literal", "SOURCE", "type/Text"],
+                0,
+                4, // we want 4 letter abbreviation
+              ],
+            },
+          },
+          database: 2,
+        },
+        display: "table",
+        visualization_settings: {},
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.server();
+        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+
+        cy.visit(`/question/${QUESTION_ID}`);
+
+        cy.wait("@cardQuery");
+        cy.findByText(CC_NAME);
+        cy.findByText("Goog");
+      });
+    });
+  });
+});

--- a/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
@@ -28,14 +28,12 @@ describe.skip("mysql > user > question > custom column", () => {
         dataset_query: {
           type: "query",
           query: {
-            "source-query": {
-              "source-table": PEOPLE_ID,
-              breakout: [["field-id", PEOPLE.SOURCE]],
-            },
+            "source-table": PEOPLE_ID,
+            breakout: [["expression", CC_NAME]],
             expressions: {
               [CC_NAME]: [
                 "substring",
-                ["field-literal", "SOURCE", "type/Text"],
+                ["field-id", PEOPLE.SOURCE],
                 0,
                 4, // we want 4 letter abbreviation
               ],


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #12445

### How to test this manually?
- `yarn test-cypress-open --testFiles frontend/test/metabase-db`
- `frontend/test/metabase-db/mysql/custom-column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed


### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

**For this particular test, remove `.skip()` from describe block as well when you fix an issue.**