### PR TITLE
Group by "pivot-grouping" column

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -182,10 +182,10 @@ export function withDatabase(databaseId, f) {
     for (const table of body.tables) {
       const fields = {};
       for (const field of table.fields) {
-        fields[field.name] = field.id;
+        fields[field.name.toUpperCase()] = field.id;
       }
-      database[table.name] = fields;
-      database[table.name + "_ID"] = table.id;
+      database[table.name.toUpperCase()] = fields;
+      database[table.name.toUpperCase() + "_ID"] = table.id;
     }
     f(database);
   });

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -4,7 +4,6 @@ import {
   addPostgresDatabase,
   withDatabase,
   visitQuestionAdhoc,
-  popover,
 } from "__support__/cypress";
 
 const PG_DB_NAME = "QA Postgres12";

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -37,7 +37,7 @@ describe("postgres > user > query", () => {
     cy.contains("37.65");
   });
 
-  it.skip("should properly switch visualization to pivot table (metabase#14148)", () => {
+  it("should properly switch visualization to pivot table (metabase#14148)", () => {
     cy.server();
     cy.route("POST", "/api/advanced_computation/pivot/dataset").as(
       "pivotDataset",

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -8,7 +8,7 @@ import {
 const PG_DB_NAME = "QA Postgres12";
 
 describe("postgres > user > query", () => {
-  before(() => {
+  beforeEach(() => {
     restore();
     signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -68,7 +68,7 @@ describe("postgres > user > query", () => {
       "**Reported failing on v0.38.0-rc1 querying Postgres, Redshift and BigQuery. It works on MySQL and H2.**",
     );
     cy.wait("@pivotDataset").then(xhr => {
-      expect(xhr.response.body.cause).not.to.contain("ERROR");
+      expect(xhr.response.body.cause || "").not.to.contain("ERROR");
     });
     cy.findByText(/Grand totals/i);
     cy.findByText("200");

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -45,17 +45,18 @@ describe("postgres > user > query", () => {
       "pivotDataset",
     );
 
-    withDatabase(PG_DB_ID, ({ PRODUCTS, PRODUCTS_ID }) =>
+    withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) =>
       visitQuestionAdhoc({
         display: "pivot",
         dataset_query: {
+          type: "query",
           database: PG_DB_ID,
           query: {
-            "source-table": PRODUCTS_ID,
+            "source-table": PEOPLE_ID,
             aggregation: [["count"]],
             breakout: [
-              ["field-id", PRODUCTS.CATEGORY],
-              ["datetime-field", ["field-id", PRODUCTS.CREATED_AT], "year"],
+              ["field-id", PEOPLE.SOURCE],
+              ["datetime-field", ["field-id", PEOPLE.CREATED_AT], "year"],
             ],
           },
         },
@@ -69,6 +70,6 @@ describe("postgres > user > query", () => {
       expect(xhr.response.body.cause || "").not.to.contain("ERROR");
     });
     cy.findByText(/Grand totals/i);
-    cy.findByText("200");
+    cy.findByText("2,500");
   });
 });

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -97,7 +97,7 @@
 
 (defmethod load-data/load-data! :oracle
   [driver dbdef tabledef]
-  (load-data/load-data-add-ids! driver dbdef tabledef))
+  (load-data/load-data-add-ids-chunked! driver dbdef tabledef))
 
 (defmethod tx/has-questionable-timezone-support? :oracle [_] true)
 
@@ -146,7 +146,7 @@
    (non-session-schemas)))
 
 
-;;; Clear out the sesion schema before and after tests run
+;;; Clear out the session schema before and after tests run
 ;; TL;DR Oracle schema == Oracle user. Create new user for session-schema
 (defn- execute! [format-string & args]
   (let [sql (apply format format-string args)]

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -136,7 +136,7 @@
 
 (defmethod load-data/load-data! :snowflake
   [& args]
-  (apply load-data/load-data-add-ids! args))
+  (apply load-data/load-data-add-ids-chunked! args))
 
 (defmethod tx/aggregate-column-info :snowflake
   ([driver ag-type]

--- a/modules/drivers/sqlserver/test/metabase/test/data/sqlserver.clj
+++ b/modules/drivers/sqlserver/test/metabase/test/data/sqlserver.clj
@@ -19,7 +19,7 @@
                                    :type/Integer        "INTEGER"
                                    ;; TEXT is considered deprecated -- see
                                    ;; https://msdn.microsoft.com/en-us/library/ms187993.aspx
-                                   :type/Text           "VARCHAR(254)"
+                                   :type/Text           "VARCHAR(1024)"
                                    :type/Time           "TIME"}]
   (defmethod sql.tx/field-base-type->sql-type [:sqlserver base-type] [_ _] database-type))
 

--- a/modules/drivers/vertica/test/metabase/test/data/vertica.clj
+++ b/modules/drivers/vertica/test/metabase/test/data/vertica.clj
@@ -24,7 +24,7 @@
                               :type/Decimal        "NUMERIC"
                               :type/Float          "FLOAT"
                               :type/Integer        "INTEGER"
-                              :type/Text           "VARCHAR(254)"
+                              :type/Text           "VARCHAR(1024)"
                               :type/Time           "TIME"}]
   (defmethod sql.tx/field-base-type->sql-type [:vertica base-type] [_ _] sql-type))
 

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -32,7 +32,7 @@
   "Add the grouping field and expression to the query"
   [query breakout bitmask]
   (-> query
-      (assoc-in [:query :breakout] (conj (seq breakout) [:expression "pivot-grouping"]))
+      (assoc-in [:query :breakout] (concat breakout [[:expression "pivot-grouping"]]))
       ;;TODO: `pivot-grouping` is not "magic" enough to mark it as an internal thing
       (update-in [:query :fields]
                  #(conj % [:expression "pivot-grouping"]))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -32,7 +32,7 @@
   "Add the grouping field and expression to the query"
   [query breakout bitmask]
   (-> query
-      (assoc-in [:query :breakout] breakout)
+      (assoc-in [:query :breakout] (conj (seq breakout) [:expression "pivot-grouping"]))
       ;;TODO: `pivot-grouping` is not "magic" enough to mark it as an internal thing
       (update-in [:query :fields]
                  #(conj % [:expression "pivot-grouping"]))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -31,14 +31,17 @@
 (defn add-grouping-field
   "Add the grouping field and expression to the query"
   [query breakout bitmask]
-  (-> query
-      (assoc-in [:query :breakout] (concat breakout [[:expression "pivot-grouping"]]))
-      ;;TODO: `pivot-grouping` is not "magic" enough to mark it as an internal thing
-      (update-in [:query :fields]
-                 #(conj % [:expression "pivot-grouping"]))
-      ;;TODO: replace this value with a bitmask or something to indicate the source better
-      (update-in [:query :expressions]
-                 #(assoc % "pivot-grouping" [:abs bitmask]))))
+  (let [new-query (-> query
+                      ;;TODO: `pivot-grouping` is not "magic" enough to mark it as an internal thing
+                      (update-in [:query :fields]
+                                 #(conj % [:expression "pivot-grouping"]))
+                      ;;TODO: replace this value with a bitmask or something to indicate the source better
+                      (update-in [:query :expressions]
+                                 #(assoc % "pivot-grouping" [:abs bitmask])))]
+    ;; in PostgreSQL and most other databases, all the expressions must be present in the breakouts
+    (assoc-in new-query [:query :breakout]
+              (concat breakout (map (fn [expr] [:expression (name expr)])
+                                    (keys (get-in new-query [:query :expressions])))))))
 
 (defn generate-queries
   "Generate the additional queries to perform a generic pivot table"

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -11,6 +11,13 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
+(def ^:private applicable-drivers
+  ;; Redshift takes A LONG TIME to insert the sample-dataset, so do not
+  ;; run these tests against Redshift (for now?)
+  ;;TODO: refactor Redshift testing to support a bulk COPY or something
+  ;; other than INSERT INTO statements
+  (disj (mt/normal-drivers-with-feature :expressions :left-join) :redshift))
+
 (defn- pivot-query
   []
   (-> (mt/mbql-query orders
@@ -73,7 +80,7 @@
          ~@body))))
 
 (deftest pivot-dataset-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+  (mt/test-drivers applicable-drivers
     (mt/dataset sample-dataset
       (testing "POST /api/advanced_computation/pivot/dataset"
         (testing "Run a pivot table"
@@ -111,7 +118,7 @@
             (is (= [nil nil nil "wheeee" 7 18760 69540] (last rows)))))))))
 
 (deftest pivot-filter-dataset-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+  (mt/test-drivers applicable-drivers
     (mt/dataset sample-dataset
       (testing "POST /api/advanced_computation/pivot/dataset"
         (testing "Run a pivot table"
@@ -129,7 +136,7 @@
             (is (= [nil nil 3 7562] (last rows)))))))))
 
 (deftest pivot-parameter-dataset-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+  (mt/test-drivers applicable-drivers
     (mt/dataset sample-dataset
       (testing "POST /api/advanced_computation/pivot/dataset"
         (testing "Run a pivot table"
@@ -147,7 +154,7 @@
             (is (= [nil nil 3 2009] (last rows)))))))))
 
 (deftest pivot-card-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+  (mt/test-drivers applicable-drivers
     (mt/dataset sample-dataset
       (testing "POST /api/advanced_computation/pivot/card/id"
         (with-temp-pivot-card [_ card]
@@ -164,7 +171,7 @@
             (is (= [nil nil nil 7 18760 69540] (last rows)))))))))
 
 (deftest pivot-public-card-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+  (mt/test-drivers applicable-drivers
     (mt/dataset sample-dataset
       (testing "GET /api/advanced_computation/public/pivot/card/:uuid/query"
         (mt/with-temporary-setting-values [enable-public-sharing true]

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -120,11 +120,11 @@
            (is (= 4 (count (get-in result [:data :cols]))))
            (is (= 230 (count rows)))
 
-           (is (= ["AK" "Google" 119 0] (first rows)))
-           (is (= ["AK" "Organic" 89 0] (second rows)))
-           (is (= ["MS" "Google" 43 0] (nth rows 135)))
-           (is (= ["MS" nil 136 2] (nth rows 205)))
-           (is (= [nil nil 7562 3] (last rows))))))))
+           (is (= [0 "AK" "Google" 119] (first rows)))
+           (is (= [0 "AK" "Organic" 89] (second rows)))
+           (is (= [0 "MS" "Google" 43] (nth rows 135)))
+           (is (= [2 "MS" nil 136] (nth rows 205)))
+           (is (= [3 nil nil 7562] (last rows))))))))
 
 (deftest pivot-parameter-dataset-test
   (mt/with-log-level :error
@@ -138,11 +138,11 @@
            (is (= 4 (count (get-in result [:data :cols]))))
            (is (= 225 (count rows)))
 
-           (is (= ["AK" "Google" 27 0] (first rows)))
-           (is (= ["AK" "Organic" 25 0] (second rows)))
-           (is (= ["MN" "Organic" 39 0] (nth rows 130)))
-           (is (= ["NE" nil 59 2] (nth rows 205)))
-           (is (= [nil nil 2009 3] (last rows)))))))))
+           (is (= [0 "AK" "Google" 27] (first rows)))
+           (is (= [0 "AK" "Organic" 25] (second rows)))
+           (is (= [0 "MN" "Organic" 39] (nth rows 130)))
+           (is (= [2 "NE" nil 59] (nth rows 205)))
+           (is (= [3 nil nil 2009] (last rows)))))))))
 
 
 (deftest pivot-card-test
@@ -156,10 +156,10 @@
           (is (= 6 (count (get-in result [:data :cols]))))
           (is (= 2273 (count rows)))
 
-          (is (= ["AK" "Affiliate" "Doohickey" 18 81 0] (first rows)))
-          (is (= ["MS" "Organic" "Gizmo" 16 42 0] (nth rows 445)))
-          (is (= ["ND" nil nil 589 2183 6] (nth rows 2250)))
-          (is (= [nil nil nil 18760 69540 7] (last rows))))))))
+          (is (= [0 "AK" "Affiliate" "Doohickey" 18 81] (first rows)))
+          (is (= [0 "MS" "Organic" "Gizmo" 16 42] (nth rows 445)))
+          (is (= [6 "ND" nil nil 589 2183] (nth rows 2250)))
+          (is (= [7 nil nil nil 18760 69540] (last rows))))))))
 
 (deftest pivot-public-card-test
   (mt/dataset sample-dataset
@@ -173,7 +173,7 @@
             (is (= 6 (count (get-in result [:data :cols]))))
             (is (= 2273 (count rows)))
 
-            (is (= ["AK" "Affiliate" "Doohickey" 18 81 0] (first rows)))
-            (is (= ["CO" "Affiliate" "Gadget" 62 211 0] (nth rows 100)))
-            (is (= ["ND" nil nil 589 2183 6] (nth rows 2250)))
-            (is (= [nil nil nil 18760 69540 7] (last rows)))))))))
+            (is (= [0 "AK" "Affiliate" "Doohickey" 18 81] (first rows)))
+            (is (= [0 "CO" "Affiliate" "Gadget" 62 211] (nth rows 100)))
+            (is (= [6 "ND" nil nil 589 2183] (nth rows 2250)))
+            (is (= [7 nil nil nil 18760 69540] (last rows)))))))))

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -107,7 +107,7 @@
                     :source "fields"}
                    (nth cols 6))))
 
