### PR TITLE
CI: Check Liquibase 000_migrations.yaml against core.spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,7 @@ jobs:
       - attach-workspace
       - create-checksum-file:
           filename: .MIGRATIONS-CHECKSUM
-          find-args: resources/migrations -type -f -name '*.yaml'
+          find-args: resources/migrations -type f -name '*.yaml'
       - create-checksum-file:
           filename: .MIGRATIONS-LINTER-CHECKSUMS
           find-args: bin/lint-migrations-file -type f -name '*.clj' -or -name 'deps.edn'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,6 +570,25 @@ jobs:
                 command: ./bin/i18n/build-translation-resources
                 no_output_timeout: 2m
 
+  check-migrations:
+    executor:
+      metabase-ci
+    steps:
+      - attach-workspace
+      - create-checksum-file:
+          filename: .MIGRATIONS-CHECKSUM
+          find-args: resources/migrations -type -f -name '*.yaml'
+      - create-checksum-file:
+          filename: .MIGRATIONS-LINTER-CHECKSUMS
+          find-args: bin/lint-migrations-file -type f -name '*.clj' -or -name 'deps.edn'
+      - run-on-change:
+          cache-key: check-migrations-{{ checksum ".MIGRATIONS-CHECKSUM" }}-{{ checksum ".MIGRATIONS-LINTER-CHECKSUMS" }}
+          steps:
+            - run:
+                name: Verify Liquibase Migrations
+                command: ./bin/lint-migrations-file.sh
+                no_output_timeout: 10m
+
 
 ########################################################################################################################
 #                                                       BACKEND                                                        #
@@ -1047,6 +1066,10 @@ workflows:
       - verify-i18n-files:
           requires:
             - fe-deps
+
+      - check-migrations:
+          requires:
+            - checkout
 
       - be-deps:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,6 +754,11 @@ jobs:
                 command: |
                   cd /home/circleci/metabase/metabase/bin/release && clojure -M:test
                 no_output_timeout: 10m
+            - run:
+                name: Run Liquibase migrations linter tests
+                command: |
+                  cd /home/circleci/metabase/metabase/bin/lint-migrations-yaml && clojure -M:test
+                no_output_timeout: 10m
 
 
 ########################################################################################################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -757,7 +757,7 @@ jobs:
             - run:
                 name: Run Liquibase migrations linter tests
                 command: |
-                  cd /home/circleci/metabase/metabase/bin/lint-migrations-yaml && clojure -M:test
+                  cd /home/circleci/metabase/metabase/bin/lint-migrations-file && clojure -M:test
                 no_output_timeout: 10m
 
 

--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -6,7 +6,7 @@
   commons-codec/commons-codec {:mvn/version "1.14"}
   hiccup/hiccup               {:mvn/version "1.0.5"}
   io.forward/yaml             {:mvn/version "1.0.9"}  ; don't upgrade to 1.0.10 -- doesn't work on Java 8 (!)
-  org.flatland/ordered        {:mvn/version "1.5.9"}  ; used by io.forward/yaml
+  org.flatland/ordered        {:mvn/version "1.5.9"}  ; used by io.forward/yaml -- need the newer version
   stencil/stencil             {:mvn/version "0.5.0"}}
 
  :aliases

--- a/bin/lint-migrations-file.sh
+++ b/bin/lint-migrations-file.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+# switch to project root directory if we're not already there
+script_directory=`dirname "${BASH_SOURCE[0]}"`
+cd "$script_directory/.."
+
+source "./bin/check-clojure-cli.sh"
+check_clojure_cli
+
+cd bin/lint-migrations-file
+clojure -M -m lint-migrations-file $@

--- a/bin/lint-migrations-file/README.md
+++ b/bin/lint-migrations-file/README.md
@@ -1,0 +1,20 @@
+Linter that validates the Liquibase migrations file against a spec. This lets us check and enforce additional
+constraints for the `000_migrations.yaml` file (e.g. make sure you're not using duplicate migration IDs, or including
+more than one change in a single `changeSet`).
+
+Older/existing migrations are validated with a less-strict spec; newer ones use a stricter spec that enforces some
+additional constraints. Migrations 172 and newer use the stricter spec. The less-strict specs are in `x.unstrict`
+namespaces while equivalent stricter ones are in `x.strict` namespaces.
+
+Run the linter with
+
+```sh
+./bin/lint-migrations-yaml.sh
+```
+
+Add some tests for the checks you add here the `test/` directory; run them with
+
+```sh
+cd bin/lint-migrations-yaml
+clojure -M:test
+```

