### PR TITLE
Support Java 15 -- add dep on nashorn core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,13 @@ executors:
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 
+  java-15:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:openjdk-15-lein-2.95-buster
+        environment:
+          MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
+
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
@@ -1060,7 +1067,7 @@ workflows:
           requires:
             - be-deps
           lein-command: with-profile +junit test
-          skip-key: tests
+          skip-key: tests-<< matrix.edition >>
           <<: *Matrix
 
       - lein:
@@ -1069,7 +1076,16 @@ workflows:
             - be-deps
           e: java-11
           lein-command: with-profile +junit test
-          skip-key: tests-java-11
+          skip-key: tests-java-11-<< matrix.edition >>
+          <<: *Matrix
+
+      - lein:
+          name: be-tests-java-15-<< matrix.edition >>
+          requires:
+            - be-deps
+          e: java-15
+          lein-command: with-profile +junit test
+          skip-key: tests-java-15-<< matrix.edition >>
           <<: *Matrix
 
       - lein:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ executors:
   java-15:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-15-lein-2.95-buster
+      - image: circleci/clojure:openjdk-15-lein-2.9.5-buster
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 

--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,6 @@
                  slingshot]]
    ;; fork to address #13102 - see upstream PR: https://github.com/dm3/clojure.java-time/pull/60
    ;; TODO: switch back to the upstream once a version is released with the above patch
-   [robdaemon/clojure.java-time "0.3.3-SNAPSHOT"]                     ; Java 8 java.time wrapper
    [clojurewerkz/quartzite "2.1.0"                                    ; scheduling library
     :exclusions [c3p0]]
    [colorize "0.1.1" :exclusions [org.clojure/clojure]]               ; string output with ANSI color codes (for logging)
@@ -135,6 +134,7 @@
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
    [org.mariadb.jdbc/mariadb-java-client "2.6.2"]                     ; MySQL/MariaDB driver
+   [org.openjdk.nashorn/nashorn-core "15.0"]                          ; JavaScript engine -- formerly shipped as part of the JVM
    [org.postgresql/postgresql "42.2.8"]                               ; Postgres driver
    [org.slf4j/slf4j-api "1.7.30"]                                     ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
    [org.tcrawley/dynapath "1.1.0"]                                    ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
@@ -148,6 +148,7 @@
    [ring/ring-core "1.8.0"]
    [ring/ring-jetty-adapter "1.8.1"]                                  ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
    [ring/ring-json "0.5.0"]                                           ; Ring middleware for reading/writing JSON automatically
+   [robdaemon/clojure.java-time "0.3.3-SNAPSHOT"]                     ; Java 8 java.time wrapper
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
    [toucan "1.15.1" :exclusions [org.clojure/java.jdbc                ; Model layer, hydration, and DB utilities
                                  org.clojure/tools.logging

--- a/project.clj
+++ b/project.clj
@@ -134,7 +134,11 @@
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
    [org.mariadb.jdbc/mariadb-java-client "2.6.2"]                     ; MySQL/MariaDB driver
-   [org.openjdk.nashorn/nashorn-core "15.0"]                          ; JavaScript engine -- formerly shipped as part of the JVM
+   [org.openjdk.nashorn/nashorn-core "15.0"]                          ; JavaScript engine (Java 15+)
+   [org.ow2.asm/asm "7.3.1"]                                          ; dependency for Nashorn
+   [org.ow2.asm/asm-commons "7.3.1"]                                  ; dependency for Nashorn
+   [org.ow2.asm/asm-tree "7.3.1"]                                     ; dependency for Nashorn
+   [org.ow2.asm/asm-util "7.3.1"]                                     ; dependency for Nashorn
    [org.postgresql/postgresql "42.2.8"]                               ; Postgres driver
    [org.slf4j/slf4j-api "1.7.30"]                                     ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
    [org.tcrawley/dynapath "1.1.0"]                                    ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -6,7 +6,7 @@
             [schema.core :as s])
   (:import java.io.InputStream
            [javax.script Invocable ScriptEngineManager]
-           jdk.nashorn.api.scripting.JSObject))
+           org.openjdk.nashorn.api.scripting.JSObject))
 
 (defn- make-js-engine-with-script [^String script]
   (let [engine-mgr (ScriptEngineManager.)

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -2,31 +2,29 @@
   "Namespaces that uses the Nashorn javascript engine to invoke some shared javascript code that we use to determine
   the background color of pulse table cells"
   (:require [cheshire.core :as json]
+            [metabase.pulse.render.engine :as engine]
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s])
-  (:import java.io.InputStream
-           [javax.script Invocable ScriptEngineManager]
-           org.openjdk.nashorn.api.scripting.JSObject))
+  (:import java.io.InputStream))
 
 (defn- make-js-engine-with-script [^String script]
-  (let [engine-mgr (ScriptEngineManager.)
-        js-engine  (.getEngineByName engine-mgr "nashorn")]
-    (.eval js-engine script)
-    js-engine))
+  (doto (engine/script-engine)
+    (.eval script)))
 
 (defn- ^InputStream get-classpath-resource [path]
   (.getResourceAsStream (class []) path))
 
