### PR TITLE
Java run-time: recommend Zulu, another OpenJDK distro with TCK compliance

### DIFF
--- a/docs/operations-guide/java-versions.md
+++ b/docs/operations-guide/java-versions.md
@@ -2,7 +2,7 @@
 
 Metabase requires a Java Runtime Environment (JRE).
 
-We recommend the latest LTS version of JRE from [AdoptOpenJDK](https://adoptopenjdk.net/releases.html) with HotSpot JVM and x64 architecture, but any [supported version](https://adoptopenjdk.net/support.html) should work, including other types of JVM and architecture, and other distributions such as [OpenJDK](https://openjdk.java.net/), [Amazon Corretto](https://aws.amazon.com/corretto/) and [Oracle Java](https://www.java.com/).
+We recommend the latest LTS version of JRE from [AdoptOpenJDK](https://adoptopenjdk.net/releases.html) with HotSpot JVM and x64 architecture, but any [supported version](https://adoptopenjdk.net/support.html) should work, including other types of JVM and architecture, and other distributions such as [OpenJDK](https://openjdk.java.net/), [Amazon Corretto](https://aws.amazon.com/corretto/), [Zulu OpenJDK](https://www.azul.com/downloads/zulu-community), and [Oracle Java](https://www.java.com/).
 
 **Note** When using a "headless" version, the JVM needs to have AWT classes, which are sometimes not included. Otherwise Pulses and other functionality might not work correctly or not at all.
 


### PR DESCRIPTION
(Just to add another viable option out there).

Zulu is what [Microsoft uses](https://azure.microsoft.com/en-us/blog/microsoft-and-azul-systems-bring-free-java-lts-support-to-azure/) for Azure for 2+ years. Bonus: Zulu passes all tests of the OpenJDK Community Technology Compatibility Kit (TCK), [unlike Adopt OpenJDK](https://adoptopenjdk.net/quality.html).