### PR TITLE
#14122 Repro: Sub-collections under Personal collection should be available in save/move modals

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -330,6 +330,40 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("Browse all items").click();
       cy.findByText("Child");
     });
+
+    it.skip("sub-collection should be available in save and move modals (#14122)", () => {
+      const COLLECTION = "14122C";
+      // Create Parent collection within `Our analytics`
+      cy.request("POST", "/api/collection", {
+        name: COLLECTION,
+        color: "#509EE3",
+        parent_id: 1,
+      });
+      cy.visit("/collection/root");
+      cy.get("[class*=CollectionSidebar]").as("sidebar");
+
+      openDropdownFor("Your personal collection");
+      cy.findByText(COLLECTION);
+      cy.get("@sidebar")
+        .contains("Our analytics")
+        .click();
+
+      openEllipsisMenuFor("Orders");
+      cy.findByText("Move this item").click();
+
+      modal().within(() => {
+        cy.findByText("My personal collection")
+          .parent()
+          .find(".Icon-chevronright")
+          .click();
+
+        cy.findByText(COLLECTION).click();
+        cy.findByText("Move")
+          .closest(".Button")
+          .should("not.be.disabled")
+          .click();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
# Important
This PR has been merged into a branch that was later deleted. It's reopened against the `master` in #14143

### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14122 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix