### PR TITLE
Pivot table styling - batch 3

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -225,12 +225,12 @@ class Column extends React.Component {
         <div>
           <ColumnDragger
             className={cx(
-              "ColumnDragger text-dark mb1 bordered rounded cursor-grab hover-parent hover--visibility text-bold flex justify-between",
+              "text-dark mb1 bordered rounded cursor-grab text-bold flex justify-between",
               { disabled: isDragging },
             )}
           >
             {column.display_name}
-            <Grabber style={{ width: 10 }} className="hover-child" />
+            <Grabber style={{ width: 10 }} />
           </ColumnDragger>
         </div>,
       ),

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -225,7 +225,7 @@ class Column extends React.Component {
         <div>
           <ColumnDragger
             className={cx(
-              "text-dark mb1 bordered rounded cursor-grab hover-parent hover--visibility text-bold flex justify-between",
+              "ColumnDragger text-dark mb1 bordered rounded cursor-grab hover-parent hover--visibility text-bold flex justify-between",
               { disabled: isDragging },
             )}
           >

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import styled from "styled-components";
 import colors, { lighten } from "metabase/lib/colors";
 
+import Label from "metabase/components/type/Label";
 import Grabber from "metabase/components/Grabber";
 
 const ColumnDragger = styled.div`
@@ -93,7 +94,7 @@ class Partition extends React.Component {
     } = this.props;
     return connectDropTarget(
       <div className={className}>
-        <h4 className="mb2">{title}</h4>
+        <Label color="medium">{title}</Label>
         {columns.length === 0 ? (
           <EmptyPartition
             columnFilter={columnFilter}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -3,8 +3,19 @@ import cx from "classnames";
 import { t } from "ttag";
 import { DragSource, DropTarget } from "react-dnd";
 import _ from "underscore";
+import styled from "styled-components";
+import colors, { lighten } from "metabase/lib/colors";
 
 import Grabber from "metabase/components/Grabber";
+
+const ColumnDragger = styled.div`
+  padding: 12px 14px;
+  box-shadow: 0 2px 3px ${lighten(colors["text-dark"], 1.5)};
+  &:hover {
+    box-shadow: 0 2px 5px ${lighten(colors["text-dark"], 1.3)};
+    transition: all 300ms linear;
+  }
+`;
 
 class ChartSettingFieldsPartition extends React.Component {
   constructor(props) {
@@ -210,14 +221,16 @@ class Column extends React.Component {
     } = this.props;
     return connectDropTarget(
       connectDragSource(
-        <div
-          className={cx(
-            "text-dark p1 mb1 bordered rounded dropshadow text-bold flex justify-between",
-            { disabled: isDragging },
-          )}
-        >
-          {column.display_name}
-          <Grabber style={{ width: 10 }} />
+        <div>
+          <ColumnDragger
+            className={cx(
+              "text-dark mb1 bordered rounded cursor-grab hover-parent hover--visibility text-bold flex justify-between",
+              { disabled: isDragging },
+            )}
+          >
+            {column.display_name}
+            <Grabber style={{ width: 10 }} className="hover-child" />
+          </ColumnDragger>
         </div>,
       ),
     );

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -150,6 +150,8 @@ function assertOnPivotTable() {
 // Rely on native drag events, rather than on the coordinates
 // We have 3 "drag-handles" in this test. Their indexes are 0-based.
 function dragField(startIndex, dropIndex) {
+  cy.get(".ColumnGrabber").trigger("mouseover");
+
   cy.get(".Grabber")
     .should("be.visible")
     .as("dragHandle");

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -150,8 +150,6 @@ function assertOnPivotTable() {
 // Rely on native drag events, rather than on the coordinates
 // We have 3 "drag-handles" in this test. Their indexes are 0-based.
 function dragField(startIndex, dropIndex) {
-  cy.get(".ColumnGrabber").trigger("mouseover");
-
   cy.get(".Grabber")
     .should("be.visible")
     .as("dragHandle");


### PR DESCRIPTION
Some sidebar focused tweaks.
- Adds some styling to the column drag UI
- Uses our `Label` component and knocks back the text color a bit.

![image](https://user-images.githubusercontent.com/5248953/102519187-2a8f3b00-4060-11eb-8d3b-2e1c7288a5b8.png)
