### PR TITLE
Piviot table scrolling fix

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -197,7 +197,7 @@ export default class PivotTable extends Component {
     }
 
     return (
-      <div className="overflow-scroll no-outline">
+      <div className="no-outline">
         <ScrollSync>
           {({ onScroll, scrollLeft, scrollTop }) => (
             <div>


### PR DESCRIPTION
## What this does
- Removes "overflow-scroll" class on the `PivotTable` visualization's wrapping div. 

`overflow-scroll` will always show scrollbars on the element which, due to where it was applied was causing scrollbars on the entire viz container to obscure the scrollbars for the actually scrollable table content.

This had the effect of making some visualizations look like they had content to scroll on either axis when they didn't, and in the case that there was a lot of horizontal or vertical content, it prevented you from easily scrolling the actual content.

It was visible on Windows because of how the OS handles scrollbars (Mac OS as we know does the hiding behavior).

## Before
E.x. 1. - Y axis
![image](https://user-images.githubusercontent.com/5248953/102799951-2ecd9800-4381-11eb-9355-f8df62aadb36.png)
E.x. 2 - both axis
![image](https://user-images.githubusercontent.com/5248953/102801412-32fab500-4383-11eb-896b-c4d27b09ba2e.png)


## After
Ex 1. - Y axis
![image](https://user-images.githubusercontent.com/5248953/102799993-4016a480-4381-11eb-99ba-aa83b922f535.png)
E.x. 2. - Both axis
![image](https://user-images.githubusercontent.com/5248953/102801267-faf37200-4382-11eb-90c3-e16a199c059e.png)


## How to test
1. Load up [this Sample Dataset pivot table visualization](http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJxdWVyeSIsInF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6MiwiYWdncmVnYXRpb24iOltbImNvdW50Il1dLCJicmVha291dCI6W1siZGF0ZXRpbWUtZmllbGQiLFsiZmllbGQtaWQiLDEyXSwibW9udGgiXSxbImZrLT4iLFsiZmllbGQtaWQiLDExXSxbImZpZWxkLWlkIiwyNl1dLFsiZmstPiIsWyJmaWVsZC1pZCIsMTFdLFsiZmllbGQtaWQiLDI1XV1dfSwiZGF0YWJhc2UiOjF9LCJkaXNwbGF5IjoicGl2b3QiLCJkaXNwbGF5SXNMb2NrZWQiOnRydWUsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsicGl2b3RfdGFibGUuY29sdW1uX3NwbGl0Ijp7InJvd3MiOltbImZrLT4iLFsiZmllbGQtaWQiLDExXSxbImZpZWxkLWlkIiwyNl1dLFsiZGF0ZXRpbWUtZmllbGQiLFsiZmllbGQtaWQiLDEyXSwibW9udGgiXV0sImNvbHVtbnMiOltbImZrLT4iLFsiZmllbGQtaWQiLDExXSxbImZpZWxkLWlkIiwyNV1dXSwidmFsdWVzIjpbWyJhZ2dyZWdhdGlvbiIsMF1dfX19).
2. Scrollbars should only appear on the table content to the right of the fixed left column, not on the entire window.