### PR TITLE
disable sharing popover if the dashboard doesn't have data

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { t } from "ttag";
+import cx from "classnames";
 
 import DashboardSharingEmbeddingModal from "../containers/DashboardSharingEmbeddingModal.jsx";
 import FullscreenIcon from "metabase/components/icons/FullscreenIcon";
@@ -26,12 +27,18 @@ export const getDashboardActions = (
     onRefreshPeriodChange,
     onSharingClick,
     onEmbeddingClick,
+    dashcardData,
   },
 ) => {
   const isPublicLinksEnabled = MetabaseSettings.get("enable-public-sharing");
   const isEmbeddingEnabled = MetabaseSettings.get("enable-embedding");
 
   const buttons = [];
+
+  /* we consider the dashboard to be shareable if there is at least one card with data in it on the dashboard
+    markdown cards don't appear in dashcardData so we check to see if there is at least one value
+  */
+  const canShareDashboard = Object.keys(dashcardData).length > 0;
 
   if (!isEditing && !isEmpty) {
     const extraButtonClassNames =
@@ -40,9 +47,22 @@ export const getDashboardActions = (
     buttons.push(
       <PopoverWithTrigger
         ref="popover"
+        disabled={!canShareDashboard}
         triggerElement={
-          <Tooltip tooltip={t`Sharing`}>
-            <Icon name="share" className="text-brand-hover" />
+          <Tooltip
+            tooltip={
+              canShareDashboard
+                ? t`Sharing`
+                : t`Add data to share this dashboard`
+            }
+          >
+            <Icon
+              name="share"
+              className={cx({
+                "text-brand-hover": canShareDashboard,
+                "text-light": !canShareDashboard,
+              })}
+            />
           </Tooltip>
         }
       >


### PR DESCRIPTION
Closes #14264 

## What this does
- Looks at the `dashcardData` of a dashboard and checks to see if there is at least one item there. If there is, there's something worth sharing (e.g. a card beyond just a markdown card). If there isn't, we set `disabled` on the sharing popover and add some copy to let people know they need to add some content before they can share the dashboard. 
 
![image](https://user-images.githubusercontent.com/5248953/103686587-0cc93d80-4f5d-11eb-9074-d06e393b3146.png)

