### PR TITLE
#13817 Repro: "Save question" modal wrong state applied to "Save" button

### DIFF
--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -6,8 +6,10 @@ import {
 } from "__support__/cypress";
 
 describe("scenarios > question > saved", () => {
-  before(restore);
-  beforeEach(signInAsNormalUser);
+  beforeEach(() => {
+    restore();
+    signInAsNormalUser();
+  });
 
   it("view and filter saved question", () => {
     cy.visit("/question/1");

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -3,12 +3,59 @@ import {
   signInAsNormalUser,
   popover,
   modal,
+  openOrdersTable,
 } from "__support__/cypress";
 
 describe("scenarios > question > saved", () => {
   beforeEach(() => {
     restore();
     signInAsNormalUser();
+  });
+
+  it.skip("should should correctly display 'Save' modal (metabase#13817)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Summarize").click();
+    cy.findByText("Count of rows").click();
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText("Total").click();
+    // Save the question
+    cy.findByText("Save").click();
+    modal().within(() => {
+      cy.findByText("Save").click();
+    });
+    cy.findByText("Not now").click();
+    cy.findByText("Save").should("not.exist");
+
+    // Add a filter in order to be able to save question again
+    cy.findByText("Filter").click();
+    cy.findByText(/^Total$/).click();
+    cy.findByText("Equal to").click();
+    cy.findByText("Greater than").click();
+    cy.findByPlaceholderText("Enter a number").type("60");
+    cy.findByText("Add filter").click();
+
+    // Save question - opens "Save question" modal
+    cy.findByText("Save").click();
+
+    modal().within(() => {
+      cy.findByText("Save question");
+      cy.findByRole("button", { name: /save/i }).as("saveButton");
+      cy.get("@saveButton").should("not.be.disabled");
+
+      cy.log(
+        "**When there is no question name, it shouldn't be possible to save**",
+      );
+      cy.findByText("Save as new question").click();
+      cy.findByLabelText("Name").should("be.empty");
+      cy.findByLabelText("Description").should("be.empty");
+      cy.get("@saveButton").should("be.disabled");
+
+      cy.log(
+        "**It should `always` be possible to overwrite the original question**",
+      );
+      cy.findByText(/^Replace original question,/).click();
+      cy.get("@saveButton").should("not.be.disabled");
+    });
   });
 
   it("view and filter saved question", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13817 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/saved.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix