### PR TITLE
#14114 Repro: Cannot see child collection in collection sidebar when access has been revoked to its parent

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -4,8 +4,14 @@ import {
   setupLocalHostEmail,
   signInAsNormalUser,
   modal,
+  signOut,
+  USERS,
+  USER_GROUPS,
 } from "__support__/cypress";
 // Ported from initial_collection.e2e.spec.js
+
+const { nocollection } = USERS;
+const { DATA_GROUP } = USER_GROUPS;
 
 // Z because the api lists them alphabetically by name, so it makes it easier to check
 const [admin, collection, sub_collection] = [
@@ -274,6 +280,55 @@ describe("scenarios > collection_defaults", () => {
         cy.visit("/collection/root");
         cy.findByText(dashboard_name);
       });
+    });
+  });
+
+  describe("Collection related issues reproductions", () => {
+    beforeEach(() => {
+      restore();
+      signInAsAdmin();
+    });
+
+    it.skip("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {
+      // Create Parent collection within `Our analytics`
+      cy.request("POST", "/api/collection", {
+        name: "Parent",
+        color: "#509EE3",
+        parent_id: null,
+      }).then(({ body: { id: PARENT_COLLECTION_ID } }) => {
+        // Create Child collection within Parent collection
+        cy.request("POST", "/api/collection", {
+          name: "Child",
+          color: "#509EE3",
+          parent_id: PARENT_COLLECTION_ID,
+        }).then(({ body: { id: CHILD_COLLECTION_ID } }) => {
+          // Fetch collection permission graph
+          cy.request("GET", "/api/collection/graph").then(
+            ({ body: { groups, revision } }) => {
+              // Give `Data` group permission to "curate" Child collection only
+              // Access to everything else is revoked by default - that's why we chose `Data` group
+              groups[DATA_GROUP][CHILD_COLLECTION_ID] = "write";
+
+              // We're chaining these 2 requestes in order to match shema (passing it from GET to PUT)
+              // Similar to what we did in `sandboxes.cy.spec.js` with the permission graph
+              cy.request("PUT", "/api/collection/graph", {
+                // Pass previously mutated `groups` object
+                groups,
+                revision,
+              });
+            },
+          );
+        });
+      });
+
+      signOut();
+      cy.log("**--Sign in as `nocollection` user--**");
+      cy.request("POST", "/api/session", nocollection);
+
+      cy.visit("/");
+      cy.findByText("Child");
+      cy.findByText("Browse all items").click();
+      cy.findByText("Child");
     });
   });
 });


### PR DESCRIPTION
### Status
READY / PENDING MERGE

### What does this PR accomplish?
- Reproduces #14114 

### How to test this manually?
- Follow the steps in https://github.com/metabase/metabase/pull/14073

### Additional notes:
- Reopened https://github.com/metabase/metabase/pull/14073, because it needs to go directly into the `master`. Release branch was deleted.