### PR TITLE
Expression post-parsing: infer metrics in aggregation

### DIFF
--- a/frontend/src/metabase/lib/expressions/compile.js
+++ b/frontend/src/metabase/lib/expressions/compile.js
@@ -68,17 +68,15 @@ class ExpressionMBQLCompilerVisitor extends ExpressionCstVisitor {
     return mbql;
   }
 
-  metricExpression(ctx) {
-    const metricName = this.visit(ctx.metricName);
-    const metric = parseMetric(metricName, this._options);
-    if (!metric) {
-      throw new Error(`Unknown Metric: ${metricName}`);
-    }
-    return ["metric", metric.id];
-  }
   dimensionExpression(ctx) {
     const name = this.visit(ctx.dimensionName);
-    if (ctx.resolveAs === "segment") {
+    if (ctx.resolveAs === "metric") {
+      const metric = parseMetric(name, this._options);
+      if (!metric) {
+        throw new Error(`Unknown Metric: ${name}`);
+      }
+      return ["metric", metric.id];
+    } else if (ctx.resolveAs === "segment") {
       const segment = parseSegment(name, this._options);
       if (!segment) {
         throw new Error(`Unknown Segment: ${name}`);

--- a/frontend/src/metabase/lib/expressions/parser.js
+++ b/frontend/src/metabase/lib/expressions/parser.js
@@ -243,13 +243,6 @@ export class ExpressionParser extends CstParser {
       $.CONSUME(RParen);
     });
 
-    $.RULE("metricExpression", () => {
-      $.OR([
-        { ALT: () => $.SUBRULE($.identifierString, { LABEL: "metricName" }) },
-        { ALT: () => $.SUBRULE($.identifier, { LABEL: "metricName" }) },
-      ]);
-    });
-
     $.RULE("dimensionExpression", () => {
       $.OR([
         {
@@ -296,14 +289,6 @@ export class ExpressionParser extends CstParser {
                 ARGS: [returnType],
               }),
           },
-          // aggregations
-          {
-            GATE: () => isExpressionType("aggregation", returnType),
-            ALT: () =>
-              $.SUBRULE($.metricExpression, {
-                LABEL: "expression",
-              }),
-          },
           // filters
           {
             GATE: () => isExpressionType("boolean", returnType),
@@ -334,7 +319,8 @@ export class ExpressionParser extends CstParser {
             GATE: () =>
               isExpressionType("string", returnType) ||
               isExpressionType("number", returnType) ||
-              isExpressionType("boolean", returnType),
+              isExpressionType("boolean", returnType) ||
+              isExpressionType("aggregation", returnType),
             ALT: () =>
               $.SUBRULE($.dimensionExpression, {
                 LABEL: "expression",

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -144,7 +144,7 @@ export function suggest({
         parentRule === "dimensionExpression" &&
         isExpressionType(expectedType, "boolean");
       const isMetric =
-        parentRule === "metricExpression" &&
+        parentRule === "dimensionExpression" &&
         isExpressionType(expectedType, "aggregation");
 
       if (isDimension) {
@@ -525,7 +525,6 @@ const ALL_RULES = [
   "multiplicationExpression",
   "functionExpression",
   "caseExpression",
-  "metricExpression",
   "dimensionExpression",
   "identifier",
   "identifierString",

--- a/frontend/src/metabase/lib/expressions/syntax.js
+++ b/frontend/src/metabase/lib/expressions/syntax.js
@@ -128,10 +128,6 @@ export class ExpressionSyntaxVisitor extends ExpressionCstVisitor {
     return this.functionExpression(ctx);
   }
 
-  metricExpression(ctx) {
-    const metricName = this.visit(ctx.metricName);
-    return syntaxNode("metric", metricName);
-  }
   dimensionExpression(ctx) {
     return syntaxNode(ctx.resolveAs, this.visit(ctx.dimensionName));
   }

--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -37,17 +37,11 @@ export function typeCheck(cst, rootType) {
       });
     }
 
-    metricExpression(ctx) {
-      const type = this.typeStack[0];
-      if (type !== "aggregation" && type !== "expression") {
-        throw new Error("Incorrect type for metric");
-      }
-      return super.metricExpression(ctx);
-    }
-
     dimensionExpression(ctx) {
       const type = this.typeStack[0];
-      if (type === "boolean") {
+      if (type === "aggregation") {
+        ctx.resolveAs = "metric";
+      } else if (type === "boolean") {
         ctx.resolveAs = "segment";
       } else {
         ctx.resolveAs = "dimension";

--- a/frontend/src/metabase/lib/expressions/visitor.js
+++ b/frontend/src/metabase/lib/expressions/visitor.js
@@ -46,9 +46,6 @@ export class ExpressionVisitor {
     return (ctx.arguments || []).map(argument => this.visit(argument));
   }
 
-  metricExpression(ctx) {
-    return this.visit(ctx.metricName);
-  }
   dimensionExpression(ctx) {
     return this.visit(ctx.dimensionName);
   }

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -38,12 +38,11 @@ describe("type-checker", () => {
       identifierString(ctx) {
         return parseIdentifierString(ctx.IdentifierString[0].image);
       }
-      metricExpression(ctx) {
-        this.metrics.push(this.visit(ctx.metricName));
-      }
       dimensionExpression(ctx) {
         const name = this.visit(ctx.dimensionName);
-        if (ctx.resolveAs === "segment") {
+        if (ctx.resolveAs === "metric") {
+          this.metrics.push(name);
+        } else if (ctx.resolveAs === "segment") {
           this.segments.push(name);
         } else {
           this.dimensions.push(name);


### PR DESCRIPTION
Use the type-checker to dynamically resolve dimensions as metrics, wherever it is constrained in the right sub-tree for an aggregation.

**Note**: This depends on PR #14232 (which must be approved + merged first).

How to verify? Run the whole expression tests:

```
yarn test-unit frontend/test/metabase/lib/expressions/
```