--- a/bin/lint-migrations-file/deps.edn
+++ b/bin/lint-migrations-file/deps.edn
@@ -1,5 +1,11 @@
 {:paths ["src"]
 
  :deps
- {io.forward/yaml      {:mvn/version "1.0.9"}   ; don't upgrade to 1.0.10 -- doesn't work on Java 8 (!)
-  org.flatland/ordered {:mvn/version "1.5.9"}}} ; used by io.forward/yaml -- need the newer version
+ {io.forward/yaml      {:mvn/version "1.0.9"}  ; don't upgrade to 1.0.10 -- doesn't work on Java 8 (!)
+  org.flatland/ordered {:mvn/version "1.5.9"}} ; used by io.forward/yaml -- need the newer version
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                  :sha     "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/bin/lint-migrations-file/deps.edn
+++ b/bin/lint-migrations-file/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src"]
+
+ :deps
+ {io.forward/yaml      {:mvn/version "1.0.9"}   ; don't upgrade to 1.0.10 -- doesn't work on Java 8 (!)
+  org.flatland/ordered {:mvn/version "1.5.9"}}} ; used by io.forward/yaml -- need the newer version

--- a/bin/lint-migrations-file/src/change/common.clj
+++ b/bin/lint-migrations-file/src/change/common.clj
@@ -1,0 +1,8 @@
+(ns change.common
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::tableName
+  string?)
+
+(s/def ::addColumn
+  (s/keys :req-un [::tableName]))

--- a/bin/lint-migrations-file/src/change/common.clj
+++ b/bin/lint-migrations-file/src/change/common.clj
@@ -6,3 +6,6 @@
 
 (s/def ::addColumn
   (s/keys :req-un [::tableName]))
+
+(s/def ::createTable
+  (s/keys :req-un [::tableName]))

--- a/bin/lint-migrations-file/src/change/strict.clj
+++ b/bin/lint-migrations-file/src/change/strict.clj
@@ -9,13 +9,25 @@
 (s/def ::column
   (s/keys :req-un [:column.strict/column]))
 
-(s/def ::columns
+(s/def :change.strict.add-column/columns
   (s/alt :column ::column))
 
 (s/def ::addColumn
   (s/merge
    :change.common/addColumn
-   (s/keys :req-un [::columns])))
+   (s/keys :req-un [:change.strict.add-column/columns])))
+
+(s/def ::remarks
+  string?)
+
+(s/def :change.strict.create-table/columns
+  (s/+ (s/alt :column ::column)))
+
+(s/def ::createTable
+  (s/merge
+   :change.common/createTable
+   ;; remarks are required for new tables in strict mode
+   (s/keys :req-un [:change.strict.create-table/columns ::remarks])))
 
 (s/def ::change
-  (s/keys :opt-un [::addColumn]))
+  (s/keys :opt-un [::addColumn ::createTable]))

--- a/bin/lint-migrations-file/src/change/strict.clj
+++ b/bin/lint-migrations-file/src/change/strict.clj
@@ -1,0 +1,21 @@
+(ns change.strict
+  (:require change.common
+            [clojure.spec.alpha :as s]
+            column.strict))
+
+(comment change.common/keep-me
+         column.strict/keep-me)
+
+(s/def ::column
+  (s/keys :req-un [:column.strict/column]))
+
+(s/def ::columns
+  (s/alt :column ::column))
+
+(s/def ::addColumn
+  (s/merge
+   :change.common/addColumn
+   (s/keys :req-un [::columns])))
+
+(s/def ::change
+  (s/keys :opt-un [::addColumn]))

--- a/bin/lint-migrations-file/src/change/unstrict.clj
+++ b/bin/lint-migrations-file/src/change/unstrict.clj
@@ -9,13 +9,24 @@
 (s/def ::column
   (s/keys :req-un [:column.unstrict/column]))
 
-(s/def ::columns
+(s/def :change.unstrict.add-column/columns
   (s/alt :column ::column))
 
 (s/def ::addColumn
   (s/merge
    :change.common/addColumn
-   (s/keys :req-un [::columns])))
+   (s/keys :req-un [:change.unstrict.add-column/columns])))
+
+(s/def ::remarks string?)
+
+(s/def :change.unstrict.create-table/columns
+  (s/+ (s/alt :column ::column)))
+
+(s/def ::createTable
+  (s/merge
+   :change.common/createTable
+   (s/keys :req-un [:change.unstrict.create-table/columns]
+           :opt-un [::remarks])))
 
 (s/def ::change
-  (s/keys :opt-un [::addColumn]))
+  (s/keys :opt-un [::addColumn ::createTable]))

--- a/bin/lint-migrations-file/src/change/unstrict.clj
+++ b/bin/lint-migrations-file/src/change/unstrict.clj
@@ -1,0 +1,21 @@
+(ns change.unstrict
+  (:require change.common
+            [clojure.spec.alpha :as s]
+            column.unstrict))
+
+(comment change.common/keep-me
+         column.unstrict/keep-me)
+
+(s/def ::column
+  (s/keys :req-un [:column.unstrict/column]))
+
+(s/def ::columns
+  (s/alt :column ::column))
+
+(s/def ::addColumn
+  (s/merge
+   :change.common/addColumn
+   (s/keys :req-un [::columns])))
+
+(s/def ::change
+  (s/keys :opt-un [::addColumn]))

