### PR TITLE
Don't return Pulses used for DashboardSubscriptions in the search endpoint

### DIFF
--- a/bin/lint-migrations-file/src/column/strict.clj
+++ b/bin/lint-migrations-file/src/column/strict.clj
@@ -2,8 +2,18 @@
   (:require [clojure.spec.alpha :as s]
             column.common))
 
-(comment column.common/keep-me)
+(defmulti column-name :name)
+
+;; remark is *required* for non-ID columns
+(defmethod column-name :default
+  [_]
+  (s/merge
+   :column.common/column
+   (s/keys :req-un [:column.common/remarks])))
+
+(defmethod column-name "id"
+  [_]
+  :column.common/column)
 
 (s/def ::column
-  (s/merge
-   :column.common/column))
+  (s/multi-spec column-name :name))

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -12,7 +12,7 @@
     (apply array-map keyvals))})
 
 (defn mock-column [& keyvals]
-  {:column (merge {:name "bird_count", :type "integer"}
+  {:column (merge {:name "bird_count", :type "integer", :remarks "Whatever"}
                   (apply array-map keyvals))})
 
 (defn- mock-add-column-changes [& keyvals]

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -54,8 +54,8 @@
    (doseq [[symb] (ns-interns a-namespace)]
      (ns-unmap a-namespace symb))
    (doseq [[symb varr] (ns-refers a-namespace)
-         :when (not (= (the-ns (:ns (meta varr)))
-                       (the-ns 'clojure.core)))]
+           :when (not= (the-ns (:ns (meta varr)))
+                       (the-ns 'clojure.core))]
      (ns-unmap a-namespace symb))))
 
 (defn ns-unalias-all

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -369,7 +369,6 @@ function Sidebars(props) {
     isSharing,
     isEditing,
     isFullscreen,
-    onCancel,
   } = props;
   if (clickBehaviorSidebarDashcard) {
     return (
@@ -417,13 +416,7 @@ function Sidebars(props) {
 
   // SharingSidebar should only show if we're not editing or in fullscreen
   if (!isEditing && !isFullscreen && isSharing) {
-    return (
-      <SharingSidebar
-        dashboard={dashboard}
-        params={props.params}
-        onCancel={onCancel}
-      />
-    );
+    return <SharingSidebar {...props} />;
   }
 
   return null;

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -26,6 +26,7 @@ import Collections from "metabase/entities/collections";
 import Pulses from "metabase/entities/pulses";
 import User from "metabase/entities/users";
 
+import { push, goBack } from "react-router-redux";
 import { connect } from "react-redux";
 
 import { cleanPulse, createChannel, pulseIsValid } from "metabase/lib/pulse";
@@ -34,7 +35,9 @@ import MetabaseSettings from "metabase/lib/settings";
 import {
   getPulseId,
   getEditingPulse,
+  getPulseCardPreviews,
   getPulseFormInput,
+  getPulseList,
 } from "metabase/pulse/selectors";
 
 import { getUser } from "metabase/selectors/user";
@@ -44,7 +47,9 @@ import {
   updateEditingPulse,
   saveEditingPulse,
   fetchPulseFormInput,
+  fetchPulseCardPreview,
   testPulse,
+  fetchPulsesByDashboardId,
 } from "metabase/pulse/actions";
 
 import cx from "classnames";
@@ -112,12 +117,14 @@ const getEditingPulseWithDefaults = (state, props) => {
 const mapStateToProps = (state, props) => ({
   pulseId: getPulseId(state, props),
   pulse: getEditingPulseWithDefaults(state, props),
+  cardPreviews: getPulseCardPreviews(state, props),
   formInput: getPulseFormInput(state, props),
   user: getUser(state),
   initialCollectionId: Collections.selectors.getInitialCollectionId(
     state,
     props,
   ),
+  pulseList: getPulseList(state, props),
 });
 
 const mapDispatchToProps = {
@@ -125,32 +132,37 @@ const mapDispatchToProps = {
   updateEditingPulse,
   saveEditingPulse,
   fetchPulseFormInput,
+  fetchPulseCardPreview,
   setPulseArchived: Pulses.actions.setArchived,
   testPulse,
+  onChangeLocation: push,
+  goBack,
+  fetchPulsesByDashboardId,
 };
 
-@Pulses.loadList({
-  query: (state, { dashboard }) => ({ dashboard_id: dashboard.id }),
-})
-@User.loadList({ loadingAndErrorWrapper: false })
+@User.loadList()
 @connect(
   mapStateToProps,
   mapDispatchToProps,
 )
 class SharingSidebar extends React.Component {
   state = {
-    editingMode: "list-pulses",
+    editingMode: undefined,
     // use this to know where to go "back" to
-    returnMode: [],
+    returnMode: undefined,
   };
 
   static propTypes = {
     dashboard: PropTypes.object.isRequired,
     fetchPulseFormInput: PropTypes.func.isRequired,
+    fetchPulsesByDashboardId: PropTypes.func.isRequired,
     formInput: PropTypes.object.isRequired,
+    goBack: PropTypes.func,
     initialCollectionId: PropTypes.number,
+    onChangeLocation: PropTypes.func.isRequired,
     pulse: PropTypes.object.isRequired,
     pulseId: PropTypes.number,
+    pulseList: PropTypes.array.isRequired,
     saveEditingPulse: PropTypes.func.isRequired,
     setEditingPulse: PropTypes.func.isRequired,
     testPulse: PropTypes.func.isRequired,
@@ -179,14 +191,29 @@ class SharingSidebar extends React.Component {
     this.setPulse(newPulse);
   }
 
-  componentDidMount = async () => {
-    await this.props.fetchPulseFormInput();
+  componentDidMount() {
+    //TODO: if these don't finish before we render, we render the wrong thing. help?
+    this.props.fetchPulseFormInput();
+    this.props.fetchPulsesByDashboardId(this.props.dashboard.id);
 
     this.props.setEditingPulse(
       this.props.pulseId,
       this.props.initialCollectionId,
     );
-  };
+  }
+
+  componentDidUpdate() {
+    const { pulseList } = this.props;
+    const { editingMode } = this.state;
+
+    if (editingMode === undefined) {
+      if (pulseList && pulseList.length > 0) {
+        this.setState({ editingMode: "list-pulses" });
+      } else {
+        this.createSubscription();
+      }
+    }
+  }
 
   onChannelPropertyChange(index, name, value) {
     const { pulse } = this.props;
@@ -258,27 +285,23 @@ class SharingSidebar extends React.Component {
 
     await this.props.saveEditingPulse();
 
+    await this.props.fetchPulsesByDashboardId(dashboard.id);
     this.setState({ editingMode: "list-pulses" });
   };
 
   createSubscription = () => {
-    this.setState(({ editingMode, returnMode }) => {
-      return {
-        editingMode: "new-pulse",
-        returnMode: returnMode.concat([editingMode]),
-      };
+    this.setState({
+      editingMode: "new-pulse",
+      returnMode: this.state.editingMode,
     });
-
     this.props.setEditingPulse(null, null);
   };
 
   editPulse = (pulse, channelType) => {
     this.setPulse(pulse);
-    this.setState(({ editingMode, returnMode }) => {
-      return {
-        editingMode: "add-edit-" + channelType,
-        returnMode: returnMode.concat([editingMode || "list-pulses"]),
-      };
+    this.setState({
+      editingMode: "add-edit-" + channelType,
+      returnMode: this.state.editingMode,
     });
   };
 
@@ -475,19 +498,19 @@ class SharingSidebar extends React.Component {
 
   handleArchive = async () => {
     await this.props.setPulseArchived(this.props.pulse, true);
-    this.setState({ editingMode: "list-pulses", returnMode: [] });
+    await this.props.fetchPulsesByDashboardId(this.props.dashboard.id);
+    this.setState({ editingMode: undefined });
   };
 
   // Because you can navigate down the sidebar, we need to wrap
   // onCancel from props and either call that or reset back a screen
   onCancel = () => {
     const { onCancel } = this.props;
-    const { returnMode } = this.state;
-    if (returnMode.length) {
+    if (this.state.returnMode) {
       // set the current mode back to what it should be
       this.setState({
-        editingMode: returnMode[returnMode.length - 1],
-        returnMode: returnMode.slice(0, -1),
+        editingMode: this.state.returnMode,
+        returnMode: undefined,
       });
     } else {
       onCancel();
@@ -496,7 +519,7 @@ class SharingSidebar extends React.Component {
 
   render() {
     const { editingMode } = this.state;
-    const { pulse, pulses, formInput } = this.props;
+    const { pulse, formInput, pulseList } = this.props;
 
     const caveatMessage = (
       <Text className="mx4 my2 p2 bg-light text-dark rounded">{jt`${(
@@ -513,11 +536,11 @@ class SharingSidebar extends React.Component {
     );
 
     // protect from empty values that will mess this up
-    if (!formInput.channels || !pulse) {
+    if (formInput === null || pulse === null || pulseList === null) {
       return <Sidebar />;
     }
 
-    if (editingMode === "list-pulses" && pulses.length > 0) {
+    if (editingMode === "list-pulses") {
       return (
         <Sidebar>
           <div className="px4 pt3 flex justify-between align-center">
@@ -543,7 +566,7 @@ class SharingSidebar extends React.Component {
             </Flex>
           </div>
           <div className="my2 mx4">
-            {pulses.map(pulse => (
+            {pulseList.map(pulse => (
               <Card
                 flat
                 className="mb3 cursor-pointer bg-brand-hover"
@@ -576,6 +599,119 @@ class SharingSidebar extends React.Component {
         </Sidebar>
       );
     }
+
+    if (editingMode === "new-pulse") {
+      const emailSpec = formInput.channels.email;
+      const slackSpec = formInput.channels.slack;
+
+      return (
+        <Sidebar onCancel={this.onCancel}>
+          <div className="mt2 pt2 px4">
+            <Heading>{t`Create a dashboard subscription`}</Heading>
+          </div>
+          <div className="my1 mx4">
+            <Card
+              flat
+              className={cx("mt1 mb3", {
+                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
+                  emailSpec.configured,
+              })}
+              onClick={() => {
+                if (emailSpec.configured) {
+                  this.setState({
+                    editingMode: "add-edit-email",
+                    returnMode: this.state.editingMode,
+                  });
+                  this.addChannel("email");
+                }
+              }}
+            >
+              <div className="px3 pt3 pb2">
+                <div className="flex align-center">
+                  <Icon
+                    name="mail"
+                    className={cx(
+                      "mr1",
+                      {
+                        "text-brand hover-child hover--inherit":
+                          emailSpec.configured,
+                      },
+                      { "text-light": !emailSpec.configured },
+                    )}
+                  />
+                  <h3
+                    className={cx({ "text-light": !emailSpec.configured })}
+                  >{t`Email it`}</h3>
+                </div>
+                <Text
+                  lineHeight={1.5}
+                  className={cx("text-medium", {
+                    "hover-child hover--inherit": emailSpec.configured,
+                  })}
+                >
+                  {!emailSpec.configured &&
+                    jt`You'll need to ${(
+                      <Link to="/admin/settings/email" className="link">
+                        set up email
+                      </Link>
+                    )} first.`}
+                  {emailSpec.configured &&
+                    t`You can send this dashboard regularly to users or email addresses.`}
+                </Text>
+              </div>
+            </Card>
+            <Card
+              flat
+              className={cx({
+                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
+                  slackSpec.configured,
+              })}
+              onClick={() => {
+                if (slackSpec.configured) {
+                  this.setState({
+                    editingMode: "add-edit-slack",
+                    returnMode: this.state.editingMode,
+                  });
+                  this.addChannel("slack");
+                }
+              }}
+            >
+              <div className="px3 pt3 pb2">
+                <div className="flex align-center mb1">
+                  <Icon
+                    name={slackSpec.configured ? "slack_colorized" : "slack"}
+                    size={24}
+                    className={cx("mr1", {
+                      "text-light": !slackSpec.configured,
+                      "hover-child hover--inherit": slackSpec.configured,
+                    })}
+                  />
+                  <h3
+                    className={cx({ "text-light": !slackSpec.configured })}
+                  >{t`Send it to Slack`}</h3>
+                </div>
+                <Text
+                  lineHeight={1.5}
+                  className={cx("text-medium", {
+                    "hover-child hover--inherit": slackSpec.configured,
+                  })}
+                >
+                  {!slackSpec.configured &&
+                    jt`First, you'll have to ${(
+                      <Link to="/admin/settings/slack" className="link">
+                        configure Slack
+                      </Link>
+                    )}.`}
+                  {slackSpec.configured &&
+                    t`Pick a channel and a schedule, and Metabase will do the rest.`}
+                </Text>
+              </div>
+            </Card>
+          </div>
+        </Sidebar>
+      );
+    }
+
     if (
       editingMode === "add-edit-email" &&
       (pulse.channels && pulse.channels.length > 0)
@@ -733,122 +869,6 @@ class SharingSidebar extends React.Component {
               />
             </div>
             {pulse.id != null && this.renderDeleteSubscription()}
-          </div>
-        </Sidebar>
-      );
-    }
-
-    if (editingMode === "new-pulse" || pulses.length === 0) {
-      const emailSpec = formInput.channels.email;
-      const slackSpec = formInput.channels.slack;
-
-      return (
-        <Sidebar onCancel={this.onCancel}>
-          <div className="mt2 pt2 px4">
-            <Heading>{t`Create a dashboard subscription`}</Heading>
-          </div>
-          <div className="my1 mx4">
-            <Card
-              flat
-              className={cx("mt1 mb3", {
-                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
-                  emailSpec.configured,
-              })}
-              onClick={() => {
-                if (emailSpec.configured) {
-                  this.setState(({ returnMode }) => {
-                    return {
-                      editingMode: "add-edit-email",
-                      returnMode: returnMode.concat([editingMode]),
-                    };
-                  });
-                  this.addChannel("email");
-                }
-              }}
-            >
-              <div className="px3 pt3 pb2">
-                <div className="flex align-center">
-                  <Icon
-                    name="mail"
-                    className={cx(
-                      "mr1",
-                      {
-                        "text-brand hover-child hover--inherit":
-                          emailSpec.configured,
-                      },
-                      { "text-light": !emailSpec.configured },
-                    )}
-                  />
-                  <h3
-                    className={cx({ "text-light": !emailSpec.configured })}
-                  >{t`Email it`}</h3>
-                </div>
-                <Text
-                  lineHeight={1.5}
-                  className={cx("text-medium", {
-                    "hover-child hover--inherit": emailSpec.configured,
-                  })}
-                >
-                  {!emailSpec.configured &&
-                    jt`You'll need to ${(
-                      <Link to="/admin/settings/email" className="link">
-                        set up email
-                      </Link>
-                    )} first.`}
-                  {emailSpec.configured &&
-                    t`You can send this dashboard regularly to users or email addresses.`}
-                </Text>
-              </div>
-            </Card>
-            <Card
-              flat
-              className={cx({
-                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
-                  slackSpec.configured,
-              })}
-              onClick={() => {
-                if (slackSpec.configured) {
-                  this.setState(({ returnMode }) => {
-                    return {
-                      editingMode: "add-edit-slack",
-                      returnMode: returnMode.concat([editingMode]),
-                    };
-                  });
-                  this.addChannel("slack");
-                }
-              }}
-            >
-              <div className="px3 pt3 pb2">
-                <div className="flex align-center mb1">
-                  <Icon
-                    name={slackSpec.configured ? "slack_colorized" : "slack"}
-                    size={24}
-                    className={cx("mr1", {
-                      "text-light": !slackSpec.configured,
-                      "hover-child hover--inherit": slackSpec.configured,
-                    })}
-                  />
-                  <h3
-                    className={cx({ "text-light": !slackSpec.configured })}
-                  >{t`Send it to Slack`}</h3>
-                </div>
-                <Text
-                  lineHeight={1.5}
-                  className={cx("text-medium", {
-                    "hover-child hover--inherit": slackSpec.configured,
-                  })}
-                >
-                  {!slackSpec.configured &&
-                    jt`First, you'll have to ${(
-                      <Link to="/admin/settings/slack" className="link">
-                        configure Slack
-                      </Link>
-                    )}.`}
-                  {slackSpec.configured &&
-                    t`Pick a channel and a schedule, and Metabase will do the rest.`}
-                </Text>
-              </div>
-            </Card>
           </div>
         </Sidebar>
       );

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -237,18 +237,6 @@ export function createBasicAlert({ firstAlert, includeNormal } = {}) {
   cy.findByText("Let's set up your alert").should("not.exist");
 }
 
-export function setupDummySMTP() {
-  cy.log("**Set up dummy SMTP server**");
-  cy.request("PUT", "/api/setting", {
-    "email-smtp-host": "smtp.foo.test",
-    "email-smtp-port": "587",
-    "email-smtp-security": "none",
-    "email-smtp-username": "nevermind",
-    "email-smtp-password": "it-is-secret-NOT",
-    "email-from-address": "nonexisting@metabase.test",
-  });
-}
-
 /*****************************************
  **            QA DATABASES             **
  ******************************************/

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -7,7 +7,6 @@ import {
   popover,
   USERS,
   USER_GROUPS,
-  setupDummySMTP,
 } from "__support__/cypress";
 
 const { normal, admin } = USERS;
@@ -180,7 +179,15 @@ describe("scenarios > admin > people", () => {
       const { first_name, last_name } = normal;
       const FULL_NAME = `${first_name} ${last_name}`;
 
-      setupDummySMTP();
+      // Dummy SMTP setup
+      cy.request("PUT", "/api/setting", {
+        "email-smtp-host": "smtp.foo.test",
+        "email-smtp-port": "587",
+        "email-smtp-security": "none",
+        "email-smtp-username": "nevermind",
+        "email-smtp-password": "it-is-secret-NOT",
+        "email-from-address": "nonexisting@metabase.test",
+      });
 
       cy.visit("/admin/people");
       showUserOptions(FULL_NAME);

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -1,108 +1,51 @@
-import {
-  restore,
-  signInAsAdmin,
-  setupDummySMTP,
-  USERS,
-} from "__support__/cypress";
+import { restore, signInAsAdmin, USERS } from "__support__/cypress";
 const { admin } = USERS;
 
-describe("scenarios > dashboard > subscriptions", () => {
+describe("scenarios > dashboard", () => {
   beforeEach(() => {
     restore();
     signInAsAdmin();
-  });
-
-  it("should not allow creation if there are no dashboard cards", () => {
-    cy.log("**Create fresh new dashboard**");
-    cy.request("POST", "/api/dashboard", {
-      name: "Empty Dashboard",
-    }).then(({ body: { id: DASHBOARD_ID } }) => {
-      cy.visit(`/dashboard/${DASHBOARD_ID}`);
-    });
-    // It would be great if we can use either aria-attributes or better class naming to suggest when icons are disabled
-    cy.get(".Icon-share")
-      .closest("a")
-      .should("have.class", "cursor-default");
-  });
-
-  describe("with no channels set up", () => {
-    it("should instruct user to connect email or slack", () => {
-      openDashboardSubscriptions();
-      // Look for the messaging about configuring slack and email
-      cy.findByRole("link", { name: /set up email/i });
-      cy.findByRole("link", { name: /configure Slack/i });
+    // Dummy SMTP setup
+    cy.request("PUT", "/api/setting", {
+      "email-smtp-host": "smtp.foo.test",
+      "email-smtp-port": "587",
+      "email-smtp-security": "none",
+      "email-smtp-username": "nevermind",
+      "email-smtp-password": "it-is-secret-NOT",
+      "email-from-address": "nonexisting@metabase.test",
     });
   });
 
-  describe("with email and slack set up", () => {
-    beforeEach(() => {
-      setupDummySMTP();
-    });
-
-    describe("with no existing subscriptions", () => {
-      it("should allow creation of a new email subscription", () => {
-        createEmailSubscription();
-        cy.findByText("Emailed daily at 8:00 AM");
+  it.skip("should persist attachments for dashboard subscriptions (metabase#14117)", () => {
+    // Orders in a dashboard
+    cy.visit("/dashboard/1");
+    cy.get(".Icon-share").click();
+    cy.findByText("Dashboard subscriptions").click();
+    cy.findByText("Email it").click();
+    cy.findByPlaceholderText("Enter user names or email addresses")
+      .click()
+      .type(`${admin.first_name} ${admin.last_name}{enter}`);
+    // This is extremely fragile
+    // TODO: update test once changes from `https://github.com/metabase/metabase/pull/14121` are merged into `master`
+    cy.findByText("Attach results")
+      .parent()
+      .parent()
+      .next()
+      .find("a") // Toggle
+      .click();
+    cy.findByText("Questions to attach").click();
+    cy.contains("Done")
+      .closest(".Button")
+      .should("not.be.disabled")
+      .click();
+    cy.findByText("Subscriptions");
+    cy.findByText("Emailed daily at 8:00 AM").click();
+    cy.findByText("Delete this subscription").scrollIntoView();
+    cy.findByText("Questions to attach");
+    cy.findAllByRole("listitem")
+      .contains("Orders") // yields the whole <li> element
+      .within(() => {
+        cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
       });
-    });
-
-    describe("with existing subscriptions", () => {
-      beforeEach(createEmailSubscription);
-      it("should show existing dashboard subscriptions", () => {
-        openDashboardSubscriptions();
-        cy.findByText("Emailed daily at 8:00 AM");
-      });
-    });
-
-    it("should persist attachments for dashboard subscriptions (metabase#14117)", () => {
-      assignRecipient();
-      // This is extremely fragile
-      // TODO: update test once changes from `https://github.com/metabase/metabase/pull/14121` are merged into `master`
-      cy.findByText("Attach results")
-        .parent()
-        .parent()
-        .next()
-        .find("a") // Toggle
-        .click();
-      cy.findByText("Questions to attach").click();
-      clickButton("Done");
-      cy.findByText("Subscriptions");
-      cy.findByText("Emailed daily at 8:00 AM").click();
-      cy.findByText("Delete this subscription").scrollIntoView();
-      cy.findByText("Questions to attach");
-      cy.findAllByRole("listitem")
-        .contains("Orders") // yields the whole <li> element
-        .within(() => {
-          cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
-        });
-    });
   });
 });
-
-// Helper functions
-function openDashboardSubscriptions(dashboard_id = 1) {
-  // Orders in a dashboard
-  cy.visit(`/dashboard/${dashboard_id}`);
-  cy.get(".Icon-share").click();
-  cy.findByText("Dashboard subscriptions").click();
-}
-
-function assignRecipient(user = admin) {
-  openDashboardSubscriptions();
-  cy.findByText("Email it").click();
-  cy.findByPlaceholderText("Enter user names or email addresses")
-    .click()
-    .type(`${user.first_name} ${user.last_name}{enter}`);
-}
-
-function clickButton(button_name) {
-  cy.contains(button_name)
-    .closest(".Button")
-    .should("not.be.disabled")
-    .click();
-}
-
-function createEmailSubscription() {
-  assignRecipient();
-  clickButton("Done");
-}

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7838,6 +7838,9 @@ databaseChangeLog:
       id: 275
       author: dpsutton
       comment: 'Added 0.38.0 refingerprint to Database'
+      validCheckSum:
+        - 8:b976d49f4eb84664649119f5f63465dd
+        - 8:447d9e294f59dd1058940defec7e0f40
       changes:
         - addColumn:
             tableName: metabase_database
@@ -7845,25 +7848,30 @@ databaseChangeLog:
               - column:
                   name: refingerprint
                   type: boolean
+                  remarks: 'Whether or not to enable periodic refingerprinting for this Database.'
                   constraints:
                     nullable: true
   - changeSet:
       id: 276
       author: robroland
       comment: Added 0.38.0 - Dashboard subscriptions
+      validCheckSum:
+        - 8:dfe9b8333b600c739306caa85d95ad55
+        - 8:59dd1fb0732c7a9b78bce896c0cff3c0
       changes:
         - addColumn:
+            tableName: pulse_card
             columns:
             - column:
                 name: dashboard_card_id
                 type: int
+                remarks: 'If this Pulse is a Dashboard subscription, the ID of the DashboardCard that corresponds to this PulseCard.'
                 constraints:
                   nullable: true
                   references: report_dashboardcard(id)
                   foreignKeyName: fk_pulse_card_ref_pulse_card_id
                   deferrable: false
                   initiallyDeferred: false
-            tableName: pulse_card
 
   - changeSet:
       id: 277
@@ -7886,3 +7894,48 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_pulse_card_ref_pulse_card_id
             onDelete: CASCADE
+
+  - changeSet:
+      id: 279
+      author: camsaul
+      comment: Added 0.38.0 - Dashboard subscriptions
+      changes:
+        - addColumn:
+            tableName: pulse
+            columns:
+              - column:
+                  name: dashboard_id
+                  type: int
+                  remarks: 'ID of the Dashboard if this Pulse is a Dashboard Subscription.'
+
+  # FK constraint is added separately because deleteCascade doesn't work in addColumn -- see #14321
+  - changeSet:
+      id: 280
+      author: camsaul
+      comment: Added 0.38.0 - Dashboard subscriptions
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse
+            baseColumnNames: dashboard_id
+            referencedTableName: report_dashboard
+            referencedColumnNames: id
+            constraintName: fk_pulse_ref_dashboard_id
+            onDelete: CASCADE
+
+
+# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
+
+########################################################################################################################
+#
+# ADVICE:
+#
+# 1) Run ./bin/lint-migrations-file.sh to run core.spec checks against any changes you make here. Liquibase is pretty
+#    forgiving and won't complain if you accidentally mix up things like deleteCascade and onDelete: CASCADE. CI runs
+#    this check but it's nicer to know now instead of waiting for CI.
+#
+# 2) Please post a message in the Metabase Slack #migrations channel to let others know you are creating a new
+#    migration so someone else doesn't steal your ID number
+#
+# PLEASE KEEP THIS MESSAGE AT THE BOTTOM OF THIS FILE!!!!! Add new migrations above the message.
+#
+########################################################################################################################

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -317,7 +317,6 @@
     (events/publish-event! :dashboard-delete (assoc dashboard :actor_id api/*current-user-id*)))
   api/generic-204-no-content)
 
-
 ;; TODO - param should be `card_id`, not `cardId` (fix here + on frontend at the same time)
 (api/defendpoint POST "/:id/cards"
   "Add a `Card` to a Dashboard."
@@ -331,7 +330,6 @@
                                                                  (assoc :creator_id api/*current-user*)
                                                                  (dissoc :cardId))))
     (events/publish-event! :dashboard-add-cards {:id id, :actor_id api/*current-user-id*, :dashcards [<>]})))
-
 
 ;; TODO - we should use schema to validate the format of the Cards :D
 (api/defendpoint PUT "/:id/cards"
@@ -350,7 +348,6 @@
   (events/publish-event! :dashboard-reposition-cards {:id id, :actor_id api/*current-user-id*, :dashcards cards})
   {:status :ok})
 
-
 (api/defendpoint DELETE "/:id/cards"
   "Remove a `DashboardCard` from a Dashboard."
   [id dashcardId]
@@ -358,15 +355,13 @@
   (api/check-not-archived (api/write-check Dashboard id))
   (when-let [dashboard-card (DashboardCard (Integer/parseInt dashcardId))]
     (api/check-500 (delete-dashboard-card! dashboard-card api/*current-user-id*))
-    {:success true})) ; TODO - why doesn't this return a 204 'No Content' response?
-
+    api/generic-204-no-content))
 
 (api/defendpoint GET "/:id/revisions"
   "Fetch `Revisions` for Dashboard with ID."
   [id]
   (api/read-check Dashboard id)
   (revision/revisions+details Dashboard id))
-
 
 (api/defendpoint POST "/:id/revert"
   "Revert a Dashboard to a prior `Revision`."

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -34,7 +34,7 @@
   {archived     (s/maybe su/BooleanString)
    dashboard_id (s/maybe su/IntGreaterThanZero)}
   (as-> (pulse/retrieve-pulses {:archived?    (Boolean/parseBoolean archived)
-                                :dashboard_id dashboard_id}) <>
+                                :dashboard-id dashboard_id}) <>
     (filter mi/can-read? <>)
     (hydrate <> :can_write)))
 

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -304,7 +304,9 @@
   (-> (base-query-for-model Pulse search-ctx)
       (add-collection-join-and-where-clauses :pulse.collection_id search-ctx)
       ;; We don't want alerts included in pulse results
-      (h/merge-where [:= :alert_condition nil])))
+      (h/merge-where [:and
+                      [:= :alert_condition nil]
+                      [:= :pulse.dashboard_id nil]])))
 
 (s/defmethod search-query-for-model (class Metric)
   [_ search-ctx :- SearchContext]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -159,7 +159,7 @@
           (dissoc dashcard :actor_id))))))
 
 (defn delete-dashboard-card!
-  "Delete a DashboardCard`"
+  "Delete a DashboardCard."
   [dashboard-card user-id]
   {:pre [(map? dashboard-card)
          (integer? user-id)]}

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -488,9 +488,7 @@
     (map? object-or-id)     (recur (:id object-or-id))
     (integer? object-or-id) object-or-id))
 
-;; TODO - now that I think about this, I think this should be called `the-id` instead, because the idea is similar to
-;; `clojure.core/the-ns`
-(defn get-id
+(defn the-id
   "If passed an integer ID, returns it. If passed a map containing an `:id` key, returns the value if it is an integer.
   Otherwise, throws an Exception.
 
@@ -500,6 +498,10 @@
   ^Integer [object-or-id]
   (or (id object-or-id)
       (throw (Exception. (tru "Not something with an ID: {0}" object-or-id)))))
+
+(def ^:deprecated ^Integer ^{:arglists '([object-or-id])} get-id
+  "DEPRECATED: Use `the-id` instead, which does the same thing, but has a clearer name."
+  the-id)
 
 ;; This is made `^:const` so it will get calculated when the uberjar is compiled. `find-namespaces` won't work if
 ;; source is excluded; either way this takes a few seconds, so doing it at compile time speeds up launch as well.

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -242,7 +242,8 @@
                                  :created_at    true})]
    :skip_if_empty       true
    :collection_id       false
-   :collection_position nil})
+   :collection_position nil
+   :dashboard_id        false})
 
 (def ^:private daily-email-channel
   {:enabled       true

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3,7 +3,6 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.walk :as walk]
-            [expectations :refer [expect]]
             [medley.core :as m]
             [metabase.api.card-test :as card-api-test]
             [metabase.api.dashboard :as dashboard-api]
@@ -25,8 +24,7 @@
             [metabase.test :as mt]
             [metabase.util :as u]
             [ring.util.codec :as codec]
-            [toucan.db :as db]
-            [toucan.util.test :as tt])
+            [toucan.db :as db])
   (:import java.util.UUID))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -73,7 +71,7 @@
 
 (defn- do-with-dashboards-in-a-collection [grant-collection-perms-fn! dashboards-or-ids f]
   (mt/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
+    (mt/with-temp Collection [collection]
       (grant-collection-perms-fn! (group/all-users) collection)
       (doseq [dashboard-or-id dashboards-or-ids]
         (db/update! Dashboard (u/get-id dashboard-or-id) :collection_id (u/get-id collection)))
@@ -132,7 +130,7 @@
 (deftest create-dashboard-test
   (testing "POST /api/dashboard"
     (mt/with-non-admin-groups-no-root-collection-perms
-      (tt/with-temp Collection [collection]
+      (mt/with-temp Collection [collection]
         (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
         (let [test-dashboard-name "Test Create Dashboard"]
           (try
@@ -155,7 +153,7 @@
   (testing "POST /api/dashboard"
     (testing "Make sure we can create a Dashboard with a Collection position"
       (mt/with-non-admin-groups-no-root-collection-perms
-        (tt/with-temp Collection [collection]
+        (mt/with-temp Collection [collection]
           (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
           (let [dashboard-name (mt/random-name)]
             (try
@@ -169,7 +167,7 @@
                 (db/delete! Dashboard :name dashboard-name)))))
 
         (testing "..but not if we don't have permissions for the Collection"
-          (tt/with-temp Collection [collection]
+          (mt/with-temp Collection [collection]
             (let [dashboard-name (mt/random-name)]
               ((mt/user->client :rasta) :post 403 "dashboard" {:name                dashboard-name
                                                                :collection_id       (u/get-id collection)
@@ -186,7 +184,7 @@
 (deftest fetch-dashboard-test
   (testing "GET /api/dashboard/:id"
     (testing "fetch a dashboard WITH a dashboard card on it"
-      (tt/with-temp* [Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
+      (mt/with-temp* [Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
                       Card          [{card-id :id}      {:name "Dashboard Test Card"}]
                       DashboardCard [_                  {:dashboard_id dashboard-id, :card_id card-id}]]
         (with-dashboards-in-readable-collection [dashboard-id]
@@ -269,7 +267,7 @@
   (testing "GET /api/dashboard/:id"
     (testing "Fetch Dashboard with a series, should fail if the User doesn't have access to the Collection"
       (mt/with-non-admin-groups-no-root-collection-perms
-        (tt/with-temp* [Collection          [{coll-id :id}      {:name "Collection 1"}]
+        (mt/with-temp* [Collection          [{coll-id :id}      {:name "Collection 1"}]
                         Dashboard           [{dashboard-id :id} {:name       "Test Dashboard"
                                                                  :creator_id (mt/user->id :crowberto)}]
                         Card                [{card-id :id}      {:name          "Dashboard Test Card"
@@ -289,7 +287,7 @@
 
 (deftest update-dashboard-test
   (testing "PUT /api/dashboard/:id"
-    (tt/with-temp Dashboard [{dashboard-id :id} {:name "Test Dashboard"}]
+    (mt/with-temp Dashboard [{dashboard-id :id} {:name "Test Dashboard"}]
       (with-dashboards-in-writeable-collection [dashboard-id]
         (testing "GET before update"
           (is (= (merge dashboard-defaults {:name          "Test Dashboard"
@@ -319,7 +317,7 @@
 (deftest update-dashboard-guide-columns-test
   (testing "PUT /api/dashboard/:id"
     (testing "allow `:caveats` and `:points_of_interest` to be empty strings, and `:show_in_getting_started` should be a boolean"
-      (tt/with-temp Dashboard [{dashboard-id :id} {:name "Test Dashboard"}]
+      (mt/with-temp Dashboard [{dashboard-id :id} {:name "Test Dashboard"}]
         (with-dashboards-in-writeable-collection [dashboard-id]
           (is (= (merge dashboard-defaults {:name                    "Test Dashboard"
                                             :creator_id              (mt/user->id :rasta)
@@ -335,7 +333,7 @@
 (deftest update-dashboard-clear-description-test
   (testing "PUT /api/dashboard/:id"
     (testing "Can we clear the description of a Dashboard? (#4738)"
-      (tt/with-temp Dashboard [dashboard {:description "What a nice Dashboard"}]
+      (mt/with-temp Dashboard [dashboard {:description "What a nice Dashboard"}]
         (with-dashboards-in-writeable-collection [dashboard]
           ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id dashboard)) {:description nil})
           (is (= nil
@@ -350,7 +348,7 @@
   (testing "PUT /api/dashboard/:id"
     (testing "Can we change the Collection a Dashboard is in (assuming we have the permissions to do so)?"
       (dashboard-test/with-dash-in-collection [db collection dash]
-        (tt/with-temp Collection [new-collection]
+        (mt/with-temp Collection [new-collection]
           ;; grant Permissions for both new and old collections
           (doseq [coll [collection new-collection]]
             (perms/grant-collection-readwrite-permissions! (group/all-users) coll))
@@ -363,7 +361,7 @@
     (testing "if we don't have the Permissions for the old collection, we should get an Exception"
       (mt/with-non-admin-groups-no-root-collection-perms
         (dashboard-test/with-dash-in-collection [db collection dash]
-          (tt/with-temp Collection [new-collection]
+          (mt/with-temp Collection [new-collection]
             ;; grant Permissions for only the *new* collection
             (perms/grant-collection-readwrite-permissions! (group/all-users) new-collection)
             ;; now make an API call to move collections. Should fail
@@ -374,7 +372,7 @@
     (testing "if we don't have the Permissions for the new collection, we should get an Exception"
       (mt/with-non-admin-groups-no-root-collection-perms
         (dashboard-test/with-dash-in-collection [db collection dash]
-          (tt/with-temp Collection [new-collection]
+          (mt/with-temp Collection [new-collection]
             ;; grant Permissions for only the *old* collection
             (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
             ;; now make an API call to move collections. Should fail
@@ -391,7 +389,7 @@
   (testing "PUT /api/dashboard/:id"
     (testing "Can we change the Collection position of a Dashboard?"
       (mt/with-non-admin-groups-no-root-collection-perms
-        (tt/with-temp* [Collection [collection]
+        (mt/with-temp* [Collection [collection]
                         Dashboard  [dashboard {:collection_id (u/get-id collection)}]]
           (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
           ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id dashboard))
@@ -406,141 +404,113 @@
                    (db/select-one-field :collection_position Dashboard :id (u/get-id dashboard))))))
 
         (testing "we shouldn't be able to if we don't have permissions for the Collection"
-          (tt/with-temp* [Collection [collection]
+          (mt/with-temp* [Collection [collection]
                           Dashboard  [dashboard {:collection_id (u/get-id collection)}]]
             ((mt/user->client :rasta) :put 403 (str "dashboard/" (u/get-id dashboard))
              {:collection_position 1})
             (is (= nil
                    (db/select-one-field :collection_position Dashboard :id (u/get-id dashboard)))))
 
-          (tt/with-temp* [Collection [collection]
+          (mt/with-temp* [Collection [collection]
                           Dashboard  [dashboard {:collection_id (u/get-id collection), :collection_position 1}]]
             ((mt/user->client :rasta) :put 403 (str "dashboard/" (u/get-id dashboard))
              {:collection_position nil})
             (is (= 1
                    (db/select-one-field :collection_position Dashboard :id (u/get-id dashboard))))))))))
 
-;; Check that we can update a dashboard's position in a collection of only dashboards
-(expect
- {"a" 1
-  "c" 2
-  "d" 3
-  "b" 4}
- (mt/with-non-admin-groups-no-root-collection-perms
-   (tt/with-temp Collection [collection]
-     (card-api-test/with-ordered-items collection [Dashboard a
-                                                   Dashboard b
-                                                   Dashboard c
-                                                   Dashboard d]
-       (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-       ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id b))
-        {:collection_position 4})
-       (card-api-test/get-name->collection-position :rasta collection)))))
+(deftest update-dashboard-position-test
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp Collection [collection]
+      (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
+      (letfn [(move-dashboard! [dashboard new-position]
+                (mt/user-http-request :rasta :put 200 (str "dashboard/" (u/the-id dashboard))
+                                      {:collection_position new-position}))
+              (items []
+                (card-api-test/get-name->collection-position :rasta collection))]
+        (testing "Check that we can update a dashboard's position in a collection of only dashboards"
+          (card-api-test/with-ordered-items collection [Dashboard a
+                                                        Dashboard b
+                                                        Dashboard c
+                                                        Dashboard d]
+            (move-dashboard! b 4)
+            (is (= {"a" 1, "c" 2, "d" 3, "b" 4}
+                   (items)))))
 
-;; Check that updating a dashboard at position 3 to position 1 will increment the positions before 3, not after
-(expect
- {"c" 1
-  "a" 2
-  "b" 3
-  "d" 4}
- (mt/with-non-admin-groups-no-root-collection-perms
-   (tt/with-temp Collection [collection]
-     (card-api-test/with-ordered-items collection [Card      a
-                                                   Pulse     b
-                                                   Dashboard c
-                                                   Dashboard d]
-       (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-       ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id c))
-        {:collection_position 1})
-       (card-api-test/get-name->collection-position :rasta collection)))))
+        (testing "Check that updating a dashboard at position 3 to position 1 will increment the positions before 3, not after"
+          (card-api-test/with-ordered-items collection [Card      a
+                                                        Pulse     b
+                                                        Dashboard c
+                                                        Dashboard d]
+            (move-dashboard! c 1)
+            (is (= {"c" 1, "a" 2, "b" 3, "d" 4}
+                   (items)))))
 
-;; Check that updating position 1 to 3 will cause b and c to be decremented
-(expect
- {"b" 1
-  "c" 2
-  "a" 3
-  "d" 4}
- (mt/with-non-admin-groups-no-root-collection-perms
-   (tt/with-temp Collection [collection]
-     (card-api-test/with-ordered-items collection [Dashboard a
-                                                   Card      b
-                                                   Pulse     c
-                                                   Dashboard d]
-       (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-       ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id a))
-        {:collection_position 3})
-       (card-api-test/get-name->collection-position :rasta collection)))))
+        (testing "Check that updating position 1 to 3 will cause b and c to be decremented"
+          (card-api-test/with-ordered-items collection [Dashboard a
+                                                        Card      b
+                                                        Pulse     c
+                                                        Dashboard d]
+            (move-dashboard! a 3)
+            (is (= {"b" 1, "c" 2, "a" 3, "d" 4}
+                   (items)))))
 
-;; Check that updating position 1 to 4 will cause a through c to be decremented
-(expect
- {"b" 1
-  "c" 2
-  "d" 3
-  "a" 4}
- (mt/with-non-admin-groups-no-root-collection-perms
-   (tt/with-temp Collection [collection]
-     (card-api-test/with-ordered-items collection [Dashboard a
-                                                   Card      b
-                                                   Pulse     c
-                                                   Pulse     d]
-       (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-       ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id a))
-        {:collection_position 4})
-       (card-api-test/get-name->collection-position :rasta collection)))))
 
-;; Check that updating position 4 to 1 will cause a through c to be incremented
-(expect
- {"d" 1
-  "a" 2
-  "b" 3
-  "c" 4}
- (mt/with-non-admin-groups-no-root-collection-perms
-   (tt/with-temp Collection [collection]
-     (card-api-test/with-ordered-items collection [Card      a
-                                                   Pulse     b
-                                                   Card      c
-                                                   Dashboard d]
-       (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
-       ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id d))
-        {:collection_position 1})
-       (card-api-test/get-name->collection-position :rasta collection)))))
+        (testing "Check that updating position 1 to 4 will cause a through c to be decremented"
+          (card-api-test/with-ordered-items collection [Dashboard a
+                                                        Card      b
+                                                        Pulse     c
+                                                        Pulse     d]
+            (move-dashboard! a 4)
+            (is (= {"b" 1, "c" 2, "d" 3, "a" 4}
+                   (items)))))
 
-;; Check that moving a dashboard to another collection will fixup both collections
-(expect
- [{"b" 1
-   "c" 2
-   "d" 3}
-  {"a" 1
-   "e" 2
-   "f" 3
-   "g" 4
-   "h" 5}]
- (mt/with-non-admin-groups-no-root-collection-perms
-   (tt/with-temp* [Collection [collection-1]
-                   Collection [collection-2]]
-     (card-api-test/with-ordered-items collection-1 [Dashboard a
-                                                     Card      b
-                                                     Card      c
-                                                     Pulse     d]
-       (card-api-test/with-ordered-items collection-2 [Pulse     e
-                                                       Pulse     f
-                                                       Dashboard g
-                                                       Card      h]
-         (perms/grant-collection-readwrite-permissions! (group/all-users) collection-1)
-         (perms/grant-collection-readwrite-permissions! (group/all-users) collection-2)
-         ;; Move the first dashboard in collection-1 to collection-1
-         ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id a))
-          {:collection_position 1, :collection_id (u/get-id collection-2)})
-         ;; "a" should now be gone from collection-1 and all the existing dashboards bumped down in position
-         [(card-api-test/get-name->collection-position :rasta collection-1)
-          ;; "a" is now first, all other dashboards in collection-2 bumped down 1
-          (card-api-test/get-name->collection-position :rasta collection-2)])))))
+        (testing "Check that updating position 4 to 1 will cause a through c to be incremented"
+          (card-api-test/with-ordered-items collection [Card      a
+                                                        Pulse     b
+                                                        Card      c
+                                                        Dashboard d]
+            (move-dashboard! d 1)
+            (is (= {"d" 1, "a" 2, "b" 3, "c" 4}
+                   (items)))))))))
+
+(deftest move-dashboard-to-different-collection-test
+  (testing "Check that moving a dashboard to another collection will fixup both collections"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [collection-1]
+                      Collection [collection-2]]
+        (card-api-test/with-ordered-items collection-1 [Dashboard a
+                                                        Card      b
+                                                        Card      c
+                                                        Pulse     d]
+          (card-api-test/with-ordered-items collection-2 [Pulse     e
+                                                          Pulse     f
+                                                          Dashboard g
+                                                          Card      h]
+            (perms/grant-collection-readwrite-permissions! (group/all-users) collection-1)
+            (perms/grant-collection-readwrite-permissions! (group/all-users) collection-2)
+            ;; Move the first dashboard in collection-1 to collection-1
+            ((mt/user->client :rasta) :put 200 (str "dashboard/" (u/get-id a))
+             {:collection_position 1, :collection_id (u/get-id collection-2)})
+            ;; "a" should now be gone from collection-1 and all the existing dashboards bumped down in position
+            (testing "original collection"
+              (is (= {"b" 1
+                      "c" 2
+                      "d" 3}
+                     (card-api-test/get-name->collection-position :rasta collection-1))))
+            ;; "a" is now first, all other dashboards in collection-2 bumped down 1
+            (testing "new collection"
+              (is (= {"a" 1
+                      "e" 2
+                      "f" 3
+                      "g" 4
+                      "h" 5}
+                     (card-api-test/get-name->collection-position :rasta collection-2))))))))))
 
 (deftest insert-dashboard-increment-existing-collection-position-test
   (testing "POST /api/dashboard"
     (testing "Check that adding a new Dashboard at Collection position 3 will increment position of the existing item at position 3"
       (mt/with-non-admin-groups-no-root-collection-perms
-        (tt/with-temp Collection [collection]
+        (mt/with-temp Collection [collection]
           (card-api-test/with-ordered-items collection [Card  a
                                                         Pulse b
                                                         Card  d]
@@ -565,7 +535,7 @@
   (testing "POST /api/dashboard"
     (testing "Check that adding a new Dashboard without a position, leaves the existing positions unchanged"
       (mt/with-non-admin-groups-no-root-collection-perms
-        (tt/with-temp Collection [collection]
+        (mt/with-temp Collection [collection]
           (card-api-test/with-ordered-items collection [Dashboard a
                                                         Card      b
                                                         Pulse     d]
@@ -591,7 +561,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest delete-test
-  (tt/with-temp Dashboard [{dashboard-id :id}]
+  (mt/with-temp Dashboard [{dashboard-id :id}]
     (with-dashboards-in-writeable-collection [dashboard-id]
       (is (= nil
              ((mt/user->client :rasta) :delete 204 (format "dashboard/%d" dashboard-id))))
@@ -605,7 +575,7 @@
 (deftest copy-dashboard-test
   (testing "POST /api/dashboard/:id/copy"
     (testing "A plain copy with nothing special"
-      (tt/with-temp Dashboard [{dashboard-id :id} {:name        "Test Dashboard"
+      (mt/with-temp Dashboard [{dashboard-id :id} {:name        "Test Dashboard"
                                                    :description "A description"
                                                    :creator_id  (mt/user->id :rasta)}]
         (let [response ((mt/user->client :rasta) :post 200 (format "dashboard/%d/copy" dashboard-id))]
@@ -621,7 +591,7 @@
               (db/delete! Dashboard :id (u/get-id response)))))))
 
     (testing "Ensure name / description / user set when copying"
-      (tt/with-temp Dashboard [{dashboard-id :id}  {:name        "Test Dashboard"
+      (mt/with-temp Dashboard [{dashboard-id :id}  {:name        "Test Dashboard"
                                                     :description "An old description"}]
         (let [response ((mt/user->client :crowberto) :post 200 (format "dashboard/%d/copy" dashboard-id)
                         {:name        "Test Dashboard - Duplicate"
@@ -640,7 +610,7 @@
 (deftest copy-dashboard-cards-test
   (testing "POST /api/dashboard/:id/copy"
     (testing "Ensure dashboard cards are copied"
-      (tt/with-temp* [Dashboard     [{dashboard-id :id}  {:name "Test Dashboard"}]
+      (mt/with-temp* [Dashboard     [{dashboard-id :id}  {:name "Test Dashboard"}]
                       Card          [{card-id :id}]
                       Card          [{card-id2 :id}]
                       DashboardCard [{dashcard-id :id} {:dashboard_id dashboard-id, :card_id card-id}]
@@ -656,7 +626,7 @@
   (testing "POST /api/dashboard/:id/copy"
     (testing "Ensure the correct collection is set when copying"
       (dashboard-test/with-dash-in-collection [db collection dash]
-        (tt/with-temp Collection [new-collection]
+        (mt/with-temp Collection [new-collection]
           ;; grant Permissions for both new and old collections
           (doseq [coll [collection new-collection]]
             (perms/grant-collection-readwrite-permissions! (group/all-users) coll))
@@ -675,7 +645,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest simple-creation-with-no-additional-series-test
-  (tt/with-temp* [Dashboard [{dashboard-id :id}]
+  (mt/with-temp* [Dashboard [{dashboard-id :id}]
                   Card      [{card-id :id}]]
     (with-dashboards-in-writeable-collection [dashboard-id]
       (card-api-test/with-cards-in-readable-collection [card-id]
@@ -708,7 +678,7 @@
                       :dashboard_id dashboard-id))))))))
 
 (deftest new-dashboard-card-with-additional-series-test
-  (tt/with-temp* [Dashboard [{dashboard-id :id}]
+  (mt/with-temp* [Dashboard [{dashboard-id :id}]
                   Card      [{card-id :id}]
                   Card      [{series-id-1 :id} {:name "Series Card"}]]
     (with-dashboards-in-writeable-collection [dashboard-id]
@@ -749,7 +719,7 @@
 (deftest delete-cards-test
   (testing "DELETE /api/dashboard/id/:cards"
     ;; fetch a dashboard WITH a dashboard card on it
-    (tt/with-temp* [Dashboard           [{dashboard-id :id}]
+    (mt/with-temp* [Dashboard           [{dashboard-id :id}]
                     Card                [{card-id :id}]
                     Card                [{series-id-1 :id}]
                     Card                [{series-id-2 :id}]
@@ -759,8 +729,9 @@
       (with-dashboards-in-writeable-collection [dashboard-id]
         (is (= 1
                (count (db/select-ids DashboardCard, :dashboard_id dashboard-id))))
-        (is (= {:success true}
-               ((mt/user->client :rasta) :delete 200 (format "dashboard/%d/cards" dashboard-id) :dashcardId dashcard-id)))
+        (is (= nil
+               (mt/user-http-request :rasta :delete 204
+                                     (format "dashboard/%d/cards" dashboard-id) :dashcardId dashcard-id)))
         (is (= 0
                (count (db/select-ids DashboardCard, :dashboard_id dashboard-id))))))))
 
@@ -772,7 +743,7 @@
 (deftest update-cards-test
   (testing "PUT /api/dashboard/:id/cards"
     ;; fetch a dashboard WITH a dashboard card on it
-    (tt/with-temp* [Dashboard     [{dashboard-id :id}]
+    (mt/with-temp* [Dashboard     [{dashboard-id :id}]
                     Card          [{card-id :id}]
                     DashboardCard [{dashcard-id-1 :id} {:dashboard_id dashboard-id, :card_id card-id}]
                     DashboardCard [{dashcard-id-2 :id} {:dashboard_id dashboard-id, :card_id card-id}]
@@ -841,52 +812,53 @@
 ;;; |                                        GET /api/dashboard/:id/revisions                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(expect
- [{:is_reversion false
-   :is_creation  false
-   :message      "updated"
-   :user         (-> (user-details (mt/fetch-user :crowberto))
-                     (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
-   :diff         {:before {:name        "b"
-                           :description nil
-                           :cards       [{:series nil, :sizeY 2, :sizeX 2}]}
-                  :after  {:name        "c"
-                           :description "something"
-                           :cards       [{:series [8 9], :sizeY 3, :sizeX 4}]}}
-   :description  "renamed it from \"b\" to \"c\", added a description, rearranged the cards and added some series to card 123."}
-  {:is_reversion false
-   :is_creation  true
-   :message      nil
-   :user         (-> (user-details (mt/fetch-user :rasta))
-                     (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
-   :diff         nil
-   :description  nil}]
- (tt/with-temp* [Dashboard [{dashboard-id :id}]
-                 Revision  [_ {:model        "Dashboard"
-                               :model_id     dashboard-id
-                               :object       {:name         "b"
-                                              :description  nil
-                                              :cards        [{:sizeX   2
-                                                              :sizeY   2
-                                                              :row     0
-                                                              :col     0
-                                                              :card_id 123
-                                                              :series  []}]}
-                               :is_creation  true}]
-                 Revision  [_ {:model    "Dashboard"
-                               :model_id dashboard-id
-                               :user_id  (mt/user->id :crowberto)
-                               :object   {:name         "c"
-                                          :description  "something"
-                                          :cards        [{:sizeX   4
-                                                          :sizeY   3
-                                                          :row     0
-                                                          :col     0
-                                                          :card_id 123
-                                                          :series  [8 9]}]}
-                               :message  "updated"}]]
-   (doall (for [revision ((mt/user->client :crowberto) :get 200 (format "dashboard/%d/revisions" dashboard-id))]
-            (dissoc revision :timestamp :id)))))
+(deftest fetch-revisions-test
+  (testing "GET /api/dashboard/:id/revisions"
+    (mt/with-temp* [Dashboard [{dashboard-id :id}]
+                    Revision  [_ {:model        "Dashboard"
+                                  :model_id     dashboard-id
+                                  :object       {:name         "b"
+                                                 :description  nil
+                                                 :cards        [{:sizeX   2
+                                                                 :sizeY   2
+                                                                 :row     0
+                                                                 :col     0
+                                                                 :card_id 123
+                                                                 :series  []}]}
+                                  :is_creation  true}]
+                    Revision  [_ {:model    "Dashboard"
+                                  :model_id dashboard-id
+                                  :user_id  (mt/user->id :crowberto)
+                                  :object   {:name         "c"
+                                             :description  "something"
+                                             :cards        [{:sizeX   4
+                                                             :sizeY   3
+                                                             :row     0
+                                                             :col     0
+                                                             :card_id 123
+                                                             :series  [8 9]}]}
+                                  :message  "updated"}]]
+      (is (= [{:is_reversion false
+               :is_creation  false
+               :message      "updated"
+               :user         (-> (user-details (mt/fetch-user :crowberto))
+                                 (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+               :diff         {:before {:name        "b"
+                                       :description nil
+                                       :cards       [{:series nil, :sizeY 2, :sizeX 2}]}
+                              :after  {:name        "c"
+                                       :description "something"
+                                       :cards       [{:series [8 9], :sizeY 3, :sizeX 4}]}}
+               :description  "renamed it from \"b\" to \"c\", added a description, rearranged the cards and added some series to card 123."}
+              {:is_reversion false
+               :is_creation  true
+               :message      nil
+               :user         (-> (user-details (mt/fetch-user :rasta))
+                                 (dissoc :email :date_joined :last_login :is_superuser :is_qbnewb))
+               :diff         nil
+               :description  nil}]
+             (doall (for [revision (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/revisions" dashboard-id))]
+                      (dissoc revision :timestamp :id))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -900,7 +872,7 @@
              ((mt/user->client :crowberto) :post 400 "dashboard/1/revert" {})))
       (is (= {:errors {:revision_id "value must be an integer greater than zero."}}
              ((mt/user->client :crowberto) :post 400 "dashboard/1/revert" {:revision_id "foobar"})))      )
-    (tt/with-temp* [Dashboard [{dashboard-id :id}]
+    (mt/with-temp* [Dashboard [{dashboard-id :id}]
                     Revision  [{revision-id :id} {:model       "Dashboard"
                                                   :model_id    dashboard-id
                                                   :object      {:name        "a"
@@ -963,56 +935,48 @@
 
 ;;; -------------------------------------- POST /api/dashboard/:id/public_link ---------------------------------------
 
-;; Test that we can share a Dashboard
-(expect
- (mt/with-temporary-setting-values [enable-public-sharing true]
-   (tt/with-temp Dashboard [dashboard]
-     (let [{uuid :uuid} ((mt/user->client :crowberto) :post 200 (format "dashboard/%d/public_link" (u/get-id dashboard)))]
-       (db/exists? Dashboard :id (u/get-id dashboard), :public_uuid uuid)))))
+(deftest share-dashboard-test
+  (mt/with-temporary-setting-values [enable-public-sharing true]
+    (testing "Test that we can share a Dashboard"
+      (mt/with-temp Dashboard [dashboard]
+        (let [{uuid :uuid} (mt/user-http-request :crowberto :post 200
+                                                 (format "dashboard/%d/public_link" (u/the-id dashboard)))]
+          (is (db/exists? Dashboard :id (u/the-id dashboard), :public_uuid uuid))
+          (testing "Test that if a Dashboard has already been shared we reüse the existing UUID"
+            (is (= uuid
+                   (:uuid (mt/user-http-request :crowberto :post 200
+                                                (format "dashboard/%d/public_link" (u/the-id dashboard))))))))))
 
-;; Test that we *cannot* share a Dashboard if we aren't admins
-(expect
- "You don't have permissions to do that."
- (mt/with-temporary-setting-values [enable-public-sharing true]
-   (tt/with-temp Dashboard [dashboard]
-     ((mt/user->client :rasta) :post 403 (format "dashboard/%d/public_link" (u/get-id dashboard))))))
+    (mt/with-temp Dashboard [dashboard]
+      (testing "Test that we *cannot* share a Dashboard if we aren't admins"
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :post 403 (format "dashboard/%d/public_link" (u/the-id dashboard))))))
 
-;; Test that we *cannot* share a Dashboard if the setting is disabled
-(expect
- "Public sharing is not enabled."
- (mt/with-temporary-setting-values [enable-public-sharing false]
-   (tt/with-temp Dashboard [dashboard]
-     ((mt/user->client :crowberto) :post 400 (format "dashboard/%d/public_link" (u/get-id dashboard))))))
+      (testing "Test that we *cannot* share a Dashboard if the setting is disabled"
+        (mt/with-temporary-setting-values [enable-public-sharing false]
+          (is (= "Public sharing is not enabled."
+                 (mt/user-http-request :crowberto :post 400 (format "dashboard/%d/public_link" (u/the-id dashboard))))))))
 
-;; Test that we get a 404 if the Dashboard doesn't exist
-(expect
- "Not found."
- (mt/with-temporary-setting-values [enable-public-sharing true]
-   ((mt/user->client :crowberto) :post 404 (format "dashboard/%d/public_link" Integer/MAX_VALUE))))
-
-;; Test that if a Dashboard has already been shared we reüse the existing UUID
-(expect
- (mt/with-temporary-setting-values [enable-public-sharing true]
-   (tt/with-temp Dashboard [dashboard (shared-dashboard)]
-     (= (:public_uuid dashboard)
-        (:uuid ((mt/user->client :crowberto) :post 200 (format "dashboard/%d/public_link" (u/get-id dashboard))))))))
+    (testing "Test that we get a 404 if the Dashboard doesn't exist"
+      (is (= "Not found."
+             (mt/user-http-request :crowberto :post 404 (format "dashboard/%d/public_link" Integer/MAX_VALUE)))))))
 
 (deftest delete-public-link-test
   (testing "DELETE /api/dashboard/:id/public_link"
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (testing "Test that we can unshare a Dashboard"
-        (tt/with-temp Dashboard [dashboard (shared-dashboard)]
+        (mt/with-temp Dashboard [dashboard (shared-dashboard)]
           ((mt/user->client :crowberto) :delete 204 (format "dashboard/%d/public_link" (u/get-id dashboard)))
           (is (= false
                  (db/exists? Dashboard :id (u/get-id dashboard), :public_uuid (:public_uuid dashboard))))))
 
       (testing "Test that we *cannot* unshare a Dashboard if we are not admins"
-        (tt/with-temp Dashboard [dashboard (shared-dashboard)]
+        (mt/with-temp Dashboard [dashboard (shared-dashboard)]
           (is (= "You don't have permissions to do that."
                  ((mt/user->client :rasta) :delete 403 (format "dashboard/%d/public_link" (u/get-id dashboard)))))))
 
       (testing "Test that we get a 404 if Dashboard isn't shared"
-        (tt/with-temp Dashboard [dashboard]
+        (mt/with-temp Dashboard [dashboard]
           (is (= "Not found."
                  ((mt/user->client :crowberto) :delete 404 (format "dashboard/%d/public_link" (u/get-id dashboard)))))))
 
@@ -1025,7 +989,7 @@
   (testing "GET /api/dashboard/public"
     (testing "Test that we can fetch a list of publicly-accessible dashboards"
       (mt/with-temporary-setting-values [enable-public-sharing true]
-        (tt/with-temp Dashboard [dashboard (shared-dashboard)]
+        (mt/with-temp Dashboard [dashboard (shared-dashboard)]
           (is (= [{:name true, :id true, :public_uuid true}]
                  (for [dash ((mt/user->client :crowberto) :get 200 "dashboard/public")]
                    (m/map-vals boolean (select-keys dash [:name :id :public_uuid]))))))))))
@@ -1034,7 +998,7 @@
   (testing "GET /api/dashboard/embeddable"
     (testing "Test that we can fetch a list of embeddable-accessible dashboards"
       (mt/with-temporary-setting-values [enable-embedding true]
-        (tt/with-temp Dashboard [dashboard {:enable_embedding true}]
+        (mt/with-temp Dashboard [dashboard {:enable_embedding true}]
           (is (= [{:name true, :id true}]
                  (for [dash ((mt/user->client :crowberto) :get 200 "dashboard/embeddable")]
                    (m/map-vals boolean (select-keys dash [:name :id]))))))))))
@@ -1044,69 +1008,73 @@
 ;;; |                                Tests for including query average duration info                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- vectorize-byte-arrays
-  "Walk form X and convert any byte arrays in the results to standard Clojure vectors. This is useful when writing
-  tests that return byte arrays (such as things that work with query hashes),since identical arrays are not considered
-  equal."
+(defn- base-64-encode-byte-arrays
+  "Walk form `x` and convert any byte arrays in the results to base-64-encoded strings. This is useful when writing
+  tests that return byte arrays (such as things that work with query hashes), since identical arrays are not
+  considered equal."
   {:style/indent 0}
   [x]
   (walk/postwalk (fn [form]
                    (if (instance? (Class/forName "[B") form)
-                     (vec form)
+                     (codec/base64-encode form)
                      form))
                  x))
 
-(expect
-  [[-109 -42 53 92 -31 19 -111 13 -11 -111 127 -110 -12 53 -42 -3 -58 -61 60 97 123 -65 -117 -110 -27 -2 -99 102 -59 -29 49 27]
-   [43 -96 52 23 -69 81 -59 15 -74 -59 -83 -9 -110 40 1 -64 -117 -44 -67 79 -123 -9 -107 20 113 -59 -93 25 60 124 -110 -30]]
-  (vectorize-byte-arrays
-   (#'dashboard-api/dashcard->query-hashes {:card {:dataset_query {:database 1}}})))
+(deftest dashcard->query-hashes-test
+  (doseq [[dashcard expected]
+          [[{:card {:dataset_query {:database 1}}}
+            ["k9Y1XOETkQ31kX+S9DXW/cbDPGF7v4uS5f6dZsXjMRs="
+             "K6A0F7tRxQ+2xa33kigBwIvUvU+F95UUccWjGTx8kuI="]]
 
-(expect
-  [[89 -75 -86 117 -35 -13 -69 -36 -17 84 37 86 -121 -59 -3 1 37 -117 -86 -42 -127 -42 -74 101 83 72 10 44 75 -126 43 66]
-   [55 56 16 11 -121 -29 71 -99 -89 -92 41 25 87 -78 34 100 54 -3 53 -9 38 41 -75 -121 63 -119 43 23 57 11 63 32]
-   [-90 55 65 61 72 22 -99 -75 111 49 -3 21 -80 68 -14 120 30 -84 -103 16 -68 73 -121 -93 -55 54 72 84 -8 118 -101 114]
-   [116 69 -44 77 100 8 -40 -67 25 -4 27 -21 111 98 -45 85 83 -27 -39 8 63 -25 -88 74 32 -10 -2 35 102 -72 -104 111]
-   [-84 -2 87 22 -4 105 68 48 -113 93 -29 52 3 102 123 -70 -123 36 31 76 -16 87 70 116 -93 109 -88 108 125 -36 -43 73]
-   [90 127 103 -71 -76 -36 41 -107 -7 -13 -83 -87 28 86 -94 110 74 -86 110 -54 -128 124 102 -73 -127 88 77 -36 62 5 -84 -100]]
-  (vectorize-byte-arrays
-    (#'dashboard-api/dashcard->query-hashes {:card   {:dataset_query {:database 2}}
-                                             :series [{:dataset_query {:database 3}}
-                                                      {:dataset_query {:database 4}}]})))
+           [{:card   {:dataset_query {:database 2}}
+             :series [{:dataset_query {:database 3}}
+                      {:dataset_query {:database 4}}]}
+            ["WbWqdd3zu9zvVCVWh8X9ASWLqtaB1rZlU0gKLEuCK0I="
+             "NzgQC4fjR52npCkZV7IiZDb9NfcmKbWHP4krFzkLPyA="
+             "pjdBPUgWnbVvMf0VsETyeB6smRC8SYejyTZIVPh2m3I="
+             "dEXUTWQI2L0Z/Bvrb2LTVVPl2Qg/56hKIPb+I2a4mG8="
+             "rP5XFvxpRDCPXeM0A2Z7uoUkH0zwV0Z0o22obH3c1Uk="
+             "Wn9nubTcKZX5862pHFaibkqqbsqAfGa3gVhN3D4FrJw="]]]]
+    (testing (pr-str dashcard)
+      (is (= expected
+             (base-64-encode-byte-arrays (#'dashboard-api/dashcard->query-hashes dashcard)))))))
 
-(expect
-  [[-109 -42 53 92 -31 19 -111 13 -11 -111 127 -110 -12 53 -42 -3 -58 -61 60 97 123 -65 -117 -110 -27 -2 -99 102 -59 -29 49 27]
-   [43 -96 52 23 -69 81 -59 15 -74 -59 -83 -9 -110 40 1 -64 -117 -44 -67 79 -123 -9 -107 20 113 -59 -93 25 60 124 -110 -30]
-   [89 -75 -86 117 -35 -13 -69 -36 -17 84 37 86 -121 -59 -3 1 37 -117 -86 -42 -127 -42 -74 101 83 72 10 44 75 -126 43 66]
-   [55 56 16 11 -121 -29 71 -99 -89 -92 41 25 87 -78 34 100 54 -3 53 -9 38 41 -75 -121 63 -119 43 23 57 11 63 32]
-   [-90 55 65 61 72 22 -99 -75 111 49 -3 21 -80 68 -14 120 30 -84 -103 16 -68 73 -121 -93 -55 54 72 84 -8 118 -101 114]
-   [116 69 -44 77 100 8 -40 -67 25 -4 27 -21 111 98 -45 85 83 -27 -39 8 63 -25 -88 74 32 -10 -2 35 102 -72 -104 111]
-   [-84 -2 87 22 -4 105 68 48 -113 93 -29 52 3 102 123 -70 -123 36 31 76 -16 87 70 116 -93 109 -88 108 125 -36 -43 73]
-   [90 127 103 -71 -76 -36 41 -107 -7 -13 -83 -87 28 86 -94 110 74 -86 110 -54 -128 124 102 -73 -127 88 77 -36 62 5 -84 -100]]
-  (vectorize-byte-arrays (#'dashboard-api/dashcards->query-hashes [{:card   {:dataset_query {:database 1}}}
-                                                                      {:card   {:dataset_query {:database 2}}
-                                                                       :series [{:dataset_query {:database 3}}
-                                                                                {:dataset_query {:database 4}}]}])))
+(deftest dashcards->query-hashes-test
+  (is (= ["k9Y1XOETkQ31kX+S9DXW/cbDPGF7v4uS5f6dZsXjMRs="
+          "K6A0F7tRxQ+2xa33kigBwIvUvU+F95UUccWjGTx8kuI="
+          "WbWqdd3zu9zvVCVWh8X9ASWLqtaB1rZlU0gKLEuCK0I="
+          "NzgQC4fjR52npCkZV7IiZDb9NfcmKbWHP4krFzkLPyA="
+          "pjdBPUgWnbVvMf0VsETyeB6smRC8SYejyTZIVPh2m3I="
+          "dEXUTWQI2L0Z/Bvrb2LTVVPl2Qg/56hKIPb+I2a4mG8="
+          "rP5XFvxpRDCPXeM0A2Z7uoUkH0zwV0Z0o22obH3c1Uk="
+          "Wn9nubTcKZX5862pHFaibkqqbsqAfGa3gVhN3D4FrJw="]
+         (base-64-encode-byte-arrays
+           (#'dashboard-api/dashcards->query-hashes
+            [{:card {:dataset_query {:database 1}}}
+             {:card   {:dataset_query {:database 2}}
+              :series [{:dataset_query {:database 3}}
+                       {:dataset_query {:database 4}}]}])))))
 
-(expect
-  [{:card   {:dataset_query {:database 1}, :query_average_duration 111}
-    :series []}
-   {:card   {:dataset_query {:database 2}, :query_average_duration 333}
-    :series [{:dataset_query {:database 3}, :query_average_duration 555}
-             {:dataset_query {:database 4}, :query_average_duration 777}]}]
-  (#'dashboard-api/add-query-average-duration-to-dashcards
-   [{:card   {:dataset_query {:database 1}}}
-    {:card   {:dataset_query {:database 2}}
-     :series [{:dataset_query {:database 3}}
-              {:dataset_query {:database 4}}]}]
-   {[-109 -42 53 92 -31 19 -111 13 -11 -111 127 -110 -12 53 -42 -3 -58 -61 60 97 123 -65 -117 -110 -27 -2 -99 102 -59 -29 49 27] 111
-    [43 -96 52 23 -69 81 -59 15 -74 -59 -83 -9 -110 40 1 -64 -117 -44 -67 79 -123 -9 -107 20 113 -59 -93 25 60 124 -110 -30]     222
-    [89 -75 -86 117 -35 -13 -69 -36 -17 84 37 86 -121 -59 -3 1 37 -117 -86 -42 -127 -42 -74 101 83 72 10 44 75 -126 43 66]       333
-    [55 56 16 11 -121 -29 71 -99 -89 -92 41 25 87 -78 34 100 54 -3 53 -9 38 41 -75 -121 63 -119 43 23 57 11 63 32]               444
-    [-90 55 65 61 72 22 -99 -75 111 49 -3 21 -80 68 -14 120 30 -84 -103 16 -68 73 -121 -93 -55 54 72 84 -8 118 -101 114]         555
-    [116 69 -44 77 100 8 -40 -67 25 -4 27 -21 111 98 -45 85 83 -27 -39 8 63 -25 -88 74 32 -10 -2 35 102 -72 -104 111]            666
-    [-84 -2 87 22 -4 105 68 48 -113 93 -29 52 3 102 123 -70 -123 36 31 76 -16 87 70 116 -93 109 -88 108 125 -36 -43 73]          777
-    [90 127 103 -71 -76 -36 41 -107 -7 -13 -83 -87 28 86 -94 110 74 -86 110 -54 -128 124 102 -73 -127 88 77 -36 62 5 -84 -100]   888}))
+(deftest add-query-average-duration-to-dashcards-test
+  (is (= [{:card   {:dataset_query {:database 1}, :query_average_duration 111}
+           :series []}
+          {:card   {:dataset_query {:database 2}, :query_average_duration 333}
+           :series [{:dataset_query {:database 3}, :query_average_duration 555}
+                    {:dataset_query {:database 4}, :query_average_duration 777}]}]
+         (#'dashboard-api/add-query-average-duration-to-dashcards
+          [{:card {:dataset_query {:database 1}}}
+           {:card   {:dataset_query {:database 2}}
+            :series [{:dataset_query {:database 3}}
+                     {:dataset_query {:database 4}}]}]
+          (into {} (for [[k v] {"k9Y1XOETkQ31kX+S9DXW/cbDPGF7v4uS5f6dZsXjMRs=" 111
+                                "K6A0F7tRxQ+2xa33kigBwIvUvU+F95UUccWjGTx8kuI=" 222
+                                "WbWqdd3zu9zvVCVWh8X9ASWLqtaB1rZlU0gKLEuCK0I=" 333
+                                "NzgQC4fjR52npCkZV7IiZDb9NfcmKbWHP4krFzkLPyA=" 444
+                                "pjdBPUgWnbVvMf0VsETyeB6smRC8SYejyTZIVPh2m3I=" 555
+                                "dEXUTWQI2L0Z/Bvrb2LTVVPl2Qg/56hKIPb+I2a4mG8=" 666
+                                "rP5XFvxpRDCPXeM0A2Z7uoUkH0zwV0Z0o22obH3c1Uk=" 777
+                                "Wn9nubTcKZX5862pHFaibkqqbsqAfGa3gVhN3D4FrJw=" 888}]
+                     [(mapv int (codec/base64-decode k)) v]))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1114,7 +1082,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest related-and-recommended-entities-test
-  (tt/with-temp Dashboard [{dashboard-id :id}]
+  (mt/with-temp Dashboard [{dashboard-id :id}]
     (is (= #{:cards}
            (-> ((mt/user->client :crowberto) :get 200 (format "dashboard/%s/related" dashboard-id)) keys set)))))
 
@@ -1266,7 +1234,7 @@
 
     (testing "Should work if Dashboard has multiple mappings for a single param"
       (with-chain-filter-fixtures [{:keys [dashboard card dashcard param-keys]}]
-        (tt/with-temp* [Card          [card-2 (dissoc card :id)]
+        (mt/with-temp* [Card          [card-2 (dissoc card :id)]
                         DashboardCard [dashcard-2 (-> dashcard
                                                       (dissoc :id :card_id)
                                                       (assoc  :card_id (:id card-2)))]]

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -44,7 +44,7 @@
   (merge
    (select-keys
     pulse
-    [:id :name :created_at :updated_at :creator_id :collection_id :collection_position :archived :skip_if_empty])
+    [:id :name :created_at :updated_at :creator_id :collection_id :collection_position :archived :skip_if_empty :dashboard_id])
    {:creator  (user-details (db/select-one 'User :id (:creator_id pulse)))
     :cards    (map pulse-card-details (:cards pulse))
     :channels (map pulse-channel-details (:channels pulse))}))
@@ -145,7 +145,8 @@
    :created_at          true
    :skip_if_empty       false
    :updated_at          true
-   :archived            false})
+   :archived            false
+   :dashboard_id        nil})
 
 (def ^:private daily-email-channel
   {:enabled       true
@@ -313,10 +314,10 @@
 (def ^:private default-put-card-ref-validation-error
   {:errors
    {:cards (str   "value may be nil, or if non-nil, value must be an array. "
-  "Each value must satisfy one of the following requirements: "
-  "1) value must be a map with the following keys "
-  "`(collection_id, description, display, id, include_csv, include_xls, name, dashboard_id, parameter_mappings)` "
-  "2) value must be a map with the keys `id`, `include_csv`, `include_xls`, and `dashboard_card_id`. The array cannot be empty.")}})
+                  "Each value must satisfy one of the following requirements: "
+                  "1) value must be a map with the following keys "
+                  "`(collection_id, description, display, id, include_csv, include_xls, name, dashboard_id, parameter_mappings)` "
+                  "2) value must be a map with the keys `id`, `include_csv`, `include_xls`, and `dashboard_card_id`. The array cannot be empty.")}})
 
 (deftest update-pulse-validation-test
   (testing "PUT /api/pulse/:id"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -3,11 +3,13 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.api.search :as api.search]
-            [metabase.models :refer [Card CardFavorite Collection Dashboard DashboardFavorite Database Metric PermissionsGroup PermissionsGroupMembership Pulse Segment Table]]
+            [metabase.models :refer [Card CardFavorite Collection Dashboard DashboardCard DashboardFavorite Database
+                                     Metric PermissionsGroup PermissionsGroupMembership Pulse PulseCard Segment Table]]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
             [metabase.test :as mt]
             [metabase.util :as u]
+            [schema.core :as s]
             [toucan.db :as db]))
 
 (def ^:private default-search-row
@@ -369,3 +371,29 @@
                   (filter #(and (= (:model %) "collection")
                                 (#{"Normal Collection" "Coin Collection"} (:name %))))
                   (map :name)))))))
+
+(deftest no-dashboard-subscription-pulses-test
+  (testing "Pulses used for Dashboard subscriptions should not be returned by search results (#14190)"
+    (letfn [(search-for-pulses [{pulse-id :id}]
+              (->> (mt/user-http-request :crowberto :get "search?q=electro")
+                   (filter #(and (= (:model %) "pulse")
+                                 (= (:id %) pulse-id)))
+                   first))]
+      (mt/with-temp Pulse [pulse {:name "Electro-Magnetic Pulse"}]
+        (testing "sanity check: should be able to fetch a Pulse normally"
+          (is (schema= {:name (s/eq "Electro-Magnetic Pulse")
+                        s/Keyword s/Any}
+                       (search-for-pulses pulse))))
+        (mt/with-temp* [Card      [card-1]
+                        PulseCard [pc-1 {:pulse_id (:id pulse), :card_id (:id card-1)}]
+                        Card      [card-2]
+                        PulseCard [pc-2 {:pulse_id (:id pulse), :card_id (:id card-2)}]]
+          (testing "Create some Pulse Cards: should still be able to search for it it"
+            (is (schema= {:name     (s/eq "Electro-Magnetic Pulse")
+                          s/Keyword s/Any}
+                         (search-for-pulses pulse))))
+          (testing "Now make this Pulse a dashboard subscription; Pulse should no longer come back from search-results"
+            (mt/with-temp* [Dashboard [dashboard]]
+              (db/update! Pulse (:id pulse) :dashboard_id (:id dashboard))
+              (is (= nil
+                     (search-for-pulses pulse))))))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -175,7 +175,7 @@
 (deftest post-update-test
   (tt/with-temp* [Dashboard           [{dashboard-id :id} {:name "Lucky the Pigeon's Lucky Stuff"}]
                   Card                [{card-id :id}]
-                  Pulse               [{pulse-id :id}]
+                  Pulse               [{pulse-id :id} {:dashboard_id dashboard-id}]
                   DashboardCard       [{dashcard-id :id} {:dashboard_id dashboard-id, :card_id card-id}]
                   PulseCard           [{pulse-card-id :id} {:pulse_id pulse-id, :card_id card-id, :dashboard_card_id dashcard-id}]]
     (testing "Pulse name updates"

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -2,28 +2,29 @@
   (:require [clojure.test :refer :all]
             [medley.core :as m]
             [metabase.api.common :as api]
-            [metabase.models.card :refer :all]
+            [metabase.models.card :refer [Card]]
             [metabase.models.collection :refer [Collection]]
+            [metabase.models.dashboard :refer [Dashboard]]
+            [metabase.models.dashboard-card :refer [DashboardCard]]
             [metabase.models.database :refer [Database]]
             [metabase.models.interface :as mi]
             [metabase.models.permissions :as perms]
-            [metabase.models.pulse :refer :all]
-            [metabase.models.pulse-card :refer :all]
-            [metabase.models.pulse-channel :refer :all]
-            [metabase.models.pulse-channel-recipient :refer :all]
+            [metabase.models.pulse :as pulse :refer [Pulse]]
+            [metabase.models.pulse-card :refer [PulseCard]]
+            [metabase.models.pulse-channel :refer [PulseChannel]]
+            [metabase.models.pulse-channel-recipient :refer [PulseChannelRecipient]]
             [metabase.models.table :refer [Table]]
             [metabase.test :as mt]
-            [metabase.test.data :refer :all]
-            [metabase.test.data.users :refer :all]
             [metabase.test.mock.util :refer [pulse-channel-defaults]]
             [metabase.util :as u]
+            [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
             [toucan.util.test :as tt]))
 
 (defn- user-details
   [username]
-  (mt/derecordize (dissoc (fetch-user username) :date_joined :last_login)))
+  (mt/derecordize (dissoc (mt/fetch-user username) :date_joined :last_login)))
 
 (defn- remove-uneeded-pulse-keys [pulse]
   (-> pulse
@@ -38,20 +39,21 @@
 ;; create a channel then select its details
 (defn- create-pulse-then-select!
   [pulse-name creator cards channels skip-if-empty?]
-  (-> (create-pulse! cards channels
+  (-> (pulse/create-pulse! cards channels
         {:name          pulse-name
-         :creator_id    (u/get-id creator)
+         :creator_id    (u/the-id creator)
          :skip_if_empty skip-if-empty?})
       remove-uneeded-pulse-keys))
 
 (defn- update-pulse-then-select!
   [pulse]
-  (-> (update-pulse! pulse)
+  (-> (pulse/update-pulse! pulse)
       remove-uneeded-pulse-keys))
 
 (def ^:private pulse-defaults
   {:collection_id       nil
    :collection_position nil
+   :dashboard_id        nil
    :skip_if_empty       false
    :archived            false})
 
@@ -63,10 +65,10 @@
                                                                            :emails ["foo@bar.com"]}}]
                     Card         [{card-id :id}                {:name "Test Card"}]]
       (db/insert! PulseCard, :pulse_id pulse-id, :card_id card-id, :position 0)
-      (db/insert! PulseChannelRecipient, :pulse_channel_id channel-id, :user_id (user->id :rasta))
+      (db/insert! PulseChannelRecipient, :pulse_channel_id channel-id, :user_id (mt/user->id :rasta))
       (is (= (merge
               pulse-defaults
-              {:creator_id (user->id :rasta)
+              {:creator_id (mt/user->id :rasta)
                :creator    (user-details :rasta)
                :name       "Lodi Dodi"
                :cards      [{:name               "Test Card"
@@ -85,8 +87,8 @@
                                     :details       {:other "stuff"}
                                     :recipients    [{:email "foo@bar.com"}
                                                     (dissoc (user-details :rasta) :is_superuser :is_qbnewb)]})]})
-             (-> (dissoc (retrieve-pulse pulse-id) :id :pulse_id :created_at :updated_at)
-                 (update :creator  (u/rpartial dissoc :date_joined :last_login))
+             (-> (dissoc (pulse/retrieve-pulse pulse-id) :id :pulse_id :created_at :updated_at)
+                 (update :creator  dissoc :date_joined :last_login)
                  (update :cards    (fn [cards] (for [card cards]
                                                  (dissoc card :id))))
                  (update :channels (fn [channels] (for [channel channels]
@@ -105,8 +107,8 @@
                               1 card-1
                               2 card-2
                               3 card-3))]
-                (update-notification-cards! pulse (map card->ref cards)))
-              (when-let [card-ids (seq (db/select-field :card_id PulseCard, :pulse_id (u/get-id pulse)))]
+                (pulse/update-notification-cards! pulse (map pulse/card->ref cards)))
+              (when-let [card-ids (seq (db/select-field :card_id PulseCard, :pulse_id (u/the-id pulse)))]
                 (db/select-field :name Card, :id [:in card-ids])))]
       (doseq [[cards expected] {[]    nil
                                 [1]   #{"card1"}
@@ -118,59 +120,83 @@
                  (update-cards! cards))))))))
 
 ;; update-notification-channels!
-(deftest updating-notification-channels-test
-  (is (= (map->PulseChannelInstance (merge pulse-channel-defaults
-                                           {:channel_type  :email
-                                            :schedule_type :daily
-                                            :schedule_hour 4
-                                            :recipients    [{:email "foo@bar.com"}
-                                                            (dissoc (user-details :rasta) :is_superuser :is_qbnewb)]}))
-
-         (mt/with-temp Pulse [{:keys [id]}]
-           (update-notification-channels! {:id id} [{:enabled       true
-                                                     :channel_type  :email
-                                                     :schedule_type :daily
-                                                     :schedule_hour 4
-                                                     :recipients    [{:email "foo@bar.com"} {:id (user->id :rasta)}]}])
+(deftest update-notification-channels-test
+  (mt/with-temp Pulse [{:keys [id]}]
+    (pulse/update-notification-channels! {:id id} [{:enabled       true
+                                                    :channel_type  :email
+                                                    :schedule_type :daily
+                                                    :schedule_hour 4
+                                                    :recipients    [{:email "foo@bar.com"} {:id (mt/user->id :rasta)}]}])
+    (is (= (merge pulse-channel-defaults
+                  {:channel_type  :email
+                   :schedule_type :daily
+                   :schedule_hour 4
+                   :recipients    [{:email "foo@bar.com"}
+                                   (dissoc (user-details :rasta) :is_superuser :is_qbnewb)]})
            (-> (PulseChannel :pulse_id id)
                (hydrate :recipients)
                (dissoc :id :pulse_id :created_at :updated_at)
-               (m/dissoc-in [:details :emails]))))))
+               (m/dissoc-in [:details :emails])
+               mt/derecordize)))))
 
 ;; create-pulse!
 ;; simple example with a single card
 (deftest create-pulse-test
-  (is (= (map->PulseInstance (merge
-                              pulse-defaults
-                              {:creator_id (user->id :rasta)
-                               :name       "Booyah!"
-                               :channels   [(map->PulseChannelInstance
-                                             (merge pulse-channel-defaults
-                                                    {:schedule_type :daily
-                                                     :schedule_hour 18
-                                                     :channel_type  :email
-                                                     :recipients    [{:email "foo@bar.com"}]}))]
-                               :cards      [(map->CardInstance
-                                             {:name               "Test Card"
-                                              :description        nil
-                                              :collection_id      nil
-                                              :display            :table
-                                              :include_csv        false
-                                              :include_xls        false
-                                              :dashboard_card_id  nil
-                                              :dashboard_id       nil
-                                              :parameter_mappings nil})]}))
-         (mt/with-temp Card [card {:name "Test Card"}]
-           (mt/with-model-cleanup [Pulse]
-             (create-pulse-then-select! "Booyah!"
-                                        (user->id :rasta)
-                                        [(card->ref card)]
-                                        [{:channel_type  :email
-                                          :schedule_type :daily
-                                          :schedule_hour 18
-                                          :enabled       true
-                                          :recipients    [{:email "foo@bar.com"}]}]
-                                        false))))))
+  (mt/with-temp Card [card {:name "Test Card"}]
+    (mt/with-model-cleanup [Pulse]
+      (is (= (merge
+              pulse-defaults
+              {:creator_id (mt/user->id :rasta)
+               :name       "Booyah!"
+               :channels   [(merge pulse-channel-defaults
+                                   {:schedule_type :daily
+                                    :schedule_hour 18
+                                    :channel_type  :email
+                                    :recipients    [{:email "foo@bar.com"}]})]
+               :cards      [{:name               "Test Card"
+                             :description        nil
+                             :collection_id      nil
+                             :display            :table
+                             :include_csv        false
+                             :include_xls        false
+                             :dashboard_card_id  nil
+                             :dashboard_id       nil
+                             :parameter_mappings nil}]})
+             (mt/derecordize
+              (create-pulse-then-select!
+               "Booyah!"
+               (mt/user->id :rasta)
+               [(pulse/card->ref card)]
+               [{:channel_type  :email
+                 :schedule_type :daily
+                 :schedule_hour 18
+                 :enabled       true
+                 :recipients    [{:email "foo@bar.com"}]}]
+               false)))))))
+
+(deftest create-dashboard-subscription-test
+  (testing "Make sure that the dashboard_id is set correctly when creating a Dashboard Subscription pulse"
+    (mt/with-model-cleanup [Pulse]
+      (mt/with-temp* [Dashboard     [{dashboard-id :id}]
+                      Card          [{card-id :id, :as card}]
+                      DashboardCard [{dashcard-id :id} {:dashboard_id dashboard-id, :card_id card-id}]]
+        (is (schema= {:name         (s/eq "Abnormal Pulse")
+                      :dashboard_id (s/eq dashboard-id)
+                      :cards        [(s/one {:dashboard_id      (s/eq dashboard-id)
+                                             :dashboard_card_id (s/eq dashcard-id)
+                                             s/Keyword          s/Any}
+                                            "pulse card")]
+                      s/Keyword     s/Any}
+                     (create-pulse-then-select!
+                      "Abnormal Pulse"
+                      (mt/user->id :rasta)
+                      [(assoc (pulse/card->ref card) :dashboard_card_id dashcard-id)]
+                      [{:channel_type  :email
+                        :schedule_type :daily
+                        :schedule_hour 18
+                        :enabled       true
+                        :recipients    [{:email "foo@bar.com"}]}]
+                      false)))))))
 
 ;; update-pulse!
 ;; basic update.  we are testing several things here
@@ -181,12 +207,13 @@
 ;;  5. ability to create new channels
 ;;  6. ability to update cards and ensure proper ordering
 (deftest update-pulse-test
-  (is (= (map->PulseInstance
-          (merge pulse-defaults
-                 {:creator_id (user->id :rasta)
-                  :name       "We like to party"
-                  :cards      [(map->CardInstance
-                                {:name               "Bar Card"
+  (mt/with-temp* [Pulse [pulse]
+                  Card  [card-1 {:name "Test Card"}]
+                  Card  [card-2 {:name "Bar Card", :display :bar}]]
+    (is (= (merge pulse-defaults
+                  {:creator_id (mt/user->id :rasta)
+                   :name       "We like to party"
+                   :cards      [{:name               "Bar Card"
                                  :description        nil
                                  :collection_id      nil
                                  :display            :bar
@@ -194,8 +221,7 @@
                                  :include_xls        false
                                  :dashboard_card_id  nil
                                  :dashboard_id       nil
-                                 :parameter_mappings nil})
-                               (map->CardInstance
+                                 :parameter_mappings nil}
                                 {:name               "Test Card"
                                  :description        nil
                                  :collection_id      nil
@@ -204,37 +230,34 @@
                                  :include_xls        false
                                  :dashboard_card_id  nil
                                  :dashboard_id       nil
-                                 :parameter_mappings nil})]
-                  :channels   [(map->PulseChannelInstance
-                                (merge pulse-channel-defaults
+                                 :parameter_mappings nil}]
+                   :channels   [(merge pulse-channel-defaults
                                        {:schedule_type :daily
                                         :schedule_hour 18
                                         :channel_type  :email
                                         :recipients    [{:email "foo@bar.com"}
-                                                        (dissoc (user-details :crowberto) :is_superuser :is_qbnewb)]}))]}))
-         (mt/with-temp* [Pulse [pulse]
-                         Card  [card-1 {:name "Test Card"}]
-                         Card  [card-2 {:name "Bar Card", :display :bar}]]
-           (update-pulse-then-select! {:id            (u/get-id pulse)
-                                       :name          "We like to party"
-                                       :cards         (map card->ref [card-2 card-1])
-                                       :channels      [{:channel_type  :email
-                                                        :schedule_type :daily
-                                                        :schedule_hour 18
-                                                        :enabled       true
-                                                        :recipients    [{:email "foo@bar.com"}
-                                                                        {:id (user->id :crowberto)}]}]
-                                       :skip_if_empty false})))))
+                                                        (dissoc (user-details :crowberto) :is_superuser :is_qbnewb)]})]})
+           (mt/derecordize
+            (update-pulse-then-select! {:id            (u/the-id pulse)
+                                        :name          "We like to party"
+                                        :cards         (map pulse/card->ref [card-2 card-1])
+                                        :channels      [{:channel_type  :email
+                                                         :schedule_type :daily
+                                                         :schedule_hour 18
+                                                         :enabled       true
+                                                         :recipients    [{:email "foo@bar.com"}
+                                                                         {:id (mt/user->id :crowberto)}]}]
+                                        :skip_if_empty false}))))))
 
-;; make sure fetching a Pulse doesn't return any archived cards
 (deftest no-archived-cards-test
-  (is (= 1
-         (mt/with-temp* [Pulse     [pulse]
-                         Card      [card-1 {:archived true}]
-                         Card      [card-2]
-                         PulseCard [_ {:pulse_id (u/get-id pulse), :card_id (u/get-id card-1), :position 0}]
-                         PulseCard [_ {:pulse_id (u/get-id pulse), :card_id (u/get-id card-2), :position 1}]]
-           (count (:cards (retrieve-pulse (u/get-id pulse))))))))
+  (testing "make sure fetching a Pulse doesn't return any archived cards"
+    (mt/with-temp* [Pulse     [pulse]
+                    Card      [card-1 {:archived true}]
+                    Card      [card-2]
+                    PulseCard [_ {:pulse_id (u/the-id pulse), :card_id (u/the-id card-1), :position 0}]
+                    PulseCard [_ {:pulse_id (u/the-id pulse), :card_id (u/the-id card-2), :position 1}]]
+      (is (= 1
+             (count (:cards (pulse/retrieve-pulse (u/the-id pulse)))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Collections Permissions Tests                                          |
@@ -243,13 +266,13 @@
 (defn do-with-pulse-in-collection [f]
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [collection]
-                    Pulse      [pulse {:collection_id (u/get-id collection)}]
+                    Pulse      [pulse {:collection_id (u/the-id collection)}]
                     Database   [db    {:engine :h2}]
-                    Table      [table {:db_id (u/get-id db)}]
-                    Card       [card  {:dataset_query {:database (u/get-id db)
+                    Table      [table {:db_id (u/the-id db)}]
+                    Card       [card  {:dataset_query {:database (u/the-id db)
                                                        :type     :query
-                                                       :query    {:source-table (u/get-id table)}}}]
-                    PulseCard  [_ {:pulse_id (u/get-id pulse), :card_id (u/get-id card)}]]
+                                                       :query    {:source-table (u/the-id table)}}}]
+                    PulseCard  [_ {:pulse_id (u/the-id pulse), :card_id (u/the-id card)}]]
       (f db collection pulse card))))
 
 (defmacro with-pulse-in-collection
@@ -272,7 +295,7 @@
 (deftest no-permissions-test
   (is (= false
          (with-pulse-in-collection [db _ pulse]
-           (binding [api/*current-user-permissions-set* (atom #{(perms/object-path (u/get-id db))})]
+           (binding [api/*current-user-permissions-set* (atom #{(perms/object-path (u/the-id db))})]
              (mi/can-read? pulse))))))
 
 (deftest validate-collection-namespace-test

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -5,7 +5,7 @@
             [clojure.walk :as walk]
             [medley.core :as m]
             [metabase.integrations.slack :as slack]
-            [metabase.models :refer [Card Collection Dashboard DashboardCard Pulse PulseCard PulseChannel PulseChannelRecipient]]
+            [metabase.models :refer [Card Collection Pulse PulseCard PulseChannel PulseChannelRecipient]]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
             [metabase.models.pulse :as models.pulse]
@@ -765,46 +765,7 @@
                    :fallback               "Test card 2"}]}
                 (thunk->boolean slack-data)))
          (testing "attachments"
-           (is (true? (every? produces-bytes? (:attachments slack-data)))))))))
-  (testing "Basic slack test, 2 cards, 1 recipient channel as a dashboard subscription"
-    (mt/with-temp* [Card          [{card-id-1 :id}     (checkins-query-card {:breakout [!hour.date]})]
-                    Card          [{card-id-2 :id}     (-> {:breakout [[:datetime-field (mt/id :checkins :date) "minute"]]}
-                                                           checkins-query-card
-                                                           (assoc :name "Test card 2"))]
-                    Pulse         [{pulse-id :id}      {:name          "Pulse Name"
-                                                        :skip_if_empty false}]
-                    Dashboard     [{dashboard-id :id}  {:name "Aviary Analytics"}]
-                    DashboardCard [{dashcard-id-1 :id} {:dashboard_id dashboard-id, :card_id card-id-1}]
-                    DashboardCard [{dashcard-id-2 :id} {:dashboard_id dashboard-id, :card_id card-id-2}]
-                    PulseCard     [_                   {:pulse_id          pulse-id
-                                                        :card_id           card-id-1
-                                                        :dashboard_card_id dashcard-id-1
-                                                        :position          0}]
-                    PulseCard     [_                   {:pulse_id          pulse-id
-                                                        :card_id           card-id-2
-                                                        :dashboard_card_id dashcard-id-2
-                                                        :position          1}]
-                    PulseChannel  [{pc-id :id}         {:pulse_id     pulse-id
-                                                        :channel_type "slack"
-                                                        :details      {:channel "#general"}}]]
-      (slack-test-setup
-       (let [[slack-data] (pulse/send-pulse! (models.pulse/retrieve-pulse pulse-id))]
-         (is (= {:channel-id "#general",
-                 :message    "Pulse Name", ;; No "Pulse: " prefix
-                 :attachments
-                 [{:title                  card-name,
-                   :attachment-bytes-thunk true,
-                   :title_link             (str "https://metabase.com/testmb/question/" card-id-1),
-                   :attachment-name        "image.png",
-                   :channel-id             "FOO",
-                   :fallback               card-name}
-                  {:title                  "Test card 2",
-                   :attachment-bytes-thunk true
-                   :title_link             (str "https://metabase.com/testmb/question/" card-id-2),
-                   :attachment-name        "image.png",
-                   :channel-id             "FOO",
-                   :fallback               "Test card 2"}]}
-                (thunk->boolean slack-data))))))))
+           (is (true? (every? produces-bytes? (:attachments slack-data))))))))))
 
 (deftest multi-channel-test
   (testing "Test with a slack channel and an email"


### PR DESCRIPTION
Fixes #14190

I added a new `pulse.dashboard_id` column to solve this. Now we can look at that to check whether a Pulse is a Dashboard subscription pulse or not