-          (is (= [7 nil nil nil 18760 69540 "wheeee"] (last rows))))))))
+          (is (= [nil nil nil 18760 69540 7 "wheeee"] (last rows))))))))
 
 (deftest pivot-filter-dataset-test
   (mt/dataset sample-dataset

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -73,107 +73,110 @@
          ~@body))))
 
 (deftest pivot-dataset-test
-  (mt/dataset sample-dataset
-    (testing "POST /api/advanced_computation/pivot/dataset"
-      (testing "Run a pivot table"
-        (let [result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" (pivot-query))
-              rows   (mt/rows result)]
-          (is (= 1192 (:row_count result)))
-          (is (= "completed" (:status result)))
-          (is (= 6 (count (get-in result [:data :cols]))))
-          (is (= 1192 (count rows)))
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+    (mt/dataset sample-dataset
+      (testing "POST /api/advanced_computation/pivot/dataset"
+        (testing "Run a pivot table"
+          (let [result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" (pivot-query))
+                rows   (mt/rows result)]
+            (is (= 1192 (:row_count result)))
+            (is (= "completed" (:status result)))
+            (is (= 6 (count (get-in result [:data :cols]))))
+            (is (= 1192 (count rows)))
 
-          (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
-          (is (= ["WV" "Facebook" nil 4 45 292] (nth rows 1000)))
-          (is (= [nil nil nil 7 18760 69540] (last rows)))))
+            (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
+            (is (= ["WV" "Facebook" nil 4 45 292] (nth rows 1000)))
+            (is (= [nil nil nil 7 18760 69540] (last rows)))))
 
-      (testing "with an added expression"
-        (let [query (-> (pivot-query)
-                        (assoc-in [:query :fields] [[:expression "test-expr"]])
-                        (assoc-in [:query :expressions] {:test-expr [:ltrim "wheeee"]}))
-              result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" query)
-              rows (mt/rows result)]
-          (is (= 1192 (:row_count result)))
-          (is (= 1192 (count rows)))
+        (testing "with an added expression"
+          (let [query (-> (pivot-query)
+                          (assoc-in [:query :fields] [[:expression "test-expr"]])
+                          (assoc-in [:query :expressions] {:test-expr [:ltrim "wheeee"]}))
+                result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" query)
+                rows (mt/rows result)]
+            (is (= 1192 (:row_count result)))
+            (is (= 1192 (count rows)))
 
-          (let [cols (get-in result [:data :cols])]
-            (is (= 7 (count cols)))
-            (is (= {:base_type "type/Text"
-                    :special_type nil
-                    :name "test-expr"
-                    :display_name "test-expr"
-                    :expression_name "test-expr"
-                    :field_ref ["expression" "test-expr"]
-                    :source "fields"}
-                   (nth cols 6))))
+            (let [cols (get-in result [:data :cols])]
+              (is (= 7 (count cols)))
+              (is (= {:base_type "type/Text"
+                      :special_type nil
+                      :name "test-expr"
+                      :display_name "test-expr"
+                      :expression_name "test-expr"
+                      :field_ref ["expression" "test-expr"]
+                      :source "breakout"}
+                     (nth cols 3))))
 
-          (is (= [nil nil nil 7 18760 69540 "wheeee"] (last rows))))))))
+            (is (= [nil nil nil "wheeee" 7 18760 69540] (last rows)))))))))
 
 (deftest pivot-filter-dataset-test
-  (mt/dataset sample-dataset
-    (testing "POST /api/advanced_computation/pivot/dataset"
-       (testing "Run a pivot table"
-         (let [result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" (filters-query))
-               rows   (mt/rows result)]
-           (is (= 230 (:row_count result)))
-           (is (= "completed" (:status result)))
-           (is (= 4 (count (get-in result [:data :cols]))))
-           (is (= 230 (count rows)))
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+    (mt/dataset sample-dataset
+      (testing "POST /api/advanced_computation/pivot/dataset"
+        (testing "Run a pivot table"
+          (let [result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" (filters-query))
+                rows   (mt/rows result)]
+            (is (= 230 (:row_count result)))
+            (is (= "completed" (:status result)))
+            (is (= 4 (count (get-in result [:data :cols]))))
+            (is (= 230 (count rows)))
 
-           (is (= ["AK" "Google" 0 119] (first rows)))
-           (is (= ["AK" "Organic" 0 89] (second rows)))
-           (is (= ["MS" "Google" 0 43] (nth rows 135)))
-           (is (= ["MS" nil 2 136] (nth rows 205)))
-           (is (= [nil nil 3 7562] (last rows))))))))
+            (is (= ["AK" "Google" 0 119] (first rows)))
+            (is (= ["AK" "Organic" 0 89] (second rows)))
+            (is (= ["MS" "Google" 0 43] (nth rows 135)))
+            (is (= ["MS" nil 2 136] (nth rows 205)))
+            (is (= [nil nil 3 7562] (last rows)))))))))
 
 (deftest pivot-parameter-dataset-test
-  (mt/with-log-level :error
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
     (mt/dataset sample-dataset
-     (testing "POST /api/advanced_computation/pivot/dataset"
-       (testing "Run a pivot table"
-         (let [result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" (parameters-query))
-               rows   (mt/rows result)]
-           (is (= 225 (:row_count result)))
-           (is (= "completed" (:status result)))
-           (is (= 4 (count (get-in result [:data :cols]))))
-           (is (= 225 (count rows)))
+      (testing "POST /api/advanced_computation/pivot/dataset"
+        (testing "Run a pivot table"
+          (let [result (mt/user-http-request :rasta :post 202 "advanced_computation/pivot/dataset" (parameters-query))
+                rows   (mt/rows result)]
+            (is (= 225 (:row_count result)))
+            (is (= "completed" (:status result)))
+            (is (= 4 (count (get-in result [:data :cols]))))
+            (is (= 225 (count rows)))
 
-           (is (= ["AK" "Google" 0 27] (first rows)))
-           (is (= ["AK" "Organic" 0 25] (second rows)))
-           (is (= ["MN" "Organic" 0 39] (nth rows 130)))
-           (is (= ["NE" nil 2 59] (nth rows 205)))
-           (is (= [nil nil 3 2009] (last rows)))))))))
-
+            (is (= ["AK" "Google" 0 27] (first rows)))
+            (is (= ["AK" "Organic" 0 25] (second rows)))
+            (is (= ["MN" "Organic" 0 39] (nth rows 130)))
+            (is (= ["NE" nil 2 59] (nth rows 205)))
+            (is (= [nil nil 3 2009] (last rows)))))))))
 
 (deftest pivot-card-test
-  (mt/dataset sample-dataset
-    (testing "POST /api/advanced_computation/pivot/card/id"
-      (with-temp-pivot-card [_ card]
-        (let [result (mt/user-http-request :rasta :post 202 (format "advanced_computation/pivot/card/%d/query" (u/get-id card)))
-              rows   (mt/rows result)]
-          (is (= 2273 (:row_count result)))
-          (is (= "completed" (:status result)))
-          (is (= 6 (count (get-in result [:data :cols]))))
-          (is (= 2273 (count rows)))
-
-          (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
-          (is (= ["MS" "Organic" "Gizmo" 0 16 42] (nth rows 445)))
-          (is (= ["ND" nil nil 6 589 2183] (nth rows 2250)))
-          (is (= [nil nil nil 7 18760 69540] (last rows))))))))
-
-(deftest pivot-public-card-test
-  (mt/dataset sample-dataset
-    (testing "GET /api/advanced_computation/public/pivot/card/:uuid/query"
-      (mt/with-temporary-setting-values [enable-public-sharing true]
-        (with-temp-pivot-public-card [{uuid :public_uuid}]
-          (let [result (http/client :get 202 (format "advanced_computation/public/pivot/card/%s/query" uuid))
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+    (mt/dataset sample-dataset
+      (testing "POST /api/advanced_computation/pivot/card/id"
+        (with-temp-pivot-card [_ card]
+          (let [result (mt/user-http-request :rasta :post 202 (format "advanced_computation/pivot/card/%d/query" (u/get-id card)))
                 rows   (mt/rows result)]
-            (is (nil? (:row_count result))) ;; row_count isn't included in public endpoints
+            (is (= 2273 (:row_count result)))
             (is (= "completed" (:status result)))
             (is (= 6 (count (get-in result [:data :cols]))))
             (is (= 2273 (count rows)))
 
             (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
-            (is (= ["CO" "Affiliate" "Gadget" 0 62 211] (nth rows 100)))
+            (is (= ["MS" "Organic" "Gizmo" 0 16 42] (nth rows 445)))
             (is (= ["ND" nil nil 6 589 2183] (nth rows 2250)))
             (is (= [nil nil nil 7 18760 69540] (last rows)))))))))
+
+(deftest pivot-public-card-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+    (mt/dataset sample-dataset
+      (testing "GET /api/advanced_computation/public/pivot/card/:uuid/query"
+        (mt/with-temporary-setting-values [enable-public-sharing true]
+          (with-temp-pivot-public-card [{uuid :public_uuid}]
+            (let [result (http/client :get 202 (format "advanced_computation/public/pivot/card/%s/query" uuid))
+                  rows   (mt/rows result)]
+              (is (nil? (:row_count result))) ;; row_count isn't included in public endpoints
+              (is (= "completed" (:status result)))
+              (is (= 6 (count (get-in result [:data :cols]))))
+              (is (= 2273 (count rows)))
+
+              (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
+              (is (= ["CO" "Affiliate" "Gadget" 0 62 211] (nth rows 100)))
+              (is (= ["ND" nil nil 6 589 2183] (nth rows 2250)))
+              (is (= [nil nil nil 7 18760 69540] (last rows))))))))))

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -156,10 +156,10 @@
           (is (= 6 (count (get-in result [:data :cols]))))
           (is (= 2273 (count rows)))
 
-          (is (= ["AK" "Affiliate" "Doohickey" 18 0 81] (first rows)))
-          (is (= ["MS" "Organic" "Gizmo" 16 0 42] (nth rows 445)))
-          (is (= ["ND" nil nil 589 6 2183] (nth rows 2250)))
-          (is (= [nil nil nil 18760 7 69540] (last rows))))))))
+          (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
+          (is (= ["MS" "Organic" "Gizmo" 0 16 42] (nth rows 445)))
+          (is (= ["ND" nil nil 6 589 2183] (nth rows 2250)))
+          (is (= [nil nil nil 7 18760 69540] (last rows))))))))
 
 (deftest pivot-public-card-test
   (mt/dataset sample-dataset
@@ -173,7 +173,7 @@
             (is (= 6 (count (get-in result [:data :cols]))))
             (is (= 2273 (count rows)))
 
-            (is (= ["AK" "Affiliate" "Doohickey" 18 0 81] (first rows)))
-            (is (= ["CO" "Affiliate" "Gadget" 62 0 211] (nth rows 100)))
-            (is (= ["ND" nil nil 589 6 2183] (nth rows 2250)))
-            (is (= [nil nil nil 18760 7 69540] (last rows)))))))))
+            (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
+            (is (= ["CO" "Affiliate" "Gadget" 0 62 211] (nth rows 100)))
+            (is (= ["ND" nil nil 6 589 2183] (nth rows 2250)))
+            (is (= [nil nil nil 7 18760 69540] (last rows)))))))))

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -83,9 +83,9 @@
           (is (= 6 (count (get-in result [:data :cols]))))
           (is (= 1192 (count rows)))
 
