### PR TITLE
Improved run on change keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,8 +223,9 @@ cache-key-frontend-deps: &CacheKeyFrontendDeps
   key: v1-{{ checksum ".CACHE-PREFIX" }}-fe-deps-{{ checksum "yarn.lock" }}
 
 # Key used for implementation of run-on-change -- this is the cache key that contains the .SUCCESS dummy file
+# By default the key ALWAYS includes the name of the test job itself ($CIRCLE_STAGE) so you don't need to add that yourself.
 cache-key-run-on-change: &CacheKeyRunOnChange
-  key: v1-{{ checksum ".CACHE-PREFIX" }}-run-on-change-<< parameters.cache-key >>
+  key: v1-{{ checksum ".CACHE-PREFIX" }}-run-on-change-{{ .Environment.CIRCLE_STAGE }}-<< parameters.checksum >>
 
 # Key for the local maven installation of metabase-core (used by build-uberjar-drivers)
 cache-key-metabase-core: &CacheKeyMetabaseCore
@@ -307,8 +308,9 @@ commands:
   #   f. If .SUCCESS is not present, proceed as normal, and create and cache .SUCCESS if the job succeeds
   run-on-change:
     parameters:
-      cache-key:
+      checksum:
         type: string
+        default: ""
       steps:
         type: steps
       # Whether to skip the rest of the job if commit message includes [ci quick]
@@ -317,7 +319,7 @@ commands:
         default: false
     steps:
       - restore_cache:
-          name: Restore dummy file .SUCCESS if it exists for cache key << parameters.cache-key >>
+          name: Restore dummy file .SUCCESS if it exists for cache key << parameters.checksum >>
           <<: *CacheKeyRunOnChange
       - when:
           condition: << parameters.skip-job-if-commit-message-includes-ci-quick >>
@@ -356,7 +358,7 @@ commands:
           command: |
             echo "$CIRCLE_BUILD_URL" > .SUCCESS
       - save_cache:
-          name: Persist dummy file .SUCCESS to cache with key << parameters.cache-key >>
+          name: Persist dummy file .SUCCESS to cache with key << parameters.checksum >>
           <<: *CacheKeyRunOnChange
           paths:
             - /home/circleci/metabase/metabase/.SUCCESS
@@ -365,7 +367,7 @@ commands:
           command: rm /home/circleci/metabase/metabase/.SUCCESS
 
   # Creates a file that contains checksums for all the files found using the find command with supplied arguments.
-  # You can use a checksum of the checksum file for cache keys including run-on-change cache-keys.
+  # You can use a checksum of the checksum file for cache keys including run-on-change cache keys.
   create-checksum-file:
     parameters:
       filename:
@@ -420,21 +422,16 @@ commands:
       after-steps:
         type: steps
         default: []
-      # If skip-key is passed, run this command using run-on-change; skip-key is used as part of the cache key used by
-      # it (.FRONTEND-CHECKSUMS is automatically used as well). It should be something unique for the job, e.g.
-      # "linter" or "unit-tests"
-      #
-      # If skip-key is not passed, the step will always be ran
-      skip-key:
-        type: string
-        default: ""
+      skip-when-no-change:
+        type: boolean
+        default: false
     steps:
       - attach-workspace
       - when:
-          condition: << parameters.skip-key >>
+          condition: << parameters.skip-when-no-change >>
           steps:
             - run-on-change:
-                cache-key: yarn-<< parameters.skip-key >>-{{ checksum ".FRONTEND-CHECKSUMS" }}
+                checksum: '{{ checksum ".FRONTEND-CHECKSUMS" }}'
                 steps:
                   - restore-fe-deps-cache
                   - steps: << parameters.before-steps >>
@@ -444,7 +441,7 @@ commands:
                       no_output_timeout: 10m
                   - steps: << parameters.after-steps >>
       - unless:
-          condition: << parameters.skip-key >>
+          condition: << parameters.skip-when-no-change >>
           steps:
             - restore-fe-deps-cache
             - steps: << parameters.before-steps >>
@@ -536,7 +533,7 @@ jobs:
           find-args: ". -type f -name '*.yaml' -or -name '*.yml'"
       - run-on-change:
           # package.json is included in the cache key in case the yamllint dependency changes
-          cache-key: lint-yaml-{{ checksum ".YAML-CHECKSUMS" }}-{{ checksum "package.json" }}
+          checksum: '{{ checksum ".YAML-CHECKSUMS" }}-{{ checksum "package.json" }}'
           steps:
             - run-yarn-command:
                 command-name: Lint YAML files
@@ -554,7 +551,7 @@ jobs:
           filename: .I18N-SCRIPT-CHECKSUMS
           find-args: "bin/i18n -type f"
       - run-on-change:
