### PR TITLE
Add basic collapse/expand for pivot table row groups

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -164,7 +164,7 @@ export default class PivotTable extends Component {
         columnIndexes,
         rowIndexes,
         valueIndexes,
-        settings["pivot_table.collapsed_rows"],
+        settings[COLLAPSED_ROWS_SETTING],
       );
     } catch (e) {
       console.warn(e);

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -447,12 +447,16 @@ function RowToggleIcon({
     updateSettings({ [COLLAPSED_ROWS_SETTING]: updatedValue });
   };
   return (
-    <Icon
-      name={isCollapsed ? "add" : "dash"}
-      className="cursor-pointer text-brand"
-      size={10}
+    <div
+      className={cx(
+        "flex align-center cursor-pointer bg-brand-hover text-light text-white-hover",
+        isCollapsed ? "bg-light" : "bg-medium",
+      )}
+      style={{ padding: "4px", borderRadius: "4px" }}
       onClick={update}
-    />
+    >
+      <Icon name={isCollapsed ? "add" : "dash"} size={8} />
+    </div>
   );
 }
 

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -203,7 +203,16 @@ describe("data_grid", () => {
               { value: "z", span: 1 },
             ],
           ],
-          [[{ isSubtotal: true, span: 1, value: "Totals for a" }]],
+          [
+            [
+              {
+                isSubtotal: true,
+                span: 1,
+                value: "Totals for a",
+                rawValue: "a",
+              },
+            ],
+          ],
         ],
         [
           [
@@ -214,7 +223,16 @@ describe("data_grid", () => {
               { value: "z", span: 1 },
             ],
           ],
-          [[{ isSubtotal: true, span: 1, value: "Totals for b" }]],
+          [
+            [
+              {
+                isSubtotal: true,
+                span: 1,
+                value: "Totals for b",
+                rawValue: "b",
+              },
+            ],
+          ],
         ],
         GRAND_TOTALS_ROW,
       ]);
@@ -314,7 +332,16 @@ describe("data_grid", () => {
               { span: 1, value: "c2" },
             ],
           ],
-          [[{ isSubtotal: true, span: 1, value: "Totals for a1" }]],
+          [
+            [
+              {
+                isSubtotal: true,
+                span: 1,
+                value: "Totals for a1",
+                rawValue: "a1",
+              },
+            ],
+          ],
         ],
         [
           [
@@ -327,7 +354,16 @@ describe("data_grid", () => {
               { span: 1, value: "c2" },
             ],
           ],
-          [[{ isSubtotal: true, span: 1, value: "Totals for a2" }]],
+          [
+            [
+              {
+                isSubtotal: true,
+                span: 1,
+                value: "Totals for a2",
+                rawValue: "a2",
+              },
+            ],
+          ],
         ],
         GRAND_TOTALS_ROW,
       ]);
@@ -448,6 +484,41 @@ describe("data_grid", () => {
       expect(extractValues(getRowSection(0, 0))).toEqual([["1"], ["2"], ["3"]]);
       expect(extractValues(getRowSection(0, 1))).toEqual([["3"], ["4"], ["7"]]);
       expect(extractValues(getRowSection(0, 2))).toEqual([["10"]]);
+    });
+
+    it("hide collapsed rows", () => {
+      const cols = [D1, D2, M];
+      const primaryGroup = 0;
+      const subtotalOne = 2;
+      const subtotalTwo = 1;
+      const subtotalThree = 3;
+      const rows = [
+        ["a", "x", 1, primaryGroup],
+        ["a", "y", 2, primaryGroup],
+        ["b", "x", 3, primaryGroup],
+        ["b", "y", 4, primaryGroup],
+        ["a", null, 3, subtotalOne],
+        ["b", null, 7, subtotalOne],
+        [null, "x", 4, subtotalTwo],
+        [null, "y", 6, subtotalTwo],
+        [null, null, 10, subtotalThree],
+      ];
+      const data = {
+        rows,
+        cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+      };
+      const { getRowSection, leftIndex, rowCount } = multiLevelPivot(
+        data,
+        [],
+        [0, 1],
+        [2],
+        ['["a"]'],
+      );
+      expect(rowCount).toEqual(3);
+      expect(leftIndex[0]).toEqual([
+        [[{ isSubtotal: true, span: 1, value: "Totals for a", rawValue: "a" }]],
+      ]);
+      expect(extractValues(getRowSection(0, 0))).toEqual([["3"]]);
     });
   });
 });


### PR DESCRIPTION
This PR adds a new visualization setting to collapse row groups.

Closes https://github.com/metabase/metabase/issues/14171

![collapse_expand](https://user-images.githubusercontent.com/691495/103960166-8b6dd880-511f-11eb-8b49-270b708a3b89.gif)


Here's the product doc image for context on style changes. I wasn't sure whether we want the icon background since the icon also appears over the subtotal background.
![image](https://user-images.githubusercontent.com/691495/103960771-f23fc180-5120-11eb-8b0f-3d8d6c06b630.png)


Also, It really seems like the open/close should be animated, but I didn't see a non-horrible way to accomplish this in the context of the virtualization library we're using.



If you checkout this branch, [this link](http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJxdWVyeSIsInF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6MiwiYWdncmVnYXRpb24iOltbImNvdW50Il1dLCJicmVha291dCI6W1siZGF0ZXRpbWUtZmllbGQiLFsiZmllbGQtaWQiLDEyXSwieWVhciJdLFsiZmstPiIsWyJmaWVsZC1pZCIsMTFdLFsiZmllbGQtaWQiLDI2XV0sWyJmay0-IixbImZpZWxkLWlkIiwxM10sWyJmaWVsZC1pZCIsNF1dXX0sImRhdGFiYXNlIjoxfSwiZGlzcGxheSI6InBpdm90IiwiZGlzcGxheUlzTG9ja2VkIjp0cnVlLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7InBpdm90X3RhYmxlLmNvbHVtbl9zcGxpdCI6eyJyb3dzIjpbWyJmay0-IixbImZpZWxkLWlkIiwxM10sWyJmaWVsZC1pZCIsNF1dLFsiZmstPiIsWyJmaWVsZC1pZCIsMTFdLFsiZmllbGQtaWQiLDI2XV1dLCJjb2x1bW5zIjpbWyJkYXRldGltZS1maWVsZCIsWyJmaWVsZC1pZCIsMTJdLCJ5ZWFyIl1dLCJ2YWx1ZXMiOltbImFnZ3JlZ2F0aW9uIiwwXV19LCJwaXZvdF90YWJsZS5jb2xsYXBzZWRfcm93cyI6WyJbXCJXaWRnZXRcIl0iLCJbXCJEb29oaWNrZXlcIl0iXX19) should open a pivot table with some rows collapsed.

Work for follow on PRs
- Collapse/expand all from the column
- Collapsing columns besides the left-most
This requires adding more subtotals first.
- Better handling for the viz setting
We should clear collapsed settings when you update the columns or change the query.