### PR TITLE
Dash subscription polish batch 3

### DIFF
--- a/frontend/src/metabase/components/Card.jsx
+++ b/frontend/src/metabase/components/Card.jsx
@@ -11,7 +11,6 @@ const Card = styled.div`
   ${props => props.dark && `color: white`};
   border-radius: 6px;
   box-shadow: 0 7px 20px ${props => color("shadow")};
-  transition: all 0.2s linear;
   line-height: 24px;
   ${props =>
     props.hoverable &&

--- a/frontend/src/metabase/components/SendTestEmail.jsx
+++ b/frontend/src/metabase/components/SendTestEmail.jsx
@@ -28,7 +28,7 @@ export default class SendTestEmail extends Component {
         normalText={t`Send email now`}
         activeText={t`Sending…`}
         failedText={t`Sending failed`}
-        successText={t`Pulse sent`}
+        successText={t`Email sent`}
         forceActiveStyle={true}
       />
     );

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 
 import CheckBox from "metabase/components/CheckBox";
 
-const OFFSET = 4;
+const OFFSET = 3;
 
 const StackedCheckBox = ({ className, ...props }) => (
   <div className={cx(className, "relative")} style={{ transform: "scale(1)" }}>

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -542,7 +542,8 @@ export default class TokenField extends Component {
         {value.map((v, index) => (
           <li
             key={index}
-            className={cx("flex align-center mr1 mb1 p1 rounded bg-medium")}
+            className={cx("flex align-center mr1 mb1 px1 rounded bg-medium")}
+            style={{ paddingTop: "12px", paddingBottom: "12px" }}
           >
             <span
               style={{ ...defaultStyleValue, ...valueStyle }}
@@ -552,14 +553,14 @@ export default class TokenField extends Component {
             </span>
             {multi && (
               <a
-                className="text-medium text-default-hover px1"
+                className="text-medium flex align-center text-error-hover px1"
                 onClick={e => {
                   e.preventDefault();
                   this.removeValue(v);
                 }}
                 onMouseDown={e => e.preventDefault()}
               >
-                <Icon name="close" size={12} />
+                <Icon name="close" className="flex align-center" size={12} />
               </a>
             )}
           </li>

--- a/frontend/src/metabase/components/type/Text.jsx
+++ b/frontend/src/metabase/components/type/Text.jsx
@@ -1,5 +1,11 @@
 import styled from "styled-components";
-import { space, fontSize, fontWeight, letterSpacing, lineHeight } from "styled-system";
+import {
+  space,
+  fontSize,
+  fontWeight,
+  letterSpacing,
+  lineHeight,
+} from "styled-system";
 import { color } from "metabase/lib/colors";
 
 const Text = styled.div`

--- a/frontend/src/metabase/components/type/Text.jsx
+++ b/frontend/src/metabase/components/type/Text.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { space, fontSize, fontWeight, letterSpacing } from "styled-system";
+import { space, fontSize, fontWeight, letterSpacing, lineHeight } from "styled-system";
 import { color } from "metabase/lib/colors";
 
 const Text = styled.div`
@@ -7,6 +7,7 @@ const Text = styled.div`
   ${fontSize};
   ${fontWeight};
   ${letterSpacing};
