### PR TITLE
#14285 Repro: Rows collapse when last value is 0

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  signInAsAdmin,
-  createNativeQuestion,
-} from "__support__/cypress";
+import { restore, signInAsAdmin } from "__support__/cypress";
 
 describe("scenarios > visualizations > rows", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
@@ -1,0 +1,43 @@
+import {
+  restore,
+  signInAsAdmin,
+  createNativeQuestion,
+} from "__support__/cypress";
+
+describe("scenarios > visualizations > rows", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
+
+  // Until we enable multi-browser support, this repro will be skipped by Cypress in CI
+  // Issue was specific to Firefox only - it is still possible to test it locally
+  it(
+    "should not collapse rows when last value is 0 (metabase#14285)",
+    { browser: "firefox" },
+    () => {
+      cy.request("POST", "/api/card", {
+        name: "14285",
+        dataset_query: {
+          type: "native",
+          native: {
+            query:
+              "with temp as (\n select 'a' col1, 25 col2\n union all \n select 'b', 10\n union all \n select 'c', 15\n union all \n select 'd', 0\n union all\n select 'e', 30\n union all \n select 'f', 35\n)\nselect * from temp\norder by 2 desc",
+            "template-tags": {},
+          },
+          database: 1,
+        },
+        display: "row",
+        visualization_settings: {},
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.visit(`/question/${QUESTION_ID}`);
+      });
+
+      cy.get(".Visualization").within(() => {
+        ["a", "b", "c", "d", "e", "f"].forEach(letter => {
+          cy.findByText(letter);
+        });
+      });
+    },
+  );
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14285 

### How to test this manually?
_This test is Firefox specific. In order to test it manually, you'll need to have Firefox installed on your machine._
- `yarn test-cypress-open`
- Choose Firefox browser in Cypress GUI prior to running tests
![image](https://user-images.githubusercontent.com/31325167/103831366-3927ab80-507c-11eb-845f-39e119fc9335.png)
- `frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js`
- Test will fail until the related issue is resolved

### Additional notes:
- Test will be automatically skipped by Cypress for any browser other than Firefox (no need to skip it manually)
![image](https://user-images.githubusercontent.com/31325167/103831523-8277fb00-507c-11eb-8c76-a8a1a44bc862.png)
- Until we enable multi-browser support for Cypress tests in CI this test will serve its purpose only for local/manual testing.
