### PR TITLE
Add initial Cypress tests for pivot table (ref: #14049)

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -49,6 +49,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.contains(`Started from ${QUESTION_NAME}`);
 
+    cy.log("**-- Assertions on a table itself --**");
     cy.get(".Visualization").within(() => {
       cy.findByText(/Users? → Source/);
       cy.findByText("783"); // Affiliate - Doohickey
@@ -58,6 +59,31 @@ describe("scenarios > visualizations > pivot tables", () => {
       cy.findByText("3,520").should("not.exist");
       cy.findByText("4,784").should("not.exist");
       cy.findByText("18,760").should("not.exist");
+    });
+  });
+
+  it("should rearrange pivoted columns", () => {
+    createAndVisitTestQuestion();
+
+    // Open Pivot table side-bar
+    cy.findByText("Settings").click();
+
+    // Give it some time to open the side-bar fully before we start dragging
+    cy.findByText(/Pivot Table options/i);
+
+    // Drag the second aggregate (Product category) from table columns to table rows
+    dragField(1, 0);
+
+    // One field should now be empty
+    cy.findByText("Drag fields here");
+
+    cy.log("**-- Implicit assertions on a table itself --**");
+    cy.get(".Visualization").within(() => {
+      cy.findByText(/Products? → Category/);
+      cy.findByText(/Users? → Source/);
+      cy.findByText("Count");
+      cy.findByText(/Totals for Doohickey/i);
+      cy.findByText("3,976");
     });
   });
 });
@@ -119,4 +145,20 @@ function assertOnPivotTable() {
     cy.findByText("4,784");
     cy.findByText("18,760");
   });
+}
+
+// Rely on native drag events, rather than on the coordinates
+// We have 3 "drag-handles" in this test. Their indexes are 0-based.
+function dragField(startIndex, dropIndex) {
+  cy.get(".Grabber")
+    .should("be.visible")
+    .as("dragHandle");
+
+  cy.get("@dragHandle")
+    .eq(startIndex)
+    .trigger("dragstart");
+
+  cy.get("@dragHandle")
+    .eq(dropIndex)
+    .trigger("drop");
 }

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -38,6 +38,31 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     assertOnPivotSettings();
   });
+
+  it("should not show sub-total data after a switch to other viz type", () => {
+    createPivotTableQuestion();
+    cy.visit("/collection/root");
+    cy.findByText(QUESTION_NAME).click();
+
+    // Switch to ordinary table
+    cy.findByText("Visualization").click();
+    cy.get(".Icon-table")
+      .should("be.visible")
+      .click();
+
+    cy.contains(`Started from ${QUESTION_NAME}`);
+
+    cy.get(".Visualization").within(() => {
+      cy.findByText(/Users? → Source/);
+      cy.findByText("783"); // Affiliate - Doohickey
+      cy.findByText("986"); // Twitter - Gizmo
+      cy.findByText(/Row totals/i).should("not.exist");
+      cy.findByText(/Grand totals/i).should("not.exist");
+      cy.findByText("3,520").should("not.exist");
+      cy.findByText("4,784").should("not.exist");
+      cy.findByText("18,760").should("not.exist");
+    });
+  });
 });
 
 function createPivotTableQuestion({ display = "pivot" } = {}) {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1,0 +1,75 @@
+import {
+  signInAsAdmin,
+  restore,
+  openOrdersTable,
+  popover,
+} from "__support__/cypress";
+
+describe("scenarios > visualizations > pivot tables", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
+
+  it("should be created from an ad-hoc question", () => {
+    cy.server();
+    cy.route("POST", "/api/dataset").as("dataset");
+    cy.route("POST", "/api/advanced_computation/pivot/dataset").as(
+      "pivotTableDataset",
+    );
+
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Summarize").click();
+    cy.findByText("Count of rows").click();
+    cy.findByText("Pick a column to group by").click();
+    popover().within(() => {
+      cy.findByText(/Orders?$/).click(); // Collapse "Orders" to avoid additional scrolling
+      cy.findByText(/Users?$/).click();
+    });
+    cy.get(".ReactVirtualized__Grid").scrollTo("bottom"); // "Source" is not visible - we have to scroll
+    cy.findByText("Source").click();
+    // Add another metric
+    cy.get(".Icon-add")
+      .last() // This is fragile, but there's no other way to get to this element right now
+      .click();
+    popover().within(() => {
+      cy.findByText(/Products?$/).click();
+      cy.findByText("Category").click();
+    });
+    cy.findByText("Visualize").click();
+    cy.wait("@dataset");
+
+    cy.findByText("Visualization").click();
+    cy.get(".Icon-pivot_table").click();
+    cy.wait("@pivotTableDataset");
+
+    cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
+    cy.get("[draggable=true]").as("fieldOption");
+
+    cy.log("**-- Implicit side-bar assertions --**");
+    cy.findByText(/Pivot Table options/i);
+
+    cy.findByText("Fields to use for the table rows");
+    cy.get("@fieldOption")
+      .eq(0)
+      .contains(/Users? → Source/);
+    cy.findByText("Fields to use for the table columns");
+    cy.get("@fieldOption")
+      .eq(1)
+      .contains(/Products? → Category/);
+    cy.findByText("Fields to use for the table values");
+    cy.get("@fieldOption")
+      .eq(2)
+      .contains("Count");
+
+    cy.log("**-- Implicit assertions on a table itself --**");
+    cy.get(".Visualization").within(() => {
+      cy.findByText(/Users? → Source/);
+      cy.findByText(/Row totals/i);
+      cy.findByText(/Grand totals/i);
+      cy.findByText("3,520");
+      cy.findByText("4,784");
+      cy.findByText("18,760");
+    });
+  });
+});


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds an initial batch of Cypress tests for pivot table functionality as described in #14049

### How to test this?
- All tests should pass in CI, because no test is skipped.

### Additional notes:
- Sidebar opening doesn't have any XHR associated with it that we can wait for. I tried to rely on UI, but I'm concerned that different visualization icons and/or drag handles may not be ready and the tests may flake.
- Cypress occasionally failed for me locally saying that icon/drag handle is not visible.
- If that presents a problem, I can remove the `.should("be.visible)` and add `{force: true}` to an associated action but that is an anti-pattern.
- FWIW, so far every CI run was successful.

### Stress-testing in GitHub CI:
- I was using OSS uberjar generated from 6697758c409d5ec030ad3da456910d49d5381525
- [20/20 runs](https://github.com/nemanjaglumac/metabase-tests/actions/runs/416375653) were successful ✅
