### PR TITLE
#14117 Repro: Dashboard subscriptions don't persist attachments

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -42,6 +42,10 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Emailed daily at 8:00 AM").click();
     cy.findByText("Delete this subscription").scrollIntoView();
     cy.findByText("Questions to attach");
-    cy.findByText("Orders");
+    cy.findAllByRole("listitem")
+      .contains("Orders") // yields the whole <li> element
+      .within(() => {
+        cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
+      });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -1,0 +1,47 @@
+import { restore, signInAsAdmin, USERS } from "__support__/cypress";
+const { admin } = USERS;
+
+describe("scenarios > dashboard", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+    // Dummy SMTP setup
+    cy.request("PUT", "/api/setting", {
+      "email-smtp-host": "smtp.foo.test",
+      "email-smtp-port": "587",
+      "email-smtp-security": "none",
+      "email-smtp-username": "nevermind",
+      "email-smtp-password": "it-is-secret-NOT",
+      "email-from-address": "nonexisting@metabase.test",
+    });
+  });
+
+  it.skip("should persist attachments for dashboard subscriptions (metabase#14117)", () => {
+    // Orders in a dashboard
+    cy.visit("/dashboard/1");
+    cy.get(".Icon-share").click();
+    cy.findByText("Dashboard subscriptions").click();
+    cy.findByText("Email it").click();
+    cy.findByPlaceholderText("Enter user names or email addresses")
+      .click()
+      .type(`${admin.first_name} ${admin.last_name}{enter}`);
+    // This is extremely fragile
+    // TODO: update test once changes from `https://github.com/metabase/metabase/pull/14121` are merged into `master`
+    cy.findByText("Attach results")
+      .parent()
+      .parent()
+      .next()
+      .find("a") // Toggle
+      .click();
+    cy.findByText("Questions to attach").click();
+    cy.contains("Done")
+      .closest(".Button")
+      .should("not.be.disabled")
+      .click();
+    cy.findByText("Subscriptions");
+    cy.findByText("Emailed daily at 8:00 AM").click();
+    cy.findByText("Delete this subscription").scrollIntoView();
+    cy.findByText("Questions to attach");
+    cy.findByText("Orders");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14117 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Cypress runner log
![image](https://user-images.githubusercontent.com/31325167/102936454-80bd0d80-44a8-11eb-836f-8876ae5f368a.png)

2. UI at the moment of failure
![image](https://user-images.githubusercontent.com/31325167/102936502-93374700-44a8-11eb-9497-62fb51db87ab.png)