--- a/bin/lint-migrations-file/src/change_set/common.clj
+++ b/bin/lint-migrations-file/src/change_set/common.clj
@@ -1,0 +1,18 @@
+(ns change-set.common
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::id
+  (s/or
+   :int int?
+   :int-string (s/and
+                string?
+                (fn [^String s]
+                  (try
+                    (Integer/parseInt s)
+                    (catch Throwable _
+                      false))))))
+
+(s/def ::author string?)
+
+(s/def ::change-set
+  (s/keys :req-un [::id ::author]))

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -1,0 +1,22 @@
+(ns change-set.strict
+  (:require change-set.common
+            change.strict
+            [clojure.spec.alpha :as s]))
+
+(comment change-set.common/keep-me
+         change.strict/keep-me)
+
+;; comment is required for strict change set spec
+(s/def ::comment
+  (s/and
+   string?
+   (partial re-find #"Added [\d.x]+")))
+
+;; only one change allowed per change set for the strict schema.
+(s/def ::changes
+  (s/alt :change :change.strict/change))
+
+(s/def ::change-set
+  (s/merge
+   :change-set.common/change-set
+   (s/keys :req-un [::changes ::comment])))

--- a/bin/lint-migrations-file/src/change_set/unstrict.clj
+++ b/bin/lint-migrations-file/src/change_set/unstrict.clj
@@ -1,0 +1,19 @@
+(ns change-set.unstrict
+  (:require change-set.common
+            change.unstrict
+            [clojure.spec.alpha :as s]))
+
+(comment change-set.common/keep-me
+         change.unstrict/keep-me)
+
+(s/def ::comment string?)
+
+;; unstrict change set: one or more changes
+(s/def ::changes
+  (s/+ :change.unstrict/change))
+
+(s/def ::change-set
+  (s/merge
+   :change-set.common/change-set
+   (s/keys :req-un [::changes]
+           :opt-un [::comment])))

--- a/bin/lint-migrations-file/src/column/common.clj
+++ b/bin/lint-migrations-file/src/column/common.clj
@@ -5,6 +5,21 @@
 (s/def ::type string?)
 (s/def ::remarks string?)
 
+(s/def :column.common.constraints/onDelete
+  (fn [_]
+    "Don't try to use onDelete in constraints! onDelete is only for addForeignKeyConstraints. Use deleteCascade!"
+    false))
+
+(s/def ::constraints
+  ;; TODO -- require foreignKeyName if this is an FK
+  (s/keys :opt-un [:column.common.constraints/nullable
+                   :column.common.constraints/references
+                   :column.common.constraints/foreignKeyName
+                   :column.common.constraints/deferrable
+                   :column.common.constraints/initiallyDeferred
+                   :column.common.constraints/deleteCascade
+                   :column.common.constraints/onDelete]))
+
 (s/def ::column
   (s/keys :req-un [::name ::type]
-          :opt-un [::remarks]))
+          :opt-un [::remarks ::constraints]))

--- a/bin/lint-migrations-file/src/column/common.clj
+++ b/bin/lint-migrations-file/src/column/common.clj
@@ -1,0 +1,10 @@
+(ns column.common
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::name string?)
+(s/def ::type string?)
+(s/def ::remarks string?)
+
+(s/def ::column
+  (s/keys :req-un [::name ::type]
+          :opt-un [::remarks]))

--- a/bin/lint-migrations-file/src/column/strict.clj
+++ b/bin/lint-migrations-file/src/column/strict.clj
@@ -1,0 +1,9 @@
+(ns column.strict
+  (:require [clojure.spec.alpha :as s]
+            column.common))
+
+(comment column.common/keep-me)
+
+(s/def ::column
+  (s/merge
+   :column.common/column))

--- a/bin/lint-migrations-file/src/column/unstrict.clj
+++ b/bin/lint-migrations-file/src/column/unstrict.clj
@@ -1,0 +1,9 @@
+(ns column.unstrict
+  (:require [clojure.spec.alpha :as s]
+            column.common))
+
+(comment column.common/keep-me)
+
+(s/def ::column
+  (s/merge
+   :column.common/column))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -11,10 +11,11 @@
   (s/+ (s/alt :property  (s/keys :req-un [::property])
               :changeSet (s/keys :req-un [::changeSet]))))
 
+;; TODO -- change sets must be distinct by ID.
 (s/def ::changeSet
-  (s/keys :req-un [:change-set/id :change-set/changes]
+  (s/keys :req-un [:change-set/id :change-set/changes :change-set/author]
           ;; TODO -- require these on new change sets
-          :opt-un [:change-set/author :change-set/comment]))
+          :opt-un [:change-set/comment]))
 
 (s/def :change-set/id
   (s/or
@@ -32,7 +33,7 @@
   (s/+ ::change))
 
 (s/def ::change
-  (s/keys :opt-un [:change/addColumn :change/addTable]))
+  (s/keys :opt-un [:change/addColumn]))
 
 (s/def :change/addColumn
   (s/keys :req-un [:add-column/tableName :add-column/columns]))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -75,8 +75,6 @@
                       (or (dissoc data :clojure.spec.alpha/value) {})))))
   :ok)
 
