### PR TITLE
Add typeahead search

### DIFF
--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -72,6 +72,7 @@ const EntityItem = ({
   ].filter(action => action);
 
   let spacing;
+  let iconSize = 18;
 
   switch (variant) {
     case "list":
@@ -85,6 +86,7 @@ const EntityItem = ({
         px: 2,
         py: 1,
       };
+      iconSize = 12;
       break;
     default:
       spacing = {
@@ -141,12 +143,12 @@ const EntityItem = ({
           <Swapper
             startSwapped={selected}
             defaultElement={
-              <Icon name={iconName} color={"inherit"} size={18} />
+              <Icon name={iconName} color={"inherit"} size={iconSize} />
             }
-            swappedElement={<CheckBox checked={selected} size={18} />}
+            swappedElement={<CheckBox checked={selected} size={iconSize} />}
           />
         ) : (
-          <Icon name={iconName} color={"inherit"} size={18} />
+          <Icon name={iconName} color={"inherit"} size={iconSize} />
         )}
       </IconWrapper>
       <Box>

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -80,6 +80,12 @@ const EntityItem = ({
         py: 2,
       };
       break;
+    case "small":
+      spacing = {
+        px: 2,
+        py: 1,
+      };
+      break;
     default:
       spacing = {
         py: 2,

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -7,14 +7,19 @@ import { t } from "ttag";
 
 import { color, lighten } from "metabase/lib/colors";
 
+import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
 
 import { DefaultSearchColor } from "metabase/nav/constants";
 
 const ActiveSearchColor = lighten(color("nav"), 0.1);
 
+import Search from "metabase/entities/search";
+
 const SearchWrapper = Flex.extend`
+  position: relative;
   background-color: ${props =>
     props.active ? ActiveSearchColor : DefaultSearchColor};
   border-radius: 6px;
@@ -78,6 +83,7 @@ export default class SearchBar extends React.Component {
       ALLOWED_SEARCH_FOCUS_ELEMENTS.has(document.activeElement.tagName)
     ) {
       ReactDOM.findDOMNode(this.searchInput).focus();
+      this.setState({ active: true });
     }
   };
 
@@ -110,6 +116,32 @@ export default class SearchBar extends React.Component {
               }
             }}
           />
+          {active && (
+            <div className="absolute left right text-dark" style={{ top: 60 }}>
+              {searchText.length > 0 ? (
+                <Card>
+                  <h3>Results for</h3>
+                  <Search.ListLoader query={{ q: searchText }} wrapped reload>
+                    {({ list }) => {
+                      if (!list) {
+                        return "No results";
+                      }
+                      return (
+                        <ol>
+                          {list.map(l => (
+                            <li key={`${l.model}:${l.id}`}>
+                              <Link to={l.getUrl()}>{l.name}</Link>
+                            </li>
+                          ))}
+                        </ol>
+                      );
+                    }}
+                  </Search.ListLoader>
+                </Card>
+              ) : null}
+              <Card></Card>
+            </div>
+          )}
         </SearchWrapper>
       </OnClickOutsideWrapper>
     );

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -9,6 +9,7 @@ import { color, lighten } from "metabase/lib/colors";
 
 import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
+import EntityItem from "metabase/components/EntityItem";
 import Link from "metabase/components/Link";
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
 
@@ -34,7 +35,8 @@ const SearchWrapper = Flex.extend`
 `;
 
 const SearchInput = styled.input`
-  ${space} background-color: transparent;
+  ${space};
+  background-color: transparent;
   width: 100%;
   border: none;
   color: white;
@@ -66,6 +68,10 @@ export default class SearchBar extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.location.pathname !== nextProps.location.pathname) {
       this._updateSearchTextFromUrl(nextProps);
+    }
+    // deactivate search on navigation
+    if (this.props.location !== nextProps.location) {
+      this.setState({ active: false });
     }
   }
   _updateSearchTextFromUrl(props) {
@@ -119,27 +125,32 @@ export default class SearchBar extends React.Component {
           {active && (
             <div className="absolute left right text-dark" style={{ top: 60 }}>
               {searchText.length > 0 ? (
-                <Card>
-                  <h3>Results for</h3>
-                  <Search.ListLoader query={{ q: searchText }} wrapped reload>
-                    {({ list }) => {
-                      if (!list) {
-                        return "No results";
-                      }
-                      return (
+                <Search.ListLoader query={{ q: searchText }} wrapped reload>
+                  {({ list }) => {
+                    if (list.length === 0) {
+                      return "No results";
+                    }
+                    return (
+                      <Card>
                         <ol>
                           {list.map(l => (
                             <li key={`${l.model}:${l.id}`}>
-                              <Link to={l.getUrl()}>{l.name}</Link>
+                              <Link to={l.getUrl()}>
+                                <EntityItem
+                                  icon={l.getIcon()}
+                                  name={l.name}
+                                  item={l}
+                                  variant="small"
+                                />
+                              </Link>
                             </li>
                           ))}
                         </ol>
-                      );
-                    }}
-                  </Search.ListLoader>
-                </Card>
+                      </Card>
+                    );
+                  }}
+                </Search.ListLoader>
               ) : null}
-              <Card></Card>
             </div>
           )}
         </SearchWrapper>

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -131,7 +131,10 @@ export default class SearchBar extends React.Component {
                       return "No results";
                     }
                     return (
-                      <Card>
+                      <Card
+                        className="overflow-y-auto"
+                        style={{ maxHeight: 400 }}
+                      >
                         <ol>
                           {list.map(l => (
                             <li key={`${l.model}:${l.id}`}>

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -125,7 +125,12 @@ export default class SearchBar extends React.Component {
           {active && (
             <div className="absolute left right text-dark" style={{ top: 60 }}>
               {searchText.length > 0 ? (
-                <Search.ListLoader query={{ q: searchText }} wrapped reload>
+                <Search.ListLoader
+                  query={{ q: searchText }}
+                  wrapped
+                  reload
+                  debounced
+                >
                   {({ list }) => {
                     if (list.length === 0) {
                       return "No results";

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -145,7 +145,7 @@ export default class SearchBar extends React.Component {
                             <li key={`${l.model}:${l.id}`}>
                               <Link to={l.getUrl()}>
                                 <EntityItem
-                                  icon={l.getIcon()}
+                                  iconName={l.getIcon()}
                                   name={l.name}
                                   item={l}
                                   variant="small"

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -93,6 +93,30 @@ export default class SearchBar extends React.Component {
     }
   };
 
+  renderResults(results) {
+    if (results.length === 0) {
+      return (
+        <li>
+          <Icon name="alert" />
+          {t`No results`}
+        </li>
+      );
+    } else {
+      return results.map(l => (
+        <li key={`${l.model}:${l.id}`}>
+          <Link to={l.getUrl()}>
+            <EntityItem
+              iconName={l.getIcon()}
+              name={l.name}
+              item={l}
+              variant="small"
+            />
+          </Link>
+        </li>
+      ));
+    }
+  }
+
   render() {
     const { active, searchText } = this.state;
     return (
@@ -132,28 +156,12 @@ export default class SearchBar extends React.Component {
                   debounced
                 >
                   {({ list }) => {
-                    if (list.length === 0) {
-                      return "No results";
-                    }
                     return (
                       <Card
                         className="overflow-y-auto"
                         style={{ maxHeight: 400 }}
                       >
-                        <ol>
-                          {list.map(l => (
-                            <li key={`${l.model}:${l.id}`}>
-                              <Link to={l.getUrl()}>
-                                <EntityItem
-                                  iconName={l.getIcon()}
-                                  name={l.name}
-                                  item={l}
-                                  variant="small"
-                                />
-                              </Link>
-                            </li>
-                          ))}
-                        </ol>
+                        <ol>{this.renderResults(list)}</ol>
                       </Card>
                     );
                   }}


### PR DESCRIPTION
## What this does
Adds feedback as you type for search results in the Navbar. Enables easier navigation for those who are more keyboard inclined.

https://user-images.githubusercontent.com/5248953/103371139-b2336b80-4a9c-11eb-89b0-308b961ecad9.mp4

## Todo
- [x] Debounce search input to avoid requests on every keystroke. I'm hoping this will be enough to address any potential performance issues.
- [x] Add item icons (don't know why `getIcon()` isn't working for these.
- [x] Prevent flickering as you type (possibly related to debouncing).
- ~~I'd like to add the ability to select items from the list with arrow keys~~ Still want to do this, but we can do it in a follow up.

## Implementation notes
I'm doing a super naive implementation at the moment and I'm just passing the value of `searchText` to our `Search.ListLoader` to get results. It's fairly effective as a short term Search UX win, although I'm sure over time we'd want to probably do something like provide a dedicated endpoint and tune the results.

## Future extensions
- I'd like to add "recents" as the default state when you activate the nav either by clicking in or by keyboard shortcut to make it easy to move around between items you're working with in a session.

*Relies on #14227 - should be rebased after that gets merged*