-          cache-key: verify-i18n-{{ checksum ".I18N-CHECKSUMS" }}-{{ checksum ".I18N-SCRIPT-CHECKSUMS" }}
+          checksum: '{{ checksum ".I18N-CHECKSUMS" }}-{{ checksum ".I18N-SCRIPT-CHECKSUMS" }}'
           steps:
             - restore-fe-deps-cache
             - run:
@@ -584,7 +581,7 @@ jobs:
       # This step is pretty slow, even with the cache, so only run it if project.clj has changed
       # TODO -- we should cache the build script deps as well, and driver deps?
       - run-on-change:
-          cache-key: be-deps-{{ checksum "project.clj" }}
+          checksum: '{{ checksum "project.clj" }}'
           steps:
             - restore-be-deps-cache
             - run: lein with-profile +include-all-drivers,+cloverage,+junit,+<< parameters.edition >> deps
@@ -607,21 +604,18 @@ jobs:
       after-steps:
         type: steps
         default: []
-      # If skip-key is present, this job is ran with run-on-change which means it will be skipped if nothing has
-      # changed. It works the same way as the skip-key command used for run-yarn-command: see comments there for more
-      # details
-      skip-key:
-        type: string
-        default: ""
+      skip-when-no-change:
+        type: boolean
+        default: false
       <<: *Params
     executor: << parameters.e >>
     steps:
       - attach-workspace
       - when:
-          condition: << parameters.skip-key >>
+          condition: << parameters.skip-when-no-change >>
           steps:
             - run-on-change:
-                cache-key: lein-<< parameters.skip-key >>-{{ checksum ".BACKEND-CHECKSUMS" }}
+                checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}'
                 steps:
                   - run-lein-command:
                       before-steps: << parameters.before-steps >>
@@ -629,7 +623,7 @@ jobs:
                       after-steps: << parameters.after-steps >>
                       edition: << parameters.edition >>
       - unless:
-          condition: << parameters.skip-key >>
+          condition: << parameters.skip-when-no-change >>
           steps:
             - run-lein-command:
                 before-steps: << parameters.before-steps >>
@@ -642,7 +636,7 @@ jobs:
     steps:
       - attach-workspace
       - run-on-change:
-          cache-key: reflection-warnings-{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum "bin/reflection-linter" }}
+          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum "bin/reflection-linter" }}'
           steps:
             - restore-be-deps-cache
             - run:
@@ -670,7 +664,7 @@ jobs:
     steps:
       - attach-workspace
       - run-on-change:
-          cache-key: driver-tests-<< parameters.driver >>-{{ checksum ".BACKEND-CHECKSUMS" }}
+          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}'
           skip-job-if-commit-message-includes-ci-quick: true
           steps:
             - restore-be-deps-cache
@@ -695,7 +689,7 @@ jobs:
     steps:
       - attach-workspace
       - run-on-change:
-          cache-key: load-and-dump-<< parameters.db-type >>-{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum "bin/test-load-and-dump.sh" }}
+          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum "bin/test-load-and-dump.sh" }}'
           steps:
             - restore-be-deps-cache
             - run:
@@ -712,7 +706,7 @@ jobs:
     steps:
       - attach-workspace
       - run-on-change:
-          cache-key: build-scripts-{{ checksum ".BACKEND-CHECKSUMS" }}
+          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}'
           steps:
             - restore-be-deps-cache
             - run:
@@ -747,7 +741,7 @@ jobs:
       - attach-workspace
       # This step is *really* slow, so we can skip it if yarn.lock hasn't changed since last time we ran it
       - run-on-change:
-          cache-key: fe-deps-{{ checksum "yarn.lock" }}
+          checksum: '{{ checksum "yarn.lock" }}'
           steps:
             - restore-fe-deps-cache
             - run:
@@ -769,7 +763,7 @@ jobs:
       - run-yarn-command:
           command-name: Run ESLint linter
           command: lint-eslint
-          skip-key: eslint
+          skip-when-no-change: true
 
   fe-linter-prettier:
     executor: node
@@ -777,7 +771,7 @@ jobs:
       - run-yarn-command:
           command-name: Run Prettier formatting linter
           command: lint-prettier
-          skip-key: prettier
+          skip-when-no-change: true
 
   fe-linter-flow:
     executor: node
@@ -785,7 +779,7 @@ jobs:
       - run-yarn-command:
           command-name: Run Flow type checker
           command: lint-flow
-          skip-key: flow
+          skip-when-no-change: true
 
   fe-linter-docs-links:
     executor: node
@@ -795,7 +789,7 @@ jobs:
           filename: ".MARKDOWN-CHECKSUMS"
           find-args: ". -type f -name '*.md'"
       - run-on-change:
