### PR TITLE
Fix duplicate plugin loading when running local dev server

### DIFF
--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -11,7 +11,8 @@
              [init-steps :as init-steps]
              [lazy-loaded-driver :as lazy-loaded-driver]]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs]]))
+            [metabase.util.i18n :refer [trs]]
+            [schema.core :as s]))
 
 (defonce ^:private initialized-plugin-names (atom #{}))
 
@@ -41,18 +42,17 @@
         (init! plugin-info)))
     :ok))
 
-(defn- initialized? [{plugin-name :name}]
+(defn- initialized? [{{plugin-name :name} :info}]
   (@initialized-plugin-names plugin-name))
 
-(defonce ^:private plugin-initialization-lock (Object.))
-
-(defn init-plugin-with-info!
+(s/defn init-plugin-with-info!
   "Initiaize plugin using parsed info from a plugin maifest. Returns truthy if plugin was successfully initialized;
   falsey otherwise."
-  [info]
+  [info :- {:info     {:name s/Str, :version s/Str, s/Keyword s/Any}
+            s/Keyword s/Any}]
   (or
    (initialized? info)
-   (locking plugin-initialization-lock
+   (locking initialized-plugin-names
      (or
       (initialized? info)
       (init! info)))))


### PR DESCRIPTION
We were looking at the wrong map key when determining whether a plugin had already been initialized resulting in duplicate init calls when running `lein run`/`lein ring server`. This speeds up local dev server launch time by 10 seconds or so