### PR TITLE
#13187 Repro: FE should respect (BE) settings for `auto_run_queries`

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -40,6 +40,24 @@ describe("scenarios > admin > databases > edit", () => {
       cy.findByText("Connection");
       cy.findByText("Scheduling");
     });
+
+    it.skip("respects the settings for automatic query running (metabase#13187)", () => {
+      cy.log("**--Turn off `auto run queries`--**");
+      cy.request("PUT", "/api/database/1", {
+        auto_run_queries: false,
+      });
+
+      cy.visit("/admin/databases/1");
+
+      cy.log("**Reported failing on v0.36.4**");
+      cy.findByLabelText(
+        "Automatically run queries when doing simple filtering and summarizing",
+      ).then($el => {
+        const className = $el[0].className;
+
+        expect(className).not.to.contain("selected");
+      });
+    });
   });
 
   describe("Scheduling tab", () => {


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #13187

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots
Example of a failing test:
![image](https://user-images.githubusercontent.com/31325167/102541342-96998f80-40b0-11eb-9dd0-f0ebe35d14dc.png)
