### PR TITLE
Hide sharing sidebar when in edit or fullscreen modes

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -367,6 +367,8 @@ function Sidebars(props) {
     dashcardData,
     setParameterFilteringParameters,
     isSharing,
+    isEditing,
+    isFullscreen,
   } = props;
   if (clickBehaviorSidebarDashcard) {
     return (
@@ -412,7 +414,8 @@ function Sidebars(props) {
     );
   }
 
-  if (isSharing) {
+  // SharingSidebar should only show if we're not editing or in fullscreen
+  if (!isEditing && !isFullscreen && isSharing) {
     return <SharingSidebar {...props} />;
   }
 


### PR DESCRIPTION
Closes #14258

- Updates the condition we use to show the `<SharingSidebar />` to be aware of `isEditing` and `isFullscreen`