### PR TITLE
Better safe than sorry: really check only the hostname

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -49,7 +49,7 @@ export default class LeafletMap extends Component {
 
       const mapTileUrl = MetabaseSettings.get("map-tile-server-url");
       const mapTileAttribution =
-        mapTileUrl.indexOf("openstreetmap.org") >= 0
+        new URL(mapTileUrl).host.indexOf("openstreetmap.org") >= 0
           ? 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
           : null;
 

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -48,10 +48,13 @@ export default class LeafletMap extends Component {
       map.setView([0, 0], 8);
 
       const mapTileUrl = MetabaseSettings.get("map-tile-server-url");
-      const mapTileAttribution =
-        new URL(mapTileUrl).host.indexOf("openstreetmap.org") >= 0
-          ? 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
-          : null;
+      let mapTileHostname = "";
+      try {
+        mapTileHostname = new URL(mapTileUrl).host;
+      } catch (e) {}
+      const mapTileAttribution = mapTileHostname.includes("openstreetmap.org")
+        ? 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+        : null;
 
       L.tileLayer(mapTileUrl, { attribution: mapTileAttribution }).addTo(map);
 


### PR DESCRIPTION
Thus, avoid matching for "openstreetmap.org" in any other parts of the URL.
https://codeql.github.com/codeql-query-help/javascript/js-incomplete-url-substring-sanitization/
