### PR TITLE
Refactor collection components

### DIFF
--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Box, Flex } from "grid-styled";
+import { t, msgid, ngettext } from "ttag";
+import _ from "underscore";
+
+import { Grid, GridItem } from "metabase/components/Grid";
+import BulkActionBar from "metabase/components/BulkActionBar";
+import Button from "metabase/components/Button";
+import StackedCheckBox from "metabase/components/StackedCheckBox";
+
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
+const BulkActionControls = ({ onArchive, onMove }) => (
+  <Box ml={1}>
+    <Button
+      ml={1}
+      medium
+      disabled={!onArchive}
+      onClick={onArchive}
+      data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Archive Items`}
+    >{t`Archive`}</Button>
+    <Button
+      ml={1}
+      medium
+      disabled={!onMove}
+      onClick={onMove}
+      data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Move Items`}
+    >{t`Move`}</Button>
+  </Box>
+);
+
+const SelectionControls = ({
+  selected,
+  deselected,
+  onSelectAll,
+  onSelectNone,
+  size = 18,
+}) =>
+  deselected.length === 0 ? (
+    <StackedCheckBox checked onChange={onSelectNone} size={size} />
+  ) : selected.length === 0 ? (
+    <StackedCheckBox onChange={onSelectAll} size={size} />
+  ) : (
+    <StackedCheckBox checked indeterminate onChange={onSelectAll} size={size} />
+  );
+
+export default function BulkActions(props) {
+  const { selected, handleBulkArchive, handleBulkMoveStart } = props;
+  return (
+    <BulkActionBar showing={selected.length > 0}>
+      {/* NOTE: these padding and grid sizes must be carefully matched
+                   to the main content above to ensure the bulk checkbox lines up */}
+      <Box px={[2, 4]} py={1}>
+        <Grid>
+          <GridItem w={[1, 1 / 3]} />
+          <GridItem w={[1, 2 / 3]} px={[1, 2]}>
+            <Flex align="center" justify="center" px={2}>
+              <SelectionControls {...props} />
+              <BulkActionControls
+                onArchive={
+                  _.all(selected, item => item.setArchived)
+                    ? handleBulkArchive
+                    : null
+                }
+                onMove={
+                  _.all(selected, item => item.setCollection)
+                    ? handleBulkMoveStart
+                    : null
+                }
+              />
+              <Box ml="auto">
+                {ngettext(
+                  msgid`${selected.length} item selected`,
+                  `${selected.length} items selected`,
+                  selected.length,
+                )}
+              </Box>
+            </Flex>
+          </GridItem>
+        </Grid>
+      </Box>
+    </BulkActionBar>
+  );
+}

--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -6,7 +6,11 @@ import _ from "underscore";
 import { Grid, GridItem } from "metabase/components/Grid";
 import BulkActionBar from "metabase/components/BulkActionBar";
 import Button from "metabase/components/Button";
+import Modal from "metabase/components/Modal";
 import StackedCheckBox from "metabase/components/StackedCheckBox";