-(def ^:private js-engine
+(def ^:private ^{:arglists '(^javax.script.Invocable [])} js-engine
   (let [js-file-path "/frontend_shared/color_selector.js"]
     ;; The code that loads the JS engine is behind a delay so that we don't incur that cost on startup. The below
     ;; assertion till look for the javascript file at startup and fail if it doesn't find it. This is to avoid a big
     ;; delay in finding out that the system is broken
     (assert (get-classpath-resource js-file-path)
-      (trs "Can''t find JS color selector at ''{0}''" js-file-path))
-    (delay
-     (with-open [stream (get-classpath-resource js-file-path)]
-       (make-js-engine-with-script (slurp stream))))))
+            (trs "Can''t find JS color selector at ''{0}''" js-file-path))
+    (let [engine* (delay
+                    (with-open [stream (get-classpath-resource js-file-path)]
+                      (make-js-engine-with-script (slurp stream))))]
+      (fn [] @engine*))))
 
 (def ^:private QueryResults
   "This is a pretty loose schema, more as a safety net as we have a long feedback loop for this being broken as it's
@@ -45,17 +43,17 @@
   `get-background-color` on each cell."
   [{:keys [cols rows]} :- QueryResults, viz-settings]
   ;; NOTE: for development it is useful to replace the following line with this one so it reload each time:
-  ; (let [^Invocable engine (make-js-engine-with-script (slurp "resources/frontend_shared/color_selector.js"))
-  (let [^Invocable engine @js-engine
-        ;; Ideally we'd convert everything to JS data before invoking the function below, but converting rows would be
-        ;; expensive. The JS code is written to deal with `rows` in it's native Nashorn format but since `cols` and
-        ;; `viz-settings` are small, pass those as JSON so that they can be deserialized to pure JS objects once in JS
-        ;; code
-        js-fn-args (object-array [rows (json/generate-string cols) (json/generate-string viz-settings)])]
-    (.invokeFunction engine "makeCellBackgroundGetter" js-fn-args)))
+  ;; (let [^Invocable engine (make-js-engine-with-script (slurp "resources/frontend_shared/color_selector.js"))
+  ;;
+  ;; Ideally we'd convert everything to JS data before invoking the function below, but converting rows would be
+  ;; expensive. The JS code is written to deal with `rows` in it's native Nashorn format but since `cols` and
+  ;; `viz-settings` are small, pass those as JSON so that they can be deserialized to pure JS objects once in JS
+  ;; code
+  (let [js-fn-args (object-array [rows (json/generate-string cols) (json/generate-string viz-settings)])]
+    (.invokeFunction (js-engine) "makeCellBackgroundGetter" js-fn-args)))
 
 (defn get-background-color
   "Get the correct color for a cell in a pulse table. This is intended to be invoked on each cell of every row in the
   table. See `make-color-selector` for more info."
-  [^JSObject color-selector, cell-value column-name row-index]
-  (.call color-selector color-selector (object-array [cell-value row-index column-name])))
+  [color-selector ^String cell-value column-name row-index]
+  (engine/call color-selector color-selector (object-array [cell-value row-index column-name])))

--- a/src/metabase/pulse/render/engine.clj
+++ b/src/metabase/pulse/render/engine.clj
@@ -1,0 +1,31 @@
+(ns metabase.pulse.render.engine
+  (:import java.lang.reflect.Method))
+
+(defn script-engine
+  "Get an instance of the Nashorn JavaScript engine. The actual class is different on Java >= 15 vs Java < 15."
+  ^javax.script.ScriptEngine []
+  (.getEngineByName (javax.script.ScriptEngineManager.) "nashorn"))
+
+(defn openjdk-nashorn-engine? []
+  #_(.getScriptEngine (org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory.))
+  (let [engine-class-name (some-> (script-engine) class .getCanonicalName)]
+    (= engine-class-name "org.openjdk.nashorn.api.scripting.NashornScriptEngine")))
+
+(defn- engine-js-object-class ^Class []
+  (Class/forName
+   (if (openjdk-nashorn-engine?)
+     "org.openjdk.nashorn.api.scripting.JSObject"
+     "jdk.nashorn.api.scripting.JSObject")))
+
+(def ^:private ^{:arglists '(^java.lang.reflect.Method [])} call-method
+  (let [dlay (delay (some
+                     (fn [^Method method]
+                       (when (= (.getName method) "call")
+                         method))
+                     (.getDeclaredMethods (engine-js-object-class))))]
+    (fn [] @dlay)))
+
+(defn call
+  "Invoke a JavaScript object."
+  [js-object & args]
+  (.invoke (call-method) js-object (object-array args)))

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -5,7 +5,7 @@
             [metabase.pulse.render
              [color :as color]
              [style :as style]])
-  (:import jdk.nashorn.api.scripting.JSObject))
+  (:import org.openjdk.nashorn.api.scripting.JSObject))
 
 ;; Our 'helpful' NS declaration linter will complain that common is unused. But we need to require it so
 ;; NumericWrapper exists in the first place.

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -1,16 +1,12 @@
 (ns metabase.pulse.render.table
   (:require [hiccup.core :refer [h]]
             [medley.core :as m]
-            [metabase.plugins.classloader :as classloader]
-            [metabase.pulse.render
+            [metabase.pulse.render common
              [color :as color]
              [style :as style]])
-  (:import org.openjdk.nashorn.api.scripting.JSObject))
+  (:import metabase.pulse.render.common.NumericWrapper))
 