-          (is (= [0 "AK" "Affiliate" "Doohickey" 18 81] (first rows)))
-          (is (= [4 "WV" "Facebook" nil 45 292] (nth rows 1000)))
-          (is (= [7 nil nil nil 18760 69540] (last rows)))))
+          (is (= ["AK" "Affiliate" "Doohickey" 0 18 81] (first rows)))
+          (is (= ["WV" "Facebook" nil 4 45 292] (nth rows 1000)))
+          (is (= [nil nil nil 7 18760 69540] (last rows)))))
 
       (testing "with an added expression"
         (let [query (-> (pivot-query)

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -120,11 +120,11 @@
            (is (= 4 (count (get-in result [:data :cols]))))
            (is (= 230 (count rows)))
 
-           (is (= [0 "AK" "Google" 119] (first rows)))
-           (is (= [0 "AK" "Organic" 89] (second rows)))
-           (is (= [0 "MS" "Google" 43] (nth rows 135)))
-           (is (= [2 "MS" nil 136] (nth rows 205)))
-           (is (= [3 nil nil 7562] (last rows))))))))
+           (is (= ["AK" "Google" 0 119] (first rows)))
+           (is (= ["AK" "Organic" 0 89] (second rows)))
+           (is (= ["MS" "Google" 0 43] (nth rows 135)))
+           (is (= ["MS" nil 2 136] (nth rows 205)))
+           (is (= [nil nil 3 7562] (last rows))))))))
 
 (deftest pivot-parameter-dataset-test
   (mt/with-log-level :error
@@ -138,11 +138,11 @@
            (is (= 4 (count (get-in result [:data :cols]))))
            (is (= 225 (count rows)))
 
-           (is (= [0 "AK" "Google" 27] (first rows)))
-           (is (= [0 "AK" "Organic" 25] (second rows)))
-           (is (= [0 "MN" "Organic" 39] (nth rows 130)))
-           (is (= [2 "NE" nil 59] (nth rows 205)))
-           (is (= [3 nil nil 2009] (last rows)))))))))
+           (is (= ["AK" "Google" 0 27] (first rows)))
+           (is (= ["AK" "Organic" 0 25] (second rows)))
+           (is (= ["MN" "Organic" 0 39] (nth rows 130)))
+           (is (= ["NE" nil 2 59] (nth rows 205)))
+           (is (= [nil nil 3 2009] (last rows)))))))))
 
 
 (deftest pivot-card-test
@@ -156,10 +156,10 @@
           (is (= 6 (count (get-in result [:data :cols]))))
           (is (= 2273 (count rows)))
 
-          (is (= [0 "AK" "Affiliate" "Doohickey" 18 81] (first rows)))
-          (is (= [0 "MS" "Organic" "Gizmo" 16 42] (nth rows 445)))
-          (is (= [6 "ND" nil nil 589 2183] (nth rows 2250)))
-          (is (= [7 nil nil nil 18760 69540] (last rows))))))))
+          (is (= ["AK" "Affiliate" "Doohickey" 18 0 81] (first rows)))
+          (is (= ["MS" "Organic" "Gizmo" 16 0 42] (nth rows 445)))
+          (is (= ["ND" nil nil 589 6 2183] (nth rows 2250)))
+          (is (= [nil nil nil 18760 7 69540] (last rows))))))))
 
 (deftest pivot-public-card-test
   (mt/dataset sample-dataset
@@ -173,7 +173,7 @@
             (is (= 6 (count (get-in result [:data :cols]))))
             (is (= 2273 (count rows)))
 
-            (is (= [0 "AK" "Affiliate" "Doohickey" 18 81] (first rows)))
-            (is (= [0 "CO" "Affiliate" "Gadget" 62 211] (nth rows 100)))
-            (is (= [6 "ND" nil nil 589 2183] (nth rows 2250)))
-            (is (= [7 nil nil nil 18760 69540] (last rows)))))))))
+            (is (= ["AK" "Affiliate" "Doohickey" 18 0 81] (first rows)))
+            (is (= ["CO" "Affiliate" "Gadget" 62 0 211] (nth rows 100)))
+            (is (= ["ND" nil nil 589 6 2183] (nth rows 2250)))
+            (is (= [nil nil nil 18760 7 69540] (last rows)))))))))

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -83,9 +83,9 @@
           (is (= 6 (count (get-in result [:data :cols]))))
           (is (= 1192 (count rows)))
 
