### PR TITLE
#14294 Repro: Native questions don't respect Start of the week

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -86,8 +86,6 @@ describe("scenarios > admin > permissions", () => {
   // This test is extremely tricky and fragile because it needs to test for the "past X weeks" to check if week starts on Sunday or Monday.
   // As the time goes by we're risking that past X weeks don't yield any result when applied to the sample dataset.
   // For that reason I've chosen the past 220 weeks (mid-October 2016). This should give us 3+ years to run this test without updates.
-  // If there is a week in sample dataset which doesn't have Sunday or Monday, that can potentially break this test.
-  // Going randomly through at least 10-15 different numbers, each week had both Sunday and Monday so we should be ok.
 
   // TODO:
   //  - Keep an eye on this test in CI and update the week range as needed.

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -4,8 +4,8 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > admin > permissions", () => {
-  before(restore);
   beforeEach(() => {
+    restore();
     signInAsAdmin();
     setFirstWeekDayTo("monday");
   });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #14294 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### !IMPORTANT!
- This test is extremely tricky and fragile because it needs to test for the "past X weeks" to check if week starts on Sunday or Monday.
- As the time goes by we're risking that past X weeks don't yield any result when applied to the sample dataset.
- I couldn't reproduce it with the previous 52 weeks, like the original issue suggested.
- For that reason I've chosen the past 220 weeks (mid-October 2016). This should give us 3+ years to run this test without updates.

**Keep an eye on this test in CI and update the week range as needed.**

### Screenshots:
1. Cypress runner
![image](https://user-images.githubusercontent.com/31325167/104062979-bd546d00-51fb-11eb-9f97-dcbe1a9a7d63.png)

2. UI
![image](https://user-images.githubusercontent.com/31325167/104063012-cb09f280-51fb-11eb-82de-fcbd9a036d54.png)
