### PR TITLE
Pivot tables - fix bug with single row of data

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -92,10 +92,8 @@ export function multiLevelPivot(
   const topIndex = getIndex(columnColumnTree, { valueColumns });
   const leftIndex = getIndex(rowColumnTree, {});
 
-  const columnCount =
-    topIndex.length + (topIndex.length > 1 && leftIndex.length > 0 ? 1 : 0);
-  const rowCount =
-    leftIndex.length + (leftIndex.length > 1 && topIndex.length > 0 ? 1 : 0);
+  const columnCount = getIndexCount(topIndex);
+  const rowCount = getIndexCount(leftIndex);
   return {
     topIndex,
     leftIndex,
@@ -111,6 +109,15 @@ export function multiLevelPivot(
       rowColumnIndexes,
     }),
   };
+}
+
+function getIndexCount({ length }) {
+  return (
+    // we need at least one row/column
+    (length === 0 ? 1 : length) +
+    // if there are multiple rows/columns, add one for totals
+    (length > 1 ? 1 : 0)
+  );
 }
 
 function createRowSectionGetter({
@@ -214,7 +221,7 @@ function enumerate({ value, children }, path = []) {
 
 function getIndex(values, { valueColumns = [], depth = 0 } = {}) {
   if (values.length === 0) {
-    if (valueColumns.length > 1 || depth === 0) {
+    if (valueColumns.length > 1 || (depth === 0 && valueColumns.length > 0)) {
       // if we have multiple value columns include their column names
       const colNames = valueColumns.map(col => ({
         value: col.display_name,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -173,7 +173,9 @@ export default class PivotTable extends Component {
       return indexItem[indexItem.length - 1].length * CELL_WIDTH;
     }
 
-    const showRowSubtotals = leftIndex[0].length > 1;
+    // show row subtotals if the left index has multiple tiers
+    const showRowSubtotals = leftIndex.length > 0 && leftIndex[0].length > 1;
+
     function rowHeight({ index }) {
       if (leftIndex.length === 0 || index === leftIndex.length) {
         return CELL_HEIGHT;

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -433,5 +433,57 @@ describe("data_grid", () => {
       ]);
       expect(extractValues(getRowSection(1, 1))).toEqual([[null, null]]);
     });
+
+    it("should return subtotals in each section", () => {
+      const cols = [
+        {
+          name: "D1",
+          display_name: "Dimension 1",
+          base_type: TYPE.Text,
+          field_ref: ["field-id", 123],
+          source: "breakout",
+        },
+        {
+          name: "D2",
+          display_name: "Dimension 2",
+          base_type: TYPE.Text,
+          field_ref: ["field-id", 456],
+          source: "breakout",
+        },
+        { name: "M", display_name: "Metric", base_type: TYPE.Integer },
+      ];
+
+      const primaryGroup = JSON.stringify(
+        cols.filter(col => col.source === "breakout").map(col => col.field_ref),
+      );
+      const subtotalOne = JSON.stringify([cols[0].field_ref]);
+      const subtotalTwo = JSON.stringify([cols[1].field_ref]);
+      const rows = [
+        ["a", "x", 1, primaryGroup],
+        ["a", "y", 2, primaryGroup],
+        ["b", "x", 3, primaryGroup],
+        ["b", "y", 4, primaryGroup],
+        ["a", null, 3, subtotalOne],
+        ["b", null, 7, subtotalOne],
+        [null, "x", 4, subtotalTwo],
+        [null, "y", 6, subtotalTwo],
+        [null, null, 10, "[]"],
+      ];
+      const data = {
+        rows,
+        cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+      };
+      const { getRowSection, rowCount, columnCount } = multiLevelPivot(
+        data,
+        [],
+        [0, 1],
+        [2],
+      );
+      expect(rowCount).toEqual(3);
+      expect(columnCount).toEqual(1);
+      expect(extractValues(getRowSection(0, 0))).toEqual([["1"], ["2"], ["3"]]);
+      expect(extractValues(getRowSection(0, 1))).toEqual([["3"], ["4"], ["7"]]);
+      expect(extractValues(getRowSection(0, 2))).toEqual([["10"]]);
+    });
   });
 });

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -2,35 +2,31 @@ import { pivot, multiLevelPivot } from "metabase/lib/data_grid";
 
 import { TYPE } from "metabase/lib/types";
 
+const D1 = {
+  name: "D1",
+  display_name: "Dimension 1",
+  base_type: TYPE.Text,
+  field_ref: ["field-id", 123],
+  source: "breakout",
+};
+const D2 = {
+  name: "D2",
+  display_name: "Dimension 2",
+  base_type: TYPE.Text,
+  field_ref: ["field-id", 456],
+  source: "breakout",
+};
+const M = { name: "M", display_name: "Metric", base_type: TYPE.Integer };
+
 function makeData(rows) {
   return {
     rows: rows,
-    cols: [
-      { name: "D1", display_name: "Dimension 1", base_type: TYPE.Text },
-      { name: "D2", display_name: "Dimension 2", base_type: TYPE.Text },
-      { name: "M", display_name: "Metric", base_type: TYPE.Integer },
-    ],
+    cols: [D1, D2, M],
   };
 }
 
 function makePivotData(rows, cols) {
-  cols = cols || [
-    {
-      name: "D1",
-      display_name: "Dimension 1",
-      base_type: TYPE.Text,
-      field_ref: ["field-id", 123],
-      source: "breakout",
-    },
-    {
-      name: "D2",
-      display_name: "Dimension 2",
-      base_type: TYPE.Text,
-      field_ref: ["field-id", 456],
-      source: "breakout",
-    },
-    { name: "M", display_name: "Metric", base_type: TYPE.Integer },
-  ];
+  cols = cols || [D1, D2, M];
 
   const primaryGroup = JSON.stringify(
     cols.filter(col => col.source === "breakout").map(col => col.field_ref),
@@ -237,20 +233,8 @@ describe("data_grid", () => {
       const data = makePivotData(
         [["a", "b", 1, 2]],
         [
-          {
-            name: "D1",
-            display_name: "Dimension 1",
-            base_type: TYPE.Text,
-            source: "breakout",
-            field_ref: ["field-id", 123],
-          },
-          {
-            name: "D2",
-            display_name: "Dimension 2",
-            base_type: TYPE.Text,
-            source: "breakout",
-            field_ref: ["field-id", 456],
-          },
+          D1,
+          D2,
           { name: "M1", display_name: "Metric", base_type: TYPE.Integer },
           { name: "M2", display_name: "Metric", base_type: TYPE.Integer },
         ],
@@ -285,20 +269,8 @@ describe("data_grid", () => {
           ["a2", "b2", "c2", 1],
         ],
         [
-          {
-            name: "D1",
-            display_name: "Dimension 1",
-            base_type: TYPE.Text,
-            source: "breakout",
-            field_ref: ["field-id", 123],
-          },
-          {
-            name: "D2",
-            display_name: "Dimension 2",
-            base_type: TYPE.Text,
-            source: "breakout",
-            field_ref: ["field-id", 456],
-          },
+          D1,
+          D2,
           {
             name: "D3",
             display_name: "Dimension 3",
@@ -399,20 +371,8 @@ describe("data_grid", () => {
           [2, 1, "2020-01-01T00:00:00", 1000],
         ],
         [
-          {
-            name: "D1",
-            display_name: "Dimension 1",
-            base_type: TYPE.Float,
-            source: "breakout",
-            field_ref: ["field-id", 123],
-          },
-          {
-            name: "D2",
-            display_name: "Dimension 2",
-            base_type: TYPE.Float,
-            source: "breakout",
-            field_ref: ["field-id", 456],
-          },
+          D1,
+          D2,
           {
             name: "M1",
             display_name: "Metric 1",
@@ -435,24 +395,7 @@ describe("data_grid", () => {
     });
 
     it("should return subtotals in each section", () => {
-      const cols = [
-        {
-          name: "D1",
-          display_name: "Dimension 1",
-          base_type: TYPE.Text,
-          field_ref: ["field-id", 123],
-          source: "breakout",
-        },
-        {
-          name: "D2",
-          display_name: "Dimension 2",
-          base_type: TYPE.Text,
-          field_ref: ["field-id", 456],
-          source: "breakout",
-        },
-        { name: "M", display_name: "Metric", base_type: TYPE.Integer },
-      ];
-
+      const cols = [D1, D2, M];
       const primaryGroup = JSON.stringify(
         cols.filter(col => col.source === "breakout").map(col => col.field_ref),
       );

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -152,7 +152,12 @@ describe("data_grid", () => {
       ["b", "z", 6],
     ]);
     it("should produce multi-level top index", () => {
-      const { topIndex, leftIndex } = multiLevelPivot(data, [0, 1], [], [2]);
+      const { topIndex, leftIndex, rowCount, columnCount } = multiLevelPivot(
+        data,
+        [0, 1],
+        [],
+        [2],
+      );
       expect(topIndex).toEqual([
         [
           [{ value: "a", span: 3 }],
@@ -171,10 +176,17 @@ describe("data_grid", () => {
           ],
         ],
       ]);
-      expect(leftIndex).toEqual([[[]]]);
+      expect(leftIndex).toEqual([]);
+      expect(rowCount).toEqual(1);
+      expect(columnCount).toEqual(3);
     });
     it("should produce multi-level left index", () => {
-      const { topIndex, leftIndex } = multiLevelPivot(data, [], [0, 1], [2]);
+      const { topIndex, leftIndex, rowCount, columnCount } = multiLevelPivot(
+        data,
+        [],
+        [0, 1],
+        [2],
+      );
       expect(leftIndex).toEqual([
         [
           [{ value: "a", span: 3 }],
@@ -194,6 +206,8 @@ describe("data_grid", () => {
         ],
       ]);
       expect(topIndex).toEqual([[[{ value: "Metric", span: 1 }]]]);
+      expect(rowCount).toEqual(3);
+      expect(columnCount).toEqual(1);
     });
     it("should allow unspecified values", () => {
       const data = makePivotData([


### PR DESCRIPTION
@nemanjaglumac mentioned this bug recently. We were hiding the data if all pivoted columns were on the top.

### Before - data is hidden
![image](https://user-images.githubusercontent.com/691495/102280261-ce5ed680-3efa-11eb-96ce-32a3699e3c48.png)

### After - data is visible
![image](https://user-images.githubusercontent.com/691495/102280203-aff8db00-3efa-11eb-8238-085224a38e9f.png)

While I was in there I also added another unit test.