### PR TITLE
Use GitHub Actions to run front-end linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,44 +758,6 @@ jobs:
                   - /home/circleci/metabase/metabase/node_modules
                   - /home/circleci/.cache/Cypress
 
-  fe-linter-eslint:
-    executor: node
-    steps:
-      - run-yarn-command:
-          command-name: Run ESLint linter
-          command: lint-eslint
-          skip-when-no-change: true
-
-  fe-linter-prettier:
-    executor: node
-    steps:
-      - run-yarn-command:
-          command-name: Run Prettier formatting linter
-          command: lint-prettier
-          skip-when-no-change: true
-
-  fe-linter-flow:
-    executor: node
-    steps:
-      - run-yarn-command:
-          command-name: Run Flow type checker
-          command: lint-flow
-          skip-when-no-change: true
-
-  fe-linter-docs-links:
-    executor: node
-    steps:
-      - attach-workspace
-      - create-checksum-file:
-          filename: ".MARKDOWN-CHECKSUMS"
-          find-args: ". -type f -name '*.md'"
-      - run-on-change:
-          checksum: '{{ checksum ".MARKDOWN-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}'
-          steps:
-            - run-yarn-command:
-                command-name: Run docs links checker
-                command: lint-docs-links
-
   fe-tests-unit:
     executor: node
     steps:
@@ -1272,18 +1234,6 @@ workflows:
       - fe-deps:
           requires:
             - checkout
-      - fe-linter-eslint:
-          requires:
-            - fe-deps
-      - fe-linter-prettier:
-          requires:
-            - fe-deps
-      - fe-linter-flow:
-          requires:
-            - fe-deps
-      - fe-linter-docs-links:
-          requires:
-            - fe-deps
       - fe-tests-unit:
           requires:
             - fe-deps

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,6 +14,7 @@ on:
     paths:
     - 'frontend/**'
     - 'enterprise/frontend/**'
+    - 'docs/**'
     - '**/yarn.lock'
     - '.github/workflows/**'
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,7 +21,6 @@ on:
 jobs:
 
   fe-linter-flow:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -40,7 +39,6 @@ jobs:
       name: Run Flow type checker
 
   fe-linter-prettier:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -59,7 +57,6 @@ jobs:
       name: Run Prettier formatting linter
 
   fe-linter-eslint:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -78,7 +75,6 @@ jobs:
       name: Run ESLint linter
 
   fe-linter-docs-links:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,96 @@
+name: Frontend
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release**'
+      - 'feature**'
+      - 'fix**'
+      - 'ci**'
+    tags:
+      - '**'
+    paths:
+    - 'frontend/**'
+    - 'enterprise/frontend/**'
+    - '**/yarn.lock'
+    - '.github/workflows/**'
+
+jobs:
+
+  fe-linter-flow:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: yarn run lint-flow
+      name: Run Flow type checker
+
+  fe-linter-prettier:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: yarn run lint-prettier
+      name: Run Prettier formatting linter
+
+  fe-linter-eslint:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: yarn run lint-eslint
+      name: Run ESLint linter
+
+  fe-linter-docs-links:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: yarn run lint-docs-links
+      name: Run docs links checker

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,6 +15,7 @@ on:
     - 'frontend/**'
     - 'enterprise/frontend/**'
     - 'docs/**'
+    - '**/package.lock'
     - '**/yarn.lock'
     - '.github/workflows/**'
 


### PR DESCRIPTION
This migrates the front-end linters (Flow, Prettier, ESLint, doc links checker) from Circle CI to GitHub Actions. The current PR workflow will be affected but it is expected that the impact is very minimal.

Some advantages:

* Linter rule violations will display a more direct feedback ("annotations", in GitHub parlance), pointing exactly to the offending location (source file, line number), clickable to jump straight to that location. No need to scroll through the build log to find out where the violation happens.

* Linters are only [executed selectively](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths), i.e. if there is a commit that changes either `frontend` or `enterprise/frontend`.

* Linters do not use Circle CI minutes (and parallelism) anymore, about 8 minutes for the above 4 linters (thus, more available minutes to run tests and other higher priority tasks).

* External PR (e.g. from a fork) will have the linters executed on *their own* repo/side of GitHub Actions. Therefore, they will get the linter feedback way before they submit it as a PR (again, this will further reduce our consumption of precious Circle CI minutes).

![image](https://user-images.githubusercontent.com/7288/101921435-da0c6f00-3b81-11eb-8b47-7490dc1e4b46.png)