-          (is (= ["AK" "Affiliate" "Doohickey" 18 81 0] (first rows)))
-          (is (= ["WV" "Facebook" nil 45 292 4] (nth rows 1000)))
-          (is (= [nil nil nil 18760 69540 7] (last rows)))))
+          (is (= [0 "AK" "Affiliate" "Doohickey" 18 81] (first rows)))
+          (is (= [4 "WV" "Facebook" nil 45 292] (nth rows 1000)))
+          (is (= [7 nil nil nil 18760 69540] (last rows)))))
 
       (testing "with an added expression"
         (let [query (-> (pivot-query)
@@ -105,9 +105,9 @@
                     :expression_name "test-expr"
                     :field_ref ["expression" "test-expr"]
                     :source "fields"}
-                   (nth cols 5))))
+                   (nth cols 6))))
 
-          (is (= [nil nil nil 18760 69540 "wheeee" 7] (last rows))))))))
+          (is (= [7 nil nil nil 18760 69540 "wheeee"] (last rows))))))))
 
 (deftest pivot-filter-dataset-test
   (mt/dataset sample-dataset

--- a/test/metabase/api/advanced_computation_test.clj
+++ b/test/metabase/api/advanced_computation_test.clj
@@ -107,7 +107,7 @@
                     :source "fields"}
                    (nth cols 6))))
 
