### PR TITLE
Custom expression: feedback upon an incorrect amount of function args

### DIFF
--- a/frontend/src/metabase/lib/expressions/parser.js
+++ b/frontend/src/metabase/lib/expressions/parser.js
@@ -453,7 +453,7 @@ export function parse({
   if (parserErrors.length > 0 && !recover) {
     throw parserErrors;
   }
-  typeCheck(cst, startRule || "expression");
+  const { typeErrors } = typeCheck(cst, startRule || "expression");
   const parserRecovered = !!(cst && parserErrors.length > 0);
 
   return {
@@ -463,6 +463,7 @@ export function parse({
     parserRecovered,
     parserErrors,
     lexerErrors,
+    typeErrors,
   };
 }
 

--- a/frontend/src/metabase/lib/expressions/process.js
+++ b/frontend/src/metabase/lib/expressions/process.js
@@ -16,14 +16,14 @@ export function processSource(options) {
   let compileError;
 
   // PARSE
-  const { cst, tokenVector, parserErrors } = parse({
+  const { cst, tokenVector, parserErrors, typeErrors } = parse({
     ...options,
     recover: true,
   });
 
   // COMPILE
-  if (parserErrors.length > 0) {
-    compileError = parserErrors;
+  if (typeErrors.length > 0 || parserErrors.length > 0) {
+    compileError = typeErrors.concat(parserErrors);
   } else {
     try {
       expression = compile({ cst, tokenVector, ...options });


### PR DESCRIPTION
How to verify:

1. Ask a question, Custom question.
2. Pick Sample Dataset, Products table
3. Filter, Add filters to narrow your answer
4. Custom Expression
5. Type `contains([Category])` for the expression input

**Before** this PR:

(There's *not* any feedback at all, and yet it's not possible to click on the _Done_ button)

![image](https://user-images.githubusercontent.com/7288/103951284-3916c280-50f3-11eb-8a68-7a1176ae371b.png)

**After** this PR:

![image](https://user-images.githubusercontent.com/7288/103951473-96ab0f00-50f3-11eb-99b2-1a7145f195c8.png)
