### PR TITLE
Do not escape closing curly braces in a regular expression

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -360,7 +360,7 @@ export default class NativeQuery extends AtomicQuery {
       for (const tag of tagsBySnippetId[snippet.id] || []) {
         if (tag["snippet-name"] !== snippet.name) {
           queryText = queryText.replace(
-            new RegExp(`\{\{\\s*${tag.name}\\s*\}\}`, "g"),
+            new RegExp(`{{\\s*${tag.name}\\s*}}`, "g"),
             `{{snippet: ${snippet.name}}}`,
           );
         }


### PR DESCRIPTION
https://codeql.github.com/codeql-query-help/javascript/js-useless-regexp-character-escape/