### PR TITLE
Mark pivot tables as not "live resizable" 

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -40,6 +40,10 @@ export default class PivotTable extends Component {
   static identifier = "pivot";
   static iconName = "pivot_table";
 
+  static isLiveResizable(series) {
+    return false;
+  }
+
   static isSensible({ cols }) {
     return (
       cols.length >= 2 &&


### PR DESCRIPTION
Visualizations that are "live resizable" are rendered continuously during animations. That kills performance for complicated virtualized tables. If a visualization implements `isLiveResizable` and returns false, we debounce this and only render every 300ms. 