+  ${lineHeight};
   color: ${props => color(`text-${props.color}`)};
 `;
 

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -179,7 +179,7 @@ export default class EmailAttachmentPicker extends Component {
                       selectedCardIds,
                     )}
                   />
-                <Text ml={1}>{t`Questions to attach`}</Text>
+                  <Text ml={1}>{t`Questions to attach`}</Text>
                 </li>
                 {cards.map(card => (
                   <li

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -169,7 +169,7 @@ export default class EmailAttachmentPicker extends Component {
             <div className="text-bold pt1 pb2 flex justify-between align-center">
               <ul>
                 <li
-                  className="mb1 flex align-center cursor-pointer border-bottom"
+                  className="mb2 flex align-center cursor-pointer border-bottom"
                   onClick={this.onToggleAll}
                 >
                   <StackedCheckBox
@@ -178,14 +178,13 @@ export default class EmailAttachmentPicker extends Component {
                       cards,
                       selectedCardIds,
                     )}
-                    className="mr2"
                   />
-                  <Text>{t`Questions to attach`}</Text>
+                <Text ml={1}>{t`Questions to attach`}</Text>
                 </li>
                 {cards.map(card => (
                   <li
                     key={card.id}
-                    className="pb1 flex align-center cursor-pointer"
+                    className="pb2 flex align-center cursor-pointer"
                     onClick={() => {
                       this.onToggleCard(card);
                     }}

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -29,6 +29,7 @@ import { push, goBack } from "react-router-redux";
 import { connect } from "react-redux";
 
 import { cleanPulse, createChannel } from "metabase/lib/pulse";
+import MetabaseSettings from "metabase/lib/settings";
 
 import {
   getPulseId,
@@ -498,6 +499,12 @@ class SharingSidebar extends React.Component {
     const { editingMode } = this.state;
     const { pulse, formInput, pulseList, onCancel } = this.props;
 
+    const caveatMessage = (<Text className="mx4 my2 p2 bg-light text-dark rounded">{jt`${<span className="text-bold">Note:</span>} charts in your subscription won't look the same as in your dashboard. ${<a
+      className="link"
+      target="_blank"
+      href={MetabaseSettings.docsUrl("users-guide/10-pulses.html#pick-your-data")}
+    >Learn more</a>}.`}</Text>);
+
     // protect from empty values that will mess this up
     if (formInput === null || pulse === null || pulseList === null) {
       return <Sidebar />;
@@ -694,10 +701,11 @@ class SharingSidebar extends React.Component {
           onCancel={onCancel}
           className="text-dark"
         >
-          <div className="pt4 flex align-center px4">
+          <div className="pt4 px4 flex align-center">
             <Icon name="mail" className="mr1" size={21} />
             <Heading>{t`Email this dashboard`}</Heading>
           </div>
+          {caveatMessage}
           <div className="my2 px4">
             <div>
               <div className="text-bold mb1">
@@ -797,6 +805,7 @@ class SharingSidebar extends React.Component {
             <Icon name="slack" className="mr1" size={21} />
             <Heading>{t`Send this dashboard to Slack`}</Heading>
           </div>
+          {caveatMessage}
           <div className="pb2 px4">
             {channelSpec.fields &&
               this.renderFields(channel, index, channelSpec)}

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -506,7 +506,7 @@ class SharingSidebar extends React.Component {
         <a
           className="link"
           target="_blank"
-          href={MetabaseSettings.docsUrl("users-guide/10-pulses.html")}
+          href={MetabaseSettings.docsUrl("users-guide/10-pulses")}
         >
           Learn more
         </a>

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -499,11 +499,21 @@ class SharingSidebar extends React.Component {
     const { editingMode } = this.state;
     const { pulse, formInput, pulseList, onCancel } = this.props;
 
-    const caveatMessage = (<Text className="mx4 my2 p2 bg-light text-dark rounded">{jt`${<span className="text-bold">Note:</span>} charts in your subscription won't look the same as in your dashboard. ${<a
-      className="link"
-      target="_blank"
-      href={MetabaseSettings.docsUrl("users-guide/10-pulses.html#pick-your-data")}
-    >Learn more</a>}.`}</Text>);
+    const caveatMessage = (
+      <Text className="mx4 my2 p2 bg-light text-dark rounded">{jt`${(
+        <span className="text-bold">Note:</span>
+      )} charts in your subscription won't look the same as in your dashboard. ${(
+        <a
+          className="link"
+          target="_blank"
+          href={MetabaseSettings.docsUrl(
+            "users-guide/10-pulses.html#pick-your-data",
+          )}
+        >
+          Learn more
+        </a>
+      )}.`}</Text>
+    );
 
     // protect from empty values that will mess this up
     if (formInput === null || pulse === null || pulseList === null) {

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -10,6 +10,7 @@ import EmailAttachmentPicker from "metabase/sharing/components/EmailAttachmentPi
 import Icon from "metabase/components/Icon";
 import Label from "metabase/components/type/Label";
 import Subhead from "metabase/components/type/Subhead";
+import Text from "metabase/components/type/Text";
 import Link from "metabase/components/Link";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import RecipientPicker from "metabase/pulse/components/RecipientPicker";
@@ -585,8 +586,8 @@ class SharingSidebar extends React.Component {
                 }
               }}
             >
-              <div className="p3">
-                <div className="flex align-center mb1">
+              <div className="px3 pt3 pb2">
+                <div className="flex align-center">
                   <Icon
                     name="mail"
                     className={cx(
@@ -602,7 +603,8 @@ class SharingSidebar extends React.Component {
                     className={cx({ "text-light": !emailSpec.configured })}
                   >{t`Email it`}</h3>
                 </div>
-                <div
+                <Text
+                  lineHeight={1.5}
                   className={cx("text-medium", {
                     "hover-child hover--inherit": emailSpec.configured,
                   })}
@@ -615,7 +617,7 @@ class SharingSidebar extends React.Component {
                     )} first.`}
                   {emailSpec.configured &&
                     t`You can send this dashboard regularly to users or email addresses.`}