-;; TODO -- correct use of onDelete: CASCADE (addForeignKeyConstraint) or deleteCascade: true (constraints)
-
 (def filename
   "../../resources/migrations/000_migrations.yaml")
 

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -1,0 +1,79 @@
+(ns lint-migrations-file
+  (:require [clojure.java.io :as io]
+            [clojure.pprint :as pprint]
+            [clojure.spec.alpha :as s]
+            [yaml.core :as yaml]))
+
+(s/def ::migrations
+  (s/keys :req-un [::databaseChangeLog]))
+
+(s/def ::databaseChangeLog
+  (s/+ (s/alt :property  (s/keys :req-un [::property])
+              :changeSet (s/keys :req-un [::changeSet]))))
+
+(s/def ::changeSet
+  (s/keys :req-un [:change-set/id :change-set/changes]
+          ;; TODO -- require these on new change sets
+          :opt-un [:change-set/author :change-set/comment]))
+
+(s/def :change-set/id
+  (s/or
+   :int int?
+   :int-string (s/and
+                string?
+                (fn [^String s]
+                  (try
+                    (Integer/parseInt s)
+                    (catch Throwable _
+                      false))))))
+
+(s/def :change-set/changes
+  ;; TODO -- only one change allowed for new change sets
+  (s/+ ::change))
+
+(s/def ::change
+  (s/keys :opt-un [:change/addColumn :change/addTable]))
+
+;; TODO -- addColumn should only include one column.
+(s/def :change/addColumn
+  (s/keys :req-un [:add-column/tableName ::columns]))
+
+(s/def ::columns
+  (s/+ :columns/column))
+
+(s/def :columns/column
+  (s/keys :req-un [::column]))
+
+(s/def ::column
+  (s/keys :req-un [:column/name :column/type]
+          :opt-un [:column/remarks]))
+
+;; TODO -- correct use of onDelete: CASCADE (addForeignKeyConstraint) or deleteCascade: true (constraints)
+
+(defn validate-migrations [migrations]
+  (when (= (s/conform ::migrations migrations) :clojure.spec.alpha/invalid)
+    (throw (ex-info (str "Validation failed: " (s/explain-str ::migrations migrations))
+                    (or (s/explain-data ::migrations migrations) {}))))
+  :ok)
+
+(def filename
+  "../../resources/migrations/000_migrations.yaml")
+
+(defn migrations []
+  (let [file (io/file filename)]
+    (assert (.exists file) (format "%s does not exist" filename))
+    (yaml/from-file file)))
+
+(defn- validate-all []
+  (validate-migrations (migrations)))
+
+(defn -main []
+  (println "Check Liquibase migrations file...")
+  (try
+    (validate-all)
+    (println "Ok.")
+    (System/exit 0)
+    (catch Throwable e
+      (println (.getMessage e))
+      (pprint/pprint (Throwable->map e))
+      (System/exit 1))))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -34,12 +34,11 @@
 (s/def ::change
   (s/keys :opt-un [:change/addColumn :change/addTable]))
 
-;; TODO -- addColumn should only include one column.
 (s/def :change/addColumn
-  (s/keys :req-un [:add-column/tableName ::columns]))
+  (s/keys :req-un [:add-column/tableName :add-column/columns]))
 
-(s/def ::columns
-  (s/+ :columns/column))
+(s/def :add-column/columns
+  (s/alt :column :columns/column))
 
 (s/def :columns/column
   (s/keys :req-un [::column]))

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -1,0 +1,78 @@
+(ns lint-migrations-file-test
+  (:require [clojure.test :refer :all]
+            [lint-migrations-file :as lint-migrations-file]))
+
+(defn mock-change-set [& keyvals]
+  {:changeSet
+   (merge
+    {:id      1
+     :author  "camsaul"
+     :comment "Added x.37.0"
+     :changes [{:whatever {}}]}
+    (apply array-map keyvals))})
+
+(defn mock-column [& keyvals]
+  {:column (merge {:name "bird_count", :type "integer"}
+                  (apply array-map keyvals))})
+
+(defn- mock-add-column-changes [& keyvals]
+  {:addColumn (merge {:tableName "my_table"
+                      :columns   [(mock-column)]}
+                     (apply array-map keyvals))})
+
+(defn- validate [& changes]
+  (lint-migrations-file/validate-migrations
+   {:databaseChangeLog changes}))
+
+(deftest require-unique-ids-test
+  (testing "Make sure all migration IDs are unique"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"distinct-change-set-ids"
+         (validate
+          (mock-change-set :id "1")
+          (mock-change-set :id 1))))))
+
+(deftest require-migrations-in-order-test
+  (testing "Migrations must be in order"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"change-set-ids-in-order"
+         (validate
+          (mock-change-set :id 2)
+          (mock-change-set :id 1))))))
+
+(deftest only-one-column-per-add-column-test
+  (testing "we should only allow one column per addColumn change"
+    (is (= :ok
+           (validate
+            (mock-change-set :changes [(mock-add-column-changes)]))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Extra input"
+         (validate
+          (mock-change-set :changes [(mock-add-column-changes :columns [(mock-column :name "A")
+                                                                        (mock-column :name "B")])]))))))
+
+(deftest one-change-per-change-set-test
+  (testing "[strict only] only allow one change per change set"
+    (is (= :ok
+           (validate
+            (mock-change-set :changes [(mock-add-column-changes) (mock-add-column-changes)]))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Extra input"
+         (validate
+          (mock-change-set :id 200
+                           :changes [(mock-add-column-changes) (mock-add-column-changes)]))))))
+
+(deftest require-comment-test
+  (testing "[strict only] require a 'Added <version>' comment for a change set"
+    (is (= :ok
+           (validate (dissoc (mock-change-set) :comment))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"clojure.core/re-find"
+         (validate (mock-change-set :id 200, :comment "Bad comment"))))
+    (is (= :ok
+           (validate (mock-change-set :id 200, :comment "Added x.38.0"))))))

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -3978,11 +3978,11 @@ databaseChangeLog:
                   constraints:
                     nullable: false
   - changeSet:
