### PR TITLE
Enclose negative values in waterfall inside parentheses

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -77,6 +77,7 @@ export type FormattingOptions = {
   prefix?: string,
   suffix?: string,
   scale?: number,
+  negativeInParentheses?: boolean,
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
   scale?: number,
   number_separators?: NumberSeparators,
@@ -171,6 +172,15 @@ export function formatNumber(number: number, options: FormattingOptions = {}) {
 
   if (typeof options.scale === "number" && !isNaN(options.scale)) {
     number = options.scale * number;
+  }
+
+  if (number < 0 && options.negativeInParentheses) {
+    return (
+      "(" +
+      // $FlowFixMe coerce into string
+      formatNumber(-number, { ...options, negativeInParentheses: false }) +
+      ")"
+    );
   }
 
   if (options.compact) {

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -265,6 +265,7 @@ export function onRenderValueLabels(
         .attr("class", klass)
         .text(({ y, seriesIndex }) =>
           formatYValue(y, {
+            negativeInParentheses: displays[seriesIndex] === "waterfall",
             compact: compact === null ? compactForSeries[seriesIndex] : compact,
           }),
         ),

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -31,6 +31,19 @@ describe("formatting", () => {
       expect(formatNumber(-1 / 3)).toEqual("-0.33");
       expect(formatNumber(0.0001 / 3)).toEqual("0.000033");
     });
+    describe("in enclosing negative mode", () => {
+      it("should format -4 as (4)", () => {
+        expect(formatNumber(-4, { negativeInParentheses: true })).toEqual(
+          "(4)",
+        );
+      });
+      it("should format 7 as 7", () => {
+        expect(formatNumber(7, { negativeInParentheses: true })).toEqual("7");
+      });
+      it("should format 0 as 0", () => {
+        expect(formatNumber(0, { negativeInParentheses: true })).toEqual("0");
+      });
+    });
     describe("in compact mode", () => {
       it("should format 0 as 0", () => {
         expect(formatNumber(0, { compact: true })).toEqual("0");


### PR DESCRIPTION
Steps to try:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 'Apples' as product, 10 as profit
union all
select 'Bananas' as product, -4 as profit
```
4. Visualization, Waterfall
5. Settings, Display, Show values on data points

**Before this change**: The value for Bananas is formatted `-4`.

**After this change**: The value for Bananas is a number enclosed in parentheses, i.e. `(4)`.

![image](https://user-images.githubusercontent.com/7288/101819370-02d92980-3ada-11eb-917b-1f6fb1efeae7.png)

