### PR TITLE
Pivot table fix - Run query when switching away from pivot

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -844,35 +844,33 @@ export const updateQuestion = (
       newQuestion.query().breakouts().length > 0;
 
     // we can only pivot queries with breakouts
-    if (queryHasBreakouts) {
-      if (isPivot && !wasPivot) {
-        // compute the pivot setting now so we can query the appropriate data
-        const series = assocIn(
-          getRawSeries(getState()),
-          [0, "card", "display"],
-          "pivot",
-        );
-        const key = "pivot_table.column_split";
-        const setting = getQuestionWithDefaultVisualizationSettings(
-          newQuestion,
-          series,
-        ).setting(key);
-        newQuestion = newQuestion.updateSettings({ [key]: setting });
-      }
+    if (isPivot && !wasPivot && queryHasBreakouts) {
+      // compute the pivot setting now so we can query the appropriate data
+      const series = assocIn(
+        getRawSeries(getState()),
+        [0, "card", "display"],
+        "pivot",
+      );
+      const key = "pivot_table.column_split";
+      const setting = getQuestionWithDefaultVisualizationSettings(
+        newQuestion,
+        series,
+      ).setting(key);
+      newQuestion = newQuestion.updateSettings({ [key]: setting });
+    }
 
-      if (
-        // switching to pivot
-        (isPivot && !wasPivot) ||
-        // switching away from pivot
-        (!isPivot && wasPivot) ||
-        // updating the pivot rows/cols
-        !_.isEqual(
-          newQuestion.setting("pivot_table.column_split"),
-          oldQuestion.setting("pivot_table.column_split"),
-        )
-      ) {
-        run = true; // force a run when switching to/from pivot or updating it's setting
-      }
+    if (
+      // switching to pivot
+      (isPivot && !wasPivot) ||
+      // switching away from pivot
+      (!isPivot && wasPivot) ||
+      // updating the pivot rows/cols
+      !_.isEqual(
+        newQuestion.setting("pivot_table.column_split"),
+        oldQuestion.setting("pivot_table.column_split"),
+      )
+    ) {
+      run = true; // force a run when switching to/from pivot or updating it's setting
     }
     // </PIVOT LOGIC>
 


### PR DESCRIPTION
This fixes a Cypress failure on master. Switching away from a pivot table visualization wouldn't rerun the query, so you'd potentially see the "pivot-grouping" column.

I broke this in #14044. I had meant to merge master in (which contained the test), but I forgot to. 

@nemanjaglumac the test caught a regression before the feature even shipped! 🎉 