### PR TITLE
Unix fingerprinters

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -207,7 +207,7 @@
    date-time-rf))
 
 (deffingerprinter [:type/DateTime :type/UNIXTimestampMicroseconds]
-  ((map (fn [x] (when x (/ x 1000))))
+  ((map (fn [x] (when x (long (/ x 1000)))))
    date-time-rf))
 
 (defn- histogram

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -186,29 +186,28 @@
 (extend-protocol ITemporalCoerceable
   nil      (->temporal [_]    nil)
   String   (->temporal [this] (->temporal (u.date/parse this)))
-  Long     (->temporal [this] (->temporal (t/instant this)))
+  Long     (->temporal [this] (->temporal (t/instant this))) ;; expects millis
   Integer  (->temporal [this] (->temporal (t/instant this)))
   ChronoLocalDateTime (->temporal [this] (.toInstant this (ZoneOffset/UTC)))
   ChronoZonedDateTime (->temporal [this] (.toInstant this))
   Temporal (->temporal [this] this))
 
 (def date-time-rf
-  "Reducing function for date times, accumulating earliest and latest values."
-  (robust-fuse {:earliest earliest
-                :latest   latest}))
+  "Reducing function for date times, coercing to temporal using `ITemporalCoerceable` and accumulating earliest and
+  latest values."
+  ((map ->temporal)
+   (robust-fuse {:earliest earliest
+                 :latest   latest})))
 
 (deffingerprinter :type/DateTime
-  ((map ->temporal)
-   date-time-rf))
+  date-time-rf)
 
 (deffingerprinter [:type/DateTime :type/UNIXTimestampSeconds]
-  ((comp (map (fn [x] (when x (* x 1000))))
-         (map ->temporal))
+  ((map (fn [x] (when x (* x 1000))))
    date-time-rf))
 
 (deffingerprinter [:type/DateTime :type/UNIXTimestampMicroseconds]
-  ((comp (map (fn [x] (when x (/ x 1000))))
-         (map ->temporal))
+  ((map (fn [x] (when x (/ x 1000))))
    date-time-rf))
 
 (defn- histogram

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -207,7 +207,7 @@
    date-time-rf))
 
 (deffingerprinter [:type/DateTime :type/UNIXTimestampMicroseconds]
-  ((map (fn [x] (when x (long (/ x 1000)))))
+  ((map (fn [x] (when x (quot x 1000))))
    date-time-rf))
 
 (defn- histogram

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -192,10 +192,24 @@
   ChronoZonedDateTime (->temporal [this] (.toInstant this))
   Temporal (->temporal [this] this))
 
+(def date-time-rf
+  "Reducing function for date times, accumulating earliest and latest values."
+  (robust-fuse {:earliest earliest
+                :latest   latest}))
+
 (deffingerprinter :type/DateTime
   ((map ->temporal)
-   (robust-fuse {:earliest earliest
-                 :latest   latest})))
+   date-time-rf))
+
+(deffingerprinter [:type/DateTime :type/UNIXTimestampSeconds]
+  ((comp (map (fn [x] (when x (* x 1000))))
+         (map ->temporal))
+   date-time-rf))
+
+(deffingerprinter [:type/DateTime :type/UNIXTimestampMicroseconds]
+  ((comp (map (fn [x] (when x (/ x 1000))))
+         (map ->temporal))
+   date-time-rf))
 
 (defn- histogram
   "Transducer that summarizes numerical data with a histogram."

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -67,7 +67,20 @@
                                  1234 ; int
                                  1594067133360 ; long
                                  "2007-12-03T10:15:30.00Z" ; string
-                                 (java.time.ZonedDateTime/of 2016 01 01 20 04 0 0 (java.time.ZoneOffset/UTC))]))))))))))
+                                 (java.time.ZonedDateTime/of 2016 01 01 20 04 0 0 (java.time.ZoneOffset/UTC))]))))
+            (testing "handle different unix units"
+              (let [expected {:earliest "2020-07-01T10:30:00Z", :latest "2020-07-01T10:30:00Z"}]
+                (are [type values] (= expected
+                                      (get-in
+                                       (transduce identity
+                                                  (f/fingerprinter
+                                                    (field/map->FieldInstance {:base_type :type/Integer
+                                                                               :special_type type}))
+                                                  values)
+                                       [:type :type/DateTime]))
+                  :type/UNIXTimestampSeconds      [      1593599400 nil]
+                  :type/UNIXTimestampMilliseconds [   1593599400000 nil]
+                  :type/UNIXTimestampMicroseconds [1593599400000000 nil])))))))))
 
 (deftest disambiguate-test
   (testing "We should correctly disambiguate multiple competing multimethods (DateTime and FK in this case)"

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -80,7 +80,9 @@
                                        [:type :type/DateTime]))
                   :type/UNIXTimestampSeconds      [      1593599400 nil]
                   :type/UNIXTimestampMilliseconds [   1593599400000 nil]
-                  :type/UNIXTimestampMicroseconds [1593599400000000 nil])))))))))
+                  :type/UNIXTimestampMicroseconds [1593599400000000 nil]
+                  ;; check that division with a residue correctly truncates in milliseconds
+                  :type/UNIXTimestampMicroseconds [1593599400000002 nil])))))))))
 
 (deftest disambiguate-test
   (testing "We should correctly disambiguate multiple competing multimethods (DateTime and FK in this case)"


### PR DESCRIPTION
Fixes #14067 

Add fingerprinters that are aware of seconds and microseconds and adjusts their values to be milliseconds