### PR TITLE
Settings/Setup - redirect to metrics/segments page

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -211,7 +211,7 @@
   {:title       (tru "Create metrics")
    :group       (tru "Curate your data")
    :description (tru "Define canonical metrics to make it easier for the rest of your team to get the right answers.")
-   :link        "/admin/datamodel/database"
+   :link        "/admin/datamodel/metrics"
    :completed   (db/exists? Metric)
    :triggered   (>= (db/count Card) 30)})
 
@@ -220,7 +220,7 @@
   {:title       (tru "Create segments")
    :group       (tru "Curate your data")
    :description (tru "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions.")
-   :link        "/admin/datamodel/database"
+   :link        "/admin/datamodel/segments"
    :completed   (db/exists? Segment)
    :triggered   (>= (db/count Card) 30)})
 


### PR DESCRIPTION
On the Settings / Setup section when you follow the steps you have a link to help you accomplish the task.
Today for the Metrics and Segments tasks you are redirected to the `/datamodel/database` and then you have to pick the correct tab, which can be confusing.

Here the links are update to redirect directly to `datamodel/segments` and `datamodel/metrics`



###### Before submitting the PR, please make sure you do the following
- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
