### PR TITLE
Fix link to Api Documentation

### DIFF
--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -13,7 +13,7 @@
        "_This file was generated from source comments by `lein run api-documentation`_."
        "\n\n"
        "Check out an introduction to the "
-       "[Metabase API](https://www.metabase.com/blog/metabase-api/index.html)."
+       "[Metabase API](https://www.metabase.com/learn/developing-applications/advanced-metabase/metabase-api.html)."
        "\n\n"
        (str/join "\n\n\n" (for [ns-symb     u/metabase-namespace-symbols
                                 :when       (.startsWith (name ns-symb) "metabase.api.")


### PR DESCRIPTION
Updated link to the correct page describing the Api Documentation.