### PR TITLE
MAGIC MAPS [Experimental]

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -17,16 +17,20 @@
                             ;; Define custom indentation for functions inside metabase.
                             ;; This list isn't complete; add more forms as we come across them.
                             (define-clojure-indent
+                              (l/matcha '(1 (:defn)))
+                              (l/matche '(1 (:defn)))
                               (let-404 1)
                               (match 1)
                               (merge-with 1)
-                              (l/matche '(1 (:defn)))
-                              (l/matcha '(1 (:defn)))
-                              (p.types/defprotocol+ '(1 (:defn)))
                               (p.types/def-abstract-type '(1 (:defn)))
+                              (p.types/defprotocol+ '(1 (:defn)))
+                              (p.types/defrecord+ '(2 nil nil (:defn)))
                               (p.types/deftype+ '(2 nil nil (:defn)))
+                              (p/def-abstract-type '(1 (:defn)))
                               (p/def-map-type '(2 nil nil (:defn)))
-                              (p.types/defrecord+ '(2 nil nil (:defn))))))
+                              (p/defprotocol+ '(1 (:defn)))
+                              (p/defrecord+ '(2 nil nil (:defn)))
+                              (p/deftype+ '(2 nil nil (:defn))))))
                   ;; if you're using clj-refactor (highly recommended!), prefer prefix notation when cleaning the ns form
                   (cljr-favor-prefix-notation . t)
                   ;; prefer keeping source width about ~118, GitHub seems to cut off stuff at either 119 or 120 and

--- a/resources/data_readers.clj
+++ b/resources/data_readers.clj
@@ -1,2 +1,3 @@
 {t      metabase.util.date-2/parse
- locale metabase.util.i18n.impl/locale}
+ locale metabase.util.i18n.impl/locale
+ magic  metabase.util.magic-map/magic-map}

--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -63,9 +63,9 @@
 (defendpoint GET "/"
   "Get recent activity."
   []
-  (filter mi/can-read? (-> (db/select Activity, {:order-by [[:timestamp :desc]], :limit 40})
-                               (hydrate :user :table :database)
-                               add-model-exists-info)))
+  (filter mi/can-read? (-> (db/select Activity {:order-by [[:timestamp :desc]], :limit 40})
+                           (hydrate :user :table :database)
+                           add-model-exists-info)))
 
 (defn- view-log-entry->matching-object [{:keys [model model_id]}]
   (when (contains? #{"card" "dashboard"} model)

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -226,10 +226,12 @@
   (try (s/validate schema value)
        (catch Throwable e
          (throw (ex-info (tru "Invalid field: {0}" field-name)
-                  {:status-code 400
-                   :errors      {(keyword field-name) (or (su/api-error-message schema)
-                                                          (:message (ex-data e))
-                                                          (.getMessage e))}})))))
+                         (merge
+                          (Throwable->map e)
+                          {:status-code 400
+                           :errors      {(keyword field-name) (or (su/api-error-message schema)
+                                                                  (:message (ex-data e))
+                                                                  (.getMessage e))}}))))))
 
 (defn validate-params
   "Generate a series of `validate-param` calls for each param and schema pair in PARAM->SCHEMA."

--- a/src/metabase/api/magic_test.clj
+++ b/src/metabase/api/magic_test.clj
@@ -1,0 +1,1 @@
+(ns metabase.api.magic-test)

--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -8,6 +8,7 @@
              [exceptions :as mw.exceptions]
              [json :as mw.json]
              [log :as mw.log]
+             [magic :as mw.magic]
              [misc :as mw.misc]
              [security :as mw.security]
              [session :as mw.session]
@@ -23,34 +24,45 @@
 ;; impls for handling `core.async` channels as web server responses
 (classloader/require 'metabase.async.api-response)
 
+(def ^:private middleware
+  ;; ▼▼▼ POST-PROCESSING ▼▼▼ happens from TOP-TO-BOTTOM
+  [#'mw.magic/convert-to-magic-maps          ; convert request to magic maps
+   #'mw.exceptions/catch-uncaught-exceptions ; catch any Exceptions that weren't passed to `raise`
+   #'mw.exceptions/catch-api-exceptions      ; catch exceptions and return them in our expected format
+   #'mw.log/log-api-call
+   #'mw.security/add-security-headers        ; Add HTTP headers to API responses to prevent them from being cached
+   #'mw.json/wrap-json-body                  ; extracts json POST body and makes it avaliable on request
+   #'mw.json/wrap-streamed-json-response     ; middleware to automatically serialize suitable objects as JSON in responses
+   #'wrap-keyword-params                     ; converts string keys in :params to keyword keys
+   #'wrap-params                             ; parses GET and POST params as :query-params/:form-params and both as :params
+   #'mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet
+   #'mw.session/bind-current-user            ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
+   #'mw.session/wrap-current-user-info       ; looks for :metabase-session-id and sets :metabase-user-id and other info if Session ID is valid
+   #'mw.session/wrap-session-id              ; looks for a Metabase Session ID and assoc as :metabase-session-id
+   #'mw.auth/wrap-api-key                    ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
+   #'wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
+   #'mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one
+   #'mw.misc/disable-streaming-buffering     ; Add header to streaming (async) responses so ngnix doesn't buffer keepalive bytes
+   #'wrap-gzip                               ; GZIP response if client can handle it
+   #'mw.misc/bind-request                    ; bind `metabase.middleware.misc/*request*` for the duration of the request
+   #'mw.ssl/redirect-to-https-middleware])
+;; ▲▲▲ PRE-PROCESSING ▲▲▲ happens from BOTTOM-TO-TOP
+
+(defn- apply-middleware [handler]
+  (reduce
+   (fn [handler middleware]
+     (middleware handler))
+   handler
+   middleware))
 
 (def app
   "The primary entry point to the Ring HTTP server."
-  (->
-   ;; in production, dereference routes now because they will not change at runtime, so we don't need to waste time
-   ;; dereferencing the var on every request. For dev & test, use the var instead so it can be tweaked without having
-   ;; to restart the web server
-   (if config/is-prod?
-     routes/routes
-     #'routes/routes)
-   ;; ▼▼▼ POST-PROCESSING ▼▼▼ happens from TOP-TO-BOTTOM
-   mw.exceptions/catch-uncaught-exceptions ; catch any Exceptions that weren't passed to `raise`
-   mw.exceptions/catch-api-exceptions      ; catch exceptions and return them in our expected format
-   mw.log/log-api-call
-   mw.security/add-security-headers        ; Add HTTP headers to API responses to prevent them from being cached
-   mw.json/wrap-json-body                  ; extracts json POST body and makes it avaliable on request
-   mw.json/wrap-streamed-json-response     ; middleware to automatically serialize suitable objects as JSON in responses
-   wrap-keyword-params                     ; converts string keys in :params to keyword keys
-   wrap-params                             ; parses GET and POST params as :query-params/:form-params and both as :params
-   mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet
-   mw.session/bind-current-user            ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
-   mw.session/wrap-current-user-info       ; looks for :metabase-session-id and sets :metabase-user-id and other info if Session ID is valid
-   mw.session/wrap-session-id              ; looks for a Metabase Session ID and assoc as :metabase-session-id
-   mw.auth/wrap-api-key                    ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
-   wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
-   mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one
-   mw.misc/disable-streaming-buffering     ; Add header to streaming (async) responses so ngnix doesn't buffer keepalive bytes
-   wrap-gzip                               ; GZIP response if client can handle it
-   mw.misc/bind-request                    ; bind `metabase.middleware.misc/*request*` for the duration of the request
-   mw.ssl/redirect-to-https-middleware))   ; Redirect to HTTPS if configured to do so
-;; ▲▲▲ PRE-PROCESSING ▲▲▲ happens from BOTTOM-TO-TOP
+  (apply-middleware routes/routes))
+
+;; during interactive dev, recreate `app` whenever a middleware var or `routes/routes` changes.
+(when config/is-dev?
+  (doseq [varr  (cons #'routes/routes middleware)
+          :when (instance? clojure.lang.IRef varr)]
+    (add-watch varr ::reload (fn [_ _ _ _]
+                               (printf "%s changed, rebuilding %s" varr #'app)
+                               (alter-var-root #'app (constantly (apply-middleware routes/routes)))))))

--- a/src/metabase/middleware/json.clj
+++ b/src/metabase/middleware/json.clj
@@ -71,17 +71,17 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- streamed-json-response
-  "Write `response-seq` to a PipedOutputStream as JSON, returning the connected PipedInputStream"
-  [response-seq opts]
+  "Write `response-body` to a PipedOutputStream as JSON, returning the connected PipedInputStream"
+  [response-body opts]
   (rui/piped-input-stream
    (fn [^OutputStream output-stream]
      (with-open [output-writer   (OutputStreamWriter. output-stream StandardCharsets/UTF_8)
                  buffered-writer (BufferedWriter. output-writer)]
-       (json/generate-stream response-seq buffered-writer opts)))))
+       (json/generate-stream response-body buffered-writer opts)))))
 
 (defn- wrap-streamed-json-response* [opts response]
   (if-let [json-response (and (coll? (:body response))
-                              (update-in response [:body] streamed-json-response opts))]
+                              (update response :body streamed-json-response opts))]
     (if (contains? (:headers json-response) "Content-Type")
       json-response
       (rr/content-type json-response "application/json; charset=utf-8"))

--- a/src/metabase/middleware/magic.clj
+++ b/src/metabase/middleware/magic.clj
@@ -1,0 +1,11 @@
+(ns metabase.middleware.magic
+  (:require [metabase.util.magic-map :as magic-map]
+            metabase.util.magic-map.hacks))
+
+(comment metabase.util.magic-map.hacks/keep-me)
+
+(defn convert-to-magic-maps
+  "Convert all maps in `request` to magic maps."
+  [handler]
+  (fn [request respond raise]
+    (handler (magic-map/magical-mappify request) respond raise)))

--- a/src/metabase/middleware/session.clj
+++ b/src/metabase/middleware/session.clj
@@ -14,7 +14,9 @@
             [metabase.models
              [session :refer [Session]]
              [user :as user :refer [User]]]
-            [metabase.util.i18n :as i18n :refer [deferred-trs tru]]
+            [metabase.util
+             [i18n :as i18n :refer [deferred-trs tru]]
+             [magic-map :as magic-map]]
             [ring.util.response :as resp]
             [schema.core :as s]
             [toucan.db :as db])
@@ -220,7 +222,7 @@
           params (concat [session-id]
                          (when (seq anti-csrf-token)
                            [anti-csrf-token]))]
-      (first (jdbc/query (db/connection) (cons sql params))))))
+      (first (jdbc/query (db/connection) (cons sql params) {:row-fn magic-map/magic-map})))))
 
 (defn- merge-current-user-info
   [{:keys [metabase-session-id anti-csrf-token], {:strs [x-metabase-locale]} :headers, :as request}]9

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -945,6 +945,7 @@
   their Personal Collection.)"
   {:batched-hydrate :personal_collection_id}
   [users]
+  (println "HYDRATE PERSONAL COLLECTION ID")
   (when (seq users)
     ;; efficiently create a map of user ID -> personal collection ID
     (let [user-id->collection-id (db/select-field->id :personal_owner_id Collection

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -10,14 +10,16 @@
             [metabase.util
              [cron :as cron-util]
              [encryption :as encryption]
-             [i18n :refer [trs tru]]]
+             [i18n :refer [trs tru]]
+             [magic-map :as magic-map]]
             [potemkin.types :as p.types]
             [schema.core :as s]
             [taoensso.nippy :as nippy]
             [toucan.models :as models])
   (:import [java.io BufferedInputStream ByteArrayInputStream DataInputStream]
            java.sql.Blob
-           java.util.zip.GZIPInputStream))
+           java.util.zip.GZIPInputStream
+           metabase.util.magic_map.MagicMap))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Toucan Extensions                                                |
@@ -226,6 +228,15 @@
   This method is appropriate for powering `PUT` API endpoints. Like `can-create?` this method was added YEARS after
   most of the current API endpoints were written, so it is used in very few places, and this logic is determined
   ad-hoc in the API endpoints themselves. Use this method going forward!"))
+
+(extend-protocol IObjectPermissions
+  MagicMap
+  (can-read? [m]
+    (can-read? (magic-map/->toucan-instance m)))
+  (can-write? [m]
+    (can-write? (magic-map/->toucan-instance m)))
+  (can-update? [m changes]
+    (can-update? (magic-map/->toucan-instance m) (magic-map/->toucan-instance changes))))
 
 (def IObjectPermissionsDefaults
   "Default implementations for `IObjectPermissions`."

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -60,58 +60,52 @@
    :details])
 
 (def ^:private DatabaseInstanceWithRequiredStoreKeys
-  (s/both
-   (class Database)
-   {:id      su/IntGreaterThanZero
-    :engine  s/Keyword
-    :name    su/NonBlankString
-    :details su/Map
-    s/Any    s/Any}))
+  {:id      su/IntGreaterThanZero
+   :engine  s/Keyword
+   :name    su/NonBlankString
+   :details su/Map
+   s/Any    s/Any})
 
 (def ^:private table-columns-to-fetch
   "Columns you should fetch for any Table you want to stash in the Store."
   [:id
    :name
-   :display_name
+   :display-name
    :schema])
 
 (def ^:private TableInstanceWithRequiredStoreKeys
-  (s/both
-   (class Table)
-   {:schema (s/maybe s/Str)
-    :name   su/NonBlankString
-    s/Any   s/Any}))
+  {:schema (s/maybe s/Str)
+   :name   su/NonBlankString
+   s/Any   s/Any})
 
 
 (def ^:private field-columns-to-fetch
   "Columns to fetch for and Field you want to stash in the Store. These get returned as part of the `:cols` metadata in
   query results. Try to keep this set pared down to just what's needed by the QP and frontend, since it has to be done
   for every MBQL query."
-  [:base_type
-   :database_type
+  [:base-type
+   :database-type
    :description
-   :display_name
+   :display-name
    :fingerprint
    :id
    :name
-   :parent_id
+   :parent-id
    :settings
-   :special_type
-   :table_id
-   :visibility_type])
+   :special-type
+   :table-id
+   :visibility-type])
 
 (def ^:private FieldInstanceWithRequiredStorekeys
-  (s/both
-   (class Field)
-   {:name          su/NonBlankString
-    :display_name  su/NonBlankString
-    :description   (s/maybe s/Str)
-    :database_type su/NonBlankString
-    :base_type     su/FieldType
-    :special_type  (s/maybe su/FieldType)
-    :fingerprint   (s/maybe su/Map)
-    :parent_id     (s/maybe su/IntGreaterThanZero)
-    s/Any          s/Any}))
+  {:name          su/NonBlankString
+   :display-name  su/NonBlankString
+   :description   (s/maybe s/Str)
+   :database-type su/NonBlankString
+   :base-type     su/FieldType
+   :special-type  (s/maybe su/FieldType)
+   :fingerprint   (s/maybe su/Map)
+   :parent-id     (s/maybe su/IntGreaterThanZero)
+   s/Any          s/Any})
 
 
 ;;; ------------------------------------------ Saving objects in the Store -------------------------------------------

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -1,10 +1,6 @@
 (ns metabase.sync.interface
   "Schemas and constants used by the sync code."
   (:require [clj-time.core :as time]
-            [metabase.models
-             [database :refer [Database]]
-             [field :refer [Field]]
-             [table :refer [Table]]]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]))
@@ -61,10 +57,21 @@
 ;; out from the ns declaration when running `cljr-clean-ns`. Plus as a bonus in the future we could add additional
 ;; validations to these, e.g. requiring that a Field have a base_type
 
-(def DatabaseInstance             "Schema for a valid instance of a Metabase Database." (class Database))
-(def TableInstance                "Schema for a valid instance of a Metabase Table."    (class Table))
-(def FieldInstance                "Schema for a valid instance of a Metabase Field."    (class Field))
-(def ResultColumnMetadataInstance "Schema for a valid instance of a Metabase Field."    (class {}))
+(def DatabaseInstance
+  "Schema for a valid instance of a Metabase Database."
+  {:id su/IntGreaterThanZero, s/Keyword s/Any})
+
+(def TableInstance
+  "Schema for a valid instance of a Metabase Table."
+  {:id su/IntGreaterThanZero, :db-id su/IntGreaterThanZero, s/Keyword s/Any})
+
+(def FieldInstance
+  "Schema for a valid instance of a Metabase Field."
+  {:id su/IntGreaterThanZero, :table-id su/IntGreaterThanZero, s/Keyword s/Any})
+
+(def ResultColumnMetadataInstance
+  "Schema for a valid instance of a Metabase Field."
+  {:id su/IntGreaterThanZero, s/Keyword s/Any})
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -637,7 +637,7 @@
     (keyword (snake-key (name k)))
     (str/replace k #"-" "_")))
 
-(defn recursive-map-keys
+(defn recursively-replace-map-keys
   "Recursively replace the keys in a map with the value of `(f key)`."
   [f m]
   (walk/postwalk
@@ -647,9 +647,9 @@
    m))
 
 (defn snake-keys
-  "Convert the keys in a map from `lisp-case` to `snake-case`."
-  [m]
-  (recursive-map-keys snake-key m))
+  "Recursively convert all map keys in `x` from `lisp-case` to `snake-case`."
+  [x]
+  (recursively-replace-map-keys snake-key x))
 
 (def ^:private do-with-us-locale-lock (Object.))
 

--- a/src/metabase/util/magic_map.clj
+++ b/src/metabase/util/magic_map.clj
@@ -1,0 +1,157 @@
+(ns metabase.util.magic-map
+  (:require [cheshire.generate :as json.generate]
+            [clojure
+             [pprint :as pprint]
+             [string :as str]
+             [walk :as walk]]
+            [medley.core :as m]
+            [metabase.util :as u]
+            [potemkin :as p]
+            [toucan.models :as t.models]))
+
+;; TODO -- consider moving to main util namespace
+(p/defprotocol+ MagicMapKey
+  (normalize-key [this]
+    "Normalize a map key to lower-cased `lisp-case`. Returns key of the same type as argument (i.e., handles either
+    keywords or strings.)"))
+
+(extend-protocol MagicMapKey
+  nil
+  (normalize-key [_] nil)
+
+  Object
+  (normalize-key [this] this)
+
+  String
+  (normalize-key [s]
+    (-> s str/lower-case (str/replace #"_" "-")))
+
+  clojure.lang.Keyword
+  (normalize-key [k]
+    (-> (str (when-let [nmspace (namespace k)]
+               (str nmspace "/"))
+             (name k))
+        normalize-key
+        keyword)))
+
+(p/def-map-type MagicMap [m mta]
+  (get [_ k default-value]
+    (get m (normalize-key k) default-value))
+  (assoc [_ k v]
+    (MagicMap. (assoc m (normalize-key k) v) mta))
+  (dissoc [_ k]
+    (MagicMap. (dissoc m (normalize-key k)) mta))
+  (keys [_]
+    (keys m))
+  (meta [_]
+    mta)
+  (with-meta [_ new-meta]
+    (MagicMap. m new-meta)))
+
+(defmethod print-method MagicMap
+  [^MagicMap m ^java.io.Writer writer]
+  (when (seq (meta m))
+    (.write writer (format "^%s " (pr-str (meta m)))))
+  (.write writer "#magic ")
+  (.write writer (pr-str (.m m))))
+
+(defmethod print-dup MagicMap
+  [m writer]
+  (print-method m writer))
+
+(defmethod pprint/simple-dispatch MagicMap
+  [m]
+  (print-method m *out*))
+
+(alter-meta! #'->MagicMap assoc :private true)
+
+(defn magic-map
+  (^metabase.util.magic_map.MagicMap []
+   (magic-map nil nil))
+
+  (^metabase.util.magic_map.MagicMap [m]
+   (into (->MagicMap {} (meta m)) m))
+
+  (^metabase.util.magic_map.MagicMap [k v & more]
+   (into (magic-map nil) (cons [k v] (partition-all 2 more)))))
+
+(defn magic-map?
+  "True if `x` is an instance of `MagicMap`."
+  [x]
+  (instance? MagicMap x))
+
+(defn magical-mappify
+  "Recursively convert all maps to magic maps."
+  [x]
+  (walk/postwalk
+   #(if (map? %)
+      (magic-map %)
+      %)
+   x))
+
+
+[:datetime-field [:joined-field "my_join_alias" [:field-literal "my_field" :type/Integer]] :month]
+
+(defn toucan-instance->magic-map [m]
+  (vary-meta (magic-map m) assoc :toucan/class (class m)))
+
+(defn ->snake-key-map [m]
+  (m/map-keys u/snake-key m))
+
+(defn- toucan-instance? [m]
+  (and (record? m)
+       (satisfies? t.models/IModel m)))
+
+(defn toucan-class ^Class [m]
+  (if (toucan-instance? m)
+    (class m)
+    (-> m meta :toucan/class)))
+
+(defn ->toucan-instance
+  ([m]
+   (assert (toucan-class m)
+           (format "Can't convert to a Toucan instance: ^%s %s" (some-> m class .getCanonicalName) (pr-str m)))
+   (->toucan-instance (toucan-class m) m))
+
+  ([klass m]
+   (if (toucan-instance? m)
+     m
+     (into (.newInstance klass) (->snake-key-map m)))))
+
+(defn toucan-name [m]
+  (some-> (toucan-class m) .newInstance name))
+
+(defn- encode-magic-map [m json-generator]
+  (json.generate/encode-map
+   (if-let [klass (toucan-class m)]
+     (->toucan-instance m)
+     (into {} (->snake-key-map m)))
+   json-generator))
+
+(json.generate/add-encoder MagicMap encode-magic-map)
+
+(defn- do-with-toucan-instance [m f]
+  (let [klass (toucan-class m)]
+    (assert klass)
+    (some-> m
+            ->toucan-instance
+            f
+            (vary-meta assoc :toucan/class klass)
+            toucan-instance->magic-map)))
+
+(defmacro with-toucan-instance {:style/indent 1} [[m-binding m] & body]
+  `(do-with-toucan-instance ~m (fn [~m-binding] ~@body)))
+
+(extend-protocol t.models/IModel
+  MagicMap
+  (pre-insert     [m] (with-toucan-instance [m m] (t.models/pre-insert m)))
+  (primary-key    [m] (with-toucan-instance [m m] (t.models/primary-key m)))
+  (post-insert    [m] (with-toucan-instance [m m] (t.models/post-insert m)))
+  (pre-update     [m] (with-toucan-instance [m m] (t.models/pre-update m)))
+  (post-update    [m] (with-toucan-instance [m m] (t.models/post-update m)))
+  (post-select    [m] (with-toucan-instance [m m] (t.models/post-select m)))
+  (pre-delete     [m] (with-toucan-instance [m m] (t.models/pre-delete m)))
+  (default-fields [m] (with-toucan-instance [m m] (t.models/default-fields m)))
+  (hydration-keys [m] (with-toucan-instance [m m] (t.models/hydration-keys m)))
+  (types          [m] (with-toucan-instance [m m] (t.models/types m)))
+  (properties     [m] (with-toucan-instance [m m] (t.models/properties m))))

--- a/src/metabase/util/magic_map/hacks.clj
+++ b/src/metabase/util/magic_map/hacks.clj
@@ -1,0 +1,47 @@
+(ns metabase.util.magic-map.hacks
+  "Proof-of-concept hacks to get magic maps working"
+  (:require [clojure.tools.logging :as log]
+            [metabase.util.magic-map :as magic-map]
+            [toucan
+             [db :as db]
+             [models :as t.models]]))
+
+(println "🧙‍♂️🧙‍♂️🧙‍♂️ INSTALLING MAGIC-MAP HACKS 🧙‍♂️🧙‍♂️🧙‍♂️")
+
+;; TODO -- should we add watches to reinstall the advice if the original var changes? Although I guess if we were in
+;; the business of changing the original var, we wouldn't need advice
+(defmacro define-around-advice
+  {:style/indent :defn}
+  [symb advice-name & fn-tail]
+  {:pre [(symbol? symb) (symbol? advice-name)]}
+  (let [advice-key (keyword "around-advice" (name advice-name))]
+    `(do
+       (when-not (~advice-key (meta #'~symb))
+         (alter-meta! #'~symb assoc ~advice-key @#'~symb))
+       (let [~'&original (~advice-key (meta #'~symb))]
+         (alter-var-root #'~symb (constantly
+                                  (fn ~@fn-tail)))
+         (log/tracef "added %s %s -> %s -> %s" ~advice-key #'~symb ~'&original @#'~symb)))))
+
+(defmacro remove-around-advice [symb advice-name]
+  {:pre [(symbol? symb) (symbol? advice-name)]}
+  (let [advice-key (keyword "around-advice" (name advice-name))]
+    `(when-let [~'&original (~advice-key (meta #'~symb))]
+       (alter-meta! #'~symb dissoc ~advice-key)
+       (alter-var-root #'~symb (constantly ~'&original))
+       (log/tracef "removed %s %s -> %s" ~advice-key #'~symb @#'~symb))))
+
+(define-around-advice db/do-post-select convert-to-magic-maps [model objects]
+  (for [m (&original model objects)]
+    (magic-map/toucan-instance->magic-map m)))
+
+(define-around-advice t.models/do-pre-update convert-to-magic-maps [model object]
+  (println "model:" model) ; NOCOMMIT
+  (println "object:" (class object) object) ; NOCOMMIT
+  (&original model (magic-map/->toucan-instance (class model) object)))
+
+(define-around-advice db/execute! extra-exception-info [honeysql-form & options]
+  (try
+    (apply &original honeysql-form options)
+    (catch Throwable e
+      (throw (ex-info "Error executing statement" {:honeysql-form honeysql-form} e)))))

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -77,6 +77,7 @@
           ;; spot checking rows, but leaving off the discriminator on the end
           (is (= ["AK" "Affiliate" "Doohickey" 18 81] (drop-last (first rows))))
           (is (= ["MS" nil "Doohickey" 78 291] (drop-last (nth rows 1000))))
+
           (is (= [nil nil nil 18760 69540] (drop-last (last rows)))))))))
 
 (deftest pivot-public-card-test

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -108,13 +108,12 @@
   (try
     (let [response (client :post 200 "session" credentials)]
       (or (:id response)
-          (throw (ex-info "Unexpected response" {:response response}))))
+          (throw (ex-info "Unexpected response: missing :id" {:response response}))))
     (catch Throwable e
       (println "Failed to authenticate with credentials" credentials e)
       (throw (ex-info "Failed to authenticate with credentials"
                       {:credentials credentials}
                       e)))))
-
 
 ;;; client
 

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -9,7 +9,8 @@
             [metabase.models.user :as user :refer [User]]
             [metabase.test.initialize :as initialize]
             [schema.core :as s]
-            [toucan.db :as db])
+            [toucan.db :as db]
+            [metabase.util.schema :as su])
   (:import clojure.lang.ExceptionInfo
            metabase.models.user.UserInstance))
 
@@ -73,7 +74,7 @@
               :is_qbnewb    true
               :is_active    active)))))
 
-(s/defn fetch-user :- UserInstance
+(s/defn fetch-user :- {:id su/IntGreaterThanZero, :email su/Email, s/Keyword s/Any}
   "Fetch the User object associated with `username`. Creates user if needed.
 
     (fetch-user :rasta) -> {:id 100 :first_name \"Rasta\" ...}"

--- a/test/metabase/util/magic_map/api_test.clj
+++ b/test/metabase/util/magic_map/api_test.clj
@@ -1,0 +1,55 @@
+(ns metabase.util.magic-map.api-test
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
+            [compojure.core :as compojure :refer [GET POST]]
+            [metabase
+             [models :refer [User]]
+             [test :as mt]]
+            [metabase.api
+             [common :as api]
+             [routes :as api-routes]]
+            metabase.util.magic-map.test-hacks
+            [metabase.util.schema :as su]
+            [schema.core :as s]
+            [toucan.db :as db]))
+
+(comment metabase.util.magic-map.test-hacks/keep-me)
+
+(deftest json-serialization-test
+  (testing "Should convert to snake_case when serializing to JSON"
+    (is (= {:table_id 100}
+           (-> #magic {:table-id 100}
+               json/generate-string
+               (json/parse-string true))))))
+
+(api/defendpoint GET "/test/:first-name"
+  [first-name last-name]
+  {first-name su/NonBlankString
+   last-name  su/NonBlankString}
+  (repeat 2 (db/select-one User :first-name first-name, :last-name last-name)))
+
+(api/defendpoint POST "/test"
+  [:as {{:keys [first-name last-name] :as body} :body}]
+  {first-name su/NonBlankString
+   last-name  su/NonBlankString}
+  (repeat 2 (db/select-one User :first-name first-name, :last-name last-name)))
+
+(api/define-routes)
+
+(deftest api-test
+  (let [orig-routes api-routes/routes]
+    (with-redefs [api-routes/routes (compojure/routes
+                                     (compojure/context "/hacks" [] routes)
+                                     orig-routes)]
+      (let [Toucan {:first_name  (s/eq "Rasta")
+                    :last_name   (s/eq "Toucan")
+                    :common_name (s/eq "Rasta Toucan")
+                    s/Keyword    s/Any}]
+        (is (schema= Toucan
+                     (mt/user-http-request :rasta :get "user/current")))
+        (testing "Should accept lisp-case query params"
+          (is (schema= [Toucan]
+                       (mt/user-http-request :rasta :get "hacks/test/Rasta?last-name=Toucan"))))
+        (testing "Should accept snake_case query params"
+          (is (schema= [Toucan]
+                       (mt/user-http-request :rasta :get "hacks/test/Rasta?last_name=Toucan"))))))))

--- a/test/metabase/util/magic_map/db_test.clj
+++ b/test/metabase/util/magic_map/db_test.clj
@@ -1,0 +1,33 @@
+(ns metabase.util.magic-map.db-test
+  (:require [clojure.test :refer :all]
+            [metabase
+             [models :refer [User]]
+             [test :as mt]]
+            [metabase.util.magic-map :as magic-map]
+            metabase.util.magic-map.test-hacks
+            [toucan.db :as db]))
+
+(comment metabase.util.magic-map.test-hacks/keep-me)
+
+(deftest db-test
+  (let [orig db/honeysql->sql]
+    (doseq [[description k] {"lisp-case" :first-name
+                             "snake_case" :first_name}]
+      (testing (format "Should be able to use %s" description)
+        (let [user-id (mt/user->id :rasta)
+              user    (magic-map/magic-map (db/select-one User :id user-id, :first_name "Rasta"))]
+          (testing "in Toucan select functions"
+            (testing "select-one"
+              (is (= user
+                     (db/select-one User :id user-id, k "Rasta"))))
+            (testing "select-one-field"
+              (is (= "Rasta"
+                     (db/select-one-field k User :id user-id)))))
+          (testing "with maps returned by Toucan functions"
+            (is (= "Rasta"
+                   (k user))))
+          (testing "with Toucan DML functions"
+            (mt/with-temp User [temp-user {k "Cam"}]
+              (db/update! User (:id temp-user) k "Cam 2")
+              (is (= "Cam 2"
+                     (k (User (:id temp-user))))))))))))

--- a/test/metabase/util/magic_map/test_hacks.clj
+++ b/test/metabase/util/magic_map/test_hacks.clj
@@ -1,0 +1,9 @@
+(ns metabase.util.magic-map.test-hacks
+  (:require [metabase.util :as u]
+            [metabase.util.magic-map.hacks :as hacks]
+            [toucan.util.test :as tt]))
+
+(println "🧙‍♂️🧙‍♂️🧙‍♂️ INSTALLING MAGIC-MAP HACKS (FOR TESTS) 🧙‍♂️🧙‍♂️🧙‍♂️")
+
+(hacks/define-around-advice tt/do-with-temp snake-keys-attributes [model attributes f]
+  (&original model (u/snake-keys attributes) f))

--- a/test/metabase/util/magic_map_test.clj
+++ b/test/metabase/util/magic_map_test.clj
@@ -1,0 +1,96 @@
+(ns metabase.util.magic-map-test
+  (:require [clojure
+             [string :as str]
+             [test :refer :all]]
+            [metabase.util.magic-map :as magic-map]))
+
+(deftest normalize-key-test
+  (doseq [k-str  ["my-key" "my_key"]
+          k-str  [k-str (str/upper-case k-str)]
+          ns-str [nil "my-ns" "my_ns"]
+          ns-str (if ns-str
+                   [ns-str (str/upper-case ns-str)]
+                   [ns-str])
+          k      [k-str
+                  (keyword ns-str k-str)]
+          :let   [expected (cond
+                             (string? k) "my-key"
+                             ns-str      :my-ns/my-key
+                             :else       :my-key)]]
+    (testing (format "%s -> %s" (pr-str k) (pr-str expected))
+      (is (= expected
+             (magic-map/normalize-key k))))))
+
+(deftest create-test
+  (let [m (magic-map/magic-map {:snake/snake_case 1, "SCREAMING_SNAKE_CASE" 2, :lisp-case 3, :ANGRY/LISP-CASE 4})]
+    (is (= (magic-map/magic-map {:snake/snake-case 1, "screaming-snake-case" 2, :lisp-case 3, :angry/lisp-case 4})
+           m)))
+  (testing "Should be able to create a map with varargs"
+    (is (= {:db-id 1}
+           (magic-map/magic-map :db_id 1)))
+    (is (= {:db-id 1, :table-id 2}
+
+           (magic-map/magic-map :db_id 1, :TABLE_ID 2))))
+  (testing "Should preserve metadata"
+    (is (= {:x 100}
+           (meta (magic-map/magic-map (with-meta {} {:x 100}))))))
+  (testing "Should be able to use #magic data reader"
+    (let [m #magic {"snake_case" :wow}]
+      (is (magic-map/magic-map? m))
+      (is (= {"snake-case" :wow}
+             m)))))
+
+(deftest keys-test
+  (testing "keys"
+    (let [m #magic {:db_id 1, :table_id 2}]
+      (testing "get keys"
+        (testing "get"
+          (is (= 1
+                 (:db_id m)))
+          (is (= 1
+                 (:db-id m))))
+        (is (= [:db-id :table-id]
+               (keys m)))
+        (testing "assoc"
+          (is (= #magic {:db-id 2, :table-id 2}
+                 (assoc m :db_id 2)))
+          (is (= #magic {:db-id 3, :table-id 2}
+                 (assoc m :db-id 3))))
+        (testing "dissoc"
+          (is (= {}
+                 (dissoc (magic-map/magic-map "ScReAmInG_SnAkE_cAsE" 1) "screaming_snake_case"))))
+        (testing "update"
+          (is (= #magic {:db-id 2, :table-id 2}
+                 (update m :db_id inc))))))))
+
+(deftest equality-test
+  (testing "Two maps created with different key cases should be equal"
+    (= #magic {:db-id 1, :table-id 2}
+       #magic {:db_id 1, :table_id 2}))
+  (testing "should be equal to normal map with the same keys"
+    (is (= {:db-id 1, :table-id 2}
+           #magic {:db_id 1, :table_id 2}))
+    (is (= {}
+           #magic {}))))
+
+(deftest meta-test
+  (testing "Set and fetch metadata"
+    (let [m (with-meta #magic {:table-id 1} {:a 100})]
+      (is (= {:table-id 1}
+             m))
+      (is (= {:a 100}
+             (meta m))))))
+
+(deftest magic-map?-test
+  (testing "Magic maps"
+    (is (= true
+           (magic-map/magic-map? #magic {:db_id 1}))))
+  (testing "Not magic maps"
+    (doseq [x [{} [] nil 100 (Object.) {:db_id 1}]]
+      (testing (pr-str x)
+        (is (= false
+               (magic-map/magic-map? {})))))))
+
+(deftest magical-mappify-test
+  ;; TODO
+  )


### PR DESCRIPTION
Experimental PR that implements a new map type to use `lisp-case` keys everywhere on the backend and auto-convert to `snake_case` at DB/API boundaries

A little hacky. I think we should migrate from Toucan -> Toucan.next (aka BlueJDBC) first