### PR TITLE
Change default Total waterfall bar color

### DIFF
--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -120,7 +120,7 @@ function syncDeprecatedColorFamilies() {
   normal.orange = colors["accent5"];
   normal.teal = colors["accent6"];
   normal.indigo = colors["accent7"];
-  normal.gray = colors["text-medium"];
+  normal.gray = colors["text-dark"];
   normal.grey1 = colors["text-light"];
   normal.grey2 = colors["text-medium"];
   normal.grey3 = colors["text-dark"];

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -41,7 +41,7 @@ export default class WaterfallChart extends LineAreaBarChart {
       section: t`Display`,
       props: { title: t`Total color` },
       widget: "color",
-      default: color("brand"),
+      default: color("text-medium"),
       getHidden: (series, vizSettings) =>
         vizSettings["waterfall.show_total"] !== true,
       readDependencies: ["waterfall.show_total"],

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -41,7 +41,7 @@ export default class WaterfallChart extends LineAreaBarChart {
       section: t`Display`,
       props: { title: t`Total color` },
       widget: "color",
-      default: color("accent7"),
+      default: color("brand"),
       getHidden: (series, vizSettings) =>
         vizSettings["waterfall.show_total"] !== true,
       readDependencies: ["waterfall.show_total"],

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -41,7 +41,7 @@ export default class WaterfallChart extends LineAreaBarChart {
       section: t`Display`,
       props: { title: t`Total color` },
       widget: "color",
-      default: color("text-medium"),
+      default: color("text-dark"),
       getHidden: (series, vizSettings) =>
         vizSettings["waterfall.show_total"] !== true,
       readDependencies: ["waterfall.show_total"],


### PR DESCRIPTION
## Before

<img width="1606" alt="image" src="https://user-images.githubusercontent.com/2223916/102914795-afe66700-4435-11eb-82ef-9931c619dff6.png">

## After

<img width="1639" alt="image" src="https://user-images.githubusercontent.com/2223916/102914504-36e70f80-4435-11eb-9de7-8517b71e9349.png">

## Global color picker is also affected

It seemed odd to me to set the Total bar to a color that you couldn't manually pick as well, so I updated this. I don't personally miss the old text-medium gray we previously had here.

<img width="685" alt="image" src="https://user-images.githubusercontent.com/2223916/102914555-5847fb80-4435-11eb-8cd8-ab19c38633dd.png">

## Alternative

I also played with using `brand` as the default bar color. Is this better?

<img width="1640" alt="image" src="https://user-images.githubusercontent.com/2223916/102915069-0c498680-4436-11eb-85c1-d7b52062ae2e.png">


## Original designs, for reference

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/2223916/102914628-71e94300-4435-11eb-8c99-1c58f1a61582.png">


