### PR TITLE
Pivot table fixes

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -707,6 +707,9 @@ export default class StructuredQuery extends AtomicQuery {
    * @returns An array of MBQL @type {Breakout}s.
    */
   breakouts(): BreakoutWrapper[] {
+    if (this.query() == null) {
+      return [];
+    }
     return Q.getBreakouts(this.query()).map(
       (breakout, index) => new BreakoutWrapper(breakout, index, this),
     );

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -163,3 +163,7 @@ textarea {
     transform: rotate(-360deg);
   }
 }
+
+.no-outline * {
+  outline: none;
+}

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -3,13 +3,47 @@ import { getIn } from "icepick";
 
 import { formatValue } from "metabase/lib/formatting";
 
+export function isPivotGroupColumn(col) {
+  return col.name === "pivot-grouping";
+}
+
+// This pulls apart the different aggregations that were packed into one result set.
+// There's a column indicating which breakouts were used to compute that row.
+// We use that column to split apart the data and convert the field refs to indexes.
+function splitPivotData(data, rowIndexes, columnIndexes) {
+  const groupIndex = data.cols.findIndex(isPivotGroupColumn);
+  const columns = data.cols.filter(col => !isPivotGroupColumn(col));
+  const pivotData = _.chain(data.rows)
+    .groupBy(row => row[groupIndex])
+    .pairs()
+    .map(([key, rows]) => {
+      const indexes = JSON.parse(key).map(breakout =>
+        columns.findIndex(col => _.isEqual(col.field_ref, breakout)),
+      );
+      const keyAsIndexes = JSON.stringify(indexes);
+      const rowsWithoutColumn = rows.map(row =>
+        row.slice(0, groupIndex).concat(row.slice(groupIndex + 1)),
+      );
+
+      return [keyAsIndexes, rowsWithoutColumn];
+    })
+    .object()
+    .value();
+  return { pivotData, columns };
+}
+
 export function multiLevelPivot(
-  pivotData,
-  columns,
+  data,
   columnColumnIndexes,
   rowColumnIndexes,
   valueColumnIndexes,
 ) {
+  const { pivotData, columns } = splitPivotData(
+    data,
+    rowColumnIndexes,
+    columnColumnIndexes,
+  );
+
   // we build a tree for each tuple of pivoted column/row values seen in the data
   const columnColumnTree = [];
   const rowColumnTree = [];
@@ -18,11 +52,10 @@ export function multiLevelPivot(
   const valuesByKey = {};
 
   // loop over the primary rows to build trees of column/row header data
-  for (const row of pivotData[
-    JSON.stringify(
-      _.range(columnColumnIndexes.length + rowColumnIndexes.length),
-    )
-  ]) {
+  const primaryRowsKey = JSON.stringify(
+    _.range(columnColumnIndexes.length + rowColumnIndexes.length),
+  );
+  for (const row of pivotData[primaryRowsKey]) {
     // mutate the trees to add the tuple from the current row
     updateValueObject(row, columnColumnIndexes, columnColumnTree);
     updateValueObject(row, rowColumnIndexes, rowColumnTree);

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -137,7 +137,7 @@ function createRowSectionGetter({
           : [];
 
       return rows
-        .map(row => [getSubtotals(rowColumnIndexes, row)])
+        .map(row => getSubtotals(rowColumnIndexes, row))
         .concat(subtotalRows);
     }
 

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -120,7 +120,7 @@ function createRowSectionGetter({
 }) {
   const formatValues = values =>
     values === undefined
-      ? new Array(valueFormatters.length).fill({ value: null })
+      ? Array(valueFormatters.length).fill({ value: null })
       : values.map((v, i) => ({ value: valueFormatters[i](v) }));
   const getSubtotals = (breakoutIndexes, values) =>
     formatValues(

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -87,8 +87,8 @@ function createRowSectionGetter({
 }) {
   const formatValues = values =>
     values === undefined
-      ? new Array(valueFormatters.length).fill(null)
-      : values.map((v, i) => valueFormatters[i](v));
+      ? new Array(valueFormatters.length).fill({ value: null })
+      : values.map((v, i) => ({ value: valueFormatters[i](v) }));
   const getSubtotals = (breakoutIndexes, values) =>
     formatValues(
       getIn(
@@ -99,7 +99,7 @@ function createRowSectionGetter({
           ),
         ),
       ),
-    );
+    ).map(value => ({ ...value, isSubtotal: true }));
 
   return (columnIndex, rowIndex) => {
     const rows =

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -26,6 +26,7 @@ import {
   EmbedApi,
   setPublicQuestionEndpoints,
   setEmbedQuestionEndpoints,
+  maybeUsePivotEndpoint,
 } from "metabase/services";
 
 import { setErrorPage } from "metabase/redux/app";
@@ -163,7 +164,7 @@ export default class PublicQuestion extends Component {
       } else if (uuid) {
         // public links currently apply parameters client-side
         const datasetQuery = applyParameters(card, parameters, parameterValues);
-        newResult = await PublicApi.cardQuery({
+        newResult = await maybeUsePivotEndpoint(PublicApi.cardQuery, card)({
           uuid,
           parameters: JSON.stringify(datasetQuery.parameters),
         });

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -839,7 +839,9 @@ export const updateQuestion = (
     const isPivot = newQuestion.display() === "pivot";
     const wasPivot = oldQuestion.display() === "pivot";
     const queryHasBreakouts =
-      isPivot && newQuestion.query().breakouts().length > 0;
+      isPivot &&
+      newQuestion.isStructured() &&
+      newQuestion.query().breakouts().length > 0;
 
     // we can only pivot queries with breakouts
     if (queryHasBreakouts) {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -838,34 +838,39 @@ export const updateQuestion = (
     // We have special logic when going to, coming from, or updating a pivot table.
     const isPivot = newQuestion.display() === "pivot";
     const wasPivot = oldQuestion.display() === "pivot";
+    const queryHasBreakouts =
+      isPivot && newQuestion.query().breakouts().length > 0;
 
-    if (isPivot && !wasPivot) {
-      // compute the pivot setting now so we can query the appropriate data
-      const series = assocIn(
-        getRawSeries(getState()),
-        [0, "card", "display"],
-        "pivot",
-      );
-      const key = "pivot_table.column_split";
-      const setting = getQuestionWithDefaultVisualizationSettings(
-        newQuestion,
-        series,
-      ).setting(key);
-      newQuestion = newQuestion.updateSettings({ [key]: setting });
-    }
+    // we can only pivot queries with breakouts
+    if (queryHasBreakouts) {
+      if (isPivot && !wasPivot) {
+        // compute the pivot setting now so we can query the appropriate data
+        const series = assocIn(
+          getRawSeries(getState()),
+          [0, "card", "display"],
+          "pivot",
+        );
+        const key = "pivot_table.column_split";
+        const setting = getQuestionWithDefaultVisualizationSettings(
+          newQuestion,
+          series,
+        ).setting(key);
+        newQuestion = newQuestion.updateSettings({ [key]: setting });
+      }
 
-    if (
-      // switching to pivot
-      (isPivot && !wasPivot) ||
-      // switching away from pivot
-      (!isPivot && wasPivot) ||
-      // updating the pivot rows/cols
-      !_.isEqual(
-        newQuestion.setting("pivot_table.column_split"),
-        oldQuestion.setting("pivot_table.column_split"),
-      )
-    ) {
-      run = true; // force a run when switching to/from pivot or updating it's setting
+      if (
+        // switching to pivot
+        (isPivot && !wasPivot) ||
+        // switching away from pivot
+        (!isPivot && wasPivot) ||
+        // updating the pivot rows/cols
+        !_.isEqual(
+          newQuestion.setting("pivot_table.column_split"),
+          oldQuestion.setting("pivot_table.column_split"),
+        )
+      ) {
+        run = true; // force a run when switching to/from pivot or updating it's setting
+      }
     }
     // </PIVOT LOGIC>
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -425,7 +425,7 @@ export const getIsVisualized = createSelector(
   (question, settings) =>
     question &&
     // table is the default
-    (question.display() !== "table" ||
+    ((question.display() !== "table" && question.display() !== "pivot") ||
       // any "table." settings has been explcitly set
       Object.keys(question.settings()).some(k => k.startsWith("table.")) ||
       // "table.pivot" setting has been implicitly set to true

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -325,7 +325,10 @@ export default class PivotTable extends Component {
                         </div>
                         {showRowSubtotals && (
                           <Cell
-                            value={t`Totals for ${leftIndex[index][0][0].value}`}
+                            value={t`Totals for ${formatValue(
+                              leftIndex[index][0][0].value,
+                              { column: columns[rowIndexes[0]] },
+                            )}`}
                             isSubtotal
                             width={leftIndex[0].length}
                           />

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -183,7 +183,7 @@ export default class PivotTable extends Component {
     }
 
     return (
-      <div className="overflow-scroll">
+      <div className="overflow-scroll no-outline">
         <ScrollSync>
           {({ onScroll, scrollLeft, scrollTop }) => (
             <div>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -153,8 +153,6 @@ export default class PivotTable extends Component {
       rowCount,
       columnCount,
     } = pivoted;
-    const CELL_WIDTH = 100;
-    const CELL_HEIGHT = 25;
     const topHeaderHeight =
       topIndex.length === 0
         ? CELL_HEIGHT

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -31,6 +31,8 @@ const partitions = [
   },
 ];
 
+const CELL_WIDTH = 100;
+const CELL_HEIGHT = 25;
 export default class PivotTable extends Component {
   props: VisualizationProps;
   static uiName = t`Pivot Table`;
@@ -39,13 +41,14 @@ export default class PivotTable extends Component {
 
   static isSensible({ cols }) {
     return (
+      cols.length >= 2 &&
       cols.every(isColumnValid) &&
       cols.filter(col => col.source === "breakout").length < 5
     );
   }
 
   static checkRenderable([{ data }]) {
-    if (!data.cols.every(isColumnValid)) {
+    if (data.cols.length < 2 || !data.cols.every(isColumnValid)) {
       throw new Error(
         t`Pivot tables can only be used with aggregated queries.`,
       );
@@ -165,30 +168,32 @@ export default class PivotTable extends Component {
       rowCount,
       columnCount,
     } = pivoted;
-    const cellWidth = 100;
-    const cellHeight = 25;
+    const CELL_WIDTH = 100;
+    const CELL_HEIGHT = 25;
     const topHeaderHeight =
-      topIndex.length === 0 ? cellHeight : topIndex[0].length * cellHeight + 8; // the extravertical padding
+      topIndex.length === 0
+        ? CELL_HEIGHT
+        : topIndex[0].length * CELL_HEIGHT + 8; // the extravertical padding
     const leftHeaderWidth =
-      leftIndex.length === 0 ? 0 : leftIndex[0].length * cellWidth;
+      leftIndex.length === 0 ? 0 : leftIndex[0].length * CELL_WIDTH;
 
     function columnWidth({ index }) {
       if (topIndex.length === 0 || index === topIndex.length) {
-        return cellWidth;
+        return CELL_WIDTH;
       }
       const indexItem = topIndex[index];
-      return indexItem[indexItem.length - 1].length * cellWidth;
+      return indexItem[indexItem.length - 1].length * CELL_WIDTH;
     }
 
     const showRowSubtotals = leftIndex[0].length > 1;
     function rowHeight({ index }) {
       if (leftIndex.length === 0 || index === leftIndex.length) {
-        return cellHeight;
+        return CELL_HEIGHT;
       }
       const indexItem = leftIndex[index];
       return (
         (indexItem[indexItem.length - 1].length + (showRowSubtotals ? 1 : 0)) *
-        cellHeight
+        CELL_HEIGHT
       );
     }
 
@@ -206,12 +211,7 @@ export default class PivotTable extends Component {
                 {/* top left corner - displays left header columns */}
                 <div className="flex align-end border-right border-bottom border-medium">
                   {rowIndexes.map(index => (
-                    <div
-                      style={{ height: cellHeight, width: cellWidth }}
-                      className="px1"
-                    >
-                      <Ellipsified>{formatColumn(columns[index])}</Ellipsified>
-                    </div>
+                    <Cell value={formatColumn(columns[index])} />
                   ))}
                 </div>
                 {/* top header */}
@@ -230,11 +230,12 @@ export default class PivotTable extends Component {
                         <div
                           key={key}
                           style={style}
-                          className="flex-column px1 pt1"
+                          className="flex-column justify-end px1 pt1"
                         >
-                          <div className="flex" style={{ height: cellHeight }}>
-                            <Ellipsified>{t`Row totals`}</Ellipsified>
-                          </div>
+                          <Cell
+                            value={t`Row totals`}
+                            width={valueIndexes.length}
+                          />
                         </div>
                       );
                     }
@@ -246,10 +247,10 @@ export default class PivotTable extends Component {
                         className="flex-column px1 pt1"
                       >
                         {rows.map((row, index) => (
-                          <div className="flex" style={{ height: cellHeight }}>
+                          <div className="flex" style={{ height: CELL_HEIGHT }}>
                             {row.map(({ value, span }) => (
                               <div
-                                style={{ width: cellWidth * span }}
+                                style={{ width: CELL_WIDTH * span }}
                                 className={cx({
                                   "border-bottom": index < rows.length - 1,
                                 })}
@@ -282,15 +283,11 @@ export default class PivotTable extends Component {
                       return (
                         <div key={key} style={style} className="flex">
                           <div className="flex flex-column">
-                            <div
-                              style={{
-                                height: cellHeight,
-                                width: cellWidth * rowIndexes.length,
-                              }}
-                              className="p1"
-                            >
-                              <Ellipsified>{t`Grand totals`}</Ellipsified>
-                            </div>
+                            <Cell
+                              value={t`Grand totals`}
+                              isSubtotal
+                              width={rowIndexes.length}
+                            />
                           </div>
                         </div>
                       );
@@ -303,15 +300,23 @@ export default class PivotTable extends Component {
                               {col.map(({ value, span = 1 }) => (
                                 <div
                                   style={{
-                                    height: cellHeight * span,
-                                    width: cellWidth,
+                                    height: CELL_HEIGHT * span,
+                                    width: CELL_WIDTH,
                                   }}
-                                  className="p1"
+                                  className="px1"
                                 >
                                   <Ellipsified>
-                                    {formatValue(value, {
-                                      column: columns[rowIndexes[index]],
-                                    })}
+                                    <div
+                                      style={{
+                                        height: CELL_HEIGHT,
+                                        lineHeight: `${CELL_HEIGHT}px`,
+                                        width: CELL_WIDTH,
+                                      }}
+                                    >
+                                      {formatValue(value, {
+                                        column: columns[rowIndexes[index]],
+                                      })}
+                                    </div>
                                   </Ellipsified>
                                 </div>
                               ))}
@@ -319,10 +324,11 @@ export default class PivotTable extends Component {
                           ))}
                         </div>
                         {showRowSubtotals && (
-                          <div
-                            style={{ height: cellHeight }}
-                            className="p1"
-                          >{t`Totals for ${leftIndex[index][0][0].value}`}</div>
+                          <Cell
+                            value={t`Totals for ${leftIndex[index][0][0].value}`}
+                            isSubtotal
+                            width={leftIndex[0].length}
+                          />
                         )}
                       </div>
                     );
@@ -346,13 +352,8 @@ export default class PivotTable extends Component {
                       <div key={key} style={style} className="flex flex-column">
                         {rows.map(row => (
                           <div className="flex">
-                            {row.map(value => (
-                              <div
-                                style={{ width: cellWidth, height: cellHeight }}
-                                className="p1"
-                              >
-                                {value}
-                              </div>
+                            {row.map(({ value, isSubtotal }) => (
+                              <Cell value={value} isSubtotal={isSubtotal} />
                             ))}
                           </div>
                         ))}
@@ -372,6 +373,22 @@ export default class PivotTable extends Component {
       </div>
     );
   }
+}
+
+function Cell({ value, isSubtotal, width = 1, height = 1 }) {
+  return (
+    <div
+      style={{
+        width: CELL_WIDTH * width,
+        height: CELL_HEIGHT * height,
+        lineHeight: `${CELL_HEIGHT * height}px`,
+        borderTop: "1px solid white",
+      }}
+      className={cx({ "bg-medium": isSubtotal }, "px1")}
+    >
+      <Ellipsified>{value}</Ellipsified>
+    </div>
+  );
 }
 
 function updateValueWithCurrentColumns(storedValue, columns) {

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -13,6 +13,34 @@ function makeData(rows) {
   };
 }
 
+function makePivotData(rows, cols) {
+  cols = cols || [
+    {
+      name: "D1",
+      display_name: "Dimension 1",
+      base_type: TYPE.Text,
+      field_ref: ["field-id", 123],
+      source: "breakout",
+    },
+    {
+      name: "D2",
+      display_name: "Dimension 2",
+      base_type: TYPE.Text,
+      field_ref: ["field-id", 456],
+      source: "breakout",
+    },
+    { name: "M", display_name: "Metric", base_type: TYPE.Integer },
+  ];
+
+  const primaryGroup = JSON.stringify(
+    cols.filter(col => col.source === "breakout").map(col => col.field_ref),
+  );
+  return {
+    rows: rows.map(row => [...row, primaryGroup]),
+    cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+  };
+}
+
 describe("data_grid", () => {
   describe("pivot", () => {
     it("should pivot values correctly", () => {
@@ -112,9 +140,8 @@ describe("data_grid", () => {
     });
   });
 
-  // skipped for now until I finalize things
-  describe.skip("multiLevelPivot", () => {
-    const data = makeData([
+  describe("multiLevelPivot", () => {
+    const data = makePivotData([
       ["a", "x", 1],
       ["a", "y", 2],
       ["a", "z", 3],
@@ -142,7 +169,7 @@ describe("data_grid", () => {
           ],
         ],
       ]);
-      expect(leftIndex).toEqual([]);
+      expect(leftIndex).toEqual([[[]]]);
     });
     it("should produce multi-level left index", () => {
       const { topIndex, leftIndex } = multiLevelPivot(data, [], [0, 1], [2]);
@@ -164,16 +191,21 @@ describe("data_grid", () => {
           ],
         ],
       ]);
-      expect(topIndex).toEqual([]);
+      expect(topIndex).toEqual([[[{ value: "Metric", span: 1 }]]]);
     });
     it("should allow unspecified values", () => {
-      const data = makeData([
+      const data = makePivotData([
         ["a", "x", 1],
         ["a", "y", 2],
         ["b", "x", 3],
         // ["b", "y", ...], not present
       ]);
-      const { leftIndex, topIndex } = multiLevelPivot(data, [0], [1], [2]);
+      const { leftIndex, topIndex, getRowSection } = multiLevelPivot(
+        data,
+        [0],
+        [1],
+        [2],
+      );
       expect(leftIndex).toEqual([
         [[{ value: "x", span: 1 }]],
         [[{ value: "y", span: 1 }]],
@@ -182,17 +214,31 @@ describe("data_grid", () => {
         [[{ value: "a", span: 1 }]],
         [[{ value: "b", span: 1 }]],
       ]);
+      expect(getRowSection(0, 0)).toEqual([[{ value: "1" }]]);
+      expect(getRowSection(1, 1)).toEqual([[{ value: null }]]);
     });
     it("should handle multiple value columns", () => {
-      const data = {
-        rows: [["a", "b", 1, 2]],
-        cols: [
-          { name: "D1", display_name: "Dimension 1", base_type: TYPE.Text },
-          { name: "D2", display_name: "Dimension 2", base_type: TYPE.Text },
+      const data = makePivotData(
+        [["a", "b", 1, 2]],
+        [
+          {
+            name: "D1",
+            display_name: "Dimension 1",
+            base_type: TYPE.Text,
+            source: "breakout",
+            field_ref: ["field-id", 123],
+          },
+          {
+            name: "D2",
+            display_name: "Dimension 2",
+            base_type: TYPE.Text,
+            source: "breakout",
+            field_ref: ["field-id", 456],
+          },
           { name: "M1", display_name: "Metric", base_type: TYPE.Integer },
           { name: "M2", display_name: "Metric", base_type: TYPE.Integer },
         ],
-      };
+      );
 
       const { topIndex, leftIndex, getRowSection } = multiLevelPivot(
         data,
@@ -207,12 +253,12 @@ describe("data_grid", () => {
         ],
       ]);
       expect(leftIndex).toEqual([[[{ value: "b", span: 1 }]]]);
-      expect(getRowSection("a", "b")).toEqual([["1", "2"]]);
+      expect(getRowSection(0, 0)).toEqual([[{ value: "1" }, { value: "2" }]]);
     });
     it("should work with three levels of row grouping", () => {
       // three was picked because there was a bug during development that showed up with at least three
-      const data = {
-        rows: [
+      const data = makePivotData(
+        [
           ["a1", "b1", "c1", 1],
           ["a1", "b1", "c2", 1],
           ["a1", "b2", "c1", 1],
@@ -222,16 +268,34 @@ describe("data_grid", () => {
           ["a2", "b2", "c1", 1],
           ["a2", "b2", "c2", 1],
         ],
-        cols: [
-          { name: "D1", display_name: "Dimension 1", base_type: TYPE.Text },
-          { name: "D2", display_name: "Dimension 2", base_type: TYPE.Text },
-          { name: "D3", display_name: "Dimension 3", base_type: TYPE.Text },
+        [
+          {
+            name: "D1",
+            display_name: "Dimension 1",
+            base_type: TYPE.Text,
+            source: "breakout",
+            field_ref: ["field-id", 123],
+          },
+          {
+            name: "D2",
+            display_name: "Dimension 2",
+            base_type: TYPE.Text,
+            source: "breakout",
+            field_ref: ["field-id", 456],
+          },
+          {
+            name: "D3",
+            display_name: "Dimension 3",
+            base_type: TYPE.Text,
+            source: "breakout",
+            field_ref: ["field-id", 789],
+          },
           { name: "M1", display_name: "Metric", base_type: TYPE.Integer },
         ],
-      };
+      );
 
       const { topIndex, leftIndex } = multiLevelPivot(data, [], [0, 1, 2], [3]);
-      expect(topIndex).toEqual([]);
+      expect(topIndex).toEqual([[[{ span: 1, value: "Metric" }]]]);
       expect(leftIndex).toEqual([
         [
           [{ span: 4, value: "a1" }],
@@ -256,16 +320,24 @@ describe("data_grid", () => {
       ]);
     });
     it("should format values", () => {
-      const data = {
-        rows: [[1, "2020-01-01T00:00:00", 1000]],
-        cols: [
+      const data = makePivotData(
+        [[1, "2020-01-01T00:00:00", 1000]],
+        [
           {
             name: "D1",
             display_name: "Dimension 1",
             base_type: TYPE.Float,
             binning_info: { bin_width: 10 },
+            source: "breakout",
+            field_ref: ["field-id", 123],
           },
-          { name: "D2", display_name: "Dimension 2", base_type: TYPE.DateTime },
+          {
+            name: "D2",
+            display_name: "Dimension 2",
+            base_type: TYPE.DateTime,
+            source: "breakout",
+            field_ref: ["field-id", 456],
+          },
           {
             name: "M1",
             display_name: "Metric",
@@ -273,19 +345,21 @@ describe("data_grid", () => {
             special_type: "type/Currency",
           },
         ],
-      };
+      );
 
       const { getRowSection } = multiLevelPivot(data, [0], [1], [2]);
-      expect(getRowSection(1, "2020-01-01T00:00:00")).toEqual([["1,000"]]);
+      expect(getRowSection(0, 0)).toEqual([[{ value: "1,000" }]]);
     });
     it("should format values without a pivoted column or row", () => {
-      const data = {
-        rows: [[1, 1000]],
-        cols: [
+      const data = makePivotData(
+        [[1, 1000]],
+        [
           {
             name: "D1",
             display_name: "Dimension 1",
             base_type: TYPE.Float,
+            source: "breakout",
+            field_ref: ["field-id", 123],
           },
           {
             name: "M1",
@@ -294,38 +368,54 @@ describe("data_grid", () => {
             special_type: "type/Currency",
           },
         ],
-      };
+      );
       let getRowSection;
       ({ getRowSection } = multiLevelPivot(data, [0], [], [1]));
-      expect(getRowSection(1)).toEqual([["1,000"]]);
+      expect(getRowSection(0, 0)).toEqual([[{ value: "1,000" }]]);
       ({ getRowSection } = multiLevelPivot(data, [], [0], [1]));
-      expect(getRowSection(undefined, 1)).toEqual([["1,000"]]);
+      expect(getRowSection(0, 0)).toEqual([[{ value: "1,000" }]]);
     });
     it("should format multiple values", () => {
-      const data = {
-        rows: [
+      const data = makePivotData(
+        [
           [1, 1, "2020-01-01T00:00:00", 1000],
           [1, 2, "2020-01-01T00:00:00", 1000],
           [2, 1, "2020-01-01T00:00:00", 1000],
         ],
-        cols: [
-          { name: "D1", display_name: "Dimension 1", base_type: TYPE.Float },
-          { name: "D2", display_name: "Dimension 2", base_type: TYPE.Float },
-          { name: "D3", display_name: "Dimension 3", base_type: TYPE.DateTime },
+        [
+          {
+            name: "D1",
+            display_name: "Dimension 1",
+            base_type: TYPE.Float,
+            source: "breakout",
+            field_ref: ["field-id", 123],
+          },
+          {
+            name: "D2",
+            display_name: "Dimension 2",
+            base_type: TYPE.Float,
+            source: "breakout",
+            field_ref: ["field-id", 456],
+          },
           {
             name: "M1",
-            display_name: "Metric",
+            display_name: "Metric 1",
+            base_type: TYPE.DateTime,
+          },
+          {
+            name: "M2",
+            display_name: "Metric 2",
             base_type: TYPE.Integer,
             special_type: "type/Currency",
           },
         ],
-      };
+      );
 
       const { getRowSection } = multiLevelPivot(data, [0], [1], [2, 3]);
-      expect(getRowSection(1, 1)).toEqual([
-        ["January 1, 2020, 12:00 AM", "1,000"],
+      expect(getRowSection(0, 0)).toEqual([
+        [{ value: "January 1, 2020, 12:00 AM" }, { value: "1,000" }],
       ]);
-      expect(getRowSection(2, 2)).toEqual([[null, null]]);
+      expect(getRowSection(1, 1)).toEqual([[{ value: null }, { value: null }]]);
     });
   });
 });


### PR DESCRIPTION
This PR bundles a handful of small fixes. The logically separate changes are in isolated commits. These descriptions are slightly better than the commit messages:

- [commit](https://github.com/metabase/metabase/commit/4f6506b6b74bc1762b1a111aadfdccbf9cd87598) Prevent hitting the pivot API when the query is missing a breakout. If you have an invalid query and switch to pivot tables we should display the error message without hitting the server.
- [commit](https://github.com/metabase/metabase/commit/ef7a28b0f2d4893df28d0742f264278c08f7e77a) Takes a first pass at differentiating subtotals with styling. Kyle is doing a better job branching off of this.
- [commit](https://github.com/metabase/metabase/commit/e2af980b473540a2e76fc79017f4ce9c83b5baa7) Fixes an issue where the "Totals for [VALUE]" didn't format [VALUE] at all. e.g. "Totals for 2020-01-01T00:00:00"
- [commit](https://github.com/metabase/metabase/commit/65582845680bc827b1d01cd4ecd8cc87a7cbe696) Fixes a bug where the "rows totals" columns would merge values together
- [commit](https://github.com/metabase/metabase/commit/7fdcf5dac9e49328aeb92c704399b0f85d499fcb) Small refactor to pair the logic that pulls apart the returned data with the general pivoting logic
- [commit](https://github.com/metabase/metabase/commit/daecf37b43fb95f5bf43b1306064f1ba04aae75b) Fixes and unskips pivot table unit tests
- [commit](https://github.com/metabase/metabase/commit/c7f6a60a3c568a3d41cfc7ccfcc3e48ad3ab7fd0) Wires up the public endpoint
- [commit](https://github.com/metabase/metabase/pull/14044/commits/80496bb1143671e88217e9c0aac6d01568748082) Avoid exception if you try to open pivot tables on native questions
- [commit](https://github.com/metabase/metabase/pull/14044/commits/5ebfedbfbcbd0949c9d366b2da983cfa90cfe8c6) Hide blue outline on pivot table clicks
- [commit](https://github.com/metabase/metabase/pull/14044/commits/7ca46b1863723d5e4f3d951deb2ffedf0a2389d8) Hide "table toggle" in QB for pivot tables