### PR TITLE
Microseconds support (:type/UNIXTimestampMicroseconds) (#1889)

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -259,6 +259,11 @@ export const field_special_types = [
     section: t`Date and Time`,
   },
   {
+    id: TYPE.UNIXTimestampMicroseconds,
+    name: t`UNIX Timestamp (Microseconds)`,
+    section: t`Date and Time`,
+  },
+  {
     id: TYPE.UNIXTimestampSeconds,
     name: t`UNIX Timestamp (Seconds)`,
     section: t`Date and Time`,

--- a/frontend/test/metabase-bootstrap.js
+++ b/frontend/test/metabase-bootstrap.js
@@ -97,6 +97,7 @@ window.MetabaseBootstrap = {
     "type/ImageURL": ["type/URL"],
     "type/Price": ["type/Currency"],
     "type/UNIXTimestampMilliseconds": ["type/UNIXTimestamp"],
+    "type/UNIXTimestampMicroseconds": ["type/UNIXTimestamp"],
     "type/Collection": ["type/*"],
     "type/User": ["type/*"],
     "type/Array": ["type/Collection"],

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -356,7 +356,8 @@
   (trunc (keyword (format "week(%s)" (name (setting/get-keyword :start-of-week)))) expr))
 
 (doseq [[unix-timestamp-type bigquery-fn] {:seconds      :timestamp_seconds
-                                           :milliseconds :timestamp_millis}]
+                                           :milliseconds :timestamp_millis
+                                           :microseconds :timestamp_micros}]
   (defmethod sql.qp/unix-timestamp->honeysql [:bigquery unix-timestamp-type]
     [_ _ expr]
     (with-temporal-type (hsql/call bigquery-fn expr) :timestamp)))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -132,6 +132,9 @@
   (let [field-name (str \$ (field->name field "."))]
     (cond
       ;; TIMEZONE FIXME — use `java.time` classes
+      (isa? (:special_type field) :type/UNIXTimestampMicroseconds)
+      {$add [(java.util.Date. 0) {$divide [field-name 1000]}]}
+
       (isa? (:special_type field) :type/UNIXTimestampMilliseconds)
       {$add [(java.util.Date. 0) field-name]}
 

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -179,7 +179,7 @@
   [driver _ field-or-value]
   (sql.qp/unix-timestamp->honeysql driver :seconds (hx// field-or-value (hsql/raw 1000))))
 
-(defmethod sql.qp/unix-timestamp->honeysql [:oracle :milliseconds]
+(defmethod sql.qp/unix-timestamp->honeysql [:oracle :microseconds]
   [driver _ field-or-value]
   (sql.qp/unix-timestamp->honeysql driver :seconds (hx// field-or-value (hsql/raw 1000000))))
 

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -179,6 +179,10 @@
   [driver _ field-or-value]
   (sql.qp/unix-timestamp->honeysql driver :seconds (hx// field-or-value (hsql/raw 1000))))
 
+(defmethod sql.qp/unix-timestamp->honeysql [:oracle :milliseconds]
+  [driver _ field-or-value]
+  (sql.qp/unix-timestamp->honeysql driver :seconds (hx// field-or-value (hsql/raw 1000000))))
+
 ;; Oracle doesn't support `LIMIT n` syntax. Instead we have to use `WHERE ROWNUM <= n` (`NEXT n ROWS ONLY` isn't
 ;; supported on Oracle versions older than 12). This has to wrap the actual query, e.g.
 ;;

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -118,6 +118,7 @@
 
 (defmethod sql.qp/unix-timestamp->honeysql [:snowflake :seconds]      [_ _ expr] (hsql/call :to_timestamp expr))
 (defmethod sql.qp/unix-timestamp->honeysql [:snowflake :milliseconds] [_ _ expr] (hsql/call :to_timestamp expr 3))
+(defmethod sql.qp/unix-timestamp->honeysql [:snowflake :microseconds] [_ _ expr] (hsql/call :to_timestamp expr 6))
 
 (defmethod sql.qp/current-datetime-honeysql-form :snowflake
   [_]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -147,6 +147,9 @@
 (defmethod sql.qp/unix-timestamp->honeysql [:h2 :millisecond] [_ _ expr]
   (add-to-1970 expr "millisecond"))
 
+(defmethod sql.qp/unix-timestamp->honeysql [:h2 :millisecond] [_ _ expr]
+  (add-to-1970 expr "microsecond"))
+
 
 ;; H2 doesn't have date_trunc() we fake it by formatting a date to an appropriate string
 ;; and then converting back to a date.

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -240,10 +240,9 @@
   (:replacement-snippet
    (honeysql->replacement-snippet-info
     driver
-    (let [identifier (sql.qp/->honeysql driver (sql.qp/field->identifier driver field))
-          identifier (cond->> identifier
-                       (isa? special-type :type/UNIXTimestampSeconds)      (sql.qp/unix-timestamp->honeysql driver :seconds)
-                       (isa? special-type :type/UNIXTimestampMilliseconds) (sql.qp/unix-timestamp->honeysql driver :milliseconds))]
+    (let [identifier (cond->> (sql.qp/->honeysql driver (sql.qp/field->identifier driver field))
+                       (isa? special-type :type/UNIXTimestamp)
+                       (sql.qp/unix-timestamp->honeysql* driver special-type))]
       (if (date-params/date-type? param-type)
         (sql.qp/date driver :day identifier)
         identifier)))))

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -242,7 +242,7 @@
     driver
     (let [identifier (cond->> (sql.qp/->honeysql driver (sql.qp/field->identifier driver field))
                        (isa? special-type :type/UNIXTimestamp)
-                       (sql.qp/unix-timestamp->honeysql* driver special-type))]
+                       (sql.qp/unix-timestamp->honeysql driver (sql.qp/special-type->unit special-type)))]
       (if (date-params/date-type? param-type)
         (sql.qp/date driver :day identifier)
         identifier)))))

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -242,7 +242,7 @@
     driver
     (let [identifier (cond->> (sql.qp/->honeysql driver (sql.qp/field->identifier driver field))
                        (isa? special-type :type/UNIXTimestamp)
-                       (sql.qp/unix-timestamp->honeysql driver (sql.qp/special-type->unit special-type)))]
+                       (sql.qp/unix-timestamp->honeysql driver (sql.qp/special-type->unix-timestamp-unit special-type)))]
       (if (date-params/date-type? param-type)
         (sql.qp/date driver :day identifier)
         identifier)))))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -271,8 +271,10 @@
   [driver [_ _ expression-definition]]
   (->honeysql driver expression-definition))
 
-(defn special-type->unit
-  "Translates types like `:type/UNIXTimestampSeconds` to the corresponding unit of time to use."
+(defn special-type->unix-timestamp-unit
+  "Translates types like `:type/UNIXTimestampSeconds` to the corresponding unit of time to use in
+  `unix-timestamp->honeysql`.  Throws an AssertionError if the argument does not descend from `:type/UNIXTimestamp`
+  and an exception if the type does not have an associated unit."
   [special-type]
   (assert (isa? special-type :type/UNIXTimestamp) "Special type must be a UNIXTimestamp")
   (or (get {:type/UNIXTimestampMicroseconds :microseconds
@@ -286,7 +288,7 @@
   [driver field field-identifier]
   (match [(:base_type field) (:special_type field)]
     [(:isa? :type/Number)   (:isa? :type/UNIXTimestamp)]  (unix-timestamp->honeysql driver
-                                                                                    (special-type->unit (:special_type field))
+                                                                                    (special-type->unix-timestamp-unit (:special_type field))
                                                                                     field-identifier)
     [:type/Text             (:isa? :type/TemporalString)] (cast-temporal-string driver (:special_type field) field-identifier)
     :else field-identifier))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -287,7 +287,7 @@
   "Wrap a `field-identifier` in appropriate HoneySQL expressions if it refers to a UNIX timestamp Field."
   [driver field field-identifier]
   (match [(:base_type field) (:special_type field)]
-    [(:isa? :type/Integer)  (:isa? :type/UNIXTimestamp)]  (unix-timestamp->honeysql* driver (:special_type field) field-identifier)
+    [(:isa? :type/Number)   (:isa? :type/UNIXTimestamp)]  (unix-timestamp->honeysql* driver (:special_type field) field-identifier)
     [:type/Text             (:isa? :type/TemporalString)] (cast-temporal-string driver (:special_type field) field-identifier)
     :else field-identifier))
 

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -109,6 +109,7 @@
 (derive :type/UNIXTimestamp :type/Integer)
 (derive :type/UNIXTimestampSeconds :type/UNIXTimestamp)
 (derive :type/UNIXTimestampMilliseconds :type/UNIXTimestamp)
+(derive :type/UNIXTimestampMicroseconds :type/UNIXTimestamp)
 
 (derive :type/TemporalString :type/Text)
 (derive :type/TemporalString :type/DateTime)

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -20,8 +20,12 @@
      [0 1433965860000000]]]])
 
 (deftest microseconds-test
-  (mt/test-drivers (mt/normal-drivers)
+  (mt/test-drivers (disj (mt/normal-drivers) :sqlite)
     (is (= #{[1 4 "2015-06-06T10:40:00Z"] [2 0 "2015-06-10T19:51:00Z"]}
+           (set (mt/rows (mt/dataset toucan-microsecond-incidents
+                           (mt/run-mbql-query incidents)))))))
+  (mt/test-drivers #{:sqlite}
+    (is (= #{[1 4 "2015-06-06 10:40:00"] [2 0 "2015-06-10 19:51:00"]}
            (set (mt/rows (mt/dataset toucan-microsecond-incidents
                            (mt/run-mbql-query incidents))))))))
 

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -21,13 +21,14 @@
 
 (deftest microseconds-test
   (mt/test-drivers (disj (mt/normal-drivers) :sqlite)
-    (is (= #{[1 4 "2015-06-06T10:40:00Z"] [2 0 "2015-06-10T19:51:00Z"]}
-           (set (mt/rows (mt/dataset toucan-microsecond-incidents
-                           (mt/run-mbql-query incidents)))))))
-  (mt/test-drivers #{:sqlite}
-    (is (= #{[1 4 "2015-06-06 10:40:00"] [2 0 "2015-06-10 19:51:00"]}
-           (set (mt/rows (mt/dataset toucan-microsecond-incidents
-                           (mt/run-mbql-query incidents))))))))
+    (let [results (get {:sqlite #{[1 4 "2015-06-06 10:40:00"] [2 0 "2015-06-10 19:51:00"]}
+                        :oracle #{[1M 4M "2015-06-06T10:40:00Z"] [2M 0M "2015-06-10T19:51:00Z"]}}
+                       driver/*driver*
+                       ;; default result shape
+                       #{[1 4 "2015-06-06T10:40:00Z"] [2 0 "2015-06-10T19:51:00Z"]})]
+      (is (= results
+             (set (mt/rows (mt/dataset toucan-microsecond-incidents
+                             (mt/run-mbql-query incidents)))))))))
 
 (deftest filter-test
   (mt/test-drivers (mt/normal-drivers)

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -8,7 +8,15 @@
              [query-processor-test :as qp.test]
              [test :as mt]
              [util :as u]]
+            [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]))
+
+(deftest special-type->unit-test
+  (testing "every descendant of `:type/UNIXTimestamp` has a unit associated with it"
+    (doseq [special-type (descendants :type/UNIXTimestamp)]
+      (is (sql.qp/special-type->unit special-type))))
+  (testing "throws if argument is not a descendant of `:type/UNIXTimestamp`"
+    (is (thrown? AssertionError (sql.qp/special-type->unit :type/Integer)))))
 
 (mt/defdataset toucan-microsecond-incidents
   [["incidents" [{:field-name "severity"

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -10,6 +10,21 @@
              [util :as u]]
             [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]))
 
+(mt/defdataset toucan-microsecond-incidents
+  [["incidents" [{:field-name "severity"
+                  :base-type  :type/Integer}
+                 {:field-name   "timestamp"
+                  :base-type    :type/BigInteger
+                  :special-type :type/UNIXTimestampMicroseconds}]
+    [[4 1433587200000000]
+     [0 1433965860000000]]]])
+
+(deftest microseconds-test
+  (mt/test-drivers (mt/normal-drivers)
+    (is (= #{[1 4 "2015-06-06T10:40:00Z"] [2 0 "2015-06-10T19:51:00Z"]}
+           (set (mt/rows (mt/dataset toucan-microsecond-incidents
+                           (mt/run-mbql-query incidents))))))))
+
 (deftest filter-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= 10

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -11,12 +11,12 @@
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]))
 
-(deftest special-type->unit-test
+(deftest special-type->unix-timestamp-unit-test
   (testing "every descendant of `:type/UNIXTimestamp` has a unit associated with it"
     (doseq [special-type (descendants :type/UNIXTimestamp)]
-      (is (sql.qp/special-type->unit special-type))))
+      (is (sql.qp/special-type->unix-timestamp-unit special-type))))
   (testing "throws if argument is not a descendant of `:type/UNIXTimestamp`"
-    (is (thrown? AssertionError (sql.qp/special-type->unit :type/Integer)))))
+    (is (thrown? AssertionError (sql.qp/special-type->unix-timestamp-unit :type/Integer)))))
 
 (mt/defdataset toucan-microsecond-incidents
   [["incidents" [{:field-name "severity"


### PR DESCRIPTION
fixes #1889 

Simple addition to support microseconds

Databases that have implementations for milliseconds also got an implementation of microseconds, presumably as there is a native way that is faster than division and converting seconds.

- oracle (seemingly just needs the literal 100000 marked as `hsql/raw`
- snowflake (uses a `to_timestamp expr 6` function)
- h2 natively understands the unit "microsecond" in its conversion function
- bigquery has a native `timestamp_micros` function
