### PR TITLE
Custom expression: type-checker should be aware of variadic functions

### DIFF
--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -64,7 +64,7 @@ export function typeCheck(cst, rootType) {
       const clause = CLAUSE_TOKENS.get(functionToken);
       const name = functionToken.name;
       const expectedArgsLength = clause.args.length;
-      if (clause.args.length !== args.length) {
+      if (!clause.multiple && clause.args.length !== args.length) {
         const message = t`Function ${name} expects ${expectedArgsLength} arguments`;
         this.errors.push({ message });
       }

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -85,6 +85,12 @@ describe("type-checker", () => {
       expect(expr("[X]+CASE([Y],4,5)").dimensions).toEqual(["X"]);
       expect(expr("[X]+CASE([Y],4,5)").segments).toEqual(["Y"]);
     });
+
+    it("should allow any number of arguments in a variadic function", () => {
+      expect(() => validate("CONCAT('1')")).not.toThrow();
+      expect(() => validate("CONCAT('1','2')")).not.toThrow();
+      expect(() => validate("CONCAT('1','2','3')")).not.toThrow();
+    });
   });
 
   describe("for a filter", () => {


### PR DESCRIPTION
I missed this case in my previous PR #14310. Variadic function should be excluded from matching the exact number of arguments.

How to verify? Run the usual unit tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/
```