-          (is (= [nil nil nil 18760 69540 7 "wheeee"] (last rows))))))))
+          (is (= [nil nil nil 7 18760 69540 "wheeee"] (last rows))))))))
 
 (deftest pivot-filter-dataset-test
   (mt/dataset sample-dataset

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -6,57 +6,57 @@
             [metabase.test :as mt]))
 
 (deftest generate-queries-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-                   (mt/dataset sample-dataset
-                               (let [request {:database   (mt/db)
-                                              :query      {:source-table (mt/$ids $$orders)
-                                                           :aggregation  [[:count] [:sum (mt/$ids $orders.quantity)]]
-                                                           :breakout     [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
-                                                                          [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                                                          [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]}
-                                              :type       :query
-                                              :parameters []
-                                              :pivot_rows [1 0]
-                                              :pivot_cols [2]}]
-                                 (testing "can generate queries for each new breakout"
-                                   (let [expected [{:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
-                                                                          [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                                                          [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
-                                                                          [:expression "pivot-grouping"]]
-                                                            :expressions {"pivot-grouping" [:abs 0]}}}
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+    (mt/dataset sample-dataset
+      (let [request {:database   (mt/db)
+                     :query      {:source-table (mt/$ids $$orders)
+                                  :aggregation  [[:count] [:sum (mt/$ids $orders.quantity)]]
+                                  :breakout     [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                 [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                 [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]}
+                     :type       :query
+                     :parameters []
+                     :pivot_rows [1 0]
+                     :pivot_cols [2]}]
+        (testing "can generate queries for each new breakout"
+          (let [expected [{:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                 [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                 [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
+                                                 [:expression "pivot-grouping"]]
+                                   :expressions {"pivot-grouping" [:abs 0]}}}
 
-                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
-                                                                          [:expression "pivot-grouping"]]
-                                                            :expressions {"pivot-grouping" [:abs 3]}}}
+                          {:query {:breakout    [[:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
+                                                 [:expression "pivot-grouping"]]
+                                   :expressions {"pivot-grouping" [:abs 3]}}}
 
-                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                                                          [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
-                                                                          [:expression "pivot-grouping"]]
-                                                            :expressions {"pivot-grouping" [:abs 1]}}}
+                          {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                 [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
+                                                 [:expression "pivot-grouping"]]
+                                   :expressions {"pivot-grouping" [:abs 1]}}}
 
-                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                                                          [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
-                                                                          [:expression "pivot-grouping"]]
-                                                            :expressions {"pivot-grouping" [:abs 4]}}}
+                          {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                 [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                 [:expression "pivot-grouping"]]
+                                   :expressions {"pivot-grouping" [:abs 4]}}}
 
-                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
-                                                                          [:expression "pivot-grouping"]]
-                                                            :expressions {"pivot-grouping" [:abs 6]}}}
+                          {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                 [:expression "pivot-grouping"]]
+                                   :expressions {"pivot-grouping" [:abs 6]}}}
 
-                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                                                          [:expression "pivot-grouping"]]
-                                                            :expressions {"pivot-grouping" [:abs 5]}}}
+                          {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                 [:expression "pivot-grouping"]]
+                                   :expressions {"pivot-grouping" [:abs 5]}}}
 
