### PR TITLE
Allow filters to work in pivot tables

### DIFF
--- a/src/metabase/api/advanced_computation/common.clj
+++ b/src/metabase/api/advanced_computation/common.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.advanced-computation.common
   "Common routines between the public and internal endpoints for /api/advanced_computation"
-  (:require [cheshire.core :as json]
-            [clojure.core.async :as a]
+  (:require [clojure.core.async :as a]
             [metabase.api.common :as api]
             [metabase.query-processor :as qp]
             [metabase.query-processor

--- a/src/metabase/api/advanced_computation/common.clj
+++ b/src/metabase/api/advanced_computation/common.clj
@@ -62,10 +62,7 @@
   ([context query info]
    (qp.store/with-store
      (let [main-breakout           (:breakout (:query query))
-           col-determination-query (-> query
-                                       ;; TODO: move this to a bitmask or something that scales better / easier to use
-                                       (assoc-in [:query :expressions] {"pivot-grouping" [:ltrim (json/generate-string main-breakout)]})
-                                       (assoc-in [:query :fields] [[:expression "pivot-grouping"]])
+           col-determination-query (-> (pivot/add-grouping-field query main-breakout)
                                        (dissoc :async?))
            all-expected-cols       (qp/query->expected-cols col-determination-query)
            all-queries             (pivot/generate-queries query)]

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -176,7 +176,7 @@
   it. This only works for pure MBQL queries, since it does not actually run the queries. Native queries or MBQL
   queries with native source queries won't work, since we don't need the results."
   [{query-type :type, :as query}]
-  (when-not (= query-type :query)
+  (when-not (= (keyword query-type) :query)
     (throw (ex-info (tru "Can only determine expected columns for MBQL queries.")
              {:type error-type/qp})))
   ;; TODO - we should throw an Exception if the query has a native source query or at least warn about it. Need to

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -11,6 +11,7 @@
              [driver :as driver]
              [util :as u]]
             [metabase.driver.util :as driver.u]
+            [metabase.mbql.util :as mbql.u]
             [metabase.plugins.classloader :as classloader]
             [metabase.query-processor
              [context :as context]
@@ -176,7 +177,7 @@
   it. This only works for pure MBQL queries, since it does not actually run the queries. Native queries or MBQL
   queries with native source queries won't work, since we don't need the results."
   [{query-type :type, :as query}]
-  (when-not (= (keyword query-type) :query)
+  (when-not (= (mbql.u/normalize-token query-type) :query)
     (throw (ex-info (tru "Can only determine expected columns for MBQL queries.")
              {:type error-type/qp})))
   ;; TODO - we should throw an Exception if the query has a native source query or at least warn about it. Need to

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -19,6 +19,14 @@
                    [:fk-> $orders.user_id $people.source]
                    [:fk-> $orders.product_id $products.category]]}))
 
+(defn- filters-query
+  []
+  (mt/mbql-query orders
+    {:aggregation [[:count]]
+     :breakout    [[:fk-> $orders.user_id $people.state]
+                   [:fk-> $orders.user_id $people.source]]
+     :filter      [:and [:= [:fk-> $orders.user_id $people.source] "Google" "Organic"]]}))
+
 (defn- pivot-card
   []
   {:dataset_query (pivot-query)})
@@ -62,6 +70,24 @@
           (is (= ["AK" "Affiliate" "Doohickey" 18 81] (drop-last (first rows))))
           (is (= ["MS" nil "Doohickey" 78 291] (drop-last (nth rows 1000))))
           (is (= [nil nil nil 18760 69540] (drop-last (last rows)))))))))
+
+(deftest pivot-filter-dataset-test
+  (mt/dataset sample-dataset
+    (testing "POST /api/advanced_computation/pivot/dataset"
+       (testing "Run a pivot table"
+         (let [result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" (filters-query))
+               rows   (mt/rows result)]
+           (is (= 140 (:row_count result)))
+           (is (= "completed" (:status result)))
+           (is (= 4 (count (get-in result [:data :cols]))))
+           (is (= 140 (count rows)))
+
+           ;; spot checking rows, but leaving off the discriminator on the end
+           (is (= ["AK" "Google" 119] (drop-last (first rows))))
+           (is (= ["AK" "Organic" 89] (drop-last (second rows))))
+           (is (= [nil "Google" 3798] (drop-last (nth rows 90))))
+           (is (= [nil "Organic" 3764] (drop-last (nth rows 91))))
+           (is (= [nil nil 7562] (drop-last (last rows)))))))))
 
 (deftest pivot-card-test
   (mt/dataset sample-dataset


### PR DESCRIPTION
The `query->expected-cols` function only worked with queries of the type `:query` but `"query"` is perfectly valid also.

Modify the function to take that type, and remove the extraneous calls to `preprocess-query` - the result of a call to
`preprocess-query` cannot be passed to `preprocess-query` a second time without causing a schema violation error.
