### PR TITLE
#14287 Repro: Should suggest questions saved in collections with colon in their name

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -411,6 +411,29 @@ describe("scenarios > collection_defaults", () => {
           cy.findByText("First collection");
         });
     });
+
+    it.skip("should suggest questions saved in collections with colon in their name (metabase#14287)", () => {
+      cy.request("POST", "/api/collection", {
+        name: "foo:bar",
+        color: "#509EE3",
+        parent_id: null,
+      }).then(({ body: { id: COLLECTION_ID } }) => {
+        // Move question #1 ("Orders") to newly created collection
+        cy.request("PUT", "/api/card/1", {
+          collection_id: COLLECTION_ID,
+        });
+        // Sanity check: make sure Orders is indeed inside new collection
+        cy.visit(`/collection/${COLLECTION_ID}`);
+        cy.findByText("Orders");
+      });
+
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      // Note: collection name's first letter is capitalized
+      cy.findByText(/foo:bar/i).click();
+      cy.findByText("Orders");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #14287 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. UI
![image](https://user-images.githubusercontent.com/31325167/104072089-c00a8e80-520a-11eb-8cfb-b40982fd39db.png)
