### PR TITLE
Allow seconds, minutes, and hours for relative date strings for "past…

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
@@ -14,6 +14,8 @@ import type {
 } from "metabase-types/types/Query";
 
 export const DATE_PERIODS: RelativeDatetimeUnit[] = [
+  "minute",
+  "hour",
   "day",
   "week",
   "month",

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -35,7 +35,7 @@
              (dates/date-string->filter "2019-04-01~" [:field-literal "field" :type/DateTime]))))))
 
 (deftest date-string->range-test
-  (t/with-clock (t/mock-clock #t "2016-06-07T12:00Z")
+  (t/with-clock (t/mock-clock #t "2016-06-07T12:00:55Z")
     (doseq [[group s->expected]
             {"absolute datetimes"         {"Q1-2016"               {:end "2016-03-31", :start "2016-01-01"}
                                            "2016-02"               {:end "2016-02-29", :start "2016-02-01"}
@@ -43,7 +43,10 @@
                                            "2016-04-18~2016-04-23" {:end "2016-04-23", :start "2016-04-18"}
                                            "2016-04-18~"           {:start "2016-04-18"}
                                            "~2016-04-18"           {:end "2016-04-18"}}
-             "relative (past)"            {"past3days"    {:end "2016-06-06", :start "2016-06-04"}
+             "relative (past)"            {"past30seconds"    {:end "2016-06-07T12:00:54", :start "2016-06-07T12:00:25"}
+                                           "past5minutes~"    {:end "2016-06-07T12:00:00", :start "2016-06-07T11:55:00"}
+                                           "past3hours"    {:end "2016-06-07T11:00:00", :start "2016-06-07T09:00:00"}
+                                           "past3days"    {:end "2016-06-06", :start "2016-06-04"}
                                            "past3days~"   {:end "2016-06-07", :start "2016-06-04"}
                                            "past7days"    {:end "2016-06-06", :start "2016-05-31"}
                                            "past30days"   {:end "2016-06-06", :start "2016-05-08"}
@@ -53,7 +56,10 @@
                                            "past1years"   {:end "2015-12-31", :start "2015-01-01"}
                                            "past1years~"  {:end "2016-12-31", :start "2015-01-01"}
                                            "past16years"  {:end "2015-12-31", :start "2000-01-01"}}
-             "relative (next)"            {"next3days"    {:end "2016-06-10", :start "2016-06-08"}
+             "relative (next)"            {"next45seconds"    {:end "2016-06-07T12:01:40", :start "2016-06-07T12:00:56"}
+                                           "next20minutes"    {:end "2016-06-07T12:20:00", :start "2016-06-07T12:01:00"}
+                                           "next6hours"    {:end "2016-06-07T18:00:00", :start "2016-06-07T13:00:00"}
+                                           "next3days"    {:end "2016-06-10", :start "2016-06-08"}
                                            "next3days~"   {:end "2016-06-10", :start "2016-06-07"}
                                            "next7days"    {:end "2016-06-14", :start "2016-06-08"}
                                            "next30days"   {:end "2016-07-07", :start "2016-06-08"}


### PR DESCRIPTION
…" and "next"

Adding tests for new options

This is for issue #6660

This is a work-in-progress review, to get feedback on the general approach.  I will make any changes requested, then look at the frontend piece.  Also, have a look at the new tests, because I'm not entirely sure all the behaviors make sense ~~(ex: `nextNhours` starts at an hour from "now", keeping the same minutes/seconds, whereas `nextNminutes` starts at the top of the next minute)~~  (correction: that was due to a bug; now fixed; but still the behavior is to start at the top of the next unit, which doesn't quite make sense to me).
