### PR TITLE
#11907 Repro: Tooltip should display correct value for unaggregated data [ci skip]

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -299,6 +299,37 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("There was a problem with your question").should("not.exist");
   });
 
+  it.skip("should display correct value in a tooltip for unaggregated data (metabase#11907)", () => {
+    cy.request("POST", "/api/card", {
+      name: "11907",
+      dataset_query: {
+        type: "native",
+        native: {
+          query:
+            "SELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 5 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 2 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 3 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 1 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 4 AS \"c\"",
+          "template-tags": {},
+        },
+        database: 1,
+      },
+      display: "line",
+      visualization_settings: {},
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.visit(`/question/${QUESTION_ID}`);
+
+      clickLineDot({ index: 0 });
+      popover().within(() => {
+        cy.findByText("January 1, 2020");
+        cy.findByText("10");
+      });
+
+      clickLineDot({ index: 1 });
+      popover().within(() => {
+        cy.findByText("January 2, 2020");
+        cy.findByText("1");
+      });
+    });
+  });
+
   describe("for an unsaved question", () => {
     before(() => {
       restore();
@@ -329,3 +360,9 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 });
+
+function clickLineDot({ index } = {}) {
+  cy.get(".Visualization .dot")
+    .eq(index)
+    .click({ force: true });
+}

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -325,7 +325,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       clickLineDot({ index: 1 });
       popover().within(() => {
         cy.findByText("January 2, 2020");
-        cy.findByText("1");
+        cy.findByText("5");
       });
     });
   });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #11907

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix