### PR TITLE
#14254 Repro: Map visualization not suggested when first column type is number

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -56,4 +56,48 @@ describe("scenarios > visualizations > maps", () => {
     // check that a map appears
     cy.get(".leaflet-container");
   });
+
+  it.skip("should suggest map visualization regardless of the first column type (metabase#14254)", () => {
+    cy.request("POST", "/api/card", {
+      name: "14254",
+      dataset_query: {
+        type: "native",
+        native: {
+          query:
+            'SELECT "PUBLIC"."PEOPLE"."LONGITUDE" AS "LONGITUDE", "PUBLIC"."PEOPLE"."LATITUDE" AS "LATITUDE", "PUBLIC"."PEOPLE"."CITY" AS "CITY"\nFROM "PUBLIC"."PEOPLE"\nLIMIT 10',
+          "template-tags": {},
+        },
+        database: 1,
+      },
+      display: "map",
+      visualization_settings: {
+        "map.region": "us_states",
+        "map.type": "pin",
+        "map.latitude_column": "LATITUDE",
+        "map.longitude_column": "LONGITUDE",
+      },
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.visit(`/question/${QUESTION_ID}`);
+    });
+
+    cy.findByText("Visualization")
+      .closest(".Button")
+      .as("vizButton");
+    cy.get("@vizButton").find(".Icon-pinmap");
+    cy.get("@vizButton").click();
+    cy.findByText("Choose a visualization");
+    // Sidebar should really have a distinct class name
+    cy.get(".scroll-y .scroll-y").as("vizSidebar");
+
+    cy.get("@vizSidebar").within(() => {
+      // There should be a unique class for "selected" viz type
+      cy.get(".Icon-pinmap")
+        .parent()
+        .should("have.class", "text-white");
+
+      cy.findByText("Map")
+        .parent()
+        .should("have.css", "opacity", "1");
+    });
+  });
 });

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -1,10 +1,18 @@
-import { signInAsNormalUser, restore, popover } from "__support__/cypress";
+import {
+  signInAsNormalUser,
+  signInAsAdmin,
+  restore,
+  popover,
+} from "__support__/cypress";
 
 describe("scenarios > visualizations > maps", () => {
-  before(restore);
-  beforeEach(signInAsNormalUser);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should display a pin map for a native query", () => {
+    signInAsNormalUser();
     // create a native query with lng/lat fields
     cy.visit("/question/new");
     cy.contains("Native query").click();


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #14254 

### How to test this manually?
- `yarn test-cypress-open`
- `relative/path/to/the/file` _(optionally, include the line number on which the test starts)_
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Cypress runner
![image](https://user-images.githubusercontent.com/31325167/103931944-64180b00-5121-11eb-8f6d-1ba96152ab1c.png)

2. UI
![image](https://user-images.githubusercontent.com/31325167/103932005-814cd980-5121-11eb-8fbb-abcf37fc476a.png)