-    - id: 68
-    - author: sbelak
-    - comment: 'Added 0.27.0'
-    - changes:
-      - addColumn:
+      id: 68
+      author: sbelak
+      comment: 'Added 0.27.0'
+      changes:
+        - addColumn:
             tableName: computation_job
             columns:
               - column:
@@ -4103,9 +4103,10 @@ databaseChangeLog:
         - addColumn:
             tableName: report_card
             columns:
-              name: read_permissions
-              type: text
-              remarks: 'Permissions required to view this Card and run its query.'
+              - column:
+                  name: read_permissions
+                  type: text
+                  remarks: 'Permissions required to view this Card and run its query.'
   - changeSet:
       id: 76
       author: senior
@@ -4114,9 +4115,10 @@ databaseChangeLog:
         - addColumn:
             tableName: metabase_table
             columns:
-              name: fields_hash
-              type: text
-              remarks: 'Computed hash of all of the fields associated to this table'
+              - column:
+                  name: fields_hash
+                  type: text
+                  remarks: 'Computed hash of all of the fields associated to this table'
   - changeSet:
       id: 77
       author: senior
@@ -4125,9 +4127,10 @@ databaseChangeLog:
         - addColumn:
             tableName: core_user
             columns:
-              name: login_attributes
-              type: text
-              remarks: 'JSON serialized map with attributes used for row level permissions'
+              - column:
+                  name: login_attributes
+                  type: text
+                  remarks: 'JSON serialized map with attributes used for row level permissions'
   - changeSet:
       id: 78
       author: camsaul
@@ -4201,12 +4204,13 @@ databaseChangeLog:
         - addColumn:
             tableName: report_dashboard
             columns:
-              name: collection_id
-              type: int
-              remarks: 'Optional ID of Collection this Dashboard belongs to.'
-              constraints:
-                references: collection(id)
-                foreignKeyName: fk_dashboard_collection_id
+              - column:
+                  name: collection_id
+                  type: int
+                  remarks: 'Optional ID of Collection this Dashboard belongs to.'
+                  constraints:
+                    references: collection(id)
+                    foreignKeyName: fk_dashboard_collection_id
               # TODO - if someone deletes a collection, what should happen to the Dashboards that are in it? Should they
               # get deleted as well? Or should collection_id be cleared, effectively putting them in the so-called
               # "root" collection?
@@ -4219,12 +4223,13 @@ databaseChangeLog:
         - addColumn:
             tableName: pulse
             columns:
-              name: collection_id
-              type: int
-              remarks: 'Options ID of Collection this Pulse belongs to.'
-              constraints:
-                references: collection(id)
-                foreignKeyName: fk_pulse_collection_id
+              - column:
+                  name: collection_id
+                  type: int
+                  remarks: 'Options ID of Collection this Pulse belongs to.'
+                  constraints:
+                    references: collection(id)
+                    foreignKeyName: fk_pulse_collection_id
         - createIndex:
             tableName: pulse
             indexName: idx_pulse_collection_id
@@ -4238,12 +4243,13 @@ databaseChangeLog:
         - addColumn:
             tableName: collection
             columns:
-              name: location
-              type: varchar(254)
-              remarks: 'Directory-structure path of ancestor Collections. e.g. "/1/2/" means our Parent is Collection 2, and their parent is Collection 1.'
-              constraints:
-                nullable: false
-              defaultValue: "/"
+              - column:
+                  name: location
+                  type: varchar(254)
+                  remarks: 'Directory-structure path of ancestor Collections. e.g. "/1/2/" means our Parent is Collection 2, and their parent is Collection 1.'
+                  constraints:
+                    nullable: false
+                  defaultValue: "/"
         - createIndex:
             tableName: collection
             indexName: idx_collection_location
@@ -4258,21 +4264,24 @@ databaseChangeLog:
         - addColumn:
             tableName: report_dashboard
             columns:
-              name: collection_position
-              type: smallint
-              remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
+              - column:
+                  name: collection_position
+                  type: smallint
+                  remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
         - addColumn:
             tableName: report_card
             columns:
