### PR TITLE
scoot SQL editor collapsed state label over

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -549,7 +549,7 @@ export default class NativeQueryEditor extends Component {
       }
     } else {
       dataSelectors = (
-        <span className="p2 text-medium">{t`This question is written in ${query.nativeQueryLanguage()}.`}</span>
+        <span className="ml2 p2 text-medium">{t`This question is written in ${query.nativeQueryLanguage()}.`}</span>
       );
     }
 


### PR DESCRIPTION
Before (inexplicably):
![image](https://user-images.githubusercontent.com/5248953/103015169-edb6be80-450d-11eb-9ead-ec1324266520.png)

After:
![image](https://user-images.githubusercontent.com/5248953/103015085-ccee6900-450d-11eb-9c6e-3f126c3bb398.png)
