### PR TITLE
#13960 Repro: Should clear default filter value and preserve "state" on reload

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -325,11 +325,11 @@ describe("scenarios > question > filter", () => {
 
         cy.location("search").should("eq", "?id=1");
 
-        // Reload" page, or rather visit the dashboard link again
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        cy.reload();
 
         cy.findByText("13960");
         cy.findAllByText("Doohickey").should("not.exist");
+        // TODO: depending on how this issue will be fixed, the next assertion might need to be updated
         cy.location("search").should("eq", "?id=1");
       });
     });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -11,8 +11,10 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { ORDERS, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > question > filter", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it.skip("should load needed data (metabase#12985)", () => {
     // Save a Question


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13960 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed


### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Test should be failing at this point before the issue is fixed:
![image](https://user-images.githubusercontent.com/31325167/101780507-eac3d300-3af6-11eb-8b56-1f9177eb5a03.png)


