### PR TITLE
Remove `react-retina-image` package

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx
@@ -18,7 +18,6 @@ import Radio from "metabase/components/Radio";
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 import { GTAPApi } from "metabase/services";
-import RetinaImage from "react-retina-image";
 
 import EntityObjectLoader from "metabase/entities/containers/EntityObjectLoader";
 import QuestionLoader from "metabase/containers/QuestionLoader";
@@ -432,8 +431,12 @@ const TargetName = ({ gtap, target }: { gtap: GTAP, target: any }) => {
 
 const AttributeOptionsEmptyState = ({ title }) => (
   <div className="flex align-center rounded bg-slate-extra-light p2">
-    <RetinaImage
+    <img
       src="app/assets/img/attributes_illustration.png"
+      srcSet="
+        app/assets/img/attributes_illustration.png    1x,
+        app/assets/img/attributes_illustration@2x.png 2x,
+      "
       className="mr2"
     />
     <div>

--- a/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
@@ -10,8 +10,6 @@ import { updateSlackSettings } from "../settings";
 import Button from "metabase/components/Button";
 import Icon from "metabase/components/Icon";
 
-import RetinaImage from "react-retina-image";
-
 import _ from "underscore";
 import { t, jt } from "ttag";
 
@@ -238,11 +236,14 @@ export default class SettingsSlackForm extends Component {
         <div className="px2" style={{ maxWidth: "585px" }}>
           <h1>
             {t`Metabase`}
-            <RetinaImage
+            <img
+              width="79px"
               className="mx1"
               src="app/assets/img/slack_emoji.png"
-              width={79}
-              forceOriginalDimensions={false /* broken in React v0.13 */}
+              srcSet="
+                app/assets/img/slack_emoji.png    1x,
+                app/assets/img/slack_emoji@2x.png 2x
+              "
             />
             Slack
           </h1>

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import ReactRetinaImage from "react-retina-image";
 import { t } from "ttag";
 import SettingsInput from "./SettingInput";
 import cx from "classnames";
@@ -96,16 +95,19 @@ class EmbeddingLevel extends Component {
     const { onChangeSetting, settingValues } = this.props;
 
     const premiumToken = settingValues[PREMIUM_EMBEDDING_SETTING_KEY];
+    const imagePath = premiumToken ? "premium_embed_added" : "premium_embed";
 
     return (
       <div
         className="bordered rounded full text-centered"
         style={{ maxWidth: 820 }}
       >
-        <ReactRetinaImage
-          src={`app/assets/img/${
-            premiumToken ? "premium_embed_added" : "premium_embed"
-          }.png`}
+        <img
+          src={`app/assets/img/${imagePath}.png}`}
+          srcSet={`
+            app/assets/img/${imagePath}.png    1x,
+            app/assets/img/${imagePath}@2x.png 2x
+          `}
         />
         <div className="flex align-center justify-center">
           <PremiumEmbedding

--- a/frontend/src/metabase/components/Icon.jsx
+++ b/frontend/src/metabase/components/Icon.jsx
@@ -1,7 +1,6 @@
 /*eslint-disable react/no-danger */
 
 import React, { Component } from "react";
-import RetinaImage from "react-retina-image";
 import styled from "styled-components";
 import { color, space, hover } from "styled-system";
 import cx from "classnames";
@@ -88,7 +87,14 @@ class BaseIcon extends Component {
       // eslint-disable-next-line no-unused-vars
       const { role, ...rest } = props;
       return (
-        <RetinaImage forceOriginalDimensions={false} src={icon.img} {...rest} />
+        <img
+          src={icon.img}
+          srcSet={`
+          ${icon.img}    1x,
+          ${icon.img}@2x 2x
+        `}
+          {...rest}
+        />
       );
     } else if (icon.svg) {
       return <svg {...props} dangerouslySetInnerHTML={{ __html: icon.svg }} />;

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -19,7 +19,6 @@ import { Grid, GridItem } from "metabase/components/Grid";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import Subhead from "metabase/components/type/Subhead";
-import RetinaImage from "react-retina-image";
 
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
@@ -224,8 +223,12 @@ class Overworld extends React.Component {
             ) : (
               <Box className="text-centered">
                 <Box style={{ opacity: 0.5 }}>
-                  <RetinaImage
+                  <img
                     src="app/img/empty.png"
+                    srcSet="
+                      app/img/empty.png 1x,
+                      app/img/empty@2x.png 2x
+                    "
                     className="block ml-auto mr-auto"
                   />
                 </Box>

--- a/frontend/src/metabase/public/components/widgets/SharingPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane.jsx
@@ -2,7 +2,6 @@
 
 import React, { Component } from "react";
 import { t } from "ttag";
-import RetinaImage from "react-retina-image";
 import Icon from "metabase/components/Icon";
 import Toggle from "metabase/components/Toggle";
 import CopyWidget from "metabase/components/CopyWidget";
@@ -145,10 +144,13 @@ export default class SharingPane extends Component {
             disabled: !resource.public_uuid,
           })}
         >
-          <RetinaImage
+          <img
             width={98}
             src="app/assets/img/simple_embed.png"
-            forceOriginalDimensions={false}
+            srcSet="
+              app/assets/img/simple_embed.png     1x,
+              app/assets/img/simple_embed.png@2x  2x
+            "
           />
           <div className="ml2">
             <h3 className="text-green mb1">{t`Public embed`}</h3>
@@ -163,10 +165,13 @@ export default class SharingPane extends Component {
             })}
             onClick={() => onChangeEmbedType("application")}
           >
-            <RetinaImage
+            <img
               width={100}
               src="app/assets/img/secure_embed.png"
-              forceOriginalDimensions={false}
+              srcSet="
+                app/assets/img/secure_embed.png     1x,
+                app/assets/img/secure_embed@2x.png  2x
+              "
             />
             <div className="ml2">
               <h3 className="text-purple mb1">{t`Embed this ${resourceType} in an application`}</h3>

--- a/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
+++ b/frontend/src/metabase/pulse/components/WhatsAPulse.jsx
@@ -3,8 +3,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
-import RetinaImage from "react-retina-image";
-
 export default class WhatsAPulse extends Component {
   static propTypes = {
     button: PropTypes.object,
@@ -16,11 +14,14 @@ export default class WhatsAPulse extends Component {
           {t`Help everyone on your team stay in sync with your data.`}
         </h2>
         <div className="mx4">
-          <RetinaImage
+          <img
             className="brand-hue"
             width={574}
             src="app/assets/img/pulse_empty_illustration.png"
-            forceOriginalDimensions={false}
+            srcSet="
+              app/assets/img/pulse_empty_illustration.png     1x,
+              app/assets/img/pulse_empty_illustration@2x.png  2x,
+            "
             style={{ maxWidth: "574px", width: "100%" }}
           />
         </div>

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -14,7 +14,6 @@ import Icon from "metabase/components/Icon";
 import ChannelSetupModal from "metabase/components/ChannelSetupModal";
 import ButtonWithStatus from "metabase/components/ButtonWithStatus";
 import PulseEditChannels from "metabase/pulse/components/PulseEditChannels";
-import RetinaImage from "react-retina-image";
 
 import User from "metabase/entities/users";
 
@@ -222,7 +221,13 @@ export class AlertEducationalScreen extends Component {
             className="relative flex align-center pr4"
             style={{ marginLeft: -80 }}
           >
-            <RetinaImage src="app/assets/img/alerts/education-illustration-01-raw-data.png" />
+            <img
+              src="app/assets/img/alerts/education-illustration-01-raw-data.png"
+              srcSet="
+                app/assets/img/alerts/education-illustration-01-raw-data.png    1x,
+                app/assets/img/alerts/education-illustration-01-raw-data@2x.png 2x,
+              "
+            />
             <p
               className="ml2 text-left"
               style={textStyle}
@@ -234,7 +239,13 @@ export class AlertEducationalScreen extends Component {
             className="relative flex align-center flex-reverse pl4"
             style={{ marginTop: -50, marginRight: -80 }}
           >
-            <RetinaImage src="app/assets/img/alerts/education-illustration-02-goal.png" />
+            <img
+              src="app/assets/img/alerts/education-illustration-02-goal.png"
+              srcSet="
+                app/assets/img/alerts/education-illustration-02-goal.png    1x,
+                app/assets/img/alerts/education-illustration-02-goal@2x.png 2x,
+              "
+            />
             <p
               className="mr2 text-right"
               style={textStyle}
@@ -246,7 +257,13 @@ export class AlertEducationalScreen extends Component {
             className="relative flex align-center"
             style={{ marginTop: -60, marginLeft: -55 }}
           >
-            <RetinaImage src="app/assets/img/alerts/education-illustration-03-progress.png" />
+            <img
+              src="app/assets/img/alerts/education-illustration-03-progress.png"
+              srcSet="
+                app/assets/img/alerts/education-illustration-03-progress.png    1x,
+                app/assets/img/alerts/education-illustration-03-progress@2x.png 2x,
+              "
+            />
             <p
               className="ml2 text-left"
               style={textStyle}
@@ -424,9 +441,13 @@ export class DeleteAlertSection extends Component {
 
 const AlertModalTitle = ({ text }) => (
   <div className="ml-auto mr-auto my4 pb2 text-centered">
-    <RetinaImage
+    <img
       className="mb3"
       src="app/assets/img/alerts/alert-bell-confetti-illustration.png"
+      srcSet="
+        app/assets/img/alerts/alert-bell-confetti-illustration.png    1x,
+        app/assets/img/alerts/alert-bell-confetti-illustration@2x.png 2x
+      "
     />
     <h1 className="text-dark">{text}</h1>
   </div>

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -34,7 +34,6 @@ import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import _ from "underscore";
 import cx from "classnames";
 
-import RetinaImage from "react-retina-image";
 import { getIn } from "icepick";
 
 import type { DatasetData } from "metabase-types/types/Dataset";
@@ -403,10 +402,13 @@ export default class Table extends Component {
             { "text-slate-light": isDashboard, "text-slate": !isDashboard },
           )}
         >
-          <RetinaImage
+          <img
             width={99}
             src="app/assets/img/hidden-field.png"
-            forceOriginalDimensions={false}
+            srcSet="
+              app/assets/img/hidden-field.png     1x,
+              app/assets/img/hidden-field@2x.png  2x
+            "
             className="mb2"
           />
           <span className="h4 text-bold">Every field is hidden right now</span>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "react-motion": "^0.4.5",
     "react-redux": "^5.0.4",
     "react-resizable": "^1.9.0",
-    "react-retina-image": "^2.0.5",
     "react-router": "3",
     "react-router-redux": "^4.0.8",
     "react-sortable-hoc": "^0.6.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6918,11 +6918,6 @@ image-diff@^1.6.3:
     mkdirp "~0.3.5"
     tmp "0.0.23"
 
-image-exists@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/image-exists/-/image-exists-1.1.0.tgz#ba49cccbaddca8cbbf10f89cafd4d1c8ecfd38d0"
-  integrity sha1-uknMy63cqMu/EPicr9TRyOz9ONA=
-
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -7472,11 +7467,6 @@ is-relative@^1.0.0:
   integrity sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==
   dependencies:
     is-unc-path "^1.0.0"
-
-is-retina@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-retina/-/is-retina-1.0.3.tgz#d7401b286bea2ae37f62477588de504d0b8647e3"
-  integrity sha1-10AbKGvqKuN/Ykd1iN5QTQuGR+M=
 
 is-ssh@^1.3.0:
   version "1.3.2"
@@ -11346,17 +11336,6 @@ react-resizable@^1.9.0:
   dependencies:
     prop-types "15.x"
     react-draggable "^4.0.3"
-
-react-retina-image@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/react-retina-image/-/react-retina-image-2.0.5.tgz#8f92efbbd454fa688d63f35e5a21eff1ab3a062f"
-  integrity sha512-/rUMXXQgZt5TU/+i0RWhkuSWmas76fL91ox8FQJkU/sziCGemeX44Tns7ki0RoUBARSp3493Of8Em7rHnvwPJQ==
-  dependencies:
-    array-equal "^1.0.0"
-    image-exists "^1.1.0"
-    is-retina "^1.0.3"
-    object-assign "^4.1.0"
-    prop-types "^15.5.6"
 
 react-router-redux@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
Since browsers have come a long way in terms of retina image support, I figured it'd be worth removing another dependency in favor of just using `srcset` directly in the few places we don't use SVGs.