### PR TITLE
Full height sharing sidebar

### DIFF
--- a/frontend/src/metabase/css/core/overflow.css
+++ b/frontend/src/metabase/css/core/overflow.css
@@ -18,6 +18,10 @@
   overflow-y: hidden;
 }
 
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
 .overflow-x-scroll {
   overflow-x: scroll;
 }

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -53,6 +53,7 @@ type Props = {
   isEditable: boolean,
   isEditing: boolean,
   isEditingParameter: boolean,
+  isSharing: boolean,
 
   parameters: Parameter[],
   parameterValues: ParameterValues,

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -249,6 +249,7 @@ export default class Dashboard extends Component {
       location,
       isFullscreen,
       isNightMode,
+      isSharing,
       hideParameters,
     } = this.props;
     const { error } = this.state;
@@ -285,7 +286,7 @@ export default class Dashboard extends Component {
         className={cx("Dashboard flex-full", {
           "Dashboard--fullscreen": isFullscreen,
           "Dashboard--night": isNightMode,
-          "full-height": isEditing, // prevents header from scrolling so we can have a fixed sidebar
+          "full-height": isEditing || isSharing, // prevents header from scrolling so we can have a fixed sidebar
         })}
         loading={!dashboard}
         error={error}
@@ -308,7 +309,7 @@ export default class Dashboard extends Component {
             </header>
             <div
               className={cx("flex shrink-below-content-size flex-full", {
-                "flex-basis-none": isEditing,
+                "flex-basis-none": isEditing || isSharing,
               })}
             >
               <div className="flex-auto overflow-x-hidden">

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -11,7 +11,7 @@ function Sidebar({ onClose, onCancel, closeIsDisabled, children }) {
       style={{ width: WIDTH }}
       className="flex flex-column border-left bg-white"
     >
-      <div className="flex flex-column flex-auto overflow-y-scroll">
+      <div className="flex flex-column flex-auto overflow-y-auto">
         {children}
       </div>
       {(onClose || onCancel) && (


### PR DESCRIPTION
Closes #14119

## What this does
- Applies the same layout CSS classes to the dashboard when sharing as when editing to allow the sidebar to stretch the full height and scroll properly if needed. 
-  Switches from `overflow-y-scroll` to `overflow-y-auto` to not show scrollbars when sidebars don't need to scroll.

![image](https://user-images.githubusercontent.com/5248953/103013814-c2cb6b00-450b-11eb-8236-8f6249572569.png)
