### PR TITLE
Pivot table styling - batch 1

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -134,7 +134,9 @@ class Partition extends React.Component {
 )
 class EmptyPartition extends React.Component {
   render() {
-    return this.props.connectDropTarget(<div>{t`Drag fields here`}</div>);
+    return this.props.connectDropTarget(
+      <div className="p2 text-centered bg-light rounded text-medium">{t`Drag fields here`}</div>,
+    );
   }
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -339,7 +339,7 @@ export default class PivotTable extends Component {
                       <Flex flexDirection="column" key={key} style={style}>
                         {rows.map(row => (
                           <Flex>
-                            {row.map(({ value, isSubtotal }) => (
+                            {row.map(({ value, isSubtotal, clicked }) => (
                               <Cell
                                 value={value}
                                 isSubtotal={isSubtotal}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -17,17 +17,17 @@ const partitions = [
   {
     name: "rows",
     columnFilter: isDimension,
-    title: t`Fields to use for the table rows`,
+    title: t`Row fields`,
   },
   {
     name: "columns",
     columnFilter: isDimension,
-    title: t`Fields to use for the table columns`,
+    title: t`Column fields`,
   },
   {
     name: "values",
     columnFilter: col => !isDimension(col),
-    title: t`Fields to use for the table values`,
+    title: t`Value fields`,
   },
 ];
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -193,7 +193,7 @@ export default class PivotTable extends Component {
                 }}
               >
                 {/* top left corner - displays left header columns */}
-                <div className="flex align-end border-right border-bottom border-medium">
+                <div className="flex align-end border-right border-bottom border-medium bg-light">
                   {rowIndexes.map(index => (
                     <Cell value={formatColumn(columns[index])} />
                   ))}
@@ -287,7 +287,7 @@ export default class PivotTable extends Component {
                                     height: CELL_HEIGHT * span,
                                     width: CELL_WIDTH,
                                   }}
-                                  className="px1"
+                                  className="px1 bg-light"
                                 >
                                   <Ellipsified>
                                     <div

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -370,7 +370,7 @@ function Cell({ value, isSubtotal, width = 1, height = 1 }) {
         lineHeight: `${CELL_HEIGHT * height}px`,
         borderTop: "1px solid white",
       }}
-      className={cx({ "bg-medium": isSubtotal }, "px1")}
+      className={cx({ "bg-medium text-bold": isSubtotal }, "px1")}
     >
       <Ellipsified>{value}</Ellipsified>
     </div>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -4,6 +4,7 @@ import cx from "classnames";
 import _ from "underscore";
 import { getIn } from "icepick";
 import { Grid, List, ScrollSync } from "react-virtualized";
+import { Flex } from "grid-styled";
 
 import Ellipsified from "metabase/components/Ellipsified";
 import { isDimension } from "metabase/lib/schema_metadata";
@@ -230,7 +231,7 @@ export default class PivotTable extends Component {
                         className="flex-column px1 pt1"
                       >
                         {rows.map((row, index) => (
-                          <div className="flex" style={{ height: CELL_HEIGHT }}>
+                          <Flex style={{ height: CELL_HEIGHT }}>
                             {row.map(({ value, span }) => (
                               <div
                                 style={{ width: CELL_WIDTH * span }}
@@ -245,7 +246,7 @@ export default class PivotTable extends Component {
                                 </Ellipsified>
                               </div>
                             ))}
-                          </div>
+                          </Flex>
                         ))}
                       </div>
                     );
@@ -264,15 +265,15 @@ export default class PivotTable extends Component {
                   rowRenderer={({ key, style, index }) => {
                     if (index === leftIndex.length) {
                       return (
-                        <div key={key} style={style} className="flex">
-                          <div className="flex flex-column">
+                        <Flex key={key} style={style}>
+                          <Flex flexDirection="column">
                             <Cell
                               value={t`Grand totals`}
                               isSubtotal
                               width={rowIndexes.length}
                             />
-                          </div>
-                        </div>
+                          </Flex>
+                        </Flex>
                       );
                     }
                     return (
@@ -335,15 +336,15 @@ export default class PivotTable extends Component {
                   cellRenderer={({ key, style, rowIndex, columnIndex }) => {
                     const rows = getRowSection(columnIndex, rowIndex);
                     return (
-                      <div key={key} style={style} className="flex flex-column">
+                      <Flex flexDirection="column" key={key} style={style}>
                         {rows.map(row => (
-                          <div className="flex">
+                          <Flex>
                             {row.map(({ value, isSubtotal }) => (
                               <Cell value={value} isSubtotal={isSubtotal} />
                             ))}
-                          </div>
+                          </Flex>
                         ))}
-                      </div>
+                      </Flex>
                     );
                   }}
                   onScroll={({ scrollLeft, scrollTop }) =>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -18,17 +18,17 @@ const partitions = [
   {
     name: "rows",
     columnFilter: isDimension,
-    title: t`Row fields`,
+    title: t`Fields to use for the table rows`,
   },
   {
     name: "columns",
     columnFilter: isDimension,
-    title: t`Column fields`,
+    title: t`Fields to use for the table columns`,
   },
   {
     name: "values",
     columnFilter: col => !isDimension(col),
-    title: t`Value fields`,
+    title: t`Fields to use for the table values`,
   },
 ];
 


### PR DESCRIPTION
The first of a few rounds of visual polish on the new pivot table visualization.

## What this does
- Bolds total rows text
- Adds a background to the left set of columns
- Adds some basic styling to empty drop areas in the viz settings panel
- ~~Tweaks the labels for the column, row, value, groupings in the viz settings panel~~

## How to look at it
[This question on the sample dataset on localhost:3000](http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjIsImFnZ3JlZ2F0aW9uIjpbWyJjb3VudCJdXSwiYnJlYWtvdXQiOltbImRhdGV0aW1lLWZpZWxkIixbImZpZWxkLWlkIiwxMl0sInllYXIiXSxbImZrLT4iLFsiZmllbGQtaWQiLDEzXSxbImZpZWxkLWlkIiw0XV1dfSwidHlwZSI6InF1ZXJ5In0sImRpc3BsYXkiOiJwaXZvdCIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6eyJwaXZvdF90YWJsZS5jb2x1bW5fc3BsaXQiOnsicm93cyI6W1siZmstPiIsWyJmaWVsZC1pZCIsMTNdLFsiZmllbGQtaWQiLDRdXSxbImRhdGV0aW1lLWZpZWxkIixbImZpZWxkLWlkIiwxMl0sIm1vbnRoIl1dLCJjb2x1bW5zIjpbXSwidmFsdWVzIjpbWyJhZ2dyZWdhdGlvbiIsMF1dfX19) is a good illustration
![image](https://user-images.githubusercontent.com/5248953/102116124-806aa580-3e0a-11eb-9521-0f5711dfe435.png)
