### PR TITLE
Fix yet-another incorrect X axis label for waterfall total

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -248,10 +248,10 @@ export function applyChartQuantitativeXAxis(
     adjustXAxisTicksIfNeeded(chart.xAxis(), chart.width(), xValues);
 
     chart.xAxis().tickFormat(d => {
-      // don't show ticks that aren't multiples of xInterval
-      if (waterfallTotalX === d) {
+      if (waterfallTotalX && waterfallTotalX === d) {
         return t`Total`;
       }
+      // don't show ticks that aren't multiples of xInterval
       if (isMultipleOf(d, xInterval)) {
         return formatValue(d, {
           ...chart.settings.column(dimensionColumn),

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -228,6 +228,12 @@ export function applyChartQuantitativeXAxis(
   );
   const dimensionColumn = firstSeries.data.cols[0];
 
+  const waterfallTotalX =
+    firstSeries.card.display === "waterfall" &&
+    chart.settings["waterfall.show_total"]
+      ? xValues[xValues.length - 1]
+      : null;
+
   if (chart.settings["graph.x_axis.labels_enabled"]) {
     chart.xAxisLabel(
       chart.settings["graph.x_axis.title_text"] ||
@@ -243,6 +249,9 @@ export function applyChartQuantitativeXAxis(
 
     chart.xAxis().tickFormat(d => {
       // don't show ticks that aren't multiples of xInterval
+      if (waterfallTotalX === d) {
+        return t`Total`;
+      }
       if (isMultipleOf(d, xInterval)) {
         return formatValue(d, {
           ...chart.settings.column(dimensionColumn),


### PR DESCRIPTION
Steps to try:

1. Ask a question, Native query
2. Choose Sample Dataset
3. Type the following and then Run query (Ctrl+Enter)

```sql
select 1 as x, 10 as y
union
select 2 as x, -2 as y
```
4. Visualization, Waterfall
5. Setting, Display, choose X and Y axis accordingly

**Before this change**: The label on the X axis for the total bar is `3`.

**After this change**: The label on the X axis for the total bar is `Total`.

![image](https://user-images.githubusercontent.com/7288/101918681-7e8cb200-3b7e-11eb-9738-1d770fde231b.png)