+
+import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
+import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
 
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 
@@ -45,7 +49,15 @@ const SelectionControls = ({
   );
 
 export default function BulkActions(props) {
-  const { selected, handleBulkArchive, handleBulkMoveStart } = props;
+  const {
+    selected,
+    selectedItems,
+    selectedAction,
+    handleBulkArchive,
+    handleBulkMoveStart,
+    handleCloseModal,
+    handleBulkMove,
+  } = props;
   return (
     <BulkActionBar showing={selected.length > 0}>
       {/* NOTE: these padding and grid sizes must be carefully matched
@@ -79,6 +91,31 @@ export default function BulkActions(props) {
           </GridItem>
         </Grid>
       </Box>
+      {!_.isEmpty(selectedItems) && selectedAction === "copy" && (
+        <Modal onClose={handleCloseModal}>
+          <CollectionCopyEntityModal
+            entityObject={selectedItems[0]}
+            onClose={handleCloseModal}
+            onSaved={newEntityObject => {
+              this.handleCloseModal();
+              this.handleBulkActionSuccess();
+            }}
+          />
+        </Modal>
+      )}
+      {!_.isEmpty(selectedItems) && selectedAction === "move" && (
+        <Modal onClose={handleCloseModal}>
+          <CollectionMoveModal
+            title={
+              selectedItems.length > 1
+                ? t`Move ${selectedItems.length} items?`
+                : t`Move "${selectedItems[0].getName()}"?`
+            }
+            onClose={handleCloseModal}
+            onMove={handleBulkMove}
+          />
+        </Modal>
+      )}
     </BulkActionBar>
   );
 }

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { dissoc } from "icepick";
+import { t } from "ttag";
+
+import * as Urls from "metabase/lib/urls";
+import withToast from "metabase/hoc/Toast";
+import { entityTypeForObject } from "metabase/schema";
+
+import Link from "metabase/components/Link";
+
+import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
+
+function CollectionCopyEntityModal({
+  entityObject,
+  onClose,
+  onSaved,
+  triggerToast,
+}) {
+  return (
+    <EntityCopyModal
+      entityType={entityTypeForObject(entityObject)}
+      entityObject={entityObject}
+      copy={async values => {
+        return entityObject.copy(dissoc(values, "id"));
+      }}
+      onClose={onClose}
+      onSaved={newEntityObject => {
+        triggerToast(
+          <div className="flex align-center">
+            {t`Duplicated ${entityObject.model}`}
+            <Link
+              className="link text-bold ml1"
+              to={Urls.modelToUrl(entityObject.model, newEntityObject.id)}
+            >
+              {t`See it`}
+            </Link>
+          </div>,
+          { icon: entityObject.model },
+        );
+
+        onSaved(newEntityObject);
+      }}
+    />
+  );
+}
+
+export default withToast()(CollectionCopyEntityModal);

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -44,4 +44,4 @@ function CollectionCopyEntityModal({
   );
 }
 
-export default withToast()(CollectionCopyEntityModal);
+export default withToast(CollectionCopyEntityModal);

--- a/frontend/src/metabase/collections/components/CollectionEditMenu.jsx
+++ b/frontend/src/metabase/collections/components/CollectionEditMenu.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import EntityMenu from "metabase/components/EntityMenu";
+
+export default function CollectionEditMenu({
+  isRoot,
+  isAdmin,
+  collectionId,
+  tooltip,
+}) {
+  const items = [];
+  if (!isRoot) {
+    items.push({
+      title: t`Edit this collection`,
+      icon: "edit_document",
+      link: `/collection/${collectionId}/edit`,
+      event: `${ANALYTICS_CONTEXT};Edit Menu;Edit Collection Click`,
+    });
+  }
+  if (!isRoot) {
+    items.push({
+      title: t`Archive this collection`,
+      icon: "view_archive",
+      link: `/collection/${collectionId}/archive`,
+      event: `${ANALYTICS_CONTEXT};Edit Menu;Archive Collection`,
+    });
+  }
+  return items.length > 0 ? (
+    <EntityMenu items={items} triggerIcon="pencil" tooltip={tooltip} />
+  ) : null;
+}

--- a/frontend/src/metabase/collections/components/CollectionEditMenu.jsx
+++ b/frontend/src/metabase/collections/components/CollectionEditMenu.jsx
@@ -1,5 +1,8 @@
 import React from "react";
+import { t } from "ttag";
+
 import EntityMenu from "metabase/components/EntityMenu";
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 
 export default function CollectionEditMenu({
   isRoot,

--- a/frontend/src/metabase/collections/components/CollectionSectionHeading.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSectionHeading.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { color } from "metabase/lib/colors";
+
+export default function CollectionSectionHeading({ children }) {
+  return (
+    <h5
+      className="text-uppercase mb2"
+      style={{ color: color("text-medium"), fontWeight: 900 }}
+    >
+      {children}
+    </h5>
+  );
+}

--- a/frontend/src/metabase/collections/components/Header.jsx
+++ b/frontend/src/metabase/collections/components/Header.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Flex } from "grid-styled";
+
+import { t } from "ttag";
+import cx from "classnames";
+import * as Urls from "metabase/lib/urls";
+import { color } from "metabase/lib/colors";
+import Icon, { IconWrapper } from "metabase/components/Icon";
+import Link from "metabase/components/Link";
+import PageHeading from "metabase/components/PageHeading";
+import Tooltip from "metabase/components/Tooltip";
+import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
+
+export default function Header({
+  showFilters,
+  collectionHasPins,
+  unpinnedItems,
+  collection,
+  isAdmin,
+  isRoot,
+  collectionId,
+}) {
+  return (
+    <Flex
+      align="center"
+      py={3}
+      className={cx({
+        "border-bottom":
+          !showFilters && !collectionHasPins && unpinnedItems.length > 0,
+      })}
+    >
+      <Flex align="center">
+        <PageHeading className="text-wrap">{collection.name}</PageHeading>
+        {collection.description && (
+          <Tooltip tooltip={collection.description}>
+            <Icon
+              name="info"
+              ml={1}
+              mt="4px"
+              color={color("bg-dark")}
+              hover={{ color: color("brand") }}
+            />
+          </Tooltip>
+        )}
+      </Flex>
+
+      <Flex ml="auto">
+        {isAdmin && !collection.personal_owner_id && (
+          <Tooltip tooltip={t`Edit the permissions for this collection`}>
+            <Link to={Urls.collectionPermissions(collectionId)}>
+              <IconWrapper>
+                <Icon name="lock" />
+              </IconWrapper>
+            </Link>
+          </Tooltip>
+        )}
+        {collection &&
+          collection.can_write &&
+          !collection.personal_owner_id && (
+            <CollectionEditMenu
+              tooltip={t`Edit collection`}
+              collectionId={collectionId}
+              isAdmin={isAdmin}
+              isRoot={isRoot}
+            />
+          )}
+        {collection && collection.can_write && (
+          <Tooltip tooltip={t`New collection`}>
+            <Link to={Urls.newCollection(collectionId)}>
+              <IconWrapper>
+                <Icon name="new_folder" />
+              </IconWrapper>
+            </Link>
+          </Tooltip>
+        )}
+      </Flex>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/collections/components/ItemList.jsx
+++ b/frontend/src/metabase/collections/components/ItemList.jsx
@@ -3,17 +3,19 @@ import { Box, Flex } from "grid-styled";
 import { assocIn } from "icepick";
 import { t } from "ttag";
 
+import { color } from "metabase/lib/colors";
+
+import CollectionEmptyState from "metabase/components/CollectionEmptyState";
 import VirtualizedList from "metabase/components/VirtualizedList";
 
-import NormalItem from "metabase/collections/components/NormalItem";
+import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
 import ItemTypeFilterBar, {
   FILTERS as ITEM_TYPE_FILTERS,
 } from "metabase/collections/components/ItemTypeFilterBar";
-import CollectionEmptyState from "metabase/components/CollectionEmptyState";
-import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
+import NormalItem from "metabase/collections/components/NormalItem";
+
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
-import { color } from "metabase/lib/colors";
 
 const ROW_HEIGHT = 72;
 

--- a/frontend/src/metabase/collections/components/ItemList.jsx
+++ b/frontend/src/metabase/collections/components/ItemList.jsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Box, Flex } from "grid-styled";
+import { assocIn } from "icepick";
+import { t } from "ttag";
+
+import VirtualizedList from "metabase/components/VirtualizedList";
+
+import NormalItem from "metabase/collections/components/NormalItem";
+import ItemTypeFilterBar, {
+  FILTERS as ITEM_TYPE_FILTERS,
+} from "metabase/collections/components/ItemTypeFilterBar";
+import CollectionEmptyState from "metabase/components/CollectionEmptyState";
+import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
+import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
+const ROW_HEIGHT = 72;
+import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
+import { color } from "metabase/lib/colors";
+
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+export default function ItemList({
+  items,
+  collection,
+  empty,
+  selection,
+  onToggleSelected,
+  collectionHasPins,
+  showFilters,
+}) {
+  const everythingName =
+    collectionHasPins && items.length > 0 ? t`Everything else` : t`Everything`;
+  const filters = assocIn(ITEM_TYPE_FILTERS, [0, "name"], everythingName);
+  return (
+    <Box className="relative">
+      {showFilters ? (
+        <ItemTypeFilterBar
+          analyticsContext={ANALYTICS_CONTEXT}
+          filters={filters}
+        />
+      ) : (
+        collectionHasPins &&
+        items.length > 0 && (
+          <CollectionSectionHeading>{t`Everything else`}</CollectionSectionHeading>
+        )
+      )}
+      {items.length > 0 && (
+        <PinDropTarget pinIndex={null} margin={8}>
+          <Box
+            style={{
+              position: "relative",
+              height: ROW_HEIGHT * items.length,
+            }}
+          >
+            <VirtualizedList
+              items={items}
+              rowHeight={ROW_HEIGHT}
+              renderItem={({ item, index }) => (
+                <Box className="relative">
+                  <ItemDragSource
+                    item={item}
+                    selection={selection}
+                    collection={collection}
+                  >
+                    <NormalItem
+                      key={`${item.model}:${item.id}`}
+                      item={item}
+                      onPin={() => item.setPinned(true)}
+                      collection={collection}
+                      selection={selection}
+                      onToggleSelected={onToggleSelected}
+                      onMove={selectedItems =>
+                        this.setState({
+                          selectedItems,
+                          selectedAction: "move",
+                        })
+                      }
+                      onCopy={selectedItems =>
+                        this.setState({
+                          selectedItems,
+                          selectedAction: "copy",
+                        })
+                      }
+                    />
+                  </ItemDragSource>
+                </Box>
+              )}
+              // needed in order to prevent an issue with content not fully rendering
+              // due to the collection content scrolling layout
+              useAutoSizerHeight={true}
+            />
+          </Box>
+        </PinDropTarget>
+      )}
+      {!collectionHasPins && !items.length > 0 && (
+        <Box mt={"120px"}>
+          <CollectionEmptyState />
+        </Box>
+      )}
+      {empty && (
+        <PinDropTarget pinIndex={null} hideUntilDrag margin={10}>
+          {({ hovered }) => (
+            <Flex
+              align="center"
+              justify="center"
+              py={2}
+              m={2}
+              color={hovered ? color("brand") : color("text-medium")}
+            >
+              {t`Drag here to un-pin`}
+            </Flex>
+          )}
+        </PinDropTarget>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/metabase/collections/components/ItemList.jsx
+++ b/frontend/src/metabase/collections/components/ItemList.jsx
@@ -12,9 +12,10 @@ import ItemTypeFilterBar, {
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
 import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
-const ROW_HEIGHT = 72;
 import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
 import { color } from "metabase/lib/colors";
+
+const ROW_HEIGHT = 72;
 
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 export default function ItemList({
@@ -25,6 +26,8 @@ export default function ItemList({
   onToggleSelected,
   collectionHasPins,
   showFilters,
+  onMove,
+  onCopy,
 }) {
   const everythingName =
     collectionHasPins && items.length > 0 ? t`Everything else` : t`Everything`;
@@ -67,18 +70,8 @@ export default function ItemList({
                       collection={collection}
                       selection={selection}
                       onToggleSelected={onToggleSelected}
-                      onMove={selectedItems =>
-                        this.setState({
-                          selectedItems,
-                          selectedAction: "move",
-                        })
-                      }
-                      onCopy={selectedItems =>
-                        this.setState({
-                          selectedItems,
-                          selectedAction: "copy",
-                        })
-                      }
+                      onMove={onMove}
+                      onCopy={onCopy}
                     />
                   </ItemDragSource>
                 </Box>

--- a/frontend/src/metabase/collections/components/NormalItem.jsx
+++ b/frontend/src/metabase/collections/components/NormalItem.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+import { entityTypeForObject } from "metabase/schema";
+
+import EntityItem from "metabase/components/EntityItem";
+import Link from "metabase/components/Link";
+
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
+export default function NormalItem({
+  item,
+  collection = {},
+  selection = new Set(),
+  onToggleSelected,
+  onMove,
+  onCopy,
+  onPin,
+  pinned,
+}) {
+  return (
+    <Link
+      to={item.getUrl()}
+      data-metabase-event={`${ANALYTICS_CONTEXT};Item Click;${item.model}`}
+    >
+      <EntityItem
+        analyticsContext={ANALYTICS_CONTEXT}
+        variant="list"
+        showSelect={selection.size > 0}
+        selectable
+        item={item}
+        type={entityTypeForObject(item)}
+        name={item.getName()}
+        iconName={item.getIcon()}
+        iconColor={item.getColor()}
+        isFavorite={item.favorite}
+        onFavorite={
+          item.setFavorited ? () => item.setFavorited(!item.favorite) : null
+        }
+        onPin={collection.can_write && onPin && onPin}
+        onMove={
+          collection.can_write && item.setCollection
+            ? () => onMove([item])
+            : null
+        }
+        onCopy={item.copy ? () => onCopy([item]) : null}
+        onArchive={
+          collection.can_write && item.setArchived
+            ? () => item.setArchived(true)
+            : null
+        }
+        selected={selection.has(item)}
+        onToggleSelected={() => {
+          onToggleSelected(item);
+        }}
+        pinned={pinned}
+      />
+    </Link>
+  );
+}

--- a/frontend/src/metabase/collections/components/PinnedItems.jsx
+++ b/frontend/src/metabase/collections/components/PinnedItems.jsx
@@ -34,7 +34,7 @@ const PinnedItem = ({ item, index, collection, onCopy, onMove }) => (
   </Link>
 );
 
-export default function PinnedItems({ items, collection }) {
+export default function PinnedItems({ items, collection, onMove, onCopy }) {
   if (items.length === 0) {
     return (
       <PinDropTarget pinIndex={1} hideUntilDrag>
@@ -69,18 +69,8 @@ export default function PinnedItems({ items, collection }) {
                 index={index}
                 item={item}
                 collection={collection}
-                onMove={selectedItems =>
-                  this.setState({
-                    selectedItems,
-                    selectedAction: "move",
-                  })
-                }
-                onCopy={selectedItems =>
-                  this.setState({
-                    selectedItems,
-                    selectedAction: "copy",
-                  })
-                }
+                onMove={onMove}
+                onCopy={onCopy}
               />
               <PinPositionDropTarget pinIndex={item.collection_position} left />
               <PinPositionDropTarget

--- a/frontend/src/metabase/collections/components/PinnedItems.jsx
+++ b/frontend/src/metabase/collections/components/PinnedItems.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Box } from "grid-styled";
+import { t } from "ttag";
+import { color } from "metabase/lib/colors";
+import cx from "classnames";
+
+import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
+import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
+import PinPositionDropTarget from "metabase/containers/dnd/PinPositionDropTarget";
+
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
+
+import NormalItem from "metabase/collections/components/NormalItem";
+import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
+const PinnedItem = ({ item, index, collection, onCopy, onMove }) => (
+  <Link
+    key={index}
+    to={item.getUrl()}
+    className="hover-parent hover--visibility"
+    hover={{ color: color("brand") }}
+    data-metabase-event={`${ANALYTICS_CONTEXT};Pinned Item;Click;${item.model}`}
+  >
+    <NormalItem
+      item={item}
+      collection={collection}
+      onPin={() => item.setPinned(false)}
+      onMove={onMove}
+      onCopy={onCopy}
+      pinned
+    />
+  </Link>
+);
+
+export default function PinnedItems({ items, collection }) {
+  if (items.length === 0) {
+    return (
+      <PinDropTarget pinIndex={1} hideUntilDrag>
+        {({ hovered }) => (
+          <div
+            className={cx(
+              "p2 flex layout-centered",
+              hovered ? "text-brand" : "text-light",
+            )}
+          >
+            <Icon name="pin" mr={1} />
+            {t`Drag something here to pin it to the top`}
+          </div>
+        )}
+      </PinDropTarget>
+    );
+  }
+  return (
+    <Box pt={2} pb={3}>
+      <CollectionSectionHeading>{t`Pinned items`}</CollectionSectionHeading>
+      <PinDropTarget
+        pinIndex={items[items.length - 1].collection_position + 1}
+        noDrop
+        marginLeft={8}
+        marginRight={8}
+      >
+        {items.map((item, index) => (
+          <Box w={[1]} className="relative" key={index}>
+            <ItemDragSource item={item} collection={collection}>
+              <PinnedItem
+                key={`${item.model}:${item.id}`}
+                index={index}
+                item={item}
+                collection={collection}
+                onMove={selectedItems =>
+                  this.setState({
+                    selectedItems,
+                    selectedAction: "move",
+                  })
+                }
+                onCopy={selectedItems =>
+                  this.setState({
+                    selectedItems,
+                    selectedAction: "copy",
+                  })
+                }
+              />
+              <PinPositionDropTarget pinIndex={item.collection_position} left />
+              <PinPositionDropTarget
+                pinIndex={item.collection_position + 1}
+                right
+              />
+            </ItemDragSource>
+          </Box>
+        ))}
+        {items.length % 2 === 1 ? (
+          <Box w={1} className="relative">
+            <PinPositionDropTarget
+              pinIndex={items[items.length - 1].collection_position + 1}
+            />
+          </Box>
+        ) : null}
+      </PinDropTarget>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/collections/constants.js
+++ b/frontend/src/metabase/collections/constants.js
@@ -1,2 +1,3 @@
 // unit to use for calculating collection sidebar spacing (in px)
 export const SIDEBAR_SPACER = 18;
+export const ANALYTICS_CONTEXT = "Collection Landing";

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -4,24 +4,18 @@ import _ from "underscore";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
 
-import listSelect from "metabase/hoc/ListSelect";
-
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 
-import Header from "metabase/collections/components/Header";
-
 import { getUserIsAdmin } from "metabase/selectors/user";
 
-// import CollectionList from "metabase/components/CollectionList";
+import listSelect from "metabase/hoc/ListSelect";
 
 import BulkActions from "metabase/collections/components/BulkActions";
-
-import PinnedItems from "metabase/collections/components/PinnedItems";
+import Header from "metabase/collections/components/Header";
 import ItemList from "metabase/collections/components/ItemList";
+import PinnedItems from "metabase/collections/components/PinnedItems";
 
-// drag-and-drop components
-//import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
 
 @Search.loadList({

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -5,7 +5,6 @@ import { t } from "ttag";
 import cx from "classnames";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
-import { assocIn } from "icepick";
 
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
@@ -21,33 +20,20 @@ import Link from "metabase/components/Link";
 import Modal from "metabase/components/Modal";
 import PageHeading from "metabase/components/PageHeading";
 import Tooltip from "metabase/components/Tooltip";
-import VirtualizedList from "metabase/components/VirtualizedList";
-
-import NormalItem from "metabase/collections/components/NormalItem";
 
 import { getUserIsAdmin } from "metabase/selectors/user";
 
-import ItemTypeFilterBar, {
-  FILTERS as ITEM_TYPE_FILTERS,
-} from "metabase/collections/components/ItemTypeFilterBar";
-import CollectionEmptyState from "metabase/components/CollectionEmptyState";
-import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
 import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
 // import CollectionList from "metabase/components/CollectionList";
 
 import BulkActions from "metabase/collections/components/BulkActions";
 
 import PinnedItems from "metabase/collections/components/PinnedItems";
+import ItemList from "metabase/collections/components/ItemList";
 
 // drag-and-drop components
-import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 //import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
-import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
-
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
-
-const ROW_HEIGHT = 72;
 
 @Search.loadList({
   query: (state, props) => ({ collection: props.collectionId }),
@@ -156,12 +142,8 @@ export default class CollectionContent extends React.Component {
     const collectionHasPins = pinned.length > 0;
 
     const avaliableTypes = _.uniq(unpinned.map(u => u.model));
+
     const showFilters = unpinned.length > 5 && avaliableTypes.length > 1;
-    const everythingName =
-      collectionHasPins && unpinned.length > 0
-        ? t`Everything else`
-        : t`Everything`;
-    const filters = assocIn(ITEM_TYPE_FILTERS, [0, "name"], everythingName);
 
     return (
       <Box pt={2}>
@@ -240,87 +222,15 @@ export default class CollectionContent extends React.Component {
               }
             />
           )}
-          <Box className="relative">
-            {showFilters ? (
-              <ItemTypeFilterBar
-                analyticsContext={ANALYTICS_CONTEXT}
-                filters={filters}
-              />
-            ) : (
-              collectionHasPins &&
-              unpinnedItems.length > 0 && (
-                <CollectionSectionHeading>{t`Everything else`}</CollectionSectionHeading>
-              )
-            )}
-            {unpinnedItems.length > 0 && (
-              <PinDropTarget pinIndex={null} margin={8}>
-                <Box
-                  style={{
-                    position: "relative",
-                    height: ROW_HEIGHT * unpinnedItems.length,
-                  }}
-                >
-                  <VirtualizedList
-                    items={unpinnedItems}
-                    rowHeight={ROW_HEIGHT}
-                    renderItem={({ item, index }) => (
-                      <Box className="relative">
-                        <ItemDragSource
-                          item={item}
-                          selection={selection}
-                          collection={collection}
-                        >
-                          <NormalItem
-                            key={`${item.model}:${item.id}`}
-                            item={item}
-                            onPin={() => item.setPinned(true)}
-                            collection={collection}
-                            selection={selection}
-                            onToggleSelected={onToggleSelected}
-                            onMove={selectedItems =>
-                              this.setState({
-                                selectedItems,
-                                selectedAction: "move",
-                              })
-                            }
-                            onCopy={selectedItems =>
-                              this.setState({
-                                selectedItems,
-                                selectedAction: "copy",
-                              })
-                            }
-                          />
-                        </ItemDragSource>
-                      </Box>
-                    )}
-                    // needed in order to prevent an issue with content not fully rendering
-                    // due to the collection content scrolling layout
-                    useAutoSizerHeight={true}
-                  />
-                </Box>
-              </PinDropTarget>
-            )}
-            {!collectionHasPins && !unpinnedItems.length > 0 && (
-              <Box mt={"120px"}>
-                <CollectionEmptyState />
-              </Box>
-            )}
-          </Box>
-          {unpinned.length === 0 && (
-            <PinDropTarget pinIndex={null} hideUntilDrag margin={10}>
-              {({ hovered }) => (
-                <Flex
-                  align="center"
-                  justify="center"
-                  py={2}
-                  m={2}
-                  color={hovered ? color("brand") : color("text-medium")}
-                >
-                  {t`Drag here to un-pin`}
-                </Flex>
-              )}
-            </PinDropTarget>
-          )}
+          <ItemList
+            items={unpinnedItems}
+            empty={unpinned.length === 0}
+            showFilters={showFilters}
+            selection={selection}
+            collection={collection}
+            onToggleSelected={onToggleSelected}
+            collectionHasPins={collectionHasPins}
+          />
         </Box>
         <BulkActions
           selected={selected}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -5,19 +5,15 @@ import { t, msgid, ngettext } from "ttag";
 import cx from "classnames";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
-import { dissoc, assocIn } from "icepick";
-
-import { entityTypeForObject } from "metabase/schema";
+import { assocIn } from "icepick";
 
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
 
-import withToast from "metabase/hoc/Toast";
 import listSelect from "metabase/hoc/ListSelect";
 
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
-import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 
 import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
 
@@ -35,6 +31,7 @@ import VirtualizedList from "metabase/components/VirtualizedList";
 import BulkActionBar from "metabase/components/BulkActionBar";
 
 import NormalItem from "metabase/collections/components/NormalItem";
+import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
 
 import { getUserIsAdmin } from "metabase/selectors/user";
 
@@ -535,37 +532,3 @@ const CollectionEditMenu = ({ isRoot, isAdmin, collectionId, tooltip }) => {
     <EntityMenu items={items} triggerIcon="pencil" tooltip={tooltip} />
   ) : null;
 };
-
-@withToast
-class CollectionCopyEntityModal extends React.Component {
-  render() {
-    const { entityObject, onClose, onSaved, triggerToast } = this.props;
-
-    return (
-      <EntityCopyModal
-        entityType={entityTypeForObject(entityObject)}
-        entityObject={entityObject}
-        copy={async values => {
-          return entityObject.copy(dissoc(values, "id"));
-        }}
-        onClose={onClose}
-        onSaved={newEntityObject => {
-          triggerToast(
-            <div className="flex align-center">
-              {t`Duplicated ${entityObject.model}`}
-              <Link
-                className="link text-bold ml1"
-                to={Urls.modelToUrl(entityObject.model, newEntityObject.id)}
-              >
-                {t`See it`}
-              </Link>
-            </div>,
-            { icon: entityObject.model },
-          );
-
-          onSaved(newEntityObject);
-        }}
-      />
-    );
-  }
-}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -15,8 +15,6 @@ import listSelect from "metabase/hoc/ListSelect";
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 
-import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
-
 import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 import Icon, { IconWrapper } from "metabase/components/Icon";
 import Link from "metabase/components/Link";
@@ -26,7 +24,6 @@ import Tooltip from "metabase/components/Tooltip";
 import VirtualizedList from "metabase/components/VirtualizedList";
 
 import NormalItem from "metabase/collections/components/NormalItem";
-import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
 
 import { getUserIsAdmin } from "metabase/selectors/user";
 
@@ -329,38 +326,17 @@ export default class CollectionContent extends React.Component {
           selected={selected}
           handleBulkArchive={this.handleBulkArchive}
           handleBulkMoveStart={this.handleBulkMoveStart}
+          handleBulkMove={this.handleBulkMove}
+          handleCloseModal={this.handleCloseModal}
           deselected={deselected}
+          selectedItems={selectedItems}
+          selectedAction={selectedAction}
         />
         {this.state.showDashboardModal && (
           <Modal onClose={() => this.setState({ showDashboardModal: null })}>
             <CreateDashboardModal
               createDashboard={this.props.createDashboard}
               onClose={() => this.setState({ modal: null })}
-            />
-          </Modal>
-        )}
-        {!_.isEmpty(selectedItems) && selectedAction === "copy" && (
-          <Modal onClose={this.handleCloseModal}>
-            <CollectionCopyEntityModal
-              entityObject={selectedItems[0]}
-              onClose={this.handleCloseModal}
-              onSaved={newEntityObject => {
-                this.handleCloseModal();
-                this.handleBulkActionSuccess();
-              }}
-            />
-          </Modal>
-        )}
-        {!_.isEmpty(selectedItems) && selectedAction === "move" && (
-          <Modal onClose={this.handleCloseModal}>
-            <CollectionMoveModal
-              title={
-                selectedItems.length > 1
-                  ? t`Move ${selectedItems.length} items?`
-                  : t`Move "${selectedItems[0].getName()}"?`
-              }
-              onClose={this.handleCloseModal}
-              onMove={this.handleBulkMove}
             />
           </Modal>
         )}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import _ from "underscore";
-import { t, msgid, ngettext } from "ttag";
+import { t } from "ttag";
 import cx from "classnames";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
@@ -17,17 +17,13 @@ import Search from "metabase/entities/search";
 
 import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
 
-import Button from "metabase/components/Button";
 import CreateDashboardModal from "metabase/components/CreateDashboardModal";
-import { Grid, GridItem } from "metabase/components/Grid";
 import Icon, { IconWrapper } from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import Modal from "metabase/components/Modal";
 import PageHeading from "metabase/components/PageHeading";
-import StackedCheckBox from "metabase/components/StackedCheckBox";
 import Tooltip from "metabase/components/Tooltip";
 import VirtualizedList from "metabase/components/VirtualizedList";
-import BulkActionBar from "metabase/components/BulkActionBar";
 
 import NormalItem from "metabase/collections/components/NormalItem";
 import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
@@ -41,6 +37,8 @@ import CollectionEmptyState from "metabase/components/CollectionEmptyState";
 import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
 import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
 // import CollectionList from "metabase/components/CollectionList";
+
+import BulkActions from "metabase/collections/components/BulkActions";
 
 import PinnedItems from "metabase/collections/components/PinnedItems";
 
@@ -145,14 +143,12 @@ export default class CollectionContent extends React.Component {
       isAdmin,
       isRoot,
       selected,
+      deselected,
       selection,
       onToggleSelected,
       location,
     } = this.props;
     const { selectedItems, selectedAction } = this.state;
-
-    const collectionWidth = [1, 1 / 3];
-    const itemWidth = [1, 2 / 3];
 
     let unpinnedItems = unpinned;
 
@@ -329,39 +325,12 @@ export default class CollectionContent extends React.Component {
             </PinDropTarget>
           )}
         </Box>
-        <BulkActionBar showing={selected.length > 0}>
-          {/* NOTE: these padding and grid sizes must be carefully matched
-                   to the main content above to ensure the bulk checkbox lines up */}
-          <Box px={[2, 4]} py={1}>
-            <Grid>
-              <GridItem w={collectionWidth} />
-              <GridItem w={itemWidth} px={[1, 2]}>
-                <Flex align="center" justify="center" px={2}>
-                  <SelectionControls {...this.props} />
-                  <BulkActionControls
-                    onArchive={
-                      _.all(selected, item => item.setArchived)
-                        ? this.handleBulkArchive
-                        : null
-                    }
-                    onMove={
-                      _.all(selected, item => item.setCollection)
-                        ? this.handleBulkMoveStart
-                        : null
-                    }
-                  />
-                  <Box ml="auto">
-                    {ngettext(
-                      msgid`${selected.length} item selected`,
-                      `${selected.length} items selected`,
-                      selected.length,
-                    )}
-                  </Box>
-                </Flex>
-              </GridItem>
-            </Grid>
-          </Box>
-        </BulkActionBar>
+        <BulkActions
+          selected={selected}
+          handleBulkArchive={this.handleBulkArchive}
+          handleBulkMoveStart={this.handleBulkMoveStart}
+          deselected={deselected}
+        />
         {this.state.showDashboardModal && (
           <Modal onClose={() => this.setState({ showDashboardModal: null })}>
             <CreateDashboardModal
@@ -400,37 +369,3 @@ export default class CollectionContent extends React.Component {
     );
   }
 }
-
-const BulkActionControls = ({ onArchive, onMove }) => (
-  <Box ml={1}>
-    <Button
-      ml={1}
-      medium
-      disabled={!onArchive}
-      onClick={onArchive}
-      data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Archive Items`}
-    >{t`Archive`}</Button>
-    <Button
-      ml={1}
-      medium
-      disabled={!onMove}
-      onClick={onMove}
-      data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Move Items`}
-    >{t`Move`}</Button>
-  </Box>
-);
-
-const SelectionControls = ({
-  selected,
-  deselected,
-  onSelectAll,
-  onSelectNone,
-  size = 18,
-}) =>
-  deselected.length === 0 ? (
-    <StackedCheckBox checked onChange={onSelectNone} size={size} />
-  ) : selected.length === 0 ? (
-    <StackedCheckBox onChange={onSelectAll} size={size} />
-  ) : (
-    <StackedCheckBox checked indeterminate onChange={onSelectAll} size={size} />
-  );

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -142,7 +142,6 @@ export default class CollectionContent extends React.Component {
     const collectionHasPins = pinned.length > 0;
 
     const avaliableTypes = _.uniq(unpinned.map(u => u.model));
-
     const showFilters = unpinned.length > 5 && avaliableTypes.length > 1;
 
     return (
@@ -230,6 +229,18 @@ export default class CollectionContent extends React.Component {
             collection={collection}
             onToggleSelected={onToggleSelected}
             collectionHasPins={collectionHasPins}
+            onMove={selectedItems =>
+              this.setState({
+                selectedItems,
+                selectedAction: "move",
+              })
+            }
+            onCopy={selectedItems =>
+              this.setState({
+                selectedItems,
+                selectedAction: "copy",
+              })
+            }
           />
         </Box>
         <BulkActions

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -24,7 +24,6 @@ import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
 import Button from "metabase/components/Button";
 import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 import EntityMenu from "metabase/components/EntityMenu";
-import EntityItem from "metabase/components/EntityItem";
 import { Grid, GridItem } from "metabase/components/Grid";
 import Icon, { IconWrapper } from "metabase/components/Icon";
 import Link from "metabase/components/Link";
@@ -34,6 +33,8 @@ import StackedCheckBox from "metabase/components/StackedCheckBox";
 import Tooltip from "metabase/components/Tooltip";
 import VirtualizedList from "metabase/components/VirtualizedList";
 import BulkActionBar from "metabase/components/BulkActionBar";
+
+import NormalItem from "metabase/collections/components/NormalItem";
 
 import { getUserIsAdmin } from "metabase/selectors/user";
 
@@ -50,7 +51,8 @@ import PinPositionDropTarget from "metabase/containers/dnd/PinPositionDropTarget
 import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
 
-const ANALYTICS_CONTEXT = "Collection Landing";
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
 const ROW_HEIGHT = 72;
 
 @Search.loadList({
@@ -567,50 +569,3 @@ class CollectionCopyEntityModal extends React.Component {
     );
   }
 }
-
-export const NormalItem = ({
-  item,
-  collection = {},
-  selection = new Set(),
-  onToggleSelected,
-  onMove,
-  onCopy,
-  onPin,
-  pinned,
-}) => (
-  <Link
-    to={item.getUrl()}
-    data-metabase-event={`${ANALYTICS_CONTEXT};Item Click;${item.model}`}
-  >
-    <EntityItem
-      analyticsContext={ANALYTICS_CONTEXT}
-      variant="list"
-      showSelect={selection.size > 0}
-      selectable
-      item={item}
-      type={entityTypeForObject(item)}
-      name={item.getName()}
-      iconName={item.getIcon()}
-      iconColor={item.getColor()}
-      isFavorite={item.favorite}
-      onFavorite={
-        item.setFavorited ? () => item.setFavorited(!item.favorite) : null
-      }
-      onPin={collection.can_write && onPin && onPin}
-      onMove={
-        collection.can_write && item.setCollection ? () => onMove([item]) : null
-      }
-      onCopy={item.copy ? () => onCopy([item]) : null}
-      onArchive={
-        collection.can_write && item.setArchived
-          ? () => item.setArchived(true)
-          : null
-      }
-      selected={selection.has(item)}
-      onToggleSelected={() => {
-        onToggleSelected(item);
-      }}
-      pinned={pinned}
-    />
-  </Link>
-);

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -39,6 +39,7 @@ import ItemTypeFilterBar, {
   FILTERS as ITEM_TYPE_FILTERS,
 } from "metabase/collections/components/ItemTypeFilterBar";
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
+import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
 // import CollectionList from "metabase/components/CollectionList";
 
 // drag-and-drop components
@@ -500,15 +501,6 @@ const SelectionControls = ({
   ) : (
     <StackedCheckBox checked indeterminate onChange={onSelectAll} size={size} />
   );
-
-const CollectionSectionHeading = ({ children }) => (
-  <h5
-    className="text-uppercase mb2"
-    style={{ color: color("text-medium"), fontWeight: 900 }}
-  >
-    {children}
-  </h5>
-);
 
 const CollectionEditMenu = ({ isRoot, isAdmin, collectionId, tooltip }) => {
   const items = [];

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -14,10 +14,8 @@ import listSelect from "metabase/hoc/ListSelect";
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 
-import CreateDashboardModal from "metabase/components/CreateDashboardModal";
 import Icon, { IconWrapper } from "metabase/components/Icon";
 import Link from "metabase/components/Link";
-import Modal from "metabase/components/Modal";
 import PageHeading from "metabase/components/PageHeading";
 import Tooltip from "metabase/components/Tooltip";
 
@@ -72,8 +70,6 @@ export default class CollectionContent extends React.Component {
   state = {
     selectedItems: null,
     selectedAction: null,
-    // TODO - this should live somewhere else eventually
-    showDashboardModal: false,
   };
 
   handleBulkArchive = async () => {
@@ -253,14 +249,6 @@ export default class CollectionContent extends React.Component {
           selectedItems={selectedItems}
           selectedAction={selectedAction}
         />
-        {this.state.showDashboardModal && (
-          <Modal onClose={() => this.setState({ showDashboardModal: null })}>
-            <CreateDashboardModal
-              createDashboard={this.props.createDashboard}
-              onClose={() => this.setState({ modal: null })}
-            />
-          </Modal>
-        )}
         <ItemsDragLayer selected={selected} />
       </Box>
     );

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -230,7 +230,22 @@ export default class CollectionContent extends React.Component {
             </Flex>
           </Flex>
           {collectionHasPins && (
-            <PinnedItems items={pinned} collection={collection} />
+            <PinnedItems
+              items={pinned}
+              collection={collection}
+              onMove={selectedItems =>
+                this.setState({
+                  selectedItems,
+                  selectedAction: "move",
+                })
+              }
+              onCopy={selectedItems =>
+                this.setState({
+                  selectedItems,
+                  selectedAction: "copy",
+                })
+              }
+            />
           )}
           <Box className="relative">
             {showFilters ? (

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -19,7 +19,6 @@ import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
 
 import Button from "metabase/components/Button";
 import CreateDashboardModal from "metabase/components/CreateDashboardModal";
-import EntityMenu from "metabase/components/EntityMenu";
 import { Grid, GridItem } from "metabase/components/Grid";
 import Icon, { IconWrapper } from "metabase/components/Icon";
 import Link from "metabase/components/Link";
@@ -40,6 +39,7 @@ import ItemTypeFilterBar, {
 } from "metabase/collections/components/ItemTypeFilterBar";
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
 import CollectionSectionHeading from "metabase/collections/components/CollectionSectionHeading";
+import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
 // import CollectionList from "metabase/components/CollectionList";
 
 // drag-and-drop components
@@ -501,26 +501,3 @@ const SelectionControls = ({
   ) : (
     <StackedCheckBox checked indeterminate onChange={onSelectAll} size={size} />
   );
-
-const CollectionEditMenu = ({ isRoot, isAdmin, collectionId, tooltip }) => {
-  const items = [];
-  if (!isRoot) {
-    items.push({
-      title: t`Edit this collection`,
-      icon: "edit_document",
-      link: `/collection/${collectionId}/edit`,
-      event: `${ANALYTICS_CONTEXT};Edit Menu;Edit Collection Click`,
-    });
-  }
-  if (!isRoot) {
-    items.push({
-      title: t`Archive this collection`,
-      icon: "view_archive",
-      link: `/collection/${collectionId}/archive`,
-      event: `${ANALYTICS_CONTEXT};Edit Menu;Archive Collection`,
-    });
-  }
-  return items.length > 0 ? (
-    <EntityMenu items={items} triggerIcon="pencil" tooltip={tooltip} />
-  ) : null;
-};

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -1,27 +1,18 @@
 import React from "react";
-import { Box, Flex } from "grid-styled";
+import { Box } from "grid-styled";
 import _ from "underscore";
-import { t } from "ttag";
-import cx from "classnames";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
-
-import * as Urls from "metabase/lib/urls";
-import { color } from "metabase/lib/colors";
 
 import listSelect from "metabase/hoc/ListSelect";
 
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 
-import Icon, { IconWrapper } from "metabase/components/Icon";
-import Link from "metabase/components/Link";
-import PageHeading from "metabase/components/PageHeading";
-import Tooltip from "metabase/components/Tooltip";
+import Header from "metabase/collections/components/Header";
 
 import { getUserIsAdmin } from "metabase/selectors/user";
 
-import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
 // import CollectionList from "metabase/components/CollectionList";
 
 import BulkActions from "metabase/collections/components/BulkActions";
@@ -143,62 +134,15 @@ export default class CollectionContent extends React.Component {
     return (
       <Box pt={2}>
         <Box w={"80%"} ml="auto" mr="auto">
-          <Flex
-            align="center"
-            py={3}
-            className={cx({
-              "border-bottom":
-                !showFilters && !collectionHasPins && unpinnedItems.length > 0,
-            })}
-          >
-            <Flex align="center">
-              <PageHeading className="text-wrap">{collection.name}</PageHeading>
-              {collection.description && (
-                <Tooltip tooltip={collection.description}>
-                  <Icon
-                    name="info"
-                    ml={1}
-                    mt="4px"
-                    color={color("bg-dark")}
-                    hover={{ color: color("brand") }}
-                  />
-                </Tooltip>
-              )}
-            </Flex>
-
-            <Flex ml="auto" align="bottom">
-              {isAdmin && !collection.personal_owner_id && (
-                <Tooltip tooltip={t`Edit the permissions for this collection`}>
-                  <Link
-                    to={Urls.collectionPermissions(this.props.collectionId)}
-                  >
-                    <IconWrapper>
-                      <Icon name="lock" size={20} />
-                    </IconWrapper>
-                  </Link>
-                </Tooltip>
-              )}
-              {collection &&
-                collection.can_write &&
-                !collection.personal_owner_id && (
-                  <CollectionEditMenu
-                    tooltip={t`Edit collection`}
-                    collectionId={collectionId}
-                    isAdmin={isAdmin}
-                    isRoot={isRoot}
-                  />
-                )}
-              {collection && collection.can_write && (
-                <Tooltip tooltip={t`New collection`}>
-                  <Link to={Urls.newCollection(this.props.collectionId)}>
-                    <IconWrapper>
-                      <Icon name="new_folder" size={20} />
-                    </IconWrapper>
-                  </Link>
-                </Tooltip>
-              )}
-            </Flex>
-          </Flex>
+          <Header
+            isRoot={isRoot}
+            isAdmin={isAdmin}
+            collectionId={collectionId}
+            showFilters={showFilters}
+            collectionHasPins={collectionHasPins}
+            collection={collection}
+            unpinnedItems={unpinnedItems}
+          />
           {collectionHasPins && (
             <PinnedItems
               items={pinned}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -42,10 +42,11 @@ import CollectionSectionHeading from "metabase/collections/components/Collection
 import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
 // import CollectionList from "metabase/components/CollectionList";
 
+import PinnedItems from "metabase/collections/components/PinnedItems";
+
 // drag-and-drop components
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 //import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
-import PinPositionDropTarget from "metabase/containers/dnd/PinPositionDropTarget";
 import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
 
@@ -228,72 +229,8 @@ export default class CollectionContent extends React.Component {
               )}
             </Flex>
           </Flex>
-          {collectionHasPins ? (
-            <Box pt={2} pb={3}>
-              <CollectionSectionHeading>{t`Pinned items`}</CollectionSectionHeading>
-              <PinDropTarget
-                pinIndex={pinned[pinned.length - 1].collection_position + 1}
-                noDrop
-                marginLeft={8}
-                marginRight={8}
-              >
-                {pinned.map((item, index) => (
-                  <Box w={[1]} className="relative" key={index}>
-                    <ItemDragSource item={item} collection={collection}>
-                      <PinnedItem
-                        key={`${item.model}:${item.id}`}
-                        index={index}
-                        item={item}
-                        collection={collection}
-                        onMove={selectedItems =>
-                          this.setState({
-                            selectedItems,
-                            selectedAction: "move",
-                          })
-                        }
-                        onCopy={selectedItems =>
-                          this.setState({
-                            selectedItems,
-                            selectedAction: "copy",
-                          })
-                        }
-                      />
-                      <PinPositionDropTarget
-                        pinIndex={item.collection_position}
-                        left
-                      />
-                      <PinPositionDropTarget
-                        pinIndex={item.collection_position + 1}
-                        right
-                      />
-                    </ItemDragSource>
-                  </Box>
-                ))}
-                {pinned.length % 2 === 1 ? (
-                  <Box w={1} className="relative">
-                    <PinPositionDropTarget
-                      pinIndex={
-                        pinned[pinned.length - 1].collection_position + 1
-                      }
-                    />
-                  </Box>
-                ) : null}
-              </PinDropTarget>
-            </Box>
-          ) : (
-            <PinDropTarget pinIndex={1} hideUntilDrag>
-              {({ hovered }) => (
-                <div
-                  className={cx(
-                    "p2 flex layout-centered",
-                    hovered ? "text-brand" : "text-light",
-                  )}
-                >
-                  <Icon name="pin" mr={1} />
-                  {t`Drag something here to pin it to the top`}
-                </div>
-              )}
-            </PinDropTarget>
+          {collectionHasPins && (
+            <PinnedItems items={pinned} collection={collection} />
           )}
           <Box className="relative">
             {showFilters ? (
@@ -448,25 +385,6 @@ export default class CollectionContent extends React.Component {
     );
   }
 }
-
-const PinnedItem = ({ item, index, collection, onCopy, onMove }) => (
-  <Link
-    key={index}
-    to={item.getUrl()}
-    className="hover-parent hover--visibility"
-    hover={{ color: color("brand") }}
-    data-metabase-event={`${ANALYTICS_CONTEXT};Pinned Item;Click;${item.model}`}
-  >
-    <NormalItem
-      item={item}
-      collection={collection}
-      onPin={() => item.setPinned(false)}
-      onMove={onMove}
-      onCopy={onCopy}
-      pinned
-    />
-  </Link>
-);
 
 const BulkActionControls = ({ onArchive, onMove }) => (
   <Box ml={1}>

--- a/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
@@ -3,7 +3,7 @@ import { DragLayer } from "react-dnd";
 import _ from "underscore";
 
 import BodyComponent from "metabase/components/BodyComponent";
-import { NormalItem } from "metabase/collections/containers/CollectionContent";
+import NormalItem from "metabase/collections/components/NormalItem";
 
 // NOTE: our verison of react-hot-loader doesn't play nice with react-dnd's DragLayer, so we exclude files named `*DragLayer.jsx` in webpack.config.js
 


### PR DESCRIPTION
## What this does
Extracts logical groupings of components from `CollectionContent` into their own files to make things easier to digest.

- Display of pinned items moves to `<PinnedItems />`
- Display of non pinned items and related empty states, filter elements etc, moves to `ItemList`
- The header and actions move into their own component.
- Other miscellaneous components get extracted to their own files `CollectionEditMenu`, `CollectionCopyEntityModal` etc.

There are still some improvements to make here, namely that I think there's still too much prop passing going on and not all the logic needs to live in the top (bulk action methods for example), but I figure that can be improved later.

In #13660 I didn't really go back and address much of how the collection code was originally structured as a big mono component. This isn't supposed to change any functionality, just move things into their own files so that we don't have to grok several hundred lines of code if we're working on different parts of the collection content.

@ariya / @paulrosenzweig Apologies for the big diff. I tried to make one major move at a time per commit, so while it's a large diff in general just due to all the new files, if you walk the commits it should hopefully be pretty easy to grok.

