### PR TITLE
Populate result_metadata when saving/updating a Card

### DIFF
--- a/backend/mbql/src/metabase/mbql/normalize.clj
+++ b/backend/mbql/src/metabase/mbql/normalize.clj
@@ -229,7 +229,8 @@
   "Normalize source/results metadata for a single column."
   [metadata]
   {:pre [(map? metadata)]}
-  (-> (reduce #(m/update-existing %1 %2 keyword) metadata [:base_type :special_type :visibility_type :field_ref :source :unit])
+  (-> (reduce #(m/update-existing %1 %2 keyword) metadata [:base_type :special_type :visibility_type :source :unit])
+      (m/update-existing :field_ref normalize-tokens)
       (m/update-existing :fingerprint walk/keywordize-keys)))
 
 (defn- normalize-native-query

--- a/backend/mbql/src/metabase/mbql/normalize.clj
+++ b/backend/mbql/src/metabase/mbql/normalize.clj
@@ -225,11 +225,12 @@
       alias
       (update :alias mbql.u/qualified-name))))
 
-(defn- normalize-source-metadata [metadata]
-  (-> metadata
-      (update :base_type    keyword)
-      (update :special_type keyword)
-      (update :fingerprint  walk/keywordize-keys)))
+(defn normalize-source-metadata
+  "Normalize source/results metadata for a single column."
+  [metadata]
+  {:pre [(map? metadata)]}
+  (-> (reduce #(m/update-existing %1 %2 keyword) metadata [:base_type :special_type :visibility_type :field_ref :source :unit])
+      (m/update-existing :fingerprint walk/keywordize-keys)))
 
 (defn- normalize-native-query
   "For native queries, normalize the top-level keys, and template tags, but nothing else."
@@ -272,35 +273,40 @@
                      (vec path))
         special-fn (when (seq path)
                      (get-in path->special-token-normalization-fn path))]
-    (cond
-      (fn? special-fn)
-      (special-fn x)
+    (try
+      (cond
+        (fn? special-fn)
+        (special-fn x)
 
-      ;; Skip record types because this query is an `expanded` query, which is not going to play nice here. Hopefully we
-      ;; can remove expanded queries entirely soon.
-      (record? x)
-      x
+        ;; Skip record types because this query is an `expanded` query, which is not going to play nice here. Hopefully we
+        ;; can remove expanded queries entirely soon.
+        (record? x)
+        x
 
-      ;; maps should just get the keys normalized and then recursively call normalize-tokens on the values.
-      ;; Each recursive call appends to the keypath above so we can handle top-level clauses in a special way if needed
-      (map? x)
-      (into {} (for [[k v] x
-                     :let  [k (mbql.u/normalize-token k)]]
-                 [k (normalize-tokens v (conj (vec path) k))]))
+        ;; maps should just get the keys normalized and then recursively call normalize-tokens on the values.
+        ;; Each recursive call appends to the keypath above so we can handle top-level clauses in a special way if needed
+        (map? x)
+        (into {} (for [[k v] x
+                       :let  [k (mbql.u/normalize-token k)]]
+                   [k (normalize-tokens v (conj (vec path) k))]))
 
-      ;; MBQL clauses handled above because of special cases
-      (mbql-clause? x)
-      (normalize-mbql-clause-tokens x)
+        ;; MBQL clauses handled above because of special cases
+        (mbql-clause? x)
+        (normalize-mbql-clause-tokens x)
 
-      ;; for non-mbql sequential collections (probably something like the subclauses of :order-by or something like
-      ;; that) recurse on all the args.
-      ;;
-      ;; To signify that we're recursing into a sequential collection, this appends `::sequence` to path
-      (sequential? x)
-      (mapv #(normalize-tokens % (conj (vec path) ::sequence)) x)
+        ;; for non-mbql sequential collections (probably something like the subclauses of :order-by or something like
+        ;; that) recurse on all the args.
+        ;;
+        ;; To signify that we're recursing into a sequential collection, this appends `::sequence` to path
+        (sequential? x)
+        (mapv #(normalize-tokens % (conj (vec path) ::sequence)) x)
 
-      :else
-      x)))
+        :else
+        x)
+      (catch Throwable e
+        (throw (ex-info (tru "Error normalizing form.")
+                        {:form x, :path path}
+                        e))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -550,10 +556,15 @@
   "Canonicalize a query [MBQL query], rewriting the query as if you perfectly followed the recommended style guides for
   writing MBQL. Does things like removes unneeded and empty clauses, converts older MBQL '95 syntax to MBQL '98, etc."
   [{:keys [query parameters source-metadata], :as outer-query}]
-  (cond-> outer-query
-    source-metadata move-source-metadata-to-mbql-query
-    query           (update :query canonicalize-inner-mbql-query)
-    parameters      (update :parameters (partial mapv canonicalize-mbql-clauses))))
+  (try
+    (cond-> outer-query
+      source-metadata move-source-metadata-to-mbql-query
+      query           (update :query canonicalize-inner-mbql-query)
+      parameters      (update :parameters (partial mapv canonicalize-mbql-clauses)))
+    (catch Throwable e
+      (throw (ex-info (tru "Error canonicalizing query")
+                      {:query query}
+                      e)))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -589,8 +600,12 @@
   "Perform transformations that operate on the query as a whole, making sure the structure as a whole is logical and
   consistent."
   [query]
-  (-> query
-      remove-breakout-fields-from-fields))
+  (try
+    (remove-breakout-fields-from-fields query)
+    (catch Throwable e
+      (throw (ex-info (tru "Error performing whole query transformations")
+                      {:query query}
+                      e)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             REMOVING EMPTY CLAUSES                                             |
@@ -634,14 +649,20 @@
    (remove-empty-clauses query []))
 
   ([x path]
-   (let [special-fn (when (seq path)
-                      (get-in path->special-remove-empty-clauses-fn path))]
-     (cond
-       (fn? special-fn) (special-fn x)
-       (record? x)      x
-       (map? x)         (remove-empty-clauses-in-map x path)
-       (sequential? x)  (remove-empty-clauses-in-sequence x path)
-       :else            x))))
+   (try
+     (let [special-fn (when (seq path)
+                        (get-in path->special-remove-empty-clauses-fn path))]
+       (cond
+         (fn? special-fn) (special-fn x)
+         (record? x)      x
+         (map? x)         (remove-empty-clauses-in-map x path)
+         (sequential? x)  (remove-empty-clauses-in-sequence x path)
+         :else            x))
+     (catch Throwable e
+       (throw (ex-info "Error removing empty clauses from form."
+                       {:form x, :path path}
+                       e))))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUTTING IT ALL TOGETHER                                             |
@@ -650,10 +671,17 @@
 (def ^{:arglists '([outer-query])} normalize
   "Normalize the tokens in a Metabase query (i.e., make them all `lisp-case` keywords), rewrite deprecated clauses as
   up-to-date MBQL 2000, and remove empty clauses."
-  (comp remove-empty-clauses
-        perform-whole-query-transformations
-        canonicalize
-        normalize-tokens))
+  (let [normalize* (comp remove-empty-clauses
+                         perform-whole-query-transformations
+                         canonicalize
+                         normalize-tokens)]
+    (fn [query]
+      (try
+        (normalize* query)
+        (catch Throwable e
+          (throw (ex-info (tru "Error normalizing query")
+                          {:query query}
+                          e)))))))
 
 (defn normalize-fragment
   "Normalize just a specific fragment of a query, such as just the inner MBQL part or just a filter clause. `path` is

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -85,7 +85,7 @@
   [entity]
   (cond-> (dissoc entity :id :creator_id :created_at :updated_at :db_id :location
                   :dashboard_id :fields_hash :personal_owner_id :made_public_by_id :collection_id
-                  :pulse_id)
+                  :pulse_id :result_metadata)
     (some #(instance? % entity) (map type [Metric Field Segment])) (dissoc :table_id)))
 
 (defmulti ^:private serialize-one

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -588,6 +588,6 @@
                         :order-by [[:asc $id]]
                         :limit    3})))))
           (testing "After running the query the first time, result_metadata should have been saved for the GTAP Card"
-            (is (= [{:name "ID", :base_type "type/BigInteger", :display_name "ID"}
-                    {:name "NAME", :base_type "type/Text", :display_name "NAME"}]
+            (is (= [{:name "ID", :base_type :type/BigInteger, :display_name "ID"}
+                    {:name "NAME", :base_type :type/Text, :display_name "NAME"}]
                    (db/select-one-field :result_metadata Card :id venues-gtap-card-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/serialize_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/serialize_test.clj
@@ -9,35 +9,34 @@
 
 (defn- all-ids-are-fully-qualified-names?
   [m]
-  (every? string? (for [[k v] m
-                        :when (and v (-> k name (str/ends-with? "_id")))]
-                    v)))
+  (testing (format "\nm = %s" (pr-str m))
+    (doseq [[k v] m
+            :when (and v (-> k name (str/ends-with? "_id")))]
+      (testing (format "\nk = %s" (pr-str k))
+        (is (string? v))))))
 
 (defn- all-mbql-ids-are-fully-qualified-names?
   [[_ & ids]]
-  (every? string? ids))
-
-(defn- valid-serialization?
-  [s]
-  (->> s
-       (tree-seq coll? identity)
-       (filter (some-fn map? #'serialize/mbql-entity-reference?))
-       (every? (fn [x]
-                 (if (map? x)
-                   (all-ids-are-fully-qualified-names? x)
-                   (all-mbql-ids-are-fully-qualified-names? x))))))
+  (testing (format "\nids = %s" (pr-str ids))
+    (doseq [id ids]
+      (is (string? id)))))
 
 (deftest serialization-test
   (ts/with-world
-    (letfn [(test-serialization [model id]
-              (testing (name model)
-                (is (valid-serialization? (serialize/serialize (model id))))))]
-      (doseq [[model id] [[Card card-id]
-                          [Metric metric-id]
-                          [Segment segment-id]
-                          [Collection collection-id]
-                          [Dashboard dashboard-id]
-                          [Table table-id]
-                          [Field numeric-field-id]
-                          [Database db-id]]]
-        (test-serialization model id)))))
+    (doseq [[model id] [[Card card-id]
+                        [Metric metric-id]
+                        [Segment segment-id]
+                        [Collection collection-id]
+                        [Dashboard dashboard-id]
+                        [Table table-id]
+                        [Field numeric-field-id]
+                        [Database db-id]]]
+      (testing (name model)
+        (let [serialization (serialize/serialize (model id))]
+          (testing (format "\nserialization = %s" (pr-str serialization))
+            (doseq [x (->> serialization
+                           (tree-seq coll? identity)
+                           (filter (some-fn map? #'serialize/mbql-entity-reference?)))]
+              (if (map? x)
+                (all-ids-are-fully-qualified-names? x)
+                (all-mbql-ids-are-fully-qualified-names? x)))))))))

--- a/src/metabase/middleware/session.clj
+++ b/src/metabase/middleware/session.clj
@@ -283,5 +283,6 @@
   {:style/indent 1}
   [current-user-id & body]
   `(do-with-current-user
-    (db/select-one [User [:id :metabase-user-id] [:is_superuser :is-superuser?] [:locale :user-locale]] :id ~current-user-id)
+    (when-let [current-user-id# ~current-user-id]
+      (db/select-one [User [:id :metabase-user-id] [:is_superuser :is-superuser?] [:locale :user-locale]] :id current-user-id#))
     (fn [] ~@body)))

--- a/src/metabase/middleware/session.clj
+++ b/src/metabase/middleware/session.clj
@@ -269,7 +269,8 @@
 
   *  `*current-user-id*`                int ID or nil of user associated with request
   *  `*current-user*`                   delay that returns current user (or nil) from DB
-  *  `metabase.util.i18n/*user-locale*` ISO locale code e.g `en` or `en-US` to use for the current User. Overrides `site-locale` if set.
+  *  `metabase.util.i18n/*user-locale*` ISO locale code e.g `en` or `en-US` to use for the current User.
+                                        Overrides `site-locale` if set.
   *  `*is-superuser?*`                  Boolean stating whether current user is a superuser.
   *  `current-user-permissions-set*`    delay that returns the set of permissions granted to the current user from DB"
   [handler]
@@ -277,12 +278,18 @@
     (with-current-user-for-request request
       (handler request respond raise))))
 
+(defn with-current-user-fetch-user-for-id
+  "Part of the impl for `with-current-user` -- don't use this directly."
+  [current-user-id]
+  (when current-user-id
+    (db/select-one [User [:id :metabase-user-id] [:is_superuser :is-superuser?] [:locale :user-locale]]
+      :id current-user-id)))
+
 (defmacro with-current-user
   "Execute code in body with User with `current-user-id` bound as the current user. (This is not used in the middleware
   itself but elsewhere where we want to simulate a User context, such as when rendering Pulses or in tests.) "
   {:style/indent 1}
   [current-user-id & body]
   `(do-with-current-user
-    (when-let [current-user-id# ~current-user-id]
-      (db/select-one [User [:id :metabase-user-id] [:is_superuser :is-superuser?] [:locale :user-locale]] :id current-user-id#))
+    (with-current-user-fetch-user-for-id ~current-user-id)
     (fn [] ~@body)))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -185,7 +185,7 @@
   (qp.store/with-store
     (let [preprocessed (query->preprocessed query)]
       (driver/with-driver (driver.u/database->driver (:database preprocessed))
-        (seq (annotate/merged-column-info preprocessed nil))))))
+        (not-empty (vec (annotate/merged-column-info preprocessed nil)))))))
 
 (defn query->native
   "Return the native form for `query` (e.g. for a MBQL query on Postgres this would return a map containing the compiled

--- a/src/metabase/query_processor/async.clj
+++ b/src/metabase/query_processor/async.clj
@@ -1,9 +1,12 @@
 (ns metabase.query-processor.async
   "Mostly legacy namespace that these days is reduced to a single util function, `result-metadata-for-query-async`. TODO
   -- Consider whether there's a place to put this to consolidate things."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.core.async :as a]
+            [clojure.tools.logging :as log]
+            [metabase
+             [query-processor :as qp]
+             [util :as u]]
             [metabase.api.common :as api]
-            [metabase.query-processor :as qp]
             [metabase.query-processor
              [context :as context]
              [interface :as qpi]
@@ -41,6 +44,12 @@
    results."
   [query]
   (binding [qpi/*disable-qp-logging* true]
+    ;; for MBQL queries we can infer the columns just by preprocessing the query.
+    (if-let [inferred-columns (not-empty (u/ignore-exceptions (qp/query->expected-cols query)))]
+      (let [chan (a/promise-chan)]
+        (a/>!! chan inferred-columns)
+        (a/close! chan)))
+    ;; for *native* queries we actually have to run it.
     (let [query (query-for-result-metadata query)]
       (qp/process-query-async query {:reducedf async-result-metadata-reducedf
                                      :raisef   async-result-metdata-raisef}))))

--- a/src/metabase/query_processor/error_type.clj
+++ b/src/metabase/query_processor/error_type.clj
@@ -50,6 +50,10 @@
   "The current user does not have required permissions to run the current query."
   :parent client)
 
+(deferror bad-configuration
+  "Something related to configuration (e.g. of a sandbox/GTAP) is preventing us from being able to run the query."
+  :parent client)
+
 (deferror invalid-query
   "Generic ancestor type for errors with the query map itself."
   :parent client)
@@ -72,7 +76,7 @@
 ;;;; ### Server-Side Errors
 
 (deferror server
-  "Generic ancestor type for all unexpected server-side errors. Equivalent of a HTTP 5xx status code."
+  "Generic ancestor type for all *unexpected* server-side errors. Equivalent of a HTTP 5xx status code."
   :parent :error)
 
 (defn server-error?
@@ -92,7 +96,7 @@
   :parent server)
 
 (deferror driver
-  "Generic ancestor type for all errors related to bad drivers and uncaught Exceptions in driver code."
+  "Generic ancestor type for all unexpected errors related to bad drivers and uncaught Exceptions in driver code."
   :parent qp)
 
 ;;;; #### Data Warehouse (DB) Errors

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -14,6 +14,9 @@
 ;; TODO - maybe we should do this more generally with the help of a macro like `do-with-suppressed-output` from the
 ;; test utils, perhaps implemented as separate middleware (and using a `:middleware` option). Or perhaps even make QP
 ;; log level an option so you could do debug individual queries
+;;
+;; TODO - I think we should just remove this entirely, it's not used consistently and it's more trouble than it's
+;; worth. Just dial down the log level a bit where we're currently using this
 (def ^:dynamic ^Boolean *disable-qp-logging*
   "Should we disable logging for the QP? (e.g., during sync we probably want to turn it off to keep logs less
   cluttered)."

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -128,7 +128,7 @@
                 (u/pprint-to-str 'yellow source-query)))
     {:source-query    source-query
      :database        database-id
-     :source-metadata (normalize/normalize-fragment [:query :source-metadata] result-metadata)}))
+     :source-metadata (seq (map normalize/normalize-source-metadata result-metadata))}))
 
 (s/defn ^:private source-table-str->card-id :- su/IntGreaterThanZero
   [source-table-str :- mbql.s/source-table-card-id-regex]
@@ -169,9 +169,9 @@
       (try
         (resolve-all* resolved)
         (catch Throwable e
-          (throw (ex-info (.getMessage e)
-                   {:resolving &match, :resolved resolved}
-                   e)))))))
+          (throw (ex-info (tru "Error resolving source query")
+                          {:resolving &match, :resolved resolved}
+                          e)))))))
 
 (defn- check-for-circular-references
   "Check that there are no circular dependencies among source cards. This is equivalent to

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -139,8 +139,8 @@
       (t/testing "Don't write any new tests using expect!"
         (let [ee? (u/ignore-exceptions (require 'metabase-enterprise.core) true)]
           ;; TODO - update the numbers for EE
-          (t/is (<= total-expect-forms (if ee? 1177 882)))
-          (t/is (<= total-namespaces-using-expect (if ee? 107 85))))))))
+          (t/is (<= total-expect-forms (if ee? 871 842)))
+          (t/is (<= total-namespaces-using-expect (if ee? 84 80))))))))
 
 (defmacro ^:deprecated expect
   "Simple macro that simulates converts an Expectations-style `expect` form into a `clojure.test` `deftest` form."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -35,7 +35,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- count-base-type []
-  (-> (mt/run-mbql-query venues {:aggregation [[:count]]}) :data :cols first :base_type u/qualified-name))
+  (-> (mt/run-mbql-query venues {:aggregation [[:count]]}) :data :cols first :base_type))
 
 (def card-defaults
   {:archived            false
@@ -329,10 +329,10 @@
                                                                  :result_metadata    metadata
                                                                  :metadata_checksum  (#'results-metadata/metadata-checksum metadata)))
             ;; now check the metadata that was saved in the DB
-            (is (= [{:base_type    "type/Integer"
+            (is (= [{:base_type    :type/Integer
                      :display_name "Count Chocula"
                      :name         "count_chocula"
-                     :special_type "type/Number"}]
+                     :special_type :type/Number}]
                    (db/select-one-field :result_metadata Card :name card-name)))))))))
 
 (deftest save-card-with-empty-result-metadata-test
@@ -374,10 +374,10 @@
                                          :result_metadata    (map fingerprint-integers->doubles metadata)
                                          :metadata_checksum  (#'results-metadata/metadata-checksum metadata)))
             (testing "check the metadata that was saved in the DB"
-              (is (= [{:base_type    "type/Integer"
+              (is (= [{:base_type    :type/Integer
                        :display_name "Count Chocula"
                        :name         "count_chocula"
-                       :special_type "type/Number"
+                       :special_type :type/Number
                        :fingerprint  {:global {:distinct-count 285},
                                       :type   {:type/Number {:min 5.0, :max 2384.0, :avg 1000.2}}}}]
                      (db/select-one-field :result_metadata Card :name card-name))))))))))
@@ -400,10 +400,10 @@
                                          ;; bad checksum
                                          :metadata_checksum  "ABCDEF"))
             (testing "check the correct metadata was fetched and was saved in the DB"
-              (is (= [{:base_type    "type/BigInteger"
+              (is (= [{:base_type    :type/BigInteger
                        :display_name "Count"
                        :name         "count"
-                       :special_type "type/Quantity"
+                       :special_type :type/Quantity
                        :fingerprint  {:global {:distinct-count 1
                                                :nil%           0.0},
                                       :type   {:type/Number {:min 100.0
@@ -442,7 +442,7 @@
                 (is (= [{:base_type    (count-base-type)
                          :display_name "Count"
                          :name         "count"
-                         :special_type "type/Quantity"
+                         :special_type :type/Quantity
                          :fingerprint  {:global {:distinct-count 1
                                                  :nil%           0.0},
                                         :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0 :sd nil}}}}]
@@ -518,7 +518,8 @@
                    :database_id            (mt/id) ; these should be inferred from the dataset_query
                    :table_id               (mt/id :venues)
                    :collection_id          (u/get-id collection)
-                   :collection             (into {} collection)})
+                   :collection             (into {} collection)
+                   :result_metadata        (mt/obj->json->obj (:result_metadata card))})
                  (mt/user-http-request :rasta :get 200 (str "card/" (u/get-id card))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -609,10 +610,10 @@
                                :result_metadata   metadata
                                :metadata_checksum (#'results-metadata/metadata-checksum metadata)})
         ;; now check the metadata that was saved in the DB
-        (is (= [{:base_type    "type/Integer"
+        (is (= [{:base_type    :type/Integer
                  :display_name "Count Chocula"
                  :name         "count_chocula"
-                 :special_type "type/Number"}]
+                 :special_type :type/Number}]
                (db/select-one-field :result_metadata Card :id (u/get-id card))))))))
 
 (deftest make-sure-when-updating-a-card-the-correct-query-metadata-is-fetched--if-incorrect-
@@ -628,10 +629,10 @@
                                :result_metadata   metadata
                                :metadata_checksum "ABC123"}) ; invalid checksum
         ;; now check the metadata that was saved in the DB
-        (is (= [{:base_type    "type/BigInteger"
+        (is (= [{:base_type    :type/BigInteger
                  :display_name "Count"
                  :name         "count"
-                 :special_type "type/Quantity"
+                 :special_type :type/Quantity
                  :fingerprint  {:global {:distinct-count 1
                                          :nil%           0.0},
                                 :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0 :sd nil}}}}]

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -660,11 +660,12 @@
           (letfn [(dimension-options []
                     (let [response ((mt/user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card)))]
                       (map #(dimension-options-for-field response %) ["latitude" "longitude"])))]
-            (testing "Nested queries missing a fingerprint should not show binning-options"
-              ;; By default result_metadata will be nil (and no fingerprint). Just asking for query_metadata after the
-              ;; card was created but before it was ran should not allow binning
-              (is (= [nil nil]
-                     (dimension-options))))
+            (testing "Nested queries missing a fingerprint/results metadata should not show binning-options"
+              (mt/with-temp-vals-in-db Card (:id card) {:result_metadata nil}
+                ;; By default result_metadata will be nil (and no fingerprint). Just asking for query_metadata after the
+                ;; card was created but before it was ran should not allow binning
+                (is (= [nil nil]
+                       (dimension-options)))))
 
             (testing "Nested queries with a fingerprint should have dimension options for binning"
               ;; run the Card which will populate its result_metadata column

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -21,7 +21,6 @@
   (mt/test-drivers (metadata-queries-test-drivers)
     (is (= 100
            (metadata-queries/field-distinct-count (Field (mt/id :checkins :venue_id)))))
-
     (is (= 15
            (metadata-queries/field-distinct-count (Field (mt/id :checkins :user_id)))))))
 

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -3,6 +3,7 @@
             [clojure.test :refer :all]
             [metabase
              [models :refer [Card Collection Dashboard DashboardCard]]
+             [query-processor :as qp]
              [test :as mt]
              [util :as u]]
             [metabase.models.card :as card]
@@ -173,3 +174,40 @@
              clojure.lang.ExceptionInfo
              #"A Card can only go in Collections in the \"default\" namespace"
              (db/update! Card card-id {:collection_id collection-id})))))))
+
+(deftest normalize-result-metadata-test
+  (testing "Should normalize result metadata keys when fetching a Card from the DB"
+    (let [metadata (qp/query->expected-cols (mt/mbql-query :venues))]
+      (mt/with-temp Card [{card-id :id} {:dataset_query   (mt/mbql-query :venues)
+                                         :result_metadata metadata}]
+        (is (= (mt/derecordize metadata)
+               (mt/derecordize (db/select-one-field :result_metadata Card :id card-id))))))))
+
+(deftest populate-result-metadata-if-needed-test
+  (doseq [[creating-or-updating f]
+          {"creating" (fn [properties f]
+                        (mt/with-temp Card [{card-id :id} properties]
+                          (f (db/select-one-field :result_metadata Card :id card-id))))
+           "updating" (fn [changes f]
+                        (mt/with-temp Card [{card-id :id} {:dataset_query   (mt/mbql-query :checkins)
+                                                           :result_metadata (qp/query->expected-cols (mt/mbql-query :checkins))}]
+                          (db/update! Card card-id changes)
+                          (f (db/select-one-field :result_metadata Card :id card-id))))}]
+    (testing (format "When %s a Card\n" creating-or-updating)
+      (testing "If result_metadata is empty, we should attempt to populate it"
+        (f {:dataset_query (mt/mbql-query :venues)}
+           (fn [metadata]
+             (is (= (map :name (qp/query->expected-cols (mt/mbql-query :venues)))
+                    (map :name metadata))))))
+      (testing "Don't overwrite result_metadata that was passed in"
+        (let [metadata (take 1 (qp/query->expected-cols (mt/mbql-query :venues)))]
+          (f {:dataset_query   (mt/mbql-query :venues)
+              :result_metadata metadata}
+             (fn [new-metadata]
+               (is (= (mt/derecordize metadata)
+                      (mt/derecordize new-metadata)))))))
+      (testing "Shouldn't barf if query can't be run (e.g. if query is a SQL query); set metadata to nil"
+        (f {:dataset_query (mt/native-query {:native "SELECT * FROM VENUES"})}
+           (fn [metadata]
+             (is (= nil
+                    metadata))))))))

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -30,18 +30,18 @@
   (mt/round-all-decimals 2 data))
 
 (def ^:private default-card-results
-  [{:name         "ID",      :display_name "ID", :base_type "type/BigInteger",
-    :special_type "type/PK", :fingerprint  (:id mutil/venue-fingerprints)}
-   {:name         "NAME",      :display_name "Name", :base_type "type/Text",
-    :special_type "type/Name", :fingerprint  (:name mutil/venue-fingerprints)}
-   {:name         "PRICE", :display_name "Price", :base_type "type/Integer",
+  [{:name         "ID",      :display_name "ID", :base_type :type/BigInteger,
+    :special_type :type/PK, :fingerprint  (:id mutil/venue-fingerprints)}
+   {:name         "NAME",      :display_name "Name", :base_type :type/Text,
+    :special_type :type/Name, :fingerprint  (:name mutil/venue-fingerprints)}
+   {:name         "PRICE", :display_name "Price", :base_type :type/Integer,
     :special_type nil,     :fingerprint  (:price mutil/venue-fingerprints)}
-   {:name         "CATEGORY_ID", :display_name "Category ID", :base_type "type/Integer",
+   {:name         "CATEGORY_ID", :display_name "Category ID", :base_type :type/Integer,
     :special_type nil,           :fingerprint  (:category_id mutil/venue-fingerprints)}
-   {:name         "LATITUDE",      :display_name "Latitude", :base_type "type/Float",
-    :special_type "type/Latitude", :fingerprint  (:latitude mutil/venue-fingerprints)}
-   {:name         "LONGITUDE",      :display_name "Longitude", :base_type "type/Float"
-    :special_type "type/Longitude", :fingerprint  (:longitude mutil/venue-fingerprints)}])
+   {:name         "LATITUDE",      :display_name "Latitude", :base_type :type/Float,
+    :special_type :type/Latitude, :fingerprint  (:latitude mutil/venue-fingerprints)}
+   {:name         "LONGITUDE",      :display_name "Longitude", :base_type :type/Float
+    :special_type :type/Longitude, :fingerprint  (:longitude mutil/venue-fingerprints)}])
 
 (def ^:private default-card-results-native
   (for [column (-> default-card-results
@@ -62,25 +62,25 @@
 
   (testing "check that using a Card as your source doesn't overwrite the results metadata..."
     (mt/with-temp Card [card {:dataset_query   (mt/native-query {:query "SELECT * FROM VENUES"})
-                              :result_metadata [{:name "NAME", :display_name "Name", :base_type "type/Text"}]}]
+                              :result_metadata [{:name "NAME", :display_name "Name", :base_type :type/Text}]}]
       (let [result (qp/process-userland-query {:database mbql.s/saved-questions-virtual-database-id
                                                :type     :query
                                                :query    {:source-table (str "card__" (u/get-id card))}})]
         (when-not (= :completed (:status result))
           (throw (ex-info "Query failed." result))))
-      (is (= [{:name "NAME", :display_name "Name", :base_type "type/Text"}]
+      (is (= [{:name "NAME", :display_name "Name", :base_type :type/Text}]
              (card-metadata card)))))
 
   (testing "...even when running via the API endpoint"
     (mt/with-temp* [Collection [collection]
                     Card       [card {:collection_id   (u/get-id collection)
                                       :dataset_query   (mt/native-query {:query "SELECT * FROM VENUES"})
-                                      :result_metadata [{:name "NAME", :display_name "Name", :base_type "type/Text"}]}]]
+                                      :result_metadata [{:name "NAME", :display_name "Name", :base_type :type/Text}]}]]
       (perms/grant-collection-read-permissions! (group/all-users) collection)
       ((users/user->client :rasta) :post 202 "dataset" {:database mbql.s/saved-questions-virtual-database-id
                                                         :type     :query
                                                         :query    {:source-table (str "card__" (u/get-id card))}})
-      (is (= [{:name "NAME", :display_name "Name", :base_type "type/Text"}]
+      (is (= [{:name "NAME", :display_name "Name", :base_type :type/Text}]
              (card-metadata card))))))
 
 (deftest valid-checksum-test
@@ -90,17 +90,17 @@
          (boolean (results-metadata/valid-checksum? "ABCD" (#'results-metadata/metadata-checksum "ABCDE"))))))
 
 (def ^:private example-metadata
-  [{:base_type    "type/Text"
+  [{:base_type    :type/Text
     :display_name "Date"
     :name         "DATE"
     :unit         nil
     :special_type nil
     :fingerprint  {:global {:distinct-count 618 :nil% 0.0}, :type {:type/DateTime {:earliest "2013-01-03T00:00:00.000Z"
                                                                                    :latest   "2015-12-29T00:00:00.000Z"}}}}
-   {:base_type    "type/Integer"
+   {:base_type    :type/Integer
     :display_name "count"
     :name         "count"
-    :special_type "type/Quantity"
+    :special_type :type/Quantity
     :fingerprint  {:global {:distinct-count 3
                             :nil%           0.0},
                    :type   {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.0 :sd 143.5}}}}])
@@ -169,17 +169,17 @@
                    :breakout     [[:datetime-field [:field-id (mt/id :checkins :date)] :year]]}
         :info     {:card-id    (u/get-id card)
                    :query-hash (qputil/query-hash {})}})
-      (is (= [{:base_type    "type/DateTime"
+      (is (= [{:base_type    :type/DateTime
                :display_name "Date"
                :name         "DATE"
-               :unit         "year"
+               :unit         :year
                :special_type nil
                :fingerprint  {:global {:distinct-count 618 :nil% 0.0}, :type {:type/DateTime {:earliest "2013-01-03"
                                                                                               :latest   "2015-12-29"}}}}
-              {:base_type    "type/BigInteger"
+              {:base_type    :type/BigInteger
                :display_name "Count"
                :name         "count"
-               :special_type "type/Quantity"
+               :special_type :type/Quantity
                :fingerprint  {:global {:distinct-count 3
                                        :nil%           0.0},
                               :type   {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.0 :sd 143.5}}}}]

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -142,6 +142,23 @@
   ([table-kw field-kw]
    (field-literal-col (col table-kw field-kw))))
 
+(defn field-literal-col-keep-extra-cols
+  "Return expected `:cols` info for a Field that was referred to as a `:field-literal`. This differs from
+  `field-literal-col` in that it doesn't remove columns like `:description` -- in some cases metadata will come back
+  with these cols, and in some it won't -- I think it has to do with whether the Card had `:source_metadata` saved for
+  it.
+
+    (field-literal-col-keep-extra-cols :venues :price)
+    (field-literal-col-keep-extra-cols (aggregate-col :count))"
+  {:arglists '([col] [table-kw field-kw])}
+  ([{field-name :name, base-type :base_type, unit :unit, :as col}]
+   (assoc col
+          :field_ref [:field-literal field-name base-type]
+          :source    :fields))
+
+  ([table-kw field-kw]
+   (field-literal-col-keep-extra-cols (col table-kw field-kw))))
+
 (defn fk-col
   "Return expected `:cols` info for a Field that came in via an implicit join (i.e, via an `fk->` clause)."
   [source-table-kw source-field-kw, dest-table-kw dest-field-kw]

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -253,12 +253,13 @@
       ;; middleware is doing the right thing
       (with-redefs [add-source-metadata/mbql-source-query->metadata (constantly nil)]
         (mt/with-temp Card [card {:dataset_query (mt/mbql-query venues)}]
-          (is (thrown?
-               Exception
-               (mt/suppress-output
-                 (qp.test/rows
+          (mt/with-temp-vals-in-db Card (:id card) {:result_metadata nil}
+            (is (thrown?
+                 Exception
+                 (mt/suppress-output
+                  (qp.test/rows
                    (qp/process-query
-                    (nested-venues-query card)))))))))))
+                    (nested-venues-query card))))))))))))
 
 (deftest field-in-breakout-and-fields-test
   (mt/test-drivers (mt/normal-drivers)

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -58,12 +58,16 @@
                       :limit        5})))))))))
 
 
-(defn- breakout-results [& {:keys [has-source-metadata?], :or {has-source-metadata? true}}]
+(defn- breakout-results [& {:keys [has-source-metadata? has-extra-cols?]
+                            :or   {has-source-metadata? true
+                                   has-extra-cols?      false}}]
   {:rows [[1 22]
           [2 59]
           [3 13]
           [4  6]]
-   :cols [(cond-> (qp.test/breakout-col (qp.test/field-literal-col :venues :price))
+   :cols [(cond-> (qp.test/breakout-col ((if has-extra-cols?
+                                           qp.test/field-literal-col-keep-extra-cols
+                                           qp.test/field-literal-col) :venues :price))
             (not has-source-metadata?)
             (dissoc :id :special_type :settings :fingerprint :table_id))
           (qp.test/aggregate-col :count)]})
@@ -186,7 +190,7 @@
     ;; This is the format that is actually used by the frontend; it gets translated to the normal `source-query`
     ;; format by middleware. It's provided as a convenience so only minimal changes need to be made to the frontend.
     (mt/with-temp Card [card (venues-mbql-card-def)]
-      (is (= (breakout-results)
+      (is (= (breakout-results :has-extra-cols? true)
              (qp.test/rows-and-cols
                (mt/format-rows-by [int int]
                  (qp/process-query
@@ -370,15 +374,14 @@
 
 (deftest correct-column-metadata-test
   (testing "make sure a query using a source query comes back with the correct columns metadata"
-    (is (= (map
-            (partial qp.test/field-literal-col :venues)
-            [:id :name :category_id :latitude :longitude :price])
+    (is (= (map (partial qp.test/field-literal-col-keep-extra-cols :venues)
+                [:id :name :category_id :latitude :longitude :price])
            (mt/cols
              (mt/with-temp Card [card (venues-mbql-card-def)]
                (qp/process-query (query-with-source-card card)))))))
 
   (testing "make sure a breakout/aggregate query using a source query comes back with the correct columns metadata"
-    (is (= [(qp.test/breakout-col (qp.test/field-literal-col :venues :price))
+    (is (= [(qp.test/breakout-col (qp.test/field-literal-col-keep-extra-cols :venues :price))
             (qp.test/aggregate-col :count)]
            (mt/cols
              (mt/with-temp Card [card (venues-mbql-card-def)]
@@ -417,7 +420,6 @@
         (let [[date-col count-col] (for [col (-> (qp/process-query {:database (mt/id), :type :query, :query source-query})
                                                  :data :cols)]
                                      (-> (into {} col)
-                                         (dissoc :description :parent_id :visibility_type)
                                          (assoc :source :fields)))]
           (is (= [(assoc date-col  :field_ref [:field-literal "DATE" :type/Date])
                   (assoc count-col :field_ref [:field-literal "count" (:base_type count-col)])]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -296,9 +296,8 @@
 
 
 (defn mappify
-  "Walk COLL and convert all record types to plain Clojure maps.
-  Useful because expectations will consider an instance of a record type to be different from a plain Clojure map,
-  even if all keys & values are the same."
+  "Walk `coll` and convert all record types to plain Clojure maps. Useful because expectations will consider an instance
+  of a record type to be different from a plain Clojure map, even if all keys & values are the same."
   [coll]
   {:style/indent 0}
   (walk/postwalk (fn [x]

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -104,6 +104,8 @@
 
     (with-log-level [metabase.query-processor :debug]
       ...)"
+  {:arglists '([level & body]
+               [[namespace level] & body])}
   [level & body]
   `(do-with-log-messages-for-level ~(if (sequential? level)
                                       `(quote ~level)


### PR DESCRIPTION
* Attempt to infer and populate Card `result_metadata` if not already populated by calling `qp/query->expected-cols`
* If Card query changes and updated metadata is not passed, update `result_metadata`, or clear it if it cannot be inferred
* Normalize Card `result_metadata` when it comes out of the DB.
* Fix some bugs where source query metadata was not being normalized the way we intended in QP middleware
* Perf optimization: don't run MBQL queries to populate result metadata in API calls -- just use inferred metadata 

This is needed for #13715 and should help with the overall goals of #13072

Normally the API already tries to run queries to populate result metadata if you save a Card and don't pass it in, so this mostly makes things more robust/affects tests