### PR TITLE
Keep PulseCards in sync with the dashboard (#13671)

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7781,3 +7781,25 @@ databaseChangeLog:
                   initiallyDeferred: false
                   onDelete: CASCADE
             tableName: pulse_card
+
+  - changeSet:
+      id: 277
+      author: tsmacdonald
+      comment: Added 0.38.0 - Dashboard subscriptions
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse_card
+            constraintName: fk_pulse_card_ref_pulse_card_id
+
+  - changeSet:
+      id: 278
+      author: tsmacdonald
+      comment: Added 0.38.0 - Dashboard subscrptions
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse_card
+            baseColumnNames: dashboard_card_id
+            referencedTableName: report_dashboardcard
+            referencedColumnNames: id
+            constraintName: fk_pulse_card_ref_pulse_card_id
+            onDelete: CASCADE

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -1,4 +1,39 @@
 (ns metabase.models.pulse-card
-  (:require [toucan.models :as models]))
+  (:require [metabase.util :as u]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
+            [toucan
+             [db :as db]
+             [models :as models]]))
 
 (models/defmodel PulseCard :pulse_card)
+
+(defn next-position-for
+  "Return the next available `pulse_card.position` for the given `pulse`"
+  [pulse-id]
+  {:pre [(integer? pulse-id)]}
+  (-> (db/select-one [PulseCard [:%max.position :max]] :pulse_id pulse-id)
+      :max
+      (some-> inc)
+      (or 0)))
+
+(def ^:private NewPulseCard
+  {:card_id                      su/IntGreaterThanZero
+   :pulse_id                     su/IntGreaterThanZero
+   :dashboard_card_id            su/IntGreaterThanZero
+   (s/optional-key :position)    (s/maybe su/NonNegativeInt)
+   (s/optional-key :include_csv) (s/maybe s/Bool)
+   (s/optional-key :include_xls) (s/maybe s/Bool)})
+
+(s/defn bulk-create!
+  "Creates new PulseCards, joining the given card, pulse, and dashboard card and setting appropriate defaults for other
+  values if they're not provided."
+  [new-pulse-cards :- [NewPulseCard]]
+  (db/insert-many! PulseCard
+    (for [{:keys [card_id pulse_id dashboard_card_id position include_csv include_xls]} new-pulse-cards]
+      {:card_id           card_id
+       :pulse_id          pulse_id
+       :dashboard_card_id dashboard_card_id
+       :position          (u/or-with some? position (next-position-for pulse_id))
+       :include_csv       (u/or-with some? include_csv false)
+       :include_xls       (u/or-with some? include_xls false)})))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -851,3 +851,14 @@
        [#","                  "."]
        ;; move minus sign at end to front
        [#"(^[^-]+)-$"         "-$1"]]))))
+
+(defmacro or-with
+  "Like or, but determines truthiness with `pred`."
+  ([pred]
+   nil)
+  ([pred x & more]
+   `(let [pred# ~pred
+          x#    ~x]
+      (if (pred# x#)
+        x#
+        (or-with pred# ~@more)))))

--- a/test/metabase/models/pulse_card_test.clj
+++ b/test/metabase/models/pulse_card_test.clj
@@ -1,0 +1,24 @@
+(ns metabase.models.pulse-card-test
+  (:require [clojure.test :refer :all]
+            [metabase.models
+             [card :refer [Card]]
+             [dashboard :refer [Dashboard]]
+             [dashboard-card :refer [DashboardCard]]
+             [pulse :refer [Pulse]]
+             [pulse-card :refer :all]]
+            [toucan.util.test :as tt]))
+
+(deftest test-next-position-for
+  (testing "No existing cards"
+    (tt/with-temp Pulse [{pulse-id :id}]
+      (is (zero? (next-position-for pulse-id)))))
+  (testing "With cards"
+    (tt/with-temp* [Pulse [{pulse-id :id}]
+                    Card  [{card-id :id}]
+                    Dashboard [{dashboard-id :id}]
+                    DashboardCard [{dashcard-id :id} {:dashboard_id dashboard-id}]
+                    PulseCard [_ {:pulse_id          pulse-id
+                                  :card_id           card-id
+                                  :dashboard_card_id dashcard-id
+                                  :position 2}]]
+      (is (= 3 (next-position-for pulse-id))))))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -269,6 +269,21 @@
     "$.05"          0.05M
     "0.05"          0.05M))
 
+(deftest or-with-test
+  (testing "empty case"
+    (is (= (or) (u/or-with identity))))
+  (testing "short-circuiting"
+    (let [counter (atom [])
+          expensive-fn (fn [x] (swap! counter conj x) x)
+          result (u/or-with even?
+                            (expensive-fn 1)
+                            (expensive-fn 2)
+                            (expensive-fn 3))]
+      (is (= [result @counter]
+             [2 [1 2]]))))
+  (testing "failure"
+    (is (nil? (u/or-with even? 1 3 5)))))
+
 ;; Local Variables:
 ;; eval: (add-to-list (make-local-variable 'clojure-align-cond-forms) "are+")
 ;; End:


### PR DESCRIPTION
Wish I wasn't querying for the `dashboard_card_id` in the inside of a loop but I don't seen an elegant way around it.