### PR TITLE
Return 400 if password login is attempted when disabled; fix flakey test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
@@ -10,10 +10,10 @@
 (use-fixtures :once (fixtures/initialize :db))
 
 (deftest can-turn-off-password-login-with-jwt-enabled
-  (is (= false
-         (tu/with-temporary-setting-values
-           [jwt-enabled               true
-            jwt-identity-provider-uri "example.com"
-            jwt-shared-secret         "0123456789012345678901234567890123456789012345678901234567890123"]
-           (public-settings/enable-password-login false)
+  (tu/with-temporary-setting-values [jwt-enabled               true
+                                     jwt-identity-provider-uri "example.com"
+                                     jwt-shared-secret         "0123456789012345678901234567890123456789012345678901234567890123"
+                                     enable-password-login true]
+    (public-settings/enable-password-login false)
+    (is (= false
            (public-settings/enable-password-login)))))

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -60,7 +60,7 @@
   [session-type, user :- CreateSessionUserInfo]
   ;; this is actually the same as `create-session!` for `:sso` but we check whether password login is enabled.
   (when-not (public-settings/enable-password-login)
-    (throw (UnsupportedOperationException. (str (tru "Password login is disabled for this instance.")))))
+    (throw (ex-info (str (tru "Password login is disabled for this instance.")) {:status-code 400})))
   ((get-method create-session! :sso) session-type user))
 
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -2,7 +2,6 @@
   "Tests for /api/session"
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
-            [clojure.test :refer :all]
             [metabase
              [email-test :as et]
              [http-client :as http-client]
@@ -481,8 +480,13 @@
             (db/update! User user-id :login_attributes nil)))))
 
     (testing "Test that login will fallback to local for users not in LDAP"
-      (is (schema= SessionResponse
-                   (mt/client :post 200 "session" (mt/user->credentials :crowberto)))))
+      (mt/with-temporary-setting-values [enable-password-login true]
+        (is (schema= SessionResponse
+                     (mt/client :post 200 "session" (mt/user->credentials :crowberto)))))
+      (testing "...but not if password login is disabled"
+        (mt/with-temporary-setting-values [enable-password-login false]
+          (is (= "Password login is disabled for this instance."
+                 (mt/client :post 400 "session" (mt/user->credentials :crowberto)))))))
 
     (testing "Test that login will NOT fallback for users in LDAP but with an invalid password"
       ;; NOTE: there's a different password in LDAP for Lucky
@@ -497,7 +501,7 @@
             (db/simple-delete! Session :user_id user-id)
             (is (schema= SessionResponse
                          (mt/suppress-output
-                          (mt/client :post 200 "session" (mt/user->credentials :rasta)))))
+                           (mt/client :post 200 "session" (mt/user->credentials :rasta)))))
             (finally
               (db/update! User user-id :login_attributes nil))))))
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -2,6 +2,7 @@
   "Tests for /api/session"
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
+            [clojure.test :refer :all]
             [metabase
              [email-test :as et]
              [http-client :as http-client]


### PR DESCRIPTION
We weren't explicitly specifying a status code, so a 500 was returned. 400 makes more sense