### PR TITLE
Update year in copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ This repository contains the source code for both the Open Source edition of Met
 
 See [LICENSE.txt](./LICENSE.txt) for details.
 
-Unless otherwise noted, all files © 2020 Metabase, Inc.
+Unless otherwise noted, all files © 2021 Metabase, Inc.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -244,6 +244,6 @@ If you see incorrect or missing strings for your language, please visit our [POE
 
 ## License
 
-Copyright © 2020 Metabase, Inc.
+Copyright © 2021 Metabase, Inc.
 
 Distributed under the terms of the GNU Affero General Public License (AGPL) except as otherwise noted. See individual files for details.

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -7,7 +7,7 @@ the [Metabase Commercial License](https://www.metabase.com/license/commercial/),
 fully-paid-up license from Metabase. Access to files in this directory and its subdirectories does not constitute
 permission to use this code or Metabase Enterprise Edition features.
 
-Unless otherwise noted, all files Copyright © 2020 Metabase, Inc.
+Unless otherwise noted, all files Copyright © 2021 Metabase, Inc.
 
 ## Running it
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Gets rid of 2020 🤛
- Updates the copyright year in readme and other docs