### PR TITLE
Tweak waterfall behavior on mouse hover

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -480,7 +480,10 @@ function setChartColor({ series, settings, chartType }, chart, groups, index) {
 
   if (chartType === "waterfall") {
     chart.on("pretransition", function(chart) {
-      chart.selectAll("g.stack._0 rect.bar").style("fill", "transparent");
+      chart
+        .selectAll("g.stack._0 rect.bar")
+        .style("fill", "transparent")
+        .style("pointer-events", "none");
       chart
         .selectAll("g.stack._3 rect.bar")
         .style("fill", settings["waterfall.total_color"]);


### PR DESCRIPTION
Hovering the mouse on the "invisible beam" (under every bar) should not trigger any fading effect or displaying any tooltip.

Steps to try:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'Apples' as product, 10 as profit
union all
select 'Bananas' as product, 4 as profit
```

**Before this change**: Hover the mouse under the Bananas bar and there will be a fading effect as well as a tooltip being shown.

**After this change**: Hover the mouse under the Bananas bar and there should not be any fading effect nor tooltip being shown.

![image](https://user-images.githubusercontent.com/7288/101691495-a0bded00-3a23-11eb-93f9-51e0edcd3d9f.png)
