### PR TITLE
Fix #13187: FE should respect settings for `auto_run_queries` on page load

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
@@ -3,7 +3,12 @@ import React from "react";
 import Toggle from "metabase/components/Toggle";
 
 const FormToggleWidget = ({ field }) => (
-  <Toggle aria-labelledby={`${field.name}-label`} {...field} />
+  <Toggle
+    aria-labelledby={`${field.name}-label`}
+    aria-checked={field.value}
+    role="switch"
+    {...field}
+  />
 );
 
 export default FormToggleWidget;

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -278,7 +278,6 @@ const forms = {
         type: "boolean",
         title: t`Automatically run queries when doing simple filtering and summarizing`,
         description: t`When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries.`,
-        initial: true,
         hidden: !engine,
       },
       {

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -41,7 +41,7 @@ describe("scenarios > admin > databases > edit", () => {
       cy.findByText("Scheduling");
     });
 
-    it.skip("respects the settings for automatic query running (metabase#13187)", () => {
+    it("respects the settings for automatic query running (metabase#13187)", () => {
       cy.log("**--Turn off `auto run queries`--**");
       cy.request("PUT", "/api/database/1", {
         auto_run_queries: false,

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -46,11 +46,7 @@ describe("scenarios > admin > databases > edit", () => {
 
       cy.findByLabelText(
         "Automatically run queries when doing simple filtering and summarizing",
-      ).then($el => {
-        const className = $el[0].className;
-
-        expect(className).to.contain("selected");
-      });
+      ).should("have.attr", "aria-checked", "true");
     });
 
     it("should respect the settings for automatic query running (metabase#13187)", () => {
@@ -64,11 +60,7 @@ describe("scenarios > admin > databases > edit", () => {
       cy.log("**Reported failing on v0.36.4**");
       cy.findByLabelText(
         "Automatically run queries when doing simple filtering and summarizing",
-      ).then($el => {
-        const className = $el[0].className;
-
-        expect(className).not.to.contain("selected");
-      });
+      ).should("have.attr", "aria-checked", "false");
     });
   });
 

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -41,7 +41,19 @@ describe("scenarios > admin > databases > edit", () => {
       cy.findByText("Scheduling");
     });
 
-    it("respects the settings for automatic query running (metabase#13187)", () => {
+    it("`auto_run_queries` toggle should be ON by default for `SAMPLE_DATASET`", () => {
+      cy.visit("/admin/databases/1");
+
+      cy.findByLabelText(
+        "Automatically run queries when doing simple filtering and summarizing",
+      ).then($el => {
+        const className = $el[0].className;
+
+        expect(className).to.contain("selected");
+      });
+    });
+
+    it("should respect the settings for automatic query running (metabase#13187)", () => {
       cy.log("**--Turn off `auto run queries`--**");
       cy.request("PUT", "/api/database/1", {
         auto_run_queries: false,


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes #13187
- It removes the initial state which was set to `true`, so it seems it was forcing the toggle to always be ON, regardless of its true state
- Improves our toggle's accessibility by adding `aria-checked` and `role="switch"` attributes, according to this [A11Y Style Guide](https://a11y-style-guide.com/style-guide/section-forms.html#kssref-forms-toggles)
- Unskips the test which proves that this is now working correctly.

### Additional notes:
- I added a test which asserts that even without this initial state, toggle is ON by default
- @paulrosenzweig and/or @kdoh - it's quite possible that I am overlooking something. Since touching code in `forms.js` can have unintended and far-reaching consequences, please double check that I did the right thing. Thanks