-              name: collection_position
-              type: smallint
-              remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
+              - column:
+                  name: collection_position
+                  type: smallint
+                  remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
         - addColumn:
             tableName: pulse
             columns:
-              name: collection_position
-              type: smallint
-              remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
+              - column:
+                  name: collection_position
+                  type: smallint
+                  remarks: 'Optional pinned position for this item in its Collection. NULL means item is not pinned.'
   - changeSet:
       id: 82
       author: senior
@@ -4281,9 +4290,10 @@ databaseChangeLog:
         - addColumn:
             tableName: core_user
             columns:
-              name: updated_at
-              type: datetime
-              remarks: 'When was this User last updated?'
+              - column:
+                  name: updated_at
+                  type: datetime
+                  remarks: 'When was this User last updated?'
         - sql:
             sql: update core_user set updated_at=date_joined
 # Remove the GTAP card_id constraint. When not included, will default to querying against the GTAP table_id.
@@ -4326,10 +4336,11 @@ databaseChangeLog:
         - addColumn:
             tableName: pulse
             columns:
-              name: archived
-              type: boolean
-              remarks: 'Has this pulse been archived?'
-              defaultValueBoolean: false
+              - column:
+                  name: archived
+                  type: boolean
+                  remarks: 'Has this pulse been archived?'
+                  defaultValueBoolean: false
         # Before this change, metrics/segments had opposite logic, rather than marking something as archived
         # it was marked as active. Since the column is now an archived column, flip the boolean value
         #
@@ -4346,15 +4357,16 @@ databaseChangeLog:
         - addColumn:
             tableName: collection
             columns:
-              name: personal_owner_id
-              type: int
-              remarks: 'If set, this Collection is a personal Collection, for exclusive use of the User with this ID.'
-              constraints:
-                references: core_user(id)
-                foreignKeyName: fk_collection_personal_owner_id
-                unique: true
-                uniqueConstraintName: unique_collection_personal_owner_id
-                deleteCascade: true
+              - column:
+                  name: personal_owner_id
+                  type: int
+                  remarks: 'If set, this Collection is a personal Collection, for exclusive use of the User with this ID.'
+                  constraints:
+                    references: core_user(id)
+                    foreignKeyName: fk_collection_personal_owner_id
+                    unique: true
+                    uniqueConstraintName: unique_collection_personal_owner_id
+                    deleteCascade: true
         # Needed so we can efficiently look up the Collection belonging to a User, and so we can efficiently enforce the
         # unique constraint
         - createIndex:
@@ -4374,9 +4386,10 @@ databaseChangeLog:
         - addColumn:
             tableName: collection
             columns:
-              name: _slug
-              type: varchar(254)
-              remarks: 'Sluggified version of the Collection name. Used only for display purposes in URL; not unique or indexed.'
+              - column:
+                  name: _slug
+                  type: varchar(254)
+                  remarks: 'Sluggified version of the Collection name. Used only for display purposes in URL; not unique or indexed.'
         # I don't know of an easy way to copy existing values of slug to _slug with Liquibase as we create the column so
         # just have to do it this way instead
         - sql:
@@ -4429,12 +4442,13 @@ databaseChangeLog:
         - addColumn:
             tableName: core_user
             columns:
-              name: saml_auth
-              type: boolean
-              defaultValueBoolean: false
-              constraints:
-                nullable: false
-              remarks: 'Boolean to indicate if this user is authenticated via SAML'
+              - column:
+                  name: saml_auth
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+                  remarks: 'Boolean to indicate if this user is authenticated via SAML'
 
 # The Quartz Task Scheduler can use a DB to 'cluster' tasks and make sure they are only ran by a single instance where
 # using a multi-instance Metabase setup.
@@ -5101,9 +5115,10 @@ databaseChangeLog:
         - addColumn:
             tableName: core_user
             columns:
-              name: sso_source
-              type: varchar(254)
-              remarks: 'String to indicate the SSO backend the user is from'
+              - column:
+                  name: sso_source
+                  type: varchar(254)
+                  remarks: 'String to indicate the SSO backend the user is from'
         - sql:
             sql: update core_user set sso_source='saml' where saml_auth=true
         - dropColumn:
@@ -5138,9 +5153,10 @@ databaseChangeLog:
         - addColumn:
             tableName: query_execution
             columns:
-              name: database_id
-              type: integer
-              remarks: 'ID of the database this query was ran against.'
+              - column:
+                  name: database_id
+                  type: integer
+                  remarks: 'ID of the database this query was ran against.'
 
 # Start recording the actual query dictionary that's been executed
 
@@ -5152,9 +5168,10 @@ databaseChangeLog:
         - addColumn:
             tableName: query
             columns:
-              name: query
-              type: text
-              remarks: 'The actual "query dictionary" for this query.'
+              - column:
+                  name: query
+                  type: text
+                  remarks: 'The actual "query dictionary" for this query.'
 
 # Create the TaskHistory table, intended to provide debugging info on our background/quartz processes
   - changeSet:
@@ -5253,9 +5270,10 @@ databaseChangeLog:
         - addColumn:
             tableName: metabase_field
             columns:
