### PR TITLE
Pivot tables - fix binned dimension issue

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -106,14 +106,16 @@ export function multiLevelPivot(
   const topIndex = getIndex(columnColumnTree, { valueColumns });
   if (topIndex.length > 1) {
     // if there are multiple columns, we should add another for row totals
-    const colNames = valueColumns.map(col => ({
-      value: col.display_name,
-      span: 1,
-    }));
-    topIndex.push([
-      [{ value: t`Row totals`, span: colNames.length }],
-      colNames,
-    ]);
+    const rowTotals = [{ value: t`Row totals`, span: valueColumns.length }];
+    if (valueColumns.length > 1) {
+      const colNames = valueColumns.map(col => ({
+        value: col.display_name,
+        span: 1,
+      }));
+      topIndex.push([rowTotals, colNames]);
+    } else {
+      topIndex.push([rowTotals]);
+    }
   }
 
   const leftIndexWithoutSubtotals = getIndex(rowColumnTree, {});

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -219,7 +219,7 @@ function createRowSectionGetter({
         rowColumnIndexes.length > 1
           ? [
               columns.flatMap(col =>
-                getSubtotals(rowColumnIndexes.slice(0, -1), [rows[0][0]]),
+                getSubtotals(rowColumnIndexes.slice(0, 1), [rows[0][0]]),
               ),
             ]
           : [];

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -180,7 +180,7 @@ describe("data_grid", () => {
             { span: 1, value: "z" },
           ],
         ],
-        [[{ span: 1, value: "Row totals" }], [{ span: 1, value: "Metric" }]],
+        [[{ span: 1, value: "Row totals" }]],
       ]);
       expect(leftIndex).toEqual([]);
       expect(rowCount).toEqual(1);
@@ -243,7 +243,7 @@ describe("data_grid", () => {
       expect(topIndex).toEqual([
         [[{ value: "a", span: 1 }]],
         [[{ value: "b", span: 1 }]],
-        [[{ span: 1, value: "Row totals" }], [{ value: "Metric", span: 1 }]],
+        [[{ span: 1, value: "Row totals" }]],
       ]);
       expect(extractValues(getRowSection(0, 0))).toEqual([["1"]]);
       expect(extractValues(getRowSection(1, 1))).toEqual([[null]]);


### PR DESCRIPTION
This PR bundles three unrelated small issues I saw:
- Canonicalize breakout/column field refs – e347b7b
- Fix issue getting right subtotals for > 2 left header fields – e9f5da4
- Don't show metric names under "row totals" if there's only one – c0b245d