### PR TITLE
Another round of pivot tables polish

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -119,7 +119,18 @@ export function multiLevelPivot(
     subtotalFormatter: leftIndexFormatters[0],
   });
   if (leftIndex.length > 1) {
-    leftIndex.push([[[{ value: t`Grand totals`, span: 1, isSubtotal: true }]]]);
+    leftIndex.push([
+      [
+        [
+          {
+            value: t`Grand totals`,
+            span: 1,
+            isSubtotal: true,
+            isGrandTotal: true,
+          },
+        ],
+      ],
+    ]);
   }
 
   const columnCount = topIndex.length || 1;
@@ -156,7 +167,7 @@ function createRowSectionGetter({
     values === undefined
       ? Array(valueFormatters.length).fill({ value: null })
       : values.map((v, i) => ({ value: valueFormatters[i](v) }));
-  const getSubtotals = (breakoutIndexes, values) =>
+  const getSubtotals = (breakoutIndexes, values, otherAttrs = {}) =>
     formatValues(
       getIn(
         subtotalValues,
@@ -166,7 +177,7 @@ function createRowSectionGetter({
           ),
         ),
       ),
-    ).map(value => ({ ...value, isSubtotal: true }));
+    ).map(value => ({ ...value, isSubtotal: true, ...otherAttrs }));
 
   const getter = (columnIndex, rowIndex) => {
     const rows =
@@ -184,12 +195,16 @@ function createRowSectionGetter({
       columnIndex === columnColumnTree.length && columnColumnTree.length > 0;
     // totals in the bottom right
     if (bottomRow && rightColumn) {
-      return [getSubtotals([], [])];
+      return [getSubtotals([], [], { isGrandTotal: true })];
     }
 
     // "grand totals" on the bottom
     if (bottomRow) {
-      return [columns.flatMap(col => getSubtotals(columnColumnIndexes, col))];
+      return [
+        columns.flatMap(col =>
+          getSubtotals(columnColumnIndexes, col, { isGrandTotal: true }),
+        ),
+      ];
     }
 
     // "row totals" on the right

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -229,49 +229,47 @@ export default class PivotTable extends Component {
     const leftHeaderRenderer = _.memoize(
       ({ key, style, index }) => {
         return (
-          <div key={key} style={style} className="flex flex-column">
-            <div className="border-right border-medium">
-              {leftIndex[index].map(row => (
-                <div className="flex">
-                  {row.map((col, index) =>
-                    col[0].isSubtotal ? (
-                      <Cell
-                        value={col[0].value}
-                        isSubtotal
-                        style={{
-                          paddingLeft: LEFT_HEADER_LEFT_SPACING,
-                          width: leftHeaderWidth,
-                        }}
-                      />
-                    ) : (
-                      <div
-                        className="flex flex-column bg-light"
-                        style={{
-                          paddingLeft:
-                            index === 0 ? LEFT_HEADER_LEFT_SPACING : 0,
-                        }}
-                      >
-                        {col.map(({ value, span = 1, isSubtotal }) => (
-                          <div
-                            style={{
-                              height: CELL_HEIGHT * span,
-                              width: LEFT_HEADER_CELL_WIDTH,
-                            }}
-                          >
-                            <Cell
-                              value={leftIndexFormatters[index](value)}
-                              isSubtotal={isSubtotal}
-                              height={span}
-                              baseWidth={LEFT_HEADER_CELL_WIDTH}
-                            />
-                          </div>
-                        ))}
-                      </div>
-                    ),
-                  )}
-                </div>
-              ))}
-            </div>
+          <div
+            key={key}
+            style={style}
+            className="flex flex-column border-right border-medium"
+          >
+            {leftIndex[index].map((row, rowIndex) => (
+              <div
+                className="flex"
+                style={{ height: row[0][0].span * CELL_HEIGHT }}
+              >
+                {row.map((col, index) =>
+                  col[0].isSubtotal ? (
+                    <Cell
+                      value={col[0].value}
+                      isSubtotal
+                      isGrandTotal={col[0].isGrandTotal}
+                      style={{
+                        paddingLeft: LEFT_HEADER_LEFT_SPACING,
+                        width: leftHeaderWidth,
+                      }}
+                    />
+                  ) : (
+                    <div
+                      className="flex flex-column bg-light flex-basis-none flex-full"
+                      style={{
+                        paddingLeft: index === 0 ? LEFT_HEADER_LEFT_SPACING : 0,
+                      }}
+                    >
+                      {col.map(({ value, span = 1, isSubtotal }) => (
+                        <Cell
+                          value={leftIndexFormatters[index](value)}
+                          isSubtotal={isSubtotal}
+                          height={span}
+                          baseWidth={LEFT_HEADER_CELL_WIDTH}
+                        />
+                      ))}
+                    </div>
+                  ),
+                )}
+              </div>
+            ))}
           </div>
         );
       },
@@ -283,24 +281,27 @@ export default class PivotTable extends Component {
         const rows = getRowSection(columnIndex, rowIndex);
         return (
           <Flex flexDirection="column" key={key} style={style}>
-            {rows.map((row, index) => (
-              <Flex key={index}>
-                {row.map(({ value, isSubtotal, clicked }, index) => (
-                  <Cell
-                    key={index}
-                    value={value}
-                    isSubtotal={isSubtotal}
-                    isBody
-                    onClick={
-                      clicked &&
-                      (() =>
-                        this.props.onVisualizationClick({
-                          ...clicked,
-                          settings: this.props.settings,
-                        }))
-                    }
-                  />
-                ))}
+            {rows.map((row, rowIndex) => (
+              <Flex key={rowIndex}>
+                {row.map(
+                  ({ value, isSubtotal, isGrandTotal, clicked }, index) => (
+                    <Cell
+                      key={index}
+                      value={value}
+                      isSubtotal={isSubtotal}
+                      isGrandTotal={isGrandTotal}
+                      isBody
+                      onClick={
+                        clicked &&
+                        (() =>
+                          this.props.onVisualizationClick({
+                            ...clicked,
+                            settings: this.props.settings,
+                          }))
+                      }
+                    />
+                  ),
+                )}
               </Flex>
             ))}
           </Flex>
@@ -390,6 +391,7 @@ export default class PivotTable extends Component {
 function Cell({
   value,
   isSubtotal,
+  isGrandTotal,
   onClick,
   width = 1,
   height = 1,
@@ -402,15 +404,18 @@ function Cell({
   return (
     <div
       style={{
-        width: baseWidth * width,
-        height: baseHeight * height,
         lineHeight: `${CELL_HEIGHT}px`,
+        ...(isGrandTotal ? { borderTop: "1px solid white" } : {}),
         ...style,
       }}
-      className={cx(className, {
-        "bg-medium text-bold": isSubtotal,
-        "cursor-pointer": onClick,
-      })}
+      className={cx(
+        "flex-basis-none flex-full shrink-below-content-size",
+        className,
+        {
+          "bg-medium text-bold": isSubtotal,
+          "cursor-pointer": onClick,
+        },
+      )}
       onClick={onClick}
     >
       <div className="px1">

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -196,30 +196,28 @@ export default class PivotTable extends Component {
       ({ key, style, columnIndex }) => {
         const rows = topIndex[columnIndex];
         return (
-          <div
-            key={key}
-            style={style}
-            className="flex-column px1 border-bottom border-medium"
-          >
-            {rows.map((row, index) => (
-              <Flex style={{ height: CELL_HEIGHT }}>
-                {row.map(({ value, span }) => (
-                  <div
-                    style={{ width: CELL_WIDTH * span }}
-                    className={cx("flex flex-column justify-center", {
-                      "border-bottom": index < rows.length - 1,
-                    })}
-                  >
-                    <Ellipsified>
-                      {index < topIndexFormatters.length
-                        ? topIndexFormatters[index](value)
-                        : value // Metric names don't have formatters
-                      }
-                    </Ellipsified>
-                  </div>
-                ))}
-              </Flex>
-            ))}
+          <div key={key} style={style} className="border-bottom border-medium">
+            <div className="flex flex-column px1 full-height justify-end">
+              {rows.map((row, index) => (
+                <Flex style={{ height: CELL_HEIGHT }}>
+                  {row.map(({ value, span }) => (
+                    <div
+                      style={{ width: CELL_WIDTH * span }}
+                      className={cx("flex flex-column justify-center", {
+                        "border-bottom": index < rows.length - 1,
+                      })}
+                    >
+                      <Ellipsified>
+                        {index < topIndexFormatters.length
+                          ? topIndexFormatters[index](value)
+                          : value // Metric names don't have formatters
+                        }
+                      </Ellipsified>
+                    </div>
+                  ))}
+                </Flex>
+              ))}
+            </div>
           </div>
         );
       },
@@ -323,10 +321,13 @@ export default class PivotTable extends Component {
               >
                 {/* top left corner - displays left header columns */}
                 <div
-                  className="flex align-end border-right border-bottom border-medium bg-light"
+                  className={cx("flex align-end bg-light", {
+                    "border-right border-bottom border-medium": leftHeaderWidth,
+                  })}
                   style={{
                     // add left spacing unless the header width is 0
                     paddingLeft: leftHeaderWidth && LEFT_HEADER_LEFT_SPACING,
+                    height: topHeaderHeight,
                   }}
                 >
                   {rowIndexes.map(index => (

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -171,7 +171,7 @@ export default class PivotTable extends Component {
           leftIndex[0].length * LEFT_HEADER_CELL_WIDTH;
 
     function columnWidth({ index }) {
-      if (topIndex.length === 0 || index === topIndex.length) {
+      if (topIndex.length === 0) {
         return CELL_WIDTH;
       }
       const indexItem = topIndex[index];
@@ -179,7 +179,7 @@ export default class PivotTable extends Component {
     }
 
     function rowHeight({ index }) {
-      if (leftIndex.length === 0 || index === leftIndex.length) {
+      if (leftIndex.length === 0) {
         return CELL_HEIGHT;
       }
       const span = leftIndex[index].reduce(

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -386,7 +386,7 @@ describe("data_grid", () => {
       expect(extractValues(getRowSection(1, 1))).toEqual([[null, null]]);
     });
 
-    it.only("should return subtotals in each section", () => {
+    it("should return subtotals in each section", () => {
       const cols = [D1, D2, M];
       const primaryGroup = 0;
       const subtotalOne = 2;

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -16,6 +16,19 @@ const D2 = {
 };
 const M = { name: "M", display_name: "Metric", base_type: TYPE.Integer };
 
+const GRAND_TOTALS_ROW = [
+  [
+    [
+      {
+        isGrandTotal: true,
+        isSubtotal: true,
+        span: 1,
+        value: "Grand totals",
+      },
+    ],
+  ],
+];
+
 function makeData(rows) {
   return {
     rows: rows,
@@ -152,21 +165,22 @@ describe("data_grid", () => {
       );
       expect(topIndex).toEqual([
         [
-          [{ value: "a", span: 3 }],
+          [{ span: 3, value: "a" }],
           [
-            { value: "x", span: 1 },
-            { value: "y", span: 1 },
-            { value: "z", span: 1 },
+            { span: 1, value: "x" },
+            { span: 1, value: "y" },
+            { span: 1, value: "z" },
           ],
         ],
         [
-          [{ value: "b", span: 3 }],
+          [{ span: 3, value: "b" }],
           [
-            { value: "x", span: 1 },
-            { value: "y", span: 1 },
-            { value: "z", span: 1 },
+            { span: 1, value: "x" },
+            { span: 1, value: "y" },
+            { span: 1, value: "z" },
           ],
         ],
+        [[{ span: 1, value: "Row totals" }], [{ span: 1, value: "Metric" }]],
       ]);
       expect(leftIndex).toEqual([]);
       expect(rowCount).toEqual(1);
@@ -181,21 +195,28 @@ describe("data_grid", () => {
       );
       expect(leftIndex).toEqual([
         [
-          [{ value: "a", span: 3 }],
           [
-            { value: "x", span: 1 },
-            { value: "y", span: 1 },
-            { value: "z", span: 1 },
+            [{ value: "a", span: 3 }],
+            [
+              { value: "x", span: 1 },
+              { value: "y", span: 1 },
+              { value: "z", span: 1 },
+            ],
           ],
+          [[{ isSubtotal: true, span: 1, value: "Totals for a" }]],
         ],
         [
-          [{ value: "b", span: 3 }],
           [
-            { value: "x", span: 1 },
-            { value: "y", span: 1 },
-            { value: "z", span: 1 },
+            [{ value: "b", span: 3 }],
+            [
+              { value: "x", span: 1 },
+              { value: "y", span: 1 },
+              { value: "z", span: 1 },
+            ],
           ],
+          [[{ isSubtotal: true, span: 1, value: "Totals for b" }]],
         ],
+        GRAND_TOTALS_ROW,
       ]);
       expect(topIndex).toEqual([[[{ value: "Metric", span: 1 }]]]);
       expect(rowCount).toEqual(3);
@@ -215,12 +236,14 @@ describe("data_grid", () => {
         [2],
       );
       expect(leftIndex).toEqual([
-        [[{ value: "x", span: 1 }]],
-        [[{ value: "y", span: 1 }]],
+        [[[{ value: "x", span: 1 }]]],
+        [[[{ value: "y", span: 1 }]]],
+        GRAND_TOTALS_ROW,
       ]);
       expect(topIndex).toEqual([
         [[{ value: "a", span: 1 }]],
         [[{ value: "b", span: 1 }]],
+        [[{ span: 1, value: "Row totals" }], [{ value: "Metric", span: 1 }]],
       ]);
       expect(extractValues(getRowSection(0, 0))).toEqual([["1"]]);
       expect(extractValues(getRowSection(1, 1))).toEqual([[null]]);
@@ -231,8 +254,8 @@ describe("data_grid", () => {
         [
           D1,
           D2,
-          { name: "M1", display_name: "Metric", base_type: TYPE.Integer },
-          { name: "M2", display_name: "Metric", base_type: TYPE.Integer },
+          { name: "M1", display_name: "Metric 1", base_type: TYPE.Integer },
+          { name: "M2", display_name: "Metric 2", base_type: TYPE.Integer },
         ],
       );
 
@@ -245,10 +268,10 @@ describe("data_grid", () => {
       expect(topIndex).toEqual([
         [
           [{ value: "a", span: 2 }],
-          [{ value: "Metric", span: 1 }, { value: "Metric", span: 1 }],
+          [{ value: "Metric 1", span: 1 }, { value: "Metric 2", span: 1 }],
         ],
       ]);
-      expect(leftIndex).toEqual([[[{ value: "b", span: 1 }]]]);
+      expect(leftIndex).toEqual([[[[{ value: "b", span: 1 }]]]]);
       expect(extractValues(getRowSection(0, 0))).toEqual([["1", "2"]]);
     });
     it("should work with three levels of row grouping", () => {
@@ -281,25 +304,32 @@ describe("data_grid", () => {
       expect(topIndex).toEqual([[[{ span: 1, value: "Metric" }]]]);
       expect(leftIndex).toEqual([
         [
-          [{ span: 4, value: "a1" }],
-          [{ span: 2, value: "b1" }, { span: 2, value: "b2" }],
           [
-            { span: 1, value: "c1" },
-            { span: 1, value: "c2" },
-            { span: 1, value: "c1" },
-            { span: 1, value: "c2" },
+            [{ span: 4, value: "a1" }],
+            [{ span: 2, value: "b1" }, { span: 2, value: "b2" }],
+            [
+              { span: 1, value: "c1" },
+              { span: 1, value: "c2" },
+              { span: 1, value: "c1" },
+              { span: 1, value: "c2" },
+            ],
           ],
+          [[{ isSubtotal: true, span: 1, value: "Totals for a1" }]],
         ],
         [
-          [{ span: 4, value: "a2" }],
-          [{ span: 2, value: "b1" }, { span: 2, value: "b2" }],
           [
-            { span: 1, value: "c1" },
-            { span: 1, value: "c2" },
-            { span: 1, value: "c1" },
-            { span: 1, value: "c2" },
+            [{ span: 4, value: "a2" }],
+            [{ span: 2, value: "b1" }, { span: 2, value: "b2" }],
+            [
+              { span: 1, value: "c1" },
+              { span: 1, value: "c2" },
+              { span: 1, value: "c1" },
+              { span: 1, value: "c2" },
+            ],
           ],
+          [[{ isSubtotal: true, span: 1, value: "Totals for a2" }]],
         ],
+        GRAND_TOTALS_ROW,
       ]);
     });
     it("should format values", () => {


### PR DESCRIPTION
This PR tackles some of the issues in #14177.

### Before

![image](https://user-images.githubusercontent.com/691495/103309751-ec8d0200-49e3-11eb-97c1-256990107b6d.png)


### After

![image](https://user-images.githubusercontent.com/691495/103309732-ded77c80-49e3-11eb-9a7f-f3c58f3301e3.png)


In support of those style changes, I refactored the data structures used to build the top and left headers. Previously, they excluded the subtotal titles, grand totals row and row totals columns. That logic now lives in `data_grid` rather than the component.