-                                                   {:query {:breakout    [[:expression "pivot-grouping"]]
-                                                            :expressions {"pivot-grouping" [:abs 7]}}}]
-                                         expected (map (fn [expected-val] (-> expected-val
-                                                                              (assoc :type       :query
-                                                                                     :parameters []
-                                                                                     :pivot_rows [1 0]
-                                                                                     :pivot_cols [2])
-                                                                              (assoc-in [:query :fields] [[:expression "pivot-grouping"]])
-                                                                              (assoc-in [:query :aggregation] [[:count] [:sum (mt/$ids $orders.quantity)]])
-                                                                              (assoc-in [:query :source-table] (mt/$ids $$orders)))) expected)
-                                         actual   (map (fn [actual-val] (dissoc actual-val :database)) (sut/generate-queries request))]
-                                     (is (= 7 (count actual)))
-                                     (is (= expected actual))))))))
+                          {:query {:breakout    [[:expression "pivot-grouping"]]
+                                   :expressions {"pivot-grouping" [:abs 7]}}}]
+                expected (map (fn [expected-val] (-> expected-val
+                                                     (assoc :type       :query
+                                                            :parameters []
+                                                            :pivot_rows [1 0]
+                                                            :pivot_cols [2])
+                                                     (assoc-in [:query :fields] [[:expression "pivot-grouping"]])
+                                                     (assoc-in [:query :aggregation] [[:count] [:sum (mt/$ids $orders.quantity)]])
+                                                     (assoc-in [:query :source-table] (mt/$ids $$orders)))) expected)
+                actual   (map (fn [actual-val] (dissoc actual-val :database)) (sut/generate-queries request))]
+            (is (= 7 (count actual)))
+            (is (= expected actual))))))))

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -6,56 +6,57 @@
             [metabase.test :as mt]))
 
 (deftest generate-queries-test
-  (mt/dataset sample-dataset
-    (let [request {:database   (mt/db)
-                   :query      {:source-table (mt/$ids $$orders)
-                                :aggregation  [[:count] [:sum (mt/$ids $orders.quantity)]]
-                                :breakout     [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                               [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]}
-                   :type       :query
-                   :parameters []
-                   :pivot_rows [1 0]
-                   :pivot_cols [2]}]
-      (testing "can generate queries for each new breakout"
-        (let [expected [{:query {:breakout    [[:expression "pivot-grouping"]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                               [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]
-                                 :expressions {"pivot-grouping" [:abs 0]}}}
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
+                   (mt/dataset sample-dataset
+                               (let [request {:database   (mt/db)
+                                              :query      {:source-table (mt/$ids $$orders)
+                                                           :aggregation  [[:count] [:sum (mt/$ids $orders.quantity)]]
+                                                           :breakout     [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                                          [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                                          [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]}
+                                              :type       :query
+                                              :parameters []
+                                              :pivot_rows [1 0]
+                                              :pivot_cols [2]}]
+                                 (testing "can generate queries for each new breakout"
+                                   (let [expected [{:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                                          [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                                          [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
+                                                                          [:expression "pivot-grouping"]]
+                                                            :expressions {"pivot-grouping" [:abs 0]}}}
 
-                        {:query {:breakout    [[:expression "pivot-grouping"]
-                                               [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]
-                                 :expressions {"pivot-grouping" [:abs 3]}}}
+                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
+                                                                          [:expression "pivot-grouping"]]
+                                                            :expressions {"pivot-grouping" [:abs 3]}}}
 
-                        {:query {:breakout    [[:expression "pivot-grouping"]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                               [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]
-                                 :expressions {"pivot-grouping" [:abs 1]}}}
+                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                                          [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
+                                                                          [:expression "pivot-grouping"]]
+                                                            :expressions {"pivot-grouping" [:abs 1]}}}
 
-                        {:query {:breakout    [[:expression "pivot-grouping"]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]]
-                                 :expressions {"pivot-grouping" [:abs 4]}}}
+                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                                          [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                                          [:expression "pivot-grouping"]]
+                                                            :expressions {"pivot-grouping" [:abs 4]}}}
 
-                        {:query {:breakout    [[:expression "pivot-grouping"]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]]
-                                 :expressions {"pivot-grouping" [:abs 6]}}}
+                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+                                                                          [:expression "pivot-grouping"]]
+                                                            :expressions {"pivot-grouping" [:abs 6]}}}
 
-                        {:query {:breakout    [[:expression "pivot-grouping"]
-                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]]
-                                 :expressions {"pivot-grouping" [:abs 5]}}}
+                                                   {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                                                                          [:expression "pivot-grouping"]]
+                                                            :expressions {"pivot-grouping" [:abs 5]}}}
 
-                        {:query {:breakout    [[:expression "pivot-grouping"]]
-                                 :expressions {"pivot-grouping" [:abs 7]}}}]
-              expected (map (fn [expected-val] (-> expected-val
-                                                   (assoc :type       :query
-                                                          :parameters []
-                                                          :pivot_rows [1 0]
-                                                          :pivot_cols [2])
-                                                   (assoc-in [:query :fields] [[:expression "pivot-grouping"]])
-                                                   (assoc-in [:query :aggregation] [[:count] [:sum (mt/$ids $orders.quantity)]])
-                                                   (assoc-in [:query :source-table] (mt/$ids $$orders)))) expected)
-              actual   (map (fn [actual-val] (dissoc actual-val :database)) (sut/generate-queries request))]
-          (is (= 7 (count actual)))
-          (is (= expected actual)))))))
+                                                   {:query {:breakout    [[:expression "pivot-grouping"]]
+                                                            :expressions {"pivot-grouping" [:abs 7]}}}]
+                                         expected (map (fn [expected-val] (-> expected-val
+                                                                              (assoc :type       :query
+                                                                                     :parameters []
+                                                                                     :pivot_rows [1 0]
+                                                                                     :pivot_cols [2])
+                                                                              (assoc-in [:query :fields] [[:expression "pivot-grouping"]])
+                                                                              (assoc-in [:query :aggregation] [[:count] [:sum (mt/$ids $orders.quantity)]])
+                                                                              (assoc-in [:query :source-table] (mt/$ids $$orders)))) expected)
+                                         actual   (map (fn [actual-val] (dissoc actual-val :database)) (sut/generate-queries request))]
+                                     (is (= 7 (count actual)))
+                                     (is (= expected actual))))))))

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -18,29 +18,35 @@
                    :pivot_rows [1 0]
                    :pivot_cols [2]}]
       (testing "can generate queries for each new breakout"
-        (let [expected [{:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
+        (let [expected [{:query {:breakout    [[:expression "pivot-grouping"]
+                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
                                                [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
                                                [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]
                                  :expressions {"pivot-grouping" [:abs 0]}}}
 
-                        {:query {:breakout    [[:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]
+                        {:query {:breakout    [[:expression "pivot-grouping"]
+                                               [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]
                                  :expressions {"pivot-grouping" [:abs 3]}}}
 
-                        {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                        {:query {:breakout    [[:expression "pivot-grouping"]
+                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
                                                [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]]
                                  :expressions {"pivot-grouping" [:abs 1]}}}
 
-                        {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
+                        {:query {:breakout    [[:expression "pivot-grouping"]
+                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
                                                [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]]
                                  :expressions {"pivot-grouping" [:abs 4]}}}
 
-                        {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]]
+                        {:query {:breakout    [[:expression "pivot-grouping"]
+                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]]
                                  :expressions {"pivot-grouping" [:abs 6]}}}
 
-                        {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]]
+                        {:query {:breakout    [[:expression "pivot-grouping"]
+                                               [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]]
                                  :expressions {"pivot-grouping" [:abs 5]}}}
 
-                        {:query {:breakout    []
+                        {:query {:breakout    [[:expression "pivot-grouping"]]
                                  :expressions {"pivot-grouping" [:abs 7]}}}]
               expected (map (fn [expected-val] (-> expected-val
                                                    (assoc :type       :query

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -5,8 +5,15 @@
             [metabase.query-processor.pivot :as sut]
             [metabase.test :as mt]))
 
+(def ^:private applicable-drivers
+  ;; Redshift takes A LONG TIME to insert the sample-dataset, so do not
+  ;; run these tests against Redshift (for now?)
+  ;;TODO: refactor Redshift testing to support a bulk COPY or something
+  ;; other than INSERT INTO statements
+  (disj (mt/normal-drivers-with-feature :expressions :left-join) :redshift))
+
 (deftest generate-queries-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+  (mt/test-drivers applicable-drivers
     (mt/dataset sample-dataset
       (let [request {:database   (mt/db)
                      :query      {:source-table (mt/$ids $$orders)

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -78,7 +78,7 @@
 
 (def ^:private create-database-timeout-ms
   "Max amount of time to wait for driver text extensions to create a DB and load test data."
-  (u/minutes->ms 4)) ; 4 minutes
+  (u/minutes->ms 9)) ; 9 minutes - Redshift is slow. Set to 9 minutes because Circle CI will timeout at 10 minutes.
 
 (def ^:private sync-timeout-ms
   "Max amount of time to wait for sync to complete."

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -148,6 +148,10 @@
   "Implementation of `load-data!`. Insert all rows at once; add IDs."
   (make-load-data-fn load-data-add-ids))
 
+(def load-data-add-ids-chunked!
+  "Implementation of `load-data!`. Insert rows in chunks of 200 at a time; add IDs."
+  (make-load-data-fn load-data-add-ids load-data-chunked))
+
 (def load-data-one-at-a-time-add-ids!
   "Implementation of `load-data!` that inserts rows one at a time, but adds IDs."
   (make-load-data-fn load-data-add-ids load-data-one-at-a-time))


### PR DESCRIPTION
Fixes #14148

The issue was due to H2's leniency towards ungrouped columns. The `pivot-grouping` column is a constant expression to identify the breakouts used in a row. Not grouping by that works fine for H2 but fails in Postgres. To fix that I added it as a breakout. 

Question: How can I ensure the tests run against all drivers? Or, are they and we never ran `[ci all]`?