-              name: settings
-              type: text
-              remarks: 'Serialized JSON FE-specific settings like formatting, etc. Scope of what is stored here may increase in future.'
+              - column:
+                  name: settings
+                  type: text
+                  remarks: 'Serialized JSON FE-specific settings like formatting, etc. Scope of what is stored here may increase in future.'
 #
 # Change MySQL/Maria's blob type to LONGBLOB to more closely match what H2 and PostgreSQL support for size limits
 #
@@ -5400,12 +5418,13 @@ databaseChangeLog:
         - addColumn:
             tableName: metabase_database
             columns:
-              name: auto_run_queries
-              remarks: 'Whether to automatically run queries when doing simple filtering and summarizing in the Query Builder.'
-              type: boolean
-              constraints:
-                nullable: false
-              defaultValueBoolean: true
+              - column:
+                  name: auto_run_queries
+                  remarks: 'Whether to automatically run queries when doing simple filtering and summarizing in the Query Builder.'
+                  type: boolean
+                  constraints:
+                    nullable: false
+                  defaultValueBoolean: true
 
 
   # To fix EE full-app embedding without compromising security. Full-app embed sessions cannot have `SameSite` attributes in their cookies.
@@ -5417,9 +5436,10 @@ databaseChangeLog:
         - addColumn:
             tableName: core_session
             columns:
-              name: anti_csrf_token
-              type: text
-              remarks: 'Anti-CSRF token for full-app embed sessions.'
+              - column:
+                  name: anti_csrf_token
+                  type: text
+                  remarks: 'Anti-CSRF token for full-app embed sessions.'
 
 #
 # Change `metabase_field.database_type` to `text` to accomodate more exotic field types (enums in Clickhouse, rows in Presto, ...)
@@ -6349,9 +6369,10 @@ databaseChangeLog:
         - addColumn:
             tableName: core_user
             columns:
-              name: locale
-              remarks: 'Preferred ISO locale (language/country) code, e.g "en" or "en-US", for this User. Overrides site default.'
-              type: varchar(5)
+              - column:
+                  name: locale
+                  remarks: 'Preferred ISO locale (language/country) code, e.g "en" or "en-US", for this User. Overrides site default.'
+                  type: varchar(5)
 
 # Add Field `database_position` to keep the order in which fields are ordered in the DB, `custom_position` for custom
 # position; and Table `field_order` setting.

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7863,5 +7863,4 @@ databaseChangeLog:
                   foreignKeyName: fk_pulse_card_ref_pulse_card_id
                   deferrable: false
                   initiallyDeferred: false
-                  onDelete: CASCADE
             tableName: pulse_card

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -1555,6 +1555,9 @@ databaseChangeLog:
   - changeSet:
       id: 12
       author: agilliland
+      validCheckSum:
+        - 8:bedbea570e5dfc694b4cf5a8f6a4f445
+        - 8:e862a199cba5b4ce0cba713110f66cfb
       changes:
         - addColumn:
             tableName: report_card
@@ -1568,6 +1571,9 @@ databaseChangeLog:
                     foreignKeyName: fk_report_card_ref_database_id
                     deferrable: false
                     initiallyDeferred: false
+        - addColumn:
+            tableName: report_card
+            columns:
               - column:
                   name: table_id
                   type: int
@@ -1577,6 +1583,9 @@ databaseChangeLog:
                     foreignKeyName: fk_report_card_ref_table_id
                     deferrable: false
                     initiallyDeferred: false
+        - addColumn:
+            tableName: report_card
+            columns:
               - column:
                   name: query_type
                   type: varchar(16)
@@ -3366,6 +3375,9 @@ databaseChangeLog:
   - changeSet:
       id: 49
       author: camsaul
+      validCheckSum:
+        - 8:56dcab086b21de1df002561efeac8bb6
+        - 8:4508e7d5f6d4da3c4a2de3bf5e3c5851
       changes:
         ######################################## Card public_uuid & indices ########################################
         - addColumn:
@@ -3377,6 +3389,9 @@ databaseChangeLog:
                   remarks: 'Unique UUID used to in publically-accessible links to this Card.'
                   constraints:
                     unique: true
+        - addColumn:
+            tableName: report_card
+            columns:
               - column:
                   name: made_public_by_id
                   type: int
@@ -3400,6 +3415,9 @@ databaseChangeLog:
                   remarks: 'Unique UUID used to in publically-accessible links to this Dashboard.'
                   constraints:
                     unique: true
+        - addColumn:
+            tableName: report_dashboard
+            columns:
               - column:
                   name: made_public_by_id
                   type: int
@@ -3421,6 +3439,9 @@ databaseChangeLog:
   - changeSet:
       id: 50
       author: camsaul
+      validCheckSum:
+        - 8:388da4c48984aad647709514e4ba9204
+        - 8:98a6ab6428ea7a589507464e34ade58a
       changes:
         ######################################## new Card columns ########################################
         - addColumn:
@@ -3433,6 +3454,9 @@ databaseChangeLog:
                   defaultValueBoolean: false
                   constraints:
                     nullable: false