-          cache-key: docs-links-{{ checksum ".MARKDOWN-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}
+          checksum: '{{ checksum ".MARKDOWN-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}'
           steps:
             - run-yarn-command:
                 command-name: Run docs links checker
@@ -807,7 +801,7 @@ jobs:
       - run-yarn-command:
           command-name: Run frontend unit tests
           command: run test-unit
-          skip-key: unit
+          skip-when-no-change: true
 
   fe-tests-integration:
     executor: node
@@ -815,7 +809,7 @@ jobs:
       - run-yarn-command:
           command-name: Run frontend integration tests
           command: run test-integration
-          skip-key: integration
+          skip-when-no-change: true
 
   fe-tests-timezones:
     executor: node
@@ -823,7 +817,7 @@ jobs:
       - run-yarn-command:
           command-name: Run frontend timezone tests
           command: run test-timezones
-          skip-key: timezones
+          skip-when-no-change: true
 
   # Unlike the other build-uberjar steps, this step should be run once overall and the results can be shared between
   # OSS and EE uberjars.
@@ -839,7 +833,7 @@ jobs:
           #
           # The build-drivers script is smart enough to only rebuild drivers if needed -- there's a chance we won't
           # need to rebuild them.
-          cache-key: drivers-{{ checksum ".MODULES-CHECKSUMS" }}-{{ checksum ".BACKEND-CHECKSUMS" }}
+          checksum: '{{ checksum ".MODULES-CHECKSUMS" }}-{{ checksum ".BACKEND-CHECKSUMS" }}'
           steps:
             - restore-be-deps-cache            #
             - restore_cache:
@@ -882,7 +876,7 @@ jobs:
     steps:
       - attach-workspace
       - run-on-change:
-          cache-key: frontend-<< parameters.edition >>-{{ checksum ".FRONTEND-CHECKSUMS" }}
+          checksum: '{{ checksum ".FRONTEND-CHECKSUMS" }}'
           steps:
             - restore-fe-deps-cache
             - run:
@@ -905,7 +899,7 @@ jobs:
     steps:
       - attach-workspace
       - run-on-change:
-          cache-key: uberjar-<< parameters.edition >>-{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}
+          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}'
           steps:
             - restore_cache:
                 name: Restore cached uberjar from previous runs
@@ -971,7 +965,7 @@ jobs:
     steps:
       - attach-workspace
       - run-on-change:
-          cache-key: cypress-<< parameters.edition >>-<< parameters.cypress-group >>-<< parameters.only-single-database >>-<< parameters.test-files-location >>-<< parameters.node >>-{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}
+          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}'
           steps:
             - run-yarn-command:
                 command-name: Run Cypress tests
@@ -1060,7 +1054,7 @@ workflows:
           requires:
             - be-deps
           lein-command: with-profile +junit test
-          skip-key: tests
+          skip-when-no-change: true
           <<: *Matrix
 
       - lein:
@@ -1069,7 +1063,7 @@ workflows:
             - be-deps
           e: java-11
           lein-command: with-profile +junit test
-          skip-key: tests-java-11
+          skip-when-no-change: true
           <<: *Matrix
 
       - lein:
@@ -1077,28 +1071,28 @@ workflows:
           requires:
             - be-deps
           lein-command: eastwood
-          skip-key: eastwood
+          skip-when-no-change: true
 
       - lein:
           name: be-linter-docstring-checker
           requires:
             - be-deps
           lein-command: docstring-checker
-          skip-key: docstring-checker
+          skip-when-no-change: true
 
       - lein:
           name: be-linter-namespace-decls
           requires:
             - be-deps
           lein-command: check-namespace-decls
-          skip-key: namespace-decls
+          skip-when-no-change: true
 
       - lein:
           name: be-linter-bikeshed
           requires:
             - be-deps
           lein-command: bikeshed
-          skip-key: bikeshed
+          skip-when-no-change: true
 
       - lein:
           name: be-linter-cloverage
@@ -1109,7 +1103,7 @@ workflows:
             - run:
                 name: Upload code coverage to codecov.io
                 command: bash <(curl -s https://codecov.io/bash)
-          skip-key: cloverage
+          skip-when-no-change: true
 
       - be-linter-reflection-warnings:
           requires:


### PR DESCRIPTION
The `run-on-change` stuff I added in #13942 uses a unique cache key based on unique job identifier + checksum of relevant files to determine whether a a job can be skipped... this was working great except for driver tests where we were using `driver` as the unique job identifier, meaning the various MySQL/MariaDB and Postgres test jobs which all use the `mysql` or `postgres` driver respectively were using the same cache key. AFAIK this hasn't caused any issues yet.

This PR eliminates the need for users of `run-on-change` to supply their own unique job identifier, and uses the env var `$CIRCLE_STAGE` automatically, which is the actual unique name of the job we're currently running. It makes our CI config harder to do the wrong way