### PR TITLE
Defer the parser and its related construction until it's needed

### DIFF
--- a/frontend/src/metabase/lib/expressions/process.js
+++ b/frontend/src/metabase/lib/expressions/process.js
@@ -1,5 +1,7 @@
 // combine compile/suggest/syntax so we only need to parse once
 export function processSource(options) {
+  // Lazily load all these parser-related stuff, because parser construction is expensive
+  // https://github.com/metabase/metabase/issues/13472
   const parse = require("./parser").parse;
   const compile = require("./compile").compile;
   const suggest = require("./suggest").suggest;

--- a/frontend/src/metabase/lib/expressions/process.js
+++ b/frontend/src/metabase/lib/expressions/process.js
@@ -1,10 +1,10 @@
-import { parse } from "metabase/lib/expressions/parser";
-import { compile } from "metabase/lib/expressions/compile";
-import { suggest } from "metabase/lib/expressions/suggest";
-import { syntax } from "metabase/lib/expressions/syntax";
-
 // combine compile/suggest/syntax so we only need to parse once
 export function processSource(options) {
+  const parse = require("./parser").parse;
+  const compile = require("./compile").compile;
+  const suggest = require("./suggest").suggest;
+  const syntax = require("./syntax").syntax;
+
   const { source, targetOffset } = options;
 
   let expression;

--- a/frontend/test/metabase/lib/expressions/process.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/process.unit.spec.js
@@ -1,0 +1,30 @@
+import { processSource } from "metabase/lib/expressions/process";
+
+describe("metabase/lib/expressions/process", () => {
+  describe("processSource", () => {
+    it("should non throw", () => {
+      expect(() =>
+        processSource({ source: "1", targetOffset: null }),
+      ).not.toThrow();
+    });
+    it("should handle valid input", () => {
+      const { compileError, syntaxTree } = processSource({
+        source: "1",
+        targetOffset: null,
+      });
+      expect(compileError).toBeUndefined();
+      expect(syntaxTree).toBeDefined();
+      expect(syntaxTree.children).toBeDefined();
+      expect(syntaxTree.children.length).toEqual(1);
+    });
+    it("should handle invalid input", () => {
+      const { compileError } = processSource({
+        source: "1+",
+        targetOffset: null,
+      });
+      expect(compileError.toString()).toEqual(
+        "NoViableAltException: Expected expression",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Expression parser construction is expensive (mainly due to grammar validation via Chevrotain's performSelfAnalysis). Thus, instantiating the parsers at the initialization time will lead to a signifant delay in DOMContentLoaded, thereby affecting (among others) the embedding performance.

To avoid this, simply defer that step until parsing is really needed (which is actually far far later, i.e. when the user is using the notebook).

For some more context, see also #13472.


To verify:

1. Launch Metabase, go to the Sign In screen
2. Open Chrome DevTools, _Network_ panel
3. Reload the page

**Before** this change: DOMContentLoaded is _X_ seconds (roughly 1-2 secs on a fast machine).

**After** this change: DOMContentLoaded is way way less than  _X_.

Another way to verify:

1. Launch Metabase, go to the Sign In screen
2. Open Chrome DevTools, _Sources_ panel
3. Find `parser.js` (e.g. Ctrl+P then search for it)
4. Place a breakpoint on the constructor of `ExpressionParser` class
5. Reload the page

**Before** this change: the breakpoint is hit.

**After** this change: the breakpoint is **not** hit.

To show that the expression parser still works (if you still have the breakpoint, it will be hit in Step 3):

1. Ask a question, Custom question
2. Pick Sample Dataset, _Orders_ table
3. Custom column, type "Price" in the Field Formula box
4. There should be still the autocomplete/suggestion

Note that with this deferred parser construction, the flame chart (and the corresponding call tree) of the JavaScript execution _before_ DOMContentLoaded becomes as fast as v0.34 or earlier (production build, tested using Chrome DevTools Performance panel, even with Fast 3G network throttle).

![image](https://user-images.githubusercontent.com/7288/102646379-c54b5080-4118-11eb-9e26-059e03e4a665.png)