+        - addColumn:
+            tableName: report_card
+            columns:
               - column:
                   name: embedding_params
                   type: text
@@ -3448,6 +3472,9 @@ databaseChangeLog:
                   defaultValueBoolean: false
                   constraints:
                     nullable: false
+        - addColumn:
+            tableName: report_dashboard
+            columns:
               - column:
                   name: embedding_params
                   type: text
@@ -3634,6 +3661,9 @@ databaseChangeLog:
   - changeSet:
       id: 55
       author: camsaul
+      validCheckSum:
+        - 8:87c4becde5fe208ba2c356128df86fba
+        - 8:11bbd199bfa57b908ea3b1a470197de9
       changes:
         - addColumn:
             tableName: report_dashboard
@@ -3645,6 +3675,9 @@ databaseChangeLog:
                   defaultValueBoolean: false
                   constraints:
                     nullable: false
+        - addColumn:
+            tableName: report_dashboard
+            columns:
               - column:
                   name: position
                   type: integer
@@ -3807,6 +3840,9 @@ databaseChangeLog:
   - changeSet:
       id: 60
       author: camsaul
+      validCheckSum:
+        - 8:4f997b2cd3309882e900493892381f38
+        - 8:2141162a1c99a5dd95e5a67c5595e6d7
       comment: 'Added 0.26.0'
       changes:
         - addColumn:
@@ -3819,6 +3855,9 @@ databaseChangeLog:
                   defaultValue: '0 50 * * * ? *' # run at the end of every hour
                   constraints:
                     nullable: false
+        - addColumn:
+            tableName: metabase_database
+            columns:
               - column:
                   name: cache_field_values_schedule
                   type: varchar(254)
@@ -3981,6 +4020,9 @@ databaseChangeLog:
       id: 68
       author: sbelak
       comment: 'Added 0.27.0'
+      validCheckSum:
+        - 8:ca201aeb20c1719a46c6bcc3fc95c81d
+        - 8:b4ac06d133dfbdc6567d992c7e18c6ec
       changes:
         - addColumn:
             tableName: computation_job
@@ -3988,12 +4030,18 @@ databaseChangeLog:
               - column:
                   name: context
                   type: text
+        - addColumn:
+            tableName: computation_job
+            columns:
               - column:
                   name: ended_at
                   type: DATETIME
   - changeSet:
       id: 69
       author: senior
+      validCheckSum:
+        - 8:97b7768436b9e8d695bae984020d754c
+        - 8:eadbe00e97eb53df4b3df60462f593f6
       comment: 'Added 0.27.0'
       remarks: 'Add columns to the pulse table for alerts'
       changes:
@@ -4004,10 +4052,16 @@ databaseChangeLog:
                   name: alert_condition
                   type: varchar(254)
                   remarks: 'Condition (i.e. "rows" or "goal") used as a guard for alerts'
+        - addColumn:
+            tableName: pulse
+            columns:
               - column:
                   name: alert_first_only
                   type: boolean
                   remarks: 'True if the alert should be disabled after the first notification'
+        - addColumn:
+            tableName: pulse
+            columns:
               - column:
                   name: alert_above_goal
                   type: boolean
@@ -4050,6 +4104,9 @@ databaseChangeLog:
   - changeSet:
       id: 72
       author: senior
+      validCheckSum:
+        - 8:ed16046dfa04c139f48e9068eb4faee4
+        - 8:4dc6debdf779ab9273cf2158a84bb154
       comment: 'Added 0.28.0'
       changes:
         - addColumn:
@@ -4062,6 +4119,9 @@ databaseChangeLog:
                   remarks: 'True if a CSV of the data should be included for this pulse card'
                   constraints:
                     nullable: false
+        - addColumn:
+            tableName: pulse_card
+            columns:
               - column:
                   name: include_xls
                   type: boolean
@@ -6394,6 +6454,9 @@ databaseChangeLog:
                   defaultValueNumeric: 0
                   constraints:
                     nullable: false
+        - addColumn:
+            tableName: metabase_field
+            columns:
               - column:
                   name: custom_position
                   type: int

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7837,7 +7837,7 @@ databaseChangeLog:
   - changeSet:
       id: 275
       author: dpsutton
-      comment: 'Add refingerprint to Database'
+      comment: 'Added 0.38.0 refingerprint to Database'
       changes:
         - addColumn:
             tableName: metabase_database
@@ -7850,7 +7850,7 @@ databaseChangeLog:
   - changeSet:
       id: 276
       author: robroland
-      comment: Added 0.37.0 - Dashboard subscriptions
+      comment: Added 0.38.0 - Dashboard subscriptions
       changes:
         - addColumn:
             columns:


### PR DESCRIPTION
Add a new step to CI that validates the Liquibase migrations file with core.spec. Should help enforce some additional constraints beyond simply requiring the YAML syntax to be valid.

I went in and fixed some old migrations where we passed a map instead of list to `columns:` or added multiple columns in a single `addColumn:` operation -- Liquibase seemed to allow these, but for consistency I changed them to match the others.

Implements #14092