### PR TITLE
add useAutoSizerHeight prop to VirtualizedList and use on CollectionContent

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -347,6 +347,9 @@ export default class CollectionContent extends React.Component {
                         </ItemDragSource>
                       </Box>
                     )}
+                    // needed in order to prevent an issue with content not fully rendering
+                    // due to the collection content scrolling layout
+                    useAutoSizerHeight={true}
                   />
                 </Box>
               </PinDropTarget>

--- a/frontend/src/metabase/components/VirtualizedList.jsx
+++ b/frontend/src/metabase/components/VirtualizedList.jsx
@@ -2,15 +2,23 @@ import React from "react";
 
 import { List, WindowScroller, AutoSizer } from "react-virtualized";
 
-const VirtualizedList = ({ items, rowHeight, renderItem }) => (
+const VirtualizedList = ({
+  items,
+  rowHeight,
+  renderItem,
+  useAutoSizerHeight = false,
+}) => (
   <AutoSizer>
-    {({ width }) => (
+    {({ height: autosizerHeight, width }) => (
       <WindowScroller>
         {({ height, isScrolling, scrollTop }) => (
           <List
             autoHeight
             width={width}
-            height={Math.min(height, rowHeight * items.length)}
+            height={Math.min(
+              useAutoSizerHeight ? autosizerHeight : height,
+              rowHeight * items.length,
+            )}
             isScrolling={isScrolling}
             rowCount={items.length}
             rowHeight={rowHeight}


### PR DESCRIPTION
## What this does
Fixes an issue where the new collection layout's `VirtualizedList` component wasn't fully rendering all non pinned items. The reason that seemed to be happening was due to an incorrectly calculated height prop being applied to the `List` component inside of `VirtualizedList` To be perfectly honest I'm not 100% sure why the switch from using the `WindowScroller` `height` to the `AutoSizer` `height` fixes this, but my current hypothesis is that our use of `calc(100vh - 65px)` to set the height of the main content area is something that `AutoSizer` was able to take into accoutn but `WindowScroller` wasn't. Or it may be unrelated. In any event, this seems to get things working again and I tried to apply this new prop in a way that is isolated to this instance.  

## To test
1. Load up any collection with  a decent number of items, > 25 seems to be enough to trigger the behavior consistently.
2. You should be able to see all your items when you scroll through your list