### PR TITLE
Cannot use an expression with an implicit join

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -289,7 +289,7 @@ describe("scenarios > question > custom columns", () => {
     });
   });
 
-  it.skip("should work with implicit joins (metabase#14080)", () => {
+  it("should work with implicit joins (metabase#14080)", () => {
     const CC_NAME = "OneisOne";
     signInAsAdmin();
 

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -859,7 +859,7 @@
 
     SELECT source.*
     FROM ( SELECT * FROM some_table ) source"
-  :source)
+  "source")
 
 (defn- apply-source-query
   "Handle a `:source-query` clause by adding a recursive `SELECT` or native query. At the time of this writing, all

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -94,8 +94,8 @@
     ;; be qualifying aliases with aliases things still work the right way.
     (mt/with-everything-store
       (driver/with-driver :h2
-        (is (= {:select    [[(bound-alias "v" (id :field "v" "NAME")) (bound-alias :source (id :field-alias "NAME"))]
-                            [:%count.*                                (bound-alias :source (id :field-alias "count"))]]
+        (is (= {:select    [[(bound-alias "v" (id :field "v" "NAME")) (bound-alias "source" (id :field-alias "NAME"))]
+                            [:%count.*                                (bound-alias "source" (id :field-alias "count"))]]
                 :from      [[{:select [[(id :field "PUBLIC" "CHECKINS" "ID")       (id :field-alias "ID")]
                                        [(id :field "PUBLIC" "CHECKINS" "DATE")     (id :field-alias "DATE")]
                                        [(id :field "PUBLIC" "CHECKINS" "USER_ID")  (id :field-alias "USER_ID")]
@@ -105,15 +105,15 @@
                                        (id :field "PUBLIC" "CHECKINS" "DATE")
                                        #t "2015-01-01T00:00:00.000-00:00"]}
                              (id :table-alias "source")]]
-                :left-join [[(id :table "PUBLIC" "VENUES") (bound-alias :source (id :table-alias "v"))]
+                :left-join [[(id :table "PUBLIC" "VENUES") (bound-alias "source" (id :table-alias "v"))]
                             [:=
-                             (bound-alias :source (id :field "source" "VENUE_ID"))
+                             (bound-alias "source" (id :field "source" "VENUE_ID"))
                              (bound-alias "v" (id :field "v" "ID"))]],
 
                 :group-by  [(bound-alias "v" (id :field "v" "NAME"))]
                 :where     [:and
                             [:like (bound-alias "v" (id :field "v" "NAME")) "F%"]
-                            [:> (bound-alias :source (id :field "source" "user_id")) 0]],
+                            [:> (bound-alias "source" (id :field "source" "user_id")) 0]],
                 :order-by  [[(bound-alias "v" (id :field "v" "NAME")) :asc]]}
                (#'sql.qp/mbql->honeysql
                 ::id-swap


### PR DESCRIPTION
The implicit "source" table alias should be a string instead of a keyword,
as the schema requires strings there. This will allow a custom expression
to work with an aggregation again.

Resolves metabase/metabase#14080