-;; Our 'helpful' NS declaration linter will complain that common is unused. But we need to require it so
-;; NumericWrapper exists in the first place.
-(classloader/require 'metabase.pulse.render.common)
-(import 'metabase.pulse.render.common.NumericWrapper)
+(comment metabase.pulse.render.common/keep-me)
 
 (defn- bar-th-style []
   (merge
@@ -45,6 +41,7 @@
 (defn- render-bar-component
   ([color positive? width-in-pixels]
    (render-bar-component color positive? width-in-pixels 0))
+
   ([color positive? width-in-pixels offset]
    [:div
     {:style (style/style
@@ -128,9 +125,10 @@
   background color for a given cell. `column-names` is different from the header in `header+rows` as the header is the
   display_name (i.e. human friendly. `header+rows` includes the text contents of the table we're about ready to
   create. If `normalized-zero` is set (defaults to 0), render values less than it as negative"
-  ([^JSObject color-selector, column-names, [header & rows :as contents]]
+  ([color-selector column-names [header & rows :as contents]]
    (render-table color-selector 0 column-names contents))
-  ([^JSObject color-selector, normalized-zero, column-names, [header & rows]]
+
+  ([color-selector normalized-zero column-names [header & rows]]
    [:table {:style (style/style {:max-width "100%"
                                  :white-space :nowrap
                                  :padding-bottom :8px

--- a/test/metabase/pulse/render/color_test.clj
+++ b/test/metabase/pulse/render/color_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.pulse.render.color-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase.pulse.render.color :as color]))
 
 (def ^:private red "#ff0000")
@@ -23,26 +23,26 @@
   "Setup a javascript engine with a stubbed script useful making sure `get-background-color` works independently from
   the real color picking script"
   [script & body]
-  `(with-redefs [color/js-engine (delay (#'color/make-js-engine-with-script ~script))]
+  `(with-redefs [color/js-engine (fn [] (#'color/make-js-engine-with-script ~script))]
      ~@body))
 
-;; The test script above should return red on even rows, green on odd rows
-(expect
-  [red green red green]
-  (with-test-js-engine test-script
-    (let [color-selector (color/make-color-selector {:cols [{:name "test"}]
-                                               :rows [[1] [2] [3] [4]]}
-                                              {"even" red, "odd" green})]
-      (for [row-index (range 0 4)]
-        (color/get-background-color color-selector "any value" "any column" row-index)))))
+(deftest color-test
+  (testing "The test script above should return red on even rows, green on odd rows"
+    (with-test-js-engine test-script
+      (let [color-selector (color/make-color-selector {:cols [{:name "test"}]
+                                                       :rows [[1] [2] [3] [4]]}
+                                                      {"even" red, "odd" green})]
+        (is (= [red green red green]
+               (for [row-index (range 0 4)]
+                 (color/get-background-color color-selector "any value" "any column" row-index))))))))
 
-;; Same test as above, but make sure we convert any keywords as keywords don't get converted to strings automatically
-;; when passed to a nashorn function
-(expect
-  [red green red green]
-  (with-test-js-engine test-script
-    (let [color-selector (color/make-color-selector {:cols [{:name "test"}]
-                                               :rows [[1] [2] [3] [4]]}
-                                              {:even red, :odd  green})]
-      (for [row-index (range 0 4)]
-        (color/get-background-color color-selector "any value" "any column" row-index)))))
+(deftest convert-keywords-test
+  (testing (str "Same test as above, but make sure we convert any keywords as keywords don't get converted to "
+                "strings automatically when passed to a nashorn function")
+    (with-test-js-engine test-script
+      (let [color-selector (color/make-color-selector {:cols [{:name "test"}]
+                                                       :rows [[1] [2] [3] [4]]}
+                                                      {:even red, :odd  green})]
+        (is (= [red green red green]
+               (for [row-index (range 0 4)]
+                 (color/get-background-color color-selector "any value" "any column" row-index))))))))

--- a/test/metabase/pulse/render/style_test.clj
+++ b/test/metabase/pulse/render/style_test.clj
@@ -1,12 +1,11 @@
 (ns metabase.pulse.render.style-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase.pulse.render.style :as style]))
 
-;; `style` should filter out nil values
-(expect
-  ""
-  (style/style {:a nil}))
+(deftest filter-out-nil-test
+  (testing "`style` should filter out nil values"
+    (is (= ""
+           (style/style {:a nil})))
 
-(expect
-  "a: 0; c: 2;"
-  (style/style {:a 0, :b nil, :c 2, :d ""}))
+    (is (= "a: 0; c: 2;"
+           (style/style {:a 0, :b nil, :c 2, :d ""})))))

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.pulse.render.table-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase.pulse.render
              [color :as color]
              [table :as table]
@@ -55,15 +55,21 @@
 ;; with the cell value. The script right now is hard coded to always return #ff0000. Once the real script is in place,
 ;; we should find some similar basic values that can rely on. The goal isn't to test out the javascript choosing in
 ;; the color (that should be done in javascript) but to verify that the pieces are all connecting correctly
-(expect
-  {"1" nil,                    "2" nil,                    "3" "rgba(0, 255, 0, 0.75)"
-   "4" nil,                    "5" nil,                    "6" "rgba(0, 128, 128, 0.75)"
-   "7" "rgba(255, 0, 0, 0.65)" "8" "rgba(255, 0, 0, 0.2)"  "9" "rgba(0, 0, 255, 0.75)"}
-  (let [query-results {:cols [{:name "a"} {:name "b"} {:name "c"}]
-                       :rows [[1 2 3]
-                              [4 5 6]
-                              [7 8 9]]}]
-    (-> (color/make-color-selector query-results (:visualization_settings render.tu/test-card))
-        (#'table/render-table 0 ["a" "b" "c"] (query-results->header+rows query-results))
-        find-table-body
-        cell-value->background-color)))
+(deftest background-color-selection-smoke-test
+ (let [query-results {:cols [{:name "a"} {:name "b"} {:name "c"}]
+                      :rows [[1 2 3]
+                             [4 5 6]
+                             [7 8 9]]}]
+   (is (= {"1" nil
+           "2" nil
+           "3" "rgba(0, 255, 0, 0.75)"
+           "4" nil
+           "5" nil
+           "6" "rgba(0, 128, 128, 0.75)"
+           "7" "rgba(255, 0, 0, 0.65)"
+           "8" "rgba(255, 0, 0, 0.2)"
+           "9" "rgba(0, 0, 255, 0.75)"}
+          (-> (color/make-color-selector query-results (:visualization_settings render.tu/test-card))
+              (#'table/render-table 0 ["a" "b" "c"] (query-results->header+rows query-results))
+              find-table-body
+              cell-value->background-color)))))

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -1,13 +1,12 @@
 (ns metabase.pulse.render-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase
              [pulse :as pulse]
-             [query-processor :as qp]]
+             [query-processor :as qp]
+             [test :as mt]]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.card :refer [Card]]
-            [metabase.pulse.render :as render]
-            [metabase.test.data :as data]
-            [toucan.util.test :as tt]))
+            [metabase.pulse.render :as render]))
 
 ;; Let's make sure rendering Pulses actually works
 
@@ -19,13 +18,13 @@
    (render/render-pulse-card-for-display (pulse/defaulted-timezone card) card results)))
 
 (defn- render-results [query]
-  (tt/with-temp Card [card {:dataset_query query}]
+  (mt/with-temp Card [card {:dataset_query query}]
     (render-pulse-card card)))
 
-;; if the pulse rendered correctly it will have this one row that says "November 2015" (not sure why)
-(expect
-  (mbql.u/match-one (render-results
-                     (data/mbql-query checkins
-                       {:aggregation  [[:count]]
-                        :breakout     [!month.date]}))
-    [:td _ "November 2015"]))
+(deftest render-test
+  (testing "if the pulse rendered correctly it will have this one row that says \"November 2015\" (not sure why)"
+    (is (some? (mbql.u/match-one (render-results
+                                  (mt/mbql-query checkins
+                                    {:aggregation [[:count]]
+                                     :breakout    [!month.date]}))
+                 [:td _ "November 2015"])))))


### PR DESCRIPTION
Fixes #13881

Adds Java 15 tests to CI. I think we can replace that with Java 16 when it comes out (etc.) -- test against the latest version. That way we'd be testing min supported version (8), preferred LTS version (11) and newest version (15)

> Nashorn is only usable as a JPMS module

It doesn't seem like this works by just adding dependencies. I've got it working like this:

```bash
lein deps

MAVEN_DIR=$(readlink -f ~/.m2/repository)

MODULE_PATH="$MAVEN_DIR/org/openjdk/nashorn/nashorn-core/15.0"

ASM_DIR="$MAVEN_DIR/org/ow2/asm"
ASM_VERSION='7.3.1'

MODULE_PATH="$MODULE_PATH:$ASM_DIR/asm/$ASM_VERSION"
MODULE_PATH="$MODULE_PATH:$ASM_DIR/asm-analysis/$ASM_VERSION"
MODULE_PATH="$MODULE_PATH:$ASM_DIR/asm-commons/$ASM_VERSION"
MODULE_PATH="$MODULE_PATH:$ASM_DIR/asm-tree/$ASM_VERSION"
MODULE_PATH="$MODULE_PATH:$ASM_DIR/asm-util/$ASM_VERSION"

JAVA_OPTS="$JAVA_OPTS --module-path $MODULE_PATH"
```

and then:

```bash
# Run the JAR
java $JAVA_OPTS -jar metabase.jar
```

```bash
# Run with leiningen
JAVA_OPTS="$JAVA_OPTS" lein
```

So this is a way to get it working on Java 15. Another option:

```
git clone git@github.com:openjdk/nashorn.git
cd nashorn/make/nashorn
ant artifacts
MODULE_PATH="/path/to/nashorn/build/nashorn/dist:/path/to/nashorn/build/nashorn/dependencies"
JAVA_OPTS="$JAVA_OPTS --module-path $MODULE_PATH"
```

This is not really a great solution, but I'm posting it here as a workaround for people who insist on using Java 15 until we come up with a better fix.
