### PR TITLE
check can_write before displaying collection create button

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -205,13 +205,15 @@ export default class CollectionContent extends React.Component {
                     isRoot={isRoot}
                   />
                 )}
-              <Tooltip tooltip={t`New collection`}>
-                <Link to={Urls.newCollection(this.props.collectionId)}>
-                  <IconWrapper>
-                    <Icon name="folder" />
-                  </IconWrapper>
-                </Link>
-              </Tooltip>
+              {collection && collection.can_write && (
+                <Tooltip tooltip={t`New collection`}>
+                  <Link to={Urls.newCollection(this.props.collectionId)}>
+                    <IconWrapper>
+                      <Icon name="folder" />
+                    </IconWrapper>
+                  </Link>
+                </Tooltip>
+              )}
             </Flex>
           </Flex>
           {collectionHasPins ? (


### PR DESCRIPTION
Closes #14115

## What this does
- Hides the collection create action unless you have write access to the collection you're currently viewing.

I went with the approach of just not displaying the control when you don't have create access. I think that makes more sense than showing you the control but disabling it.  We do the same thing with permission controls on collections and I think across the board in the case of permissions rather than have actions you can't use, the lack of the action itself is a better outcome.

I think showing disabled controls make more sense in the context of validation, where the control could reasonably become "enabled" in a clear way while you're working. (e.g. you just saved, so wait to enable the save button until things are dirty, or a save button on a form becoming active when you fill out a required field). In general I want people's read / write access to be explicit but not something we're making them think about too often with UI elements. (Especially because we don't have any in app recourse for requesting permissions yet).

(@mazameli I noticed you'd originally had the issue as "hide" but changed it to go with disabled, so happy to hash it out here if you have strong feelings). 

## How to test 
- Visit a collection you have view, but not write access to. (If you're using the dev db I set up for collections the easiest way is to login as Dallas Default and visit the "Marketing collection").
- In the top right of the content area you should no longer see the folder icon.