### PR TITLE
Fix SQL columns action menu appearance

### DIFF
--- a/frontend/src/metabase/modes/components/drill/FormatAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/FormatAction.jsx
@@ -22,6 +22,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   return [
     {
       name: "formatting",
+      title: "Column formatting",
       section: "sort",
       buttonType: "formatting",
       icon: "gear",

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -175,7 +175,11 @@ export default class ChartClickActions extends Component {
       });
       delete groupedClickActions["sum"];
     }
-    if (clicked.column.source === "native" && groupedClickActions["sort"]) {
+    if (
+      clicked.column &&
+      clicked.column.source === "native" &&
+      groupedClickActions["sort"]
+    ) {
       // restyle the Formatting action for SQL columns
       groupedClickActions["sort"][0] = {
         ...groupedClickActions["sort"][0],

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -175,7 +175,7 @@ export default class ChartClickActions extends Component {
       });
       delete groupedClickActions["sum"];
     }
-    if (!groupedClickActions["filter"]) {
+    if (!groupedClickActions["filter"] && groupedClickActions["formatting"]) {
       // Only SQL column headings do not have filter actions, and we want to restyle the Formatting action for SQL columns
       groupedClickActions["formatting"][0] = {
         ...groupedClickActions["formatting"][0],
@@ -282,7 +282,7 @@ export const ChartClickAction = ({
   const className = cx("cursor-pointer no-decoration", {
     "text-center sort token-blue mr1 bg-brand-hover":
       action.buttonType === "sort",
-    "formatting-button flex-align-right text-brand-hover":
+    "formatting-button flex-align-right text-brand-hover text-light":
       action.buttonType === "formatting",
     "horizontal-button p1 flex flex-auto align-center bg-brand-hover text-dark text-white-hover":
       action.buttonType === "horizontal",
@@ -320,16 +320,14 @@ export const ChartClickAction = ({
         </Link>
       </div>
     );
-  } else if (action.tooltip) {
-    // Only the Sort and Formatting actions have tooltips.
+  } else if (
+    action.buttonType === "sort" ||
+    action.buttonType === "formatting"
+  ) {
     return (
       <Tooltip tooltip={action.tooltip}>
         <div
-          className={cx(className, {
-            "flex flex-row align-center":
-              action.buttonType === "formatting" ||
-              action.buttonType === "sort",
-          })}
+          className={cx(className, "flex flex-row align-center")}
           onClick={() => handleClickAction(action)}
         >
           {action.icon && (
@@ -342,7 +340,6 @@ export const ChartClickAction = ({
               name={action.icon}
             />
           )}
-          {action.title && action.title}
         </div>
       </Tooltip>
     );

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -175,12 +175,11 @@ export default class ChartClickActions extends Component {
       });
       delete groupedClickActions["sum"];
     }
-    if (!groupedClickActions["filter"] && groupedClickActions["formatting"]) {
-      // Only SQL column headings do not have filter actions, and we want to restyle the Formatting action for SQL columns
-      groupedClickActions["formatting"][0] = {
-        ...groupedClickActions["formatting"][0],
+    if (clicked.column.source === "native" && groupedClickActions["sort"]) {
+      // restyle the Formatting action for SQL columns
+      groupedClickActions["sort"][0] = {
+        ...groupedClickActions["sort"][0],
         buttonType: "horizontal",
-        icon: "gear",
       };
     }
     const sections = _.chain(groupedClickActions)

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -175,6 +175,14 @@ export default class ChartClickActions extends Component {
       });
       delete groupedClickActions["sum"];
     }
+    if (!groupedClickActions["filter"]) {
+      // Only SQL column headings do not have filter actions, and we want to restyle the Formatting action for SQL columns
+      groupedClickActions["formatting"][0] = {
+        ...groupedClickActions["formatting"][0],
+        buttonType: "horizontal",
+        icon: "gear",
+      };
+    }
     const sections = _.chain(groupedClickActions)
       .pairs()
       .sortBy(([key]) => (SECTIONS[key] ? SECTIONS[key].index : 99))


### PR DESCRIPTION
Fixes #14027

Current state of this is that while everything builds, the conditional I added doesn't seem to be tripping correctly when it should; if it did, the SQL column when clicked on should have the words "Column formatting" here instead of just a gear:

<img width="208" alt="image" src="https://user-images.githubusercontent.com/2223916/102834280-77e51280-43a8-11eb-968b-3d0990eaaacd.png">

This is the conditional in question:

`if (!groupedClickActions["filter"] && groupedClickActions["formatting"]) {`