### PR TITLE
Collections UX tweaks

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -50,7 +50,7 @@ export function generateQuestions(users) {
 export function generateDashboards(users) {
   users.forEach(user => {
     signIn(user);
-    cy.visit("/collection/root");
+    cy.visit("/");
     cy.get(".Icon-add").click();
     cy.findByText("New dashboard").click();
     cy.findByLabelText("Name").type(user + " test dash");

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -212,18 +212,6 @@ export default class CollectionContent extends React.Component {
                   triggerIcon="add"
                   items={[
                     {
-                      title: t`New dashboard`,
-                      icon: `dashboard`,
-                      action: () => this.setState({ showDashboardModal: true }),
-                      event: `NavBar;New Dashboard Click;`,
-                    },
-                    {
-                      title: t`New pulse`,
-                      icon: `pulse`,
-                      link: Urls.newPulse(),
-                      event: `NavBar;New Pulse Click;`,
-                    },
-                    {
                       title: t`New collection`,
                       icon: `folder`,
                       link: Urls.newCollection(this.props.collectionId),

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -205,21 +205,13 @@ export default class CollectionContent extends React.Component {
                     isRoot={isRoot}
                   />
                 )}
-              <Box>
-                <EntityMenu
-                  tooltip={t`Create`}
-                  className="hide sm-show mr1 text-brand"
-                  triggerIcon="add"
-                  items={[
-                    {
-                      title: t`New collection`,
-                      icon: `folder`,
-                      link: Urls.newCollection(this.props.collectionId),
-                      event: `NavBar;New Dashboard Click;`,
-                    },
-                  ]}
-                />
-              </Box>
+              <Tooltip tooltip={t`New collection`}>
+                <Link to={Urls.newCollection(this.props.collectionId)}>
+                  <IconWrapper>
+                    <Icon name="folder" />
+                  </IconWrapper>
+                </Link>
+              </Tooltip>
             </Flex>
           </Flex>
           {collectionHasPins ? (

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -70,7 +70,7 @@ class CollectionSidebar extends React.Component {
         <CollectionLink
           to={Urls.collection("root")}
           selected={isRoot}
-          mb={2}
+          mb={1}
           mt={2}
         >
           <Icon name="folder" mr={1} />
@@ -86,7 +86,7 @@ class CollectionSidebar extends React.Component {
             currentCollection={collectionId}
           />
 
-          <Box mt={"32px"}>
+          <Box>
             <CollectionsList
               openCollections={this.state.openCollections}
               onClose={this.onClose}
@@ -96,16 +96,19 @@ class CollectionSidebar extends React.Component {
               currentCollection={collectionId}
             />
           </Box>
-
-          {currentUser.is_superuser && (
-            <CollectionLink to={Urls.collection("users")}>
-              <Icon name="group" mr={1} />
-              {t`Other users' personal collections`}
-            </CollectionLink>
-          )}
         </Box>
 
         <Box className="mt-auto" pb={2} pl={SIDEBAR_SPACER * 2}>
+          {currentUser.is_superuser && (
+            <Link
+              my={2}
+              to={Urls.collection("users")}
+              className="flex align-center text-bold text-light text-brand-hover"
+            >
+              <Icon name="group" mr={1} />
+              {t`Other users' personal collections`}
+            </Link>
+          )}
           <Link
             to={`/archive`}
             className="flex align-center text-bold text-light text-brand-hover"

--- a/frontend/test/metabase-smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin.cy.spec.js
@@ -234,7 +234,7 @@ describe("metabase-smoketest > admin", () => {
     });
 
     it.skip("should create a new dashboard with the previous questions as admin", () => {
-      cy.visit("/collection/root");
+      cy.visit("/");
       // New dashboard
       cy.get(".Icon-add").click();
       cy.findByText("New dashboard").click();

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -24,7 +24,7 @@ describe("scenarios > dashboard", () => {
 
   it("should create new dashboard", () => {
     // Create dashboard
-    cy.visit("/collection/root");
+    cy.visit("/");
     cy.get(".Icon-add").click();
     cy.findByText("New dashboard").click();
     cy.findByLabelText("Name").type("Test Dash");

--- a/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
+++ b/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
@@ -17,7 +17,7 @@ describe("scenarios > pulse", () => {
   before(restore);
   beforeEach(signInAsAdmin);
   it("should be able get to the new pulse page from a collection page", () => {
-    cy.visit("/collection/root");
+    cy.visit("/");
 
     cy.get(".Icon-add").click();
     cy.contains("New pulse").click();

--- a/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
+++ b/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
@@ -16,7 +16,7 @@ const MOCK_PULSE_FORM_INPUT = {
 describe("scenarios > pulse", () => {
   before(restore);
   beforeEach(signInAsAdmin);
-  it("should be able get to the new pulse page from a collection page", () => {
+  it("should be able get to the new pulse page from the navbar", () => {
     cy.visit("/");
 
     cy.get(".Icon-add").click();


### PR DESCRIPTION
## What this does
After living with the collections redesign for a little bit we wanted to make a few changes to make things feel smoother, especially in the case of a a fresh out of the box Metabase instance.
- We make a couple future looking moves too quickly, namely moving the create button to collections. That made more sense in a world where we were going to eventually just have you land on your root collection, but we're not 100% confident we're going to do that just yet so this puts it back in its more visible place for the time being.
- In a brand new instance when you're really only likely to have your initial "Our analytics" collection the "Other users' personal collections" nav item - which is an infrequent, admin only need -  was too prominent in the sidebar. This moves that sidebar item down to the bottom in the secondary actions spot, alongside "archive."

## How to test
- You should be able to create new dashboards and pulses (until they're deprecated fully in favor of dashboard subscriptions) from the main nav again by hitting the plus button.
- If you're logged in as an admin you should see "Other users' personal collections" in the bottom left