### PR TITLE
#13175 Repro: Can not do arithmetic in filter expressions

### DIFF
--- a/frontend/test/metabase/lib/expressions/parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/parser.unit.spec.js
@@ -1,0 +1,40 @@
+import { parse } from "metabase/lib/expressions/parser";
+
+describe("metabase/lib/expressions/parser", () => {
+  describe("in aggregation mode", () => {
+    function parseAggregation(source) {
+      const tokenVector = null;
+      const startRule = "aggregation";
+      return parse({ source, tokenVector, startRule });
+    }
+    it("should handle a simple aggregation", () => {
+      expect(() => parseAggregation("Sum([Price])")).not.toThrow();
+    });
+    it("should handle a conditional aggregation", () => {
+      expect(() => parseAggregation("CountIf( [Discount] > 0 )")).not.toThrow();
+    });
+    it.skip("should handle a complex conditional aggregation", () => {
+      expect(() =>
+        parseAggregation("CountIf( ( [Subtotal] + [Tax] ) > 100 )"),
+      ).not.toThrow();
+    });
+  });
+
+  describe("in expression mode", () => {
+    function parseExpression(source) {
+      const tokenVector = null;
+      const startRule = "expression";
+      return parse({ source, tokenVector, startRule });
+    }
+    it("should handle a conditional using CASE", () => {
+      expect(() =>
+        parseExpression("Case( [Discount] > 0, 'Sale', 'Normal' )"),
+      ).not.toThrow();
+    });
+    it.skip("should handle a complex conditional using CASE", () => {
+      expect(() =>
+        parseExpression("Case( [Price]-[Discount] > 50, 'Deal', 'Regular' )"),
+      ).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
How to test:
```
yarn test-unit
```

or, to run only these new repro tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/parser.unit.spec.js
```