-                </div>
+                </Text>
               </div>
             </Card>
             <Card
@@ -631,7 +633,7 @@ class SharingSidebar extends React.Component {
                 }
               }}
             >
-              <div className="p3">
+              <div className="px3 pt3 pb2">
                 <div className="flex align-center mb1">
                   <Icon
                     name={slackSpec.configured ? "slack_colorized" : "slack"}
@@ -645,7 +647,8 @@ class SharingSidebar extends React.Component {
                     className={cx({ "text-light": !slackSpec.configured })}
                   >{t`Send it to Slack`}</h3>
                 </div>
-                <div
+                <Text
+                  lineHeight={1.5}
                   className={cx("text-medium", {
                     "hover-child hover--inherit": slackSpec.configured,
                   })}
@@ -658,7 +661,7 @@ class SharingSidebar extends React.Component {
                     )}.`}
                   {slackSpec.configured &&
                     t`Pick a channel and a schedule, and Metabase will do the rest.`}
-                </div>
+                </Text>
               </div>
             </Card>
           </div>

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -506,9 +506,7 @@ class SharingSidebar extends React.Component {
         <a
           className="link"
           target="_blank"
-          href={MetabaseSettings.docsUrl(
-            "users-guide/10-pulses.html#pick-your-data",
-          )}
+          href={MetabaseSettings.docsUrl("users-guide/10-pulses.html")}
         >
           Learn more
         </a>

--- a/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
+++ b/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
@@ -198,7 +198,7 @@ exports[`ButtonBar should render "left, right, and center" correctly 1`] = `
 
 exports[`Card should render "dark" correctly 1`] = `
 <div
-  className="Card-fqt8sg-0 cWXXUc"
+  className="Card-fqt8sg-0 bnAjGM"
 >
   <div
     className="p4"
@@ -210,7 +210,7 @@ exports[`Card should render "dark" correctly 1`] = `
 
 exports[`Card should render "hoverable" correctly 1`] = `
 <div
-  className="Card-fqt8sg-0 fQGlCM"
+  className="Card-fqt8sg-0 fDXUKg"
 >
   <div
     className="p4"
@@ -222,7 +222,7 @@ exports[`Card should render "hoverable" correctly 1`] = `
 
 exports[`Card should render "normal" correctly 1`] = `
 <div
-  className="Card-fqt8sg-0 IqgNc"
+  className="Card-fqt8sg-0 kYEIzT"
 >
   <div
     className="p4"
@@ -1326,8 +1326,8 @@ exports[`StackedCheckBox should render "Checked with color" correctly 1`] = `
         "border": "2px solid #A989C5",
         "borderRadius": 4,
         "height": 16,
-        "left": 4,
-        "top": -4,
+        "left": 3,
+        "top": -3,
         "width": 16,
         "zIndex": -1,
       }
@@ -1386,8 +1386,8 @@ exports[`StackedCheckBox should render "Checked" correctly 1`] = `
         "border": "2px solid #509EE3",
         "borderRadius": 4,
         "height": 16,
-        "left": 4,
-        "top": -4,
+        "left": 3,
+        "top": -3,
         "width": 16,
         "zIndex": -1,
       }
@@ -1427,8 +1427,8 @@ exports[`StackedCheckBox should render "Off - Default" correctly 1`] = `
         "border": "2px solid #B8BBC3",
         "borderRadius": 4,
         "height": 16,
-        "left": 4,
-        "top": -4,
+        "left": 3,
+        "top": -3,
         "width": 16,
         "zIndex": -1,
       }


### PR DESCRIPTION
- Added a caveat message to the creation state of the sidebar to let folks know that the subscription email/slack will look different from the dashboard (because Pulses).
- Changes "Pulse sent" to "Email sent" on the send test email button.
- Styling tweaks to the Email and Slack option cards (hovers and line-height).
- Styling tweaks to the attachment list and the multi-checkbox icon.
- Styling for recipient token padding and X icon hover state.

Note: I initially attempted to add a focus state to the recipient picker, but it's an oddly nested set of inputs and divs. Tried putting `focus-within` on the parent input but it either didn't work or I did it wrong, so it's not included in this PR.
