### PR TITLE
Misc code improvements

### DIFF
--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -8,8 +8,6 @@ import { delay } from "../../src/metabase/lib/promise";
 
 export const DEFAULT_DB_KEY = "/test_db_fixture.db";
 
-const e2eHost = process.env["E2E_HOST"];
-
 let testDbId = 0;
 const getDbFile = () =>
   path.join(os.tmpdir(), `metabase-test-${process.pid}-${testDbId++}.db`);
@@ -24,6 +22,7 @@ export const BackendResource = createSharedResource("BackendResource", {
   create({ dbKey = DEFAULT_DB_KEY }) {
     const dbFile = getDbFile();
     const absoluteDbKey = dbKey ? __dirname + dbKey : dbFile;
+    const e2eHost = process.env["E2E_HOST"];
     if (e2eHost) {
       return {
         dbKey: absoluteDbKey,

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -8,6 +8,8 @@ import { delay } from "../../src/metabase/lib/promise";
 
 export const DEFAULT_DB_KEY = "/test_db_fixture.db";
 
+const e2eHost = process.env["E2E_HOST"];
+
 let testDbId = 0;
 const getDbFile = () =>
   path.join(os.tmpdir(), `metabase-test-${process.pid}-${testDbId++}.db`);
@@ -22,10 +24,10 @@ export const BackendResource = createSharedResource("BackendResource", {
   create({ dbKey = DEFAULT_DB_KEY }) {
     const dbFile = getDbFile();
     const absoluteDbKey = dbKey ? __dirname + dbKey : dbFile;
-    if (process.env["E2E_HOST"] && dbKey === DEFAULT_DB_KEY) {
+    if (e2eHost) {
       return {
         dbKey: absoluteDbKey,
-        host: process.env["E2E_HOST"],
+        host: e2eHost,
         process: { kill: () => {} },
       };
     } else {

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "ci-backend": "lein docstring-checker && lein bikeshed && lein eastwood && lein test",
     "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-no-build && yarn test-cypress-smoketest",
     "test-cypress-open": "./bin/build-for-test && yarn test-cypress-no-build --open",
+    "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-no-build --open",
     "test-cypress-no-build": "yarn && CONFIG_FILE=frontend/test/cypress.json babel-node ./frontend/test/__runner__/run_cypress_tests.js",
     "test-cypress-smoketest": "yarn test-cypress-no-build --testFiles frontend/test/metabase-smoketest"
   },

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -11,7 +11,7 @@
             [metabase.api.common.internal :refer :all]
             [metabase.models.interface :as mi]
             [metabase.util
-             [i18n :as ui18n :refer [deferred-trs deferred-tru tru]]
+             [i18n :as ui18n :refer [deferred-tru tru]]
              [schema :as su]]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -225,6 +225,38 @@
 
 ;;; --------------------------------------- DEFENDPOINT AND RELATED FUNCTIONS ----------------------------------------
 
+(defn- parse-defendpoint-args [[method route & more]]
+  (let [fn-name                (route-fn-name method route)
+        route                  (add-route-param-regexes route)
+        [docstr [args & more]] (u/optional string? more)
+        [arg->schema body]     (u/optional (every-pred map? #(every? symbol? (keys %))) more)]
+    (when-not docstr
+      ;; Don't i18n this, it's dev-facing only
+      (log/warn (u/format-color 'red "Warning: endpoint %s/%s does not have a docstring. Go add one."
+                  (ns-name *ns*) fn-name)))
+    {:method      method
+     :route       route
+     :fn-name     fn-name
+     ;; eval the vals in arg->schema to make sure the actual schemas are resolved so we can document
+     ;; their API error messages
+     :docstr      (route-dox method route docstr args (m/map-vals eval arg->schema) body)
+     :args        args
+     :arg->schema arg->schema
+     :body        body}))
+
+(defmacro defendpoint*
+  "Impl macro for `defendpoint`; don't use this directly."
+  [{:keys [method route fn-name docstr args arg->schema original-body body]}]
+  {:pre [(or (string? route) (vector? route))]}
+  (require 'compojure.core)
+  `(def ~(vary-meta fn-name
+                    assoc
+
+                    :doc          docstr
+                    :is-endpoint? true)
+     (~(symbol "compojure.core" (name method)) ~route ~args
+      ~@body)))
+
 ;; TODO - several of the things `defendpoint` does could and should just be done by custom Ring middleware instead
 ;; e.g. `auto-parse`
 (defmacro defendpoint
@@ -245,50 +277,24 @@
 
    -  Generates a super-sophisticated Markdown-formatted docstring"
   {:arglists '([method route docstr? args schemas-map? & body])}
-  [method route & more]
-  {:pre [(or (string? route)
-             (vector? route))]}
-  (let [fn-name                (route-fn-name method route)
-        route                  (typify-route route)
-        [docstr [args & more]] (u/optional string? more)
-        [arg->schema body]     (u/optional (every-pred map? #(every? symbol? (keys %))) more)
-        validate-param-calls   (validate-params arg->schema)]
-    (when-not docstr
-      ;; Don't i18n this, it's dev-facing only
-      (log/warn (u/format-color 'red "Warning: endpoint %s/%s does not have a docstring. Go add one."
-                  (ns-name *ns*) fn-name)))
-    `(def ~(vary-meta fn-name
-                      merge
-                      (meta method)
-                      ;; eval the vals in arg->schema to make sure the actual schemas are resolved so we can document
-                      ;; their API error messages
-                      {:doc          (route-dox method route docstr args (m/map-vals eval arg->schema) body)
-                       :is-endpoint? true})
-       (~method ~route ~args
-        (auto-parse ~args
-          ~@validate-param-calls
-          (wrap-response-if-needed (do ~@body)))))))
+  [& defendpoint-args]
+  (let [{:keys [args body arg->schema], :as defendpoint-args} (parse-defendpoint-args defendpoint-args)]
+    `(defendpoint* ~(assoc defendpoint-args
+                           :body `((auto-parse ~args
+                                     ~@(validate-params arg->schema)
+                                     (wrap-response-if-needed
+                                      (do ~@body))))))))
 
 (defmacro defendpoint-async
   "Like `defendpoint`, but generates an endpoint that accepts the usual `[request respond raise]` params."
   {:arglists '([method route docstr? args schemas-map? & body])}
-  [method route & more]
-  (let [fn-name                (route-fn-name method route)
-        route                  (typify-route route)
-        [docstr [args & more]] (u/optional string? more)
-        [arg->schema body]     (u/optional (every-pred map? #(every? symbol? (keys %))) more)
-        validate-param-calls   (validate-params arg->schema)]
-    (when-not docstr
-      (log/warn (deferred-trs "Warning: endpoint {0}/{1} does not have a docstring." (ns-name *ns*) fn-name)))
-    `(def ~(vary-meta fn-name assoc
-                      ;; eval the vals in arg->schema to make sure the actual schemas are resolved so we can document
-                      ;; their API error messages
-                      :doc (route-dox method route docstr args (m/map-vals eval arg->schema) body)
-                      :is-endpoint? true)
-       (~method ~route []
-        (fn ~args
-          ~@validate-param-calls
-          ~@body)))))
+  [& defendpoint-args]
+  (let [{:keys [args body arg->schema], :as defendpoint-args} (parse-defendpoint-args defendpoint-args)]
+    `(defendpoint* ~(assoc defendpoint-args
+                           :args []
+                           :body `((fn ~args
+                                     ~@(validate-params arg->schema)
+                                     ~@body))))))
 
 (defn- namespace->api-route-fns
   "Return a sequence of all API endpoint functions defined by `defendpoint` in a namespace."
@@ -344,9 +350,9 @@
 ;;; ---------------------------------------- PERMISSIONS CHECKING HELPER FNS -----------------------------------------
 
 (defn read-check
-  "Check whether we can read an existing OBJ, or ENTITY with ID.
-   If the object doesn't exist, throw a 404; if we don't have proper permissions, throw a 403.
-   This will fetch the object if it was not already fetched, and returns OBJ if the check is successful."
+  "Check whether we can read an existing `obj`, or `entity` with `id`. If the object doesn't exist, throw a 404; if we
+  don't have proper permissions, throw a 403. This will fetch the object if it was not already fetched, and returns
+  `obj` if the check is successful."
   {:style/indent 2}
   ([obj]
    (check-404 obj)

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -113,7 +113,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn parse-int
-  "Parse VALUE (presumabily a string) as an Integer, or throw a 400 exception. Used to automatically to parse `id`
+  "Parse `value` (presumabily a string) as an Integer, or throw a 400 exception. Used to automatically to parse `id`
   parameters in `defendpoint` functions."
   [^String value]
   (try (Integer/parseInt value)
@@ -170,7 +170,7 @@
        (map second)
        (map keyword)))
 
-(defn typify-args
+(defn- typify-args
   "Given a sequence of keyword `args`, return a sequence of `[:arg pattern :arg pattern ...]` for args that have
   matching types."
   [args]
@@ -178,11 +178,11 @@
        (mapcat route-param-regex)
        (filterv identity)))
 
-(defn typify-route
+(defn add-route-param-regexes
   "Expand a `route` string like \"/:id\" into a Compojure route form that uses regexes to match parameters whose name
   matches a regex from `auto-parse-arg-name-patterns`.
 
-    (typify-route \"/:id/card\") -> [\"/:id/card\" :id #\"[0-9]+\"]"
+    (add-route-param-regexes \"/:id/card\") -> [\"/:id/card\" :id #\"[0-9]+\"]"
   [route]
   (if (vector? route)
     route

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -101,7 +101,8 @@
   (context "/slack"                [] (+auth slack/routes))
   (context "/table"                [] (+auth table/routes))
   (context "/task"                 [] (+auth task/routes))
-  (context "/testing"              [] (if (config/config-bool :mb-enable-test-endpoints)
+  (context "/testing"              [] (if (or config/is-dev?
+                                              (config/config-bool :mb-enable-test-endpoints))
                                         testing/routes
                                         (fn [_ respond _] (respond nil))))
   (context "/tiles"                [] (+auth tiles/routes))

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -1,136 +1,89 @@
 (ns metabase.api.common.internal-test
-  (:require [expectations :refer :all]
+  (:require [clojure.test :refer :all]
             [medley.core :as m]
-            [metabase.api.common.internal :refer :all]
-            [metabase.util :as u]))
+            [metabase
+             [test :as mt]
+             [util :as u]]
+            [metabase.api.common.internal :as internal :refer :all]))
 
-;;; TESTS FOR ROUTE-FN-NAME
+(deftest route-fn-name-test
+  (mt/are+ [method route expected] (= expected
+                                      (internal/route-fn-name method route))
+    'GET "/"                    'GET_
+    'GET "/:id/cards"           'GET_:id_cards
+    ;; check that internal/route-fn-name can handle routes with regex conditions
+    'GET ["/:id" :id #"[0-9]+"] 'GET_:id))
 
-(expect 'GET_
-  (route-fn-name 'GET "/"))
+(deftest arg-type-test
+  (mt/are+ [param expected] (= expected
+                               (internal/arg-type param))
+    :fish    nil
+    :id      :int
+    :card-id :int))
 
-(expect 'GET_:id_cards
-  (route-fn-name 'GET "/:id/cards"))
+(defmacro ^:private no-route-regexes
+  "`clojure.data/diff` doesn't think two regexes with the same exact pattern are equal. so in order to make sure we're
+  getting back the right output we'll just change them to strings, e.g.
 
-;; check that route-fn-name can handle routes with regex conditions
-(expect 'GET_:id
-  (route-fn-name 'GET ["/:id" :id #"[0-9]+"]))
-
-;;; TESTS FOR ARG-TYPE
-
-(expect nil
-  (arg-type :fish))
-
-(expect :int
-  (arg-type :id))
-
-(expect :int
-  (arg-type :card-id))
-
-
-;;; TESTS FOR ROUTE-PARAM-REGEX
-
-;; expectations (internally, `clojure.data/diff`) doesn't think two regexes with the same exact pattern are equal.
-;; so in order to make sure we're getting back the right output we'll just change them to strings, e.g. `#"[0-9]+" -> "#[0-9]+"`
-(defmacro no-regex [& body]
+    #\"[0-9]+\" -> \"#[0-9]+\""
+  {:style/indent 0}
+  [& body]
   `(binding [*auto-parse-types* (m/map-vals #(update % :route-param-regex (partial str "#"))
-                                            *auto-parse-types*) ]
+                                            *auto-parse-types*)]
      ~@body))
 
-(expect nil
-  (no-regex (route-param-regex :fish)))
+(deftest route-param-regex-test
+  (no-route-regexes
+    (mt/are+ [param expected] (= expected
+                                 (internal/route-param-regex param))
+      :fish    nil
+      :id      [:id "#[0-9]+"]
+      :card-id [:card-id "#[0-9]+"])))
 
-(expect [:id "#[0-9]+"]
-  (no-regex (route-param-regex :id)))
+(deftest route-arg-keywords-test
+  (no-route-regexes
+    (mt/are+ [route expected] (= expected
+                                 (internal/route-arg-keywords route))
+      "/"             []
+      "/:id"          [:id]
+      "/:id/card"     [:id]
+      "/:id/etc/:org" [:id :org]
+      "/:card-id"     [:card-id])))
 
-(expect [:card-id "#[0-9]+"]
-  (no-regex (route-param-regex :card-id)))
+(deftest type-args-test
+  (no-route-regexes
+    (mt/are+ [args expected] (= expected
+                                (#'internal/typify-args args))
+      []             []
+      [:fish]        []
+      [:fish :fry]   []
+      [:id]          [:id "#[0-9]+"]
+      [:id :fish]    [:id "#[0-9]+"]
+      [:id :card-id] [:id "#[0-9]+" :card-id "#[0-9]+"])))
 
+(deftest add-route-param-regexes-test
+  (no-route-regexes
+    (mt/are+ [route expected] (= expected
+                                 (internal/add-route-param-regexes route))
+      "/"                                    "/"
+      "/:id"                                 ["/:id" :id "#[0-9]+"]
+      "/:id/card"                            ["/:id/card" :id "#[0-9]+"]
+      "/:card-id"                            ["/:card-id" :card-id "#[0-9]+"]
+      "/:fish"                               "/:fish"
+      "/:id/tables/:card-id"                 ["/:id/tables/:card-id" :id "#[0-9]+" :card-id "#[0-9]+"]
+      ;; don't try to typify route that's already typified
+      ["/:id/:crazy-id" :crazy-id "#[0-9]+"] ["/:id/:crazy-id" :crazy-id "#[0-9]+"]
+      ;; Check :uuid args
+      "/:uuid/toucans"                       ["/:uuid/toucans" :uuid (str \# u/uuid-regex)])))
 
-;;; TESTS FOR ROUTE-ARG-KEYWORDS
-
-(expect []
-  (no-regex (route-arg-keywords "/")))
-
-(expect [:id]
-  (no-regex (route-arg-keywords "/:id")))
-
-(expect [:id]
-  (no-regex (route-arg-keywords "/:id/card")))
-
-(expect [:id :org]
-  (no-regex (route-arg-keywords "/:id/etc/:org")))
-
-(expect [:card-id]
-  (no-regex (route-arg-keywords "/:card-id")))
-
-
-;;; TESTS FOR TYPE-ARGS
-
-(expect []
-  (no-regex (typify-args [])))
-
-(expect []
-  (no-regex (typify-args [:fish])))
-
-(expect []
-  (no-regex (typify-args [:fish :fry])))
-
-(expect [:id "#[0-9]+"]
-  (no-regex (typify-args [:id])))
-
-(expect [:id "#[0-9]+"]
-  (no-regex (typify-args [:id :fish])))
-
-(expect [:id "#[0-9]+" :card-id "#[0-9]+"]
-  (no-regex (typify-args [:id :card-id])))
-
-
-;;; TESTS FOR TYPE-ROUTE
-
-(expect "/"
-  (no-regex (typify-route "/")))
-
-(expect ["/:id" :id "#[0-9]+"]
-  (no-regex (typify-route "/:id")))
-
-(expect ["/:id/card" :id "#[0-9]+"]
-  (no-regex (typify-route "/:id/card")))
-
-(expect ["/:card-id" :card-id "#[0-9]+"]
-  (no-regex (typify-route "/:card-id")))
-
-(expect "/:fish"
-  (no-regex (typify-route "/:fish")))
-
-(expect ["/:id/tables/:card-id" :id "#[0-9]+" :card-id "#[0-9]+"]
-  (no-regex (typify-route "/:id/tables/:card-id")))
-
-;; don't try to typify route that's already typified
-(expect ["/:id/:crazy-id" :crazy-id "#[0-9]+"]
-  (no-regex (typify-route ["/:id/:crazy-id" :crazy-id "#[0-9]+"])))
-
-;; Check :uuid args
-(expect ["/:uuid/toucans" :uuid (str \# u/uuid-regex)]
-  (no-regex (typify-route "/:uuid/toucans")))
-
-
-;; TESTS FOR LET-FORM-FOR-ARG
-
-(expect '[id (clojure.core/when id (metabase.api.common.internal/parse-int id))]
-  (let-form-for-arg 'id))
-
-(expect '[org_id (clojure.core/when org_id (metabase.api.common.internal/parse-int org_id))]
-  (let-form-for-arg 'org_id))
-
-(expect nil
-  (let-form-for-arg 'fish))
-
-;; make sure we don't try to generate let forms for any fancy destructuring
-(expect nil
-  (let-form-for-arg :as))
-
-(expect nil
-  (let-form-for-arg '{body :body}))
+(deftest let-form-for-arg-test
+  (mt/are+ [arg expected] (= expected
+                             (internal/let-form-for-arg arg))
+    'id           '[id (clojure.core/when id (metabase.api.common.internal/parse-int id))]
+    'org_id       '[org_id (clojure.core/when org_id (metabase.api.common.internal/parse-int org_id))]
+    'fish         nil
+    ;; make sure we don't try to generate let forms for any fancy destructuring
+    :as           nil
+    '{body :body} nil))
 
 ;; Tests for AUTO-PARSE presently live in `metabase.api.common-test`

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.api.common-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase.api.common :as api :refer :all]
             [metabase.api.common.internal :refer :all]
             [metabase.middleware
@@ -44,92 +44,46 @@
      {:status 200
       :body   @*current-user*})))
 
-; check that `check-404` doesn't throw an exception if TEST is true
-(expect
-  {:status  200
-   :body    "Cam Saul"
-   :headers {"Content-Type" "text/plain"}}
-  (binding [*current-user* (atom "Cam Saul")]
-    (my-mock-api-fn)))
+(deftest check-404-test
+  (testing "check that `check-404` doesn't throw an exception if `test` is true"
+    (is (= {:status  200
+            :body    "Cam Saul"
+            :headers {"Content-Type" "text/plain"}}
+           (binding [*current-user* (atom "Cam Saul")]
+             (my-mock-api-fn)))))
 
-; check that 404 is returned otherwise
-(expect
-  four-oh-four
-  (-> (my-mock-api-fn)
-      (update-in [:headers "Last-Modified"] string?)))
+  (testing "check that 404 is returned otherwise"
+    (is (= four-oh-four
+           (-> (my-mock-api-fn)
+               (update-in [:headers "Last-Modified"] string?)))))
 
-;;let-404 should return nil if test fails
-(expect
-  four-oh-four
-  (-> (mock-api-fn
-       (fn [_]
-         (let-404 [user nil]
-           {:user user})))
-      (update-in [:headers "Last-Modified"] string?)))
+  (testing "let-404 should return nil if test fails"
+    (is (= four-oh-four
+           (-> (mock-api-fn
+                (fn [_]
+                  (let-404 [user nil]
+                    {:user user})))
+               (update-in [:headers "Last-Modified"] string?)))))
 
-;; otherwise let-404 should bind as expected
-(expect
-  {:user {:name "Cam"}}
-  ((mw.exceptions/catch-api-exceptions
-    (fn [_ respond _]
-      (respond
-       (let-404 [user {:name "Cam"}]
-         {:user user}))))
-   nil
-   identity
-   (fn [e] (throw e))))
+  (testing "otherwise let-404 should bind as expected"
+    (is (= {:user {:name "Cam"}}
+           ((mw.exceptions/catch-api-exceptions
+             (fn [_ respond _]
+               (respond
+                (let-404 [user {:name "Cam"}]
+                  {:user user}))))
+            nil
+            identity
+            (fn [e] (throw e)))))))
 
-
-(defmacro ^:private expect-expansion
-  "Helper to test that a macro expands the way we expect;
-   Automatically calls `macroexpand-1` on MACRO."
-  {:style/indent 0}
-  [expected-expansion macro]
-  `(let [actual-expansion# (macroexpand-1 '~macro)]
-     (expect '~expected-expansion
-       actual-expansion#)))
-
-
-;;; TESTS FOR AUTO-PARSE
-;; TODO - these need to be moved to `metabase.api.common.internal-test`. But first `expect-expansion` needs to be put
-;; somewhere central
-
-;; when auto-parse gets an args form where arg is present in *autoparse-types*
-;; the appropriate let binding should be generated
-(expect-expansion (clojure.core/let [id (clojure.core/when id (metabase.api.common.internal/parse-int id))] 'body)
-                  (auto-parse [id] 'body))
-
-;; params not in *autoparse-types* should be ignored
-(expect-expansion (clojure.core/let [id (clojure.core/when id (metabase.api.common.internal/parse-int id))] 'body)
-                  (auto-parse [id some-other-param] 'body))
-
-;; make sure multiple autoparse params work correctly
-(expect-expansion (clojure.core/let [id (clojure.core/when id (metabase.api.common.internal/parse-int id))
-                                     org_id (clojure.core/when org_id (metabase.api.common.internal/parse-int org_id))] 'body)
-                  (auto-parse [id org_id] 'body))
-
-;; make sure it still works if no autoparse params are passed
-(expect-expansion (clojure.core/let [] 'body)
-                  (auto-parse [some-other-param] 'body))
-
-;; should work with no params at all
-(expect-expansion (clojure.core/let [] 'body)
-                  (auto-parse [] 'body))
-
-;; should work with some wacky binding form
-(expect-expansion (clojure.core/let [id (clojure.core/when id (metabase.api.common.internal/parse-int id))] 'body)
-                  (auto-parse [id :as {body :body}] 'body))
-
-;;; TESTS FOR DEFENDPOINT
-
-;; replace regex `#"[0-9]+"` with str `"#[0-9]+" so expectations doesn't barf
-(binding [*auto-parse-types* (update-in *auto-parse-types* [:int :route-param-regex] (partial str "#"))]
-  (expect-expansion
-    (def GET_:id
-      (GET ["/:id" :id "#[0-9]+"] [id]
-           (metabase.api.common.internal/auto-parse [id]
-             (metabase.api.common.internal/validate-param 'id id su/IntGreaterThanZero)
-             (metabase.api.common.internal/wrap-response-if-needed (do (select-one Card :id id))))))
-    (defendpoint GET "/:id" [id]
-      {id su/IntGreaterThanZero}
-      (select-one Card :id id))))
+(deftest defendpoint-test
+  ;; replace regex `#"[0-9]+"` with str `"#[0-9]+" so expectations doesn't barf
+  (binding [*auto-parse-types* (update-in *auto-parse-types* [:int :route-param-regex] (partial str "#"))]
+    (is (= '(def GET_:id
+              (compojure.core/GET ["/:id" :id "#[0-9]+"] [id]
+                                  (metabase.api.common.internal/auto-parse [id]
+                                    (metabase.api.common.internal/validate-param 'id id metabase.util.schema/IntGreaterThanZero)
+                                    (metabase.api.common.internal/wrap-response-if-needed (do (select-one Card :id id))))))
+           (macroexpand `(defendpoint GET "/:id" [~'id]
+                           {~'id su/IntGreaterThanZero}
+                           (~'select-one ~'Card :id ~'id)))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -109,6 +109,7 @@
                          #(str/ends-with? % "_id")
                          #(str/ends-with? % "_at")))
     data))
+
   ([pred data]
    (walk/prewalk (fn [maybe-map]
                    (if (map? maybe-map)
@@ -127,124 +128,113 @@
 
 (defn- rasta-id [] (user-id :rasta))
 
+(def ^:private with-temp-defaults-fns
+  {Card
+   (fn [_] {:creator_id             (rasta-id)
+            :dataset_query          {}
+            :display                :table
+            :name                   (random-name)
+            :visualization_settings {}})
+
+   Collection
+   (fn [_] {:name  (random-name)
+            :color "#ABCDEF"})
+
+   Dashboard
+   (fn [_] {:creator_id   (rasta-id)
+            :name         (random-name)})
+
+   DashboardCardSeries
+   (constantly {:position 0})
+
+   Database
+   (fn [_] {:details   {}
+            :engine    :h2
+            :is_sample false
+            :name      (random-name)})
+
+   Dimension
+   (fn [_] {:name (random-name)
+            :type "internal"})
+
+   Field
+   (fn [_] {:database_type "VARCHAR"
+            :base_type     :type/Text
+            :name          (random-name)
+            :position      1
+            :table_id      (data/id :checkins)})
+
+   Metric
+   (fn [_] {:creator_id  (rasta-id)
+            :definition  {}
+            :description "Lookin' for a blueberry"
+            :name        "Toucans in the rainforest"
+            :table_id    (data/id :checkins)})
+
+   NativeQuerySnippet
+   (fn [_] {:creator_id (user-id :crowberto)
+            :name       (random-name)
+            :content    "1 = 1"})
+
+   PermissionsGroup
+   (fn [_] {:name (random-name)})
+
+   Pulse
+   (fn [_] {:creator_id (rasta-id)
+            :name       (random-name)})
+
+   PulseCard
+   (fn [_] {:position    0
+            :include_csv false
+            :include_xls false})
+
+   PulseChannel
+   (constantly {:channel_type  :email
+                :details       {}
+                :schedule_type :daily
+                :schedule_hour 15})
+
+   Revision
+   (fn [_] {:user_id      (rasta-id)
+            :is_creation  false
+            :is_reversion false})
+
+   Segment
+   (fn [_] {:creator_id (rasta-id)
+            :definition  {}
+            :description "Lookin' for a blueberry"
+            :name        "Toucans in the rainforest"
+            :table_id    (data/id :checkins)})
+
+   ;; TODO - `with-temp` doesn't return `Sessions`, probably because their ID is a string?
+
+   Table
+   (fn [_] {:db_id  (data/id)
+            :active true
+            :name   (random-name)})
+
+   TaskHistory
+   (fn [_]
+     (let [started (t/zoned-date-time)
+           ended   (t/plus started (t/millis 10))]
+       {:db_id      (data/id)
+        :task       (random-name)
+        :started_at started
+        :ended_at   ended
+        :duration   (.toMillis (t/duration started ended))}))
+
+   User
+   (fn [_] {:first_name (random-name)
+            :last_name  (random-name)
+            :email      (random-email)
+            :password   (random-name)})})
+
 (defn- set-with-temp-defaults! []
-  (extend (class Card)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:creator_id             (rasta-id)
-                                  :dataset_query          {}
-                                  :display                :table
-                                  :name                   (random-name)
-                                  :visualization_settings {}})})
-
-  (extend (class Collection)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:name  (random-name)
-                                  :color "#ABCDEF"})})
-
-  (extend (class Dashboard)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:creator_id   (rasta-id)
-                                  :name         (random-name)})})
-
-  (extend (class DashboardCardSeries)
-    tt/WithTempDefaults
-    {:with-temp-defaults (constantly {:position 0})})
-
-  (extend (class Database)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:details   {}
-                                  :engine    :h2
-                                  :is_sample false
-                                  :name      (random-name)})})
-
-  (extend (class Dimension)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:name (random-name)
-                                  :type "internal"})})
-
-  (extend (class Field)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:database_type "VARCHAR"
-                                  :base_type     :type/Text
-                                  :name          (random-name)
-                                  :position      1
-                                  :table_id      (data/id :checkins)})})
-
-  (extend (class Metric)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:creator_id  (rasta-id)
-                                  :definition  {}
-                                  :description "Lookin' for a blueberry"
-                                  :name        "Toucans in the rainforest"
-                                  :table_id    (data/id :checkins)})})
-
-  (extend (class NativeQuerySnippet)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:creator_id (user-id :crowberto)
-                                  :name       (random-name)
-                                  :content    "1 = 1"})})
-
-  (extend (class PermissionsGroup)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:name (random-name)})})
-
-  (extend (class Pulse)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:creator_id (rasta-id)
-                                  :name       (random-name)})})
-
-  (extend (class PulseCard)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:position    0
-                                  :include_csv false
-                                  :include_xls false})})
-
-  (extend (class PulseChannel)
-    tt/WithTempDefaults
-    {:with-temp-defaults (constantly {:channel_type  :email
-                                      :details       {}
-                                      :schedule_type :daily
-                                      :schedule_hour 15})})
-
-  (extend (class Revision)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:user_id      (rasta-id)
-                                  :is_creation  false
-                                  :is_reversion false})})
-
-  (extend (class Segment)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:creator_id (rasta-id)
-                                  :definition  {}
-                                  :description "Lookin' for a blueberry"
-                                  :name        "Toucans in the rainforest"
-                                  :table_id    (data/id :checkins)})})
-
-  ;; TODO - `with-temp` doesn't return `Sessions`, probably because their ID is a string?
-
-  (extend (class Table)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:db_id  (data/id)
-                                  :active true
-                                  :name   (random-name)})})
-
-  (extend (class TaskHistory)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_]
-                           (let [started (t/zoned-date-time)
-                                 ended   (t/plus started (t/millis 10))]
-                             {:db_id      (data/id)
-                              :task       (random-name)
-                              :started_at started
-                              :ended_at   ended
-                              :duration   (.toMillis (t/duration started ended))}))})
-
-  (extend (class User)
-    tt/WithTempDefaults
-    {:with-temp-defaults (fn [_] {:first_name (random-name)
-                                  :last_name  (random-name)
-                                  :email      (random-email)
-                                  :password   (random-name)})}))
+  (doseq [[model defaults-fn] with-temp-defaults-fns]
+    ;; make sure we have the latest version of the class in case it was redefined since we imported it
+    (extend (Class/forName (.getCanonicalName (class model)))
+      tt/WithTempDefaults
+      {:with-temp-defaults defaults-fn})))
 
 (set-with-temp-defaults!)
 
@@ -274,7 +264,7 @@
    ::reload
    (fn [_ reference _ _]
      (println (format "%s changed, reloading with-temp-defaults" model-var))
-     #_(set-with-temp-defaults!))))
+     (set-with-temp-defaults!))))
 
 
 ;;; ------------------------------------------------- Other Util Fns -------------------------------------------------
@@ -295,9 +285,8 @@
 
 
 (defn mappify
-  "Walk COLL and convert all record types to plain Clojure maps.
-  Useful because expectations will consider an instance of a record type to be different from a plain Clojure map,
-  even if all keys & values are the same."
+  "Walk `coll` and convert all record types to plain Clojure maps. Useful because expectations will consider an instance
+  of a record type to be different from a plain Clojure map, even if all keys & values are the same."
   [coll]
   {:style/indent 0}
   (walk/postwalk (fn [x]

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.util-test
   "Tests for functions in `metabase.util`."
   (:require [clojure.test :refer :all]
-            [clojure.tools.macro :as tools.macro]
             [flatland.ordered.map :refer [ordered-map]]
             [metabase
              [test :as mt]
@@ -17,34 +16,10 @@
   (is (= nil
          (u/decolorize nil))))
 
-(defn- are+-message [expr arglist args]
-  (pr-str
-   (second
-    (macroexpand-1
-     (list
-      `tools.macro/symbol-macrolet
-      (vec (apply concat (map-indexed (fn [i arg]
-                                        [arg (nth args i)])
-                                      arglist)))
-      expr)))))
-
-(defmacro ^:private are+
-  "Like `clojure.test/are` but includes a message for easier test failure debugging. (Also this is somewhat more
-  efficient since it generates far less code ­ it uses `doseq` rather than repeating the entire test each time.)
-
-  TODO ­ if this macro proves useful, we should consider moving it to somewhere more general, such as
-  `metabase.test`."
-  {:style/indent 2}
-  [argv expr & args]
-  `(doseq [args# ~(mapv vec (partition (count argv) args))
-           :let [~argv args#]]
-     (is ~expr
-         (are+-message '~expr '~argv args#))))
-
 (deftest host-up?-test
   (testing "host-up?"
-    (are+ [s expected] (= expected
-                          (u/host-up? s))
+    (mt/are+ [s expected] (= expected
+                             (u/host-up? s))
       "localhost"  true
       "nosuchhost" false))
   (testing "host-port-up?"
@@ -52,7 +27,7 @@
            (u/host-port-up? "nosuchhost" 8005)))))
 
 (deftest url?-test
-  (are+ [s expected] (= expected
+  (mt/are+ [s expected] (= expected
                         (u/url? s))
     "http://google.com"                                                                      true
     "https://google.com"                                                                     true
@@ -80,7 +55,7 @@
     "http:/"                                                                                 false))
 
 (deftest state?-test
-  (are+ [s expected] (= expected
+  (mt/are+ [s expected] (= expected
                         (u/state? s))
     "louisiana"      true
     "north carolina" true
@@ -93,7 +68,7 @@
     (Object.)        false))
 
 (deftest qualified-name-test
-  (are+ [k expected] (= expected
+  (mt/are+ [k expected] (= expected
                         (u/qualified-name k))
     :keyword                          "keyword"
     :namespace/keyword                "namespace/keyword"
@@ -151,7 +126,7 @@
                  (u/slugify s))))))))
 
 (deftest select-nested-keys-test
-  (are+ [m keyseq expected] (= expected
+  (mt/are+ [m keyseq expected] (= expected
                                (u/select-nested-keys m keyseq))
     {:a 100, :b {:c 200, :d 300}}              [:a [:b :d] :c]   {:a 100, :b {:d 300}}
     {:a 100, :b {:c 200, :d 300}}              [:b]              {:b {:c 200, :d 300}}
@@ -167,7 +142,7 @@
     {}                                         [:c]              {}))
 
 (deftest base64-string?-test
-  (are+ [s expected]    (= expected
+  (mt/are+ [s expected]    (= expected
                         (u/base64-string? s))
     "ABc="         true
     "ABc/+asdasd=" true
@@ -194,7 +169,7 @@
              :non-nil #{:d :e :f})))))
 
 (deftest order-of-magnitude-test
-  (are+ [n expected] (= expected
+  (mt/are+ [n expected] (= expected
                         (u/order-of-magnitude n))
     0.01  -2
     0.5   -1
@@ -218,7 +193,7 @@
          (u/snake-keys {:num-cans 2, :lisp-case? {:nested-maps? true}}))))
 
 (deftest one-or-many-test
-  (are+ [input expected] (= expected
+  (mt/are+ [input expected] (= expected
                             (u/one-or-many input))
     nil   nil
     [nil] [nil]
@@ -226,7 +201,7 @@
     [42]  [42]))
 
 (deftest topological-sort-test
-  (are+ [input expected] (= expected
+  (mt/are+ [input expected] (= expected
                             (u/topological-sort identity input))
     {:b []
      :c [:a]
@@ -249,7 +224,7 @@
            (u/upper-case-en "id")))))
 
 (deftest parse-currency-test
-  (are+ [s expected] (= expected
+  (mt/are+ [s expected] (= expected
                         (u/parse-currency s))
     nil             nil
     ""              nil
@@ -270,5 +245,5 @@
     "0.05"          0.05M))
 
 ;; Local Variables:
-;; eval: (add-to-list (make-local-variable 'clojure-align-cond-forms) "are+")
+;; eval: (add-to-list (make-local-variable 'clojure-align-cond-forms) "mt/are+")
 ;; End:


### PR DESCRIPTION
1. Adds a `test-cypress-open-no-backend` alias so you can open the Cypress GUI and have it use http://localhost:3000 (e.g. if you started the backend from the REPL)
2. Enables the test endpoints used by Cypress when running a server from the REPL (`:dev` mode)
3. Move `are+` util function to `metabase.test`. This is just like `clojure.test/are` but generates a better message on test failure and generates more concise/efficient code
4. Improve the way the impls of `with-temp-defaults` are automatically reloaded when Toucan models get redefined during interactive dev
5. You no longer need to explicitly require `compojure.core/GET` (etc.) when using `defendpoint`
5. Simplify `defendpoint` macro/remove code duplication; convert tests to modern style