### PR TITLE
#13415 Repro: Visualization type should be respected when entering a question from a dashboard

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -2,7 +2,7 @@
 import { restore, signInAsAdmin } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
-const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
+const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
 
 // This question is part of our pre-defined data set used for testing
 const Q2 = {
@@ -127,6 +127,110 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       it("should result in a correct query result", () => {
         cy.findByText("Affiliate");
         cy.get(".dot").should("have.length.of.at.least", 100);
+      });
+    });
+
+    describe("saved visualizations", () => {
+      beforeEach(() => {
+        restore();
+        signInAsAdmin();
+      });
+
+      it.skip("should respect visualization type when entering a question from a dashboard (metabase#13415)", () => {
+        const QUESTION_NAME = "13415";
+
+        cy.log("**--1. Create a question--**");
+        cy.request("POST", "/api/card", {
+          name: QUESTION_NAME,
+          dataset_query: {
+            database: 1,
+            query: {
+              "source-table": ORDERS_ID,
+              aggregation: [["count"]],
+              breakout: [
+                [
+                  "fk->",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["field-id", PRODUCTS.CATEGORY],
+                ],
+                ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+              ],
+            },
+            type: "query",
+          },
+          display: "table",
+          description: null,
+          visualization_settings: {
+            "table.pivot_column": "CATEGORY",
+            "table.cell_column": "count",
+          },
+        }).then(({ body: { id: QUESTION_ID } }) => {
+          cy.log("**--2. Create a dashboard--**");
+
+          cy.request("POST", "/api/dashboard", {
+            name: "13415D",
+          }).then(({ body: { id: DASHBOARD_ID } }) => {
+            cy.log(
+              "**--3. Add filter with the default value to the dashboard--**",
+            );
+
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+              parameters: [
+                {
+                  id: "91bace6e",
+                  name: "Category",
+                  slug: "category",
+                  type: "category",
+                  default: ["Doohickey"],
+                },
+              ],
+            });
+
+            cy.log(
+              "**--4. Add previously created question to the dashboard--**",
+            );
+
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: QUESTION_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log("**--5. Connect filter to that question--**");
+
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: QUESTION_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 10,
+                    sizeY: 8,
+                    parameter_mappings: [
+                      {
+                        parameter_id: "91bace6e",
+                        card_id: QUESTION_ID,
+                        target: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
+                      },
+                    ],
+                  },
+                ],
+              });
+            });
+            cy.server();
+            cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+            cy.route("POST", `/api/dataset`).as("dataset");
+
+            cy.visit(`/dashboard/${DASHBOARD_ID}`);
+
+            cy.wait("@cardQuery");
+            cy.findByText(QUESTION_NAME).click();
+
+            cy.wait("@dataset");
+            cy.findByText("Category is Doohickey");
+            cy.get(".Visualization .ReactVirtualized__Grid").within(() => {
+              cy.findByText("177"); // Doohickeys for 2016
+            });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #13415

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix