### PR TITLE
Revert "Unix fingerprinters (#14068)"

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -186,29 +186,16 @@
 (extend-protocol ITemporalCoerceable
   nil      (->temporal [_]    nil)
   String   (->temporal [this] (->temporal (u.date/parse this)))
-  Long     (->temporal [this] (->temporal (t/instant this))) ;; expects millis
+  Long     (->temporal [this] (->temporal (t/instant this)))
   Integer  (->temporal [this] (->temporal (t/instant this)))
   ChronoLocalDateTime (->temporal [this] (.toInstant this (ZoneOffset/UTC)))
   ChronoZonedDateTime (->temporal [this] (.toInstant this))
   Temporal (->temporal [this] this))
 
-(def date-time-rf
-  "Reducing function for date times, coercing to temporal using `ITemporalCoerceable` and accumulating earliest and
-  latest values."
+(deffingerprinter :type/DateTime
   ((map ->temporal)
    (robust-fuse {:earliest earliest
                  :latest   latest})))
-
-(deffingerprinter :type/DateTime
-  date-time-rf)
-
-(deffingerprinter [:type/DateTime :type/UNIXTimestampSeconds]
-  ((map (fn [x] (when x (* x 1000))))
-   date-time-rf))
-
-(deffingerprinter [:type/DateTime :type/UNIXTimestampMicroseconds]
-  ((map (fn [x] (when x (quot x 1000))))
-   date-time-rf))
 
 (defn- histogram
   "Transducer that summarizes numerical data with a histogram."

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -67,22 +67,7 @@
                                  1234 ; int
                                  1594067133360 ; long
                                  "2007-12-03T10:15:30.00Z" ; string
-                                 (java.time.ZonedDateTime/of 2016 01 01 20 04 0 0 (java.time.ZoneOffset/UTC))]))))
-            (testing "handle different unix units"
-              (let [expected {:earliest "2020-07-01T10:30:00Z", :latest "2020-07-01T10:30:00Z"}]
-                (are [type values] (= expected
-                                      (get-in
-                                       (transduce identity
-                                                  (f/fingerprinter
-                                                    (field/map->FieldInstance {:base_type :type/Integer
-                                                                               :special_type type}))
-                                                  values)
-                                       [:type :type/DateTime]))
-                  :type/UNIXTimestampSeconds      [      1593599400 nil]
-                  :type/UNIXTimestampMilliseconds [   1593599400000 nil]
-                  :type/UNIXTimestampMicroseconds [1593599400000000 nil]
-                  ;; check that division with a residue correctly truncates in milliseconds
-                  :type/UNIXTimestampMicroseconds [1593599400000002 nil])))))))))
+                                 (java.time.ZonedDateTime/of 2016 01 01 20 04 0 0 (java.time.ZoneOffset/UTC))]))))))))))
 
 (deftest disambiguate-test
   (testing "We should correctly disambiguate multiple competing multimethods (DateTime and FK in this case)"


### PR DESCRIPTION
This reverts commit 30e5948d358f103070588b4b7b112e26e8f48415.

The casting is done in the query processor, so when we fingerprint, we
are already dealing with dates, not the underlying integral
values. This change actually broke what was working with an error of
"cannot cast <some datetime type> to long
