### PR TITLE
Fixing bug where queries fail with joins on agg and expressions

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -888,7 +888,7 @@
 
     SELECT source.*
     FROM ( SELECT * FROM some_table ) source"
-  :source)
+  "source")
 
 (defn- apply-source-query
   "Handle a `:source-query` clause by adding a recursive `SELECT` or native query. At the time of this writing, all

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -89,13 +89,13 @@
 
 (deftest correct-identifiers-test
   (testing "This HAIRY query tests that the correct identifiers and aliases are used with both a nested query and JOIN in play."
-    ;; TODO `*table-alias*` stays bound to `:source` in a few places below where it probably shouldn't (for the
+    ;; TODO `*table-alias*` stays bound to `"source"` in a few places below where it probably shouldn't (for the
     ;; top-level SELECT `:field-alias` identifiers and the `v` `:table-alias` identifier) but since drivers shouldn't
     ;; be qualifying aliases with aliases things still work the right way.
     (mt/with-everything-store
       (driver/with-driver :h2
-        (is (= {:select    [[(bound-alias "v" (id :field "v" "NAME")) (bound-alias :source (id :field-alias "NAME"))]
-                            [:%count.*                                (bound-alias :source (id :field-alias "count"))]]
+        (is (= {:select    [[(bound-alias "v" (id :field "v" "NAME")) (bound-alias "source" (id :field-alias "NAME"))]
+                            [:%count.*                                (bound-alias "source" (id :field-alias "count"))]]
                 :from      [[{:select [[(id :field "PUBLIC" "CHECKINS" "ID")       (id :field-alias "ID")]
                                        [(id :field "PUBLIC" "CHECKINS" "DATE")     (id :field-alias "DATE")]
                                        [(id :field "PUBLIC" "CHECKINS" "USER_ID")  (id :field-alias "USER_ID")]
@@ -105,15 +105,15 @@
                                        (id :field "PUBLIC" "CHECKINS" "DATE")
                                        #t "2015-01-01T00:00:00.000-00:00"]}
                              (id :table-alias "source")]]
-                :left-join [[(id :table "PUBLIC" "VENUES") (bound-alias :source (id :table-alias "v"))]
+                :left-join [[(id :table "PUBLIC" "VENUES") (bound-alias "source" (id :table-alias "v"))]
                             [:=
-                             (bound-alias :source (id :field "source" "VENUE_ID"))
+                             (bound-alias "source" (id :field "source" "VENUE_ID"))
                              (bound-alias "v" (id :field "v" "ID"))]],
 
                 :group-by  [(bound-alias "v" (id :field "v" "NAME"))]
                 :where     [:and
                             [:like (bound-alias "v" (id :field "v" "NAME")) "F%"]
-                            [:> (bound-alias :source (id :field "source" "user_id")) 0]],
+                            [:> (bound-alias "source" (id :field "source" "user_id")) 0]],
                 :order-by  [[(bound-alias "v" (id :field "v" "NAME")) :asc]]}
                (#'sql.qp/mbql->honeysql
                 ::id-swap


### PR DESCRIPTION
A condition where you have a query with joins, and an aggregation uses that
join, and there are custom expressions in the query, can cause a schema
error when processing the query.

Example of a failing query:

    (mt/mbql-query orders
      {:aggregation [[:count] [:avg $orders.subtotal]]
       :breakout    [[:datetime-field $orders.created_at :month]
                     [:fk-> $orders.user_id $people.source]]
       :fields      [[:expression "pivot-grouping"]]
       :expressions {:pivot-grouping [:ltrim "foobar"]}})

[ci all]