### PR TITLE
Refactor sandboxes

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -249,7 +249,7 @@ describeWithToken("formatting > sandboxes", () => {
         .should("have.length", 11);
     });
 
-    it("should be sandbox with a filter (after applying a filter to a JOINed question)", () => {
+    it("should be sandboxed with a filter (after applying a filter to a JOINed question)", () => {
       cy.visit("/question/5");
 
       // Notebook filter
@@ -351,7 +351,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("11"); // Sum of orders for user with ID #1
     });
 
-    it.skip("SB question with `case` CC should substitue the `else` argument's table (metabase-enterprise#548)", () => {
+    it.skip("SB question with `case` CC should substitute the `else` argument's table (metabase-enterprise#548)", () => {
       const QUESTION_NAME = "EE_548";
       const CC_NAME = "CC_548"; // Custom column
 

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -59,11 +59,11 @@ function createUser(user) {
 
 describeWithToken("formatting > sandboxes", () => {
   before(restore);
+  describe("Sandboxes should work", () => {
+    beforeEach(() => {
+      signInAsAdmin();
 
-  describe("Setup for sandbox tests", () => {
-    beforeEach(signInAsAdmin);
-
-    it("should make SQL question", () => {
+      cy.log("**--Create parametrized SQL question--**");
       cy.request("POST", "/api/card", {
         name: "sql param",
         dataset_query: {
@@ -86,39 +86,35 @@ describeWithToken("formatting > sandboxes", () => {
         display: "table",
         visualization_settings: {},
       });
+
+      cy.log("**--Create question with joins--**");
+      cy.request("POST", "/api/card", {
+        name: "test joins table",
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            joins: [
+              {
+                fields: "all",
+                "source-table": PRODUCTS_ID,
+                condition: [
+                  "=",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+                ],
+                alias: "Products",
+              },
+            ],
+          },
+          database: 1,
+        },
+        display: "table",
+        visualization_settings: {},
+      });
     });
-
-    // TODO: Remove manual waiting
-    it("should make a JOINs table", () => {
-      openOrdersTable();
-      cy.wait(1000)
-        .get(".Icon-notebook")
-        .click();
-      cy.wait(1000)
-        .findByText("Join data")
-        .click();
-      cy.findByText("Products").click();
-      cy.findByText("Visualize").click();
-      cy.findByText("Save").click();
-
-      cy.findByLabelText("Name")
-        .clear()
-        .wait(1)
-        .type("test joins table");
-      cy.findAllByText("Save")
-        .last()
-        .click();
-      cy.findByText("Not now").click();
-    });
-  });
-
-  describe("Sandboxes should work", () => {
-    beforeEach(signInAsNormalUser);
 
     it("should add key attributes to new user and existing user", () => {
-      signOut();
-      signInAsAdmin();
-
       // Existing user
       cy.visit("/admin/people");
       cy.get(".Icon-ellipsis")
@@ -146,9 +142,6 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should change sandbox permissions as admin", () => {
-      signOut();
-      signInAsAdmin();
-
       // Changes Orders permssions to use filter and People to use SQL filter
       cy.request("POST", "/api/mt/gtap", {
         id: 1,
@@ -188,6 +181,7 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should be sandboxed with a filter (on normal table)", () => {
+      signInAsNormalUser();
       cy.visit("/browse/1");
       cy.findByText("Orders").click();
 
@@ -242,6 +236,7 @@ describeWithToken("formatting > sandboxes", () => {
 
     // TODO: Restore before each test and avoid using hard coded question IDs
     it("should be sandboxed with a filter (on a saved JOINed question)", () => {
+      signInAsNormalUser();
       cy.visit("/question/5");
 
       cy.wait(2000)
@@ -250,6 +245,7 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should be sandboxed with a filter (after applying a filter to a JOINed question)", () => {
+      signInAsNormalUser();
       cy.visit("/question/5");
 
       // Notebook filter
@@ -271,6 +267,7 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should filter categories on saved SQL question (for a new question - column number)", () => {
+      signInAsNormalUser();
       openPeopleTable();
       cy.get(".TableInteractive-cellWrapper--firstColumn").should(
         "have.length",
@@ -279,6 +276,7 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should filter categories on saved SQL question (for a new question - row number)", () => {
+      signInAsNormalUser();
       openPeopleTable();
       cy.get(".TableInteractive-headerCellData").should("have.length", 4);
     });

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -30,12 +30,6 @@ const {
   COLLECTION_GROUP,
 } = USER_GROUPS;
 
-const new_user = {
-  first_name: "Barb",
-  last_name: "Tabley",
-  username: "new@metabase.com",
-};
-
 // TODO: If we ever have the need to use this user across multiple tests, extract it to `__support__/cypress`
 const sandboxed_user = {
   first_name: "User",
@@ -58,227 +52,233 @@ function createUser(user) {
 }
 
 describeWithToken("formatting > sandboxes", () => {
-  before(restore);
-  describe("Sandboxes should work", () => {
+  describe("should work", () => {
     beforeEach(() => {
+      restore();
       signInAsAdmin();
+    });
+    describe("for admins", () => {
+      beforeEach(() => {
+        cy.visit("/admin/people");
+      });
 
-      cy.log("**--Create parametrized SQL question--**");
-      cy.request("POST", "/api/card", {
-        name: "sql param",
-        dataset_query: {
-          type: "native",
-          native: {
-            query: "select id,name,address,email from people where {{cid}}",
-            "template-tags": {
-              cid: {
-                id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
-                name: "cid",
-                "display-name": "CID",
-                type: "dimension",
-                dimension: ["field-id", PEOPLE.ID],
-                "widget-type": "id",
+      it("should add key attributes to an existing user", () => {
+        cy.get(".Icon-ellipsis")
+          .last()
+          .click();
+        cy.findByText("Edit user").click();
+        cy.findByText("Add an attribute").click();
+        cy.findByPlaceholderText("Key").type("User ID");
+        cy.findByPlaceholderText("Value").type("3");
+        cy.findByText("Update").click();
+      });
+
+      it("should add key attributes to a new user", () => {
+        cy.findByText("Add someone").click();
+        cy.findByPlaceholderText("Johnny").type(sandboxed_user.first_name);
+        cy.findByPlaceholderText("Appleseed").type(sandboxed_user.last_name);
+        cy.findByPlaceholderText("youlooknicetoday@email.com").type(
+          sandboxed_user.email,
+        );
+        cy.findByText("Add an attribute").click();
+        cy.findByPlaceholderText("Key").type("User ID");
+        cy.findByPlaceholderText("Value").type("1");
+        cy.findAllByText("Create").click();
+        cy.findByText("Done").click();
+      });
+    });
+
+    describe("on sandboxed users", () => {
+      beforeEach(() => {
+        cy.log("**--Create parametrized SQL question--**");
+        cy.request("POST", "/api/card", {
+          name: "sql param",
+          dataset_query: {
+            type: "native",
+            native: {
+              query: "select id,name,address,email from people where {{cid}}",
+              "template-tags": {
+                cid: {
+                  id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
+                  name: "cid",
+                  "display-name": "CID",
+                  type: "dimension",
+                  dimension: ["field-id", PEOPLE.ID],
+                  "widget-type": "id",
+                },
               },
             },
+            database: 1,
           },
-          database: 1,
-        },
-        display: "table",
-        visualization_settings: {},
-      });
+          display: "table",
+          visualization_settings: {},
+        });
 
-      cy.log("**--Create question with joins--**");
-      cy.request("POST", "/api/card", {
-        name: "test joins table",
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": ORDERS_ID,
-            joins: [
-              {
-                fields: "all",
-                "source-table": PRODUCTS_ID,
-                condition: [
-                  "=",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-                ],
-                alias: "Products",
-              },
-            ],
+        cy.log("**--Create question with joins--**");
+        cy.request("POST", "/api/card", {
+          name: "test joins table",
+          dataset_query: {
+            type: "query",
+            query: {
+              "source-table": ORDERS_ID,
+              joins: [
+                {
+                  fields: "all",
+                  "source-table": PRODUCTS_ID,
+                  condition: [
+                    "=",
+                    ["field-id", ORDERS.PRODUCT_ID],
+                    ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+                  ],
+                  alias: "Products",
+                },
+              ],
+            },
+            database: 1,
           },
-          database: 1,
-        },
-        display: "table",
-        visualization_settings: {},
-      });
-    });
+          display: "table",
+          visualization_settings: {},
+        });
+        // Existing user ("normal")
+        cy.request("PUT", "/api/user/2", {
+          login_attributes: { "User ID": "3" },
+        });
 
-    it("should add key attributes to new user and existing user", () => {
-      // Existing user
-      cy.visit("/admin/people");
-      cy.get(".Icon-ellipsis")
-        .last()
-        .click();
-      cy.findByText("Edit user").click();
-      cy.findByText("Add an attribute").click();
-      cy.findByPlaceholderText("Key").type("User ID");
-      cy.findByPlaceholderText("Value").type("3");
-      cy.findByText("Update").click();
-
-      // New user
-      cy.visit("/admin/people");
-      cy.findByText("Add someone").click();
-      cy.findByPlaceholderText("Johnny").type(new_user.first_name);
-      cy.findByPlaceholderText("Appleseed").type(new_user.last_name);
-      cy.findByPlaceholderText("youlooknicetoday@email.com").type(
-        new_user.username,
-      );
-      cy.findByText("Add an attribute").click();
-      cy.findByPlaceholderText("Key").type("User ID");
-      cy.findByPlaceholderText("Value").type("1");
-      cy.findAllByText("Create").click();
-      cy.findByText("Done").click();
-    });
-
-    it("should change sandbox permissions as admin", () => {
-      // Changes Orders permssions to use filter and People to use SQL filter
-      cy.request("POST", "/api/mt/gtap", {
-        id: 1,
-        group_id: DATA_GROUP,
-        table_id: ORDERS_ID,
-        card_id: null,
-        attribute_remappings: {
-          "User ID": ["dimension", ["field-id", ORDERS.USER_ID]],
-        },
-      });
-      cy.request("POST", "/api/mt/gtap", {
-        group_id: DATA_GROUP,
-        table_id: PEOPLE_ID,
-        card_id: 4,
-        attribute_remappings: {
-          "User ID": ["dimension", ["template-tag", "cid"]],
-        },
-      });
-      cy.request("PUT", "/api/permissions/graph", {
-        revision: 1,
-        groups: {
-          [ADMIN_GROUP]: { "1": { native: "write", schemas: "all" } },
-          [DATA_GROUP]: {
-            "1": {
-              schemas: {
-                PUBLIC: {
-                  [ORDERS_ID]: { query: "segmented", read: "all" },
-                  [PEOPLE_ID]: { query: "segmented", read: "all" },
-                  [PRODUCTS_ID]: "all",
-                  [REVIEWS_ID]: "all",
+        // Changes Orders permssions to use filter...
+        cy.request("POST", "/api/mt/gtap", {
+          group_id: DATA_GROUP,
+          table_id: ORDERS_ID,
+          card_id: null,
+          attribute_remappings: {
+            "User ID": ["dimension", ["field-id", ORDERS.USER_ID]],
+          },
+        });
+        // and People to use SQL filter
+        cy.request("POST", "/api/mt/gtap", {
+          group_id: DATA_GROUP,
+          table_id: PEOPLE_ID,
+          card_id: 4,
+          attribute_remappings: {
+            "User ID": ["dimension", ["template-tag", "cid"]],
+          },
+        });
+        cy.request("PUT", "/api/permissions/graph", {
+          revision: 1,
+          groups: {
+            [ADMIN_GROUP]: { "1": { native: "write", schemas: "all" } },
+            [DATA_GROUP]: {
+              "1": {
+                schemas: {
+                  PUBLIC: {
+                    [ORDERS_ID]: { query: "segmented", read: "all" },
+                    [PEOPLE_ID]: { query: "segmented", read: "all" },
+                    [PRODUCTS_ID]: "all",
+                    [REVIEWS_ID]: "all",
+                  },
                 },
               },
             },
           },
-        },
-      });
-    });
-
-    it("should be sandboxed with a filter (on normal table)", () => {
-      signInAsNormalUser();
-      cy.visit("/browse/1");
-      cy.findByText("Orders").click();
-
-      // TODO: Refactor - asserting on the number of rows proved to be risky.
-      // Table filter - only 10 rows should show up
-      cy.contains("Showing 10");
-
-      // And those rows should only show the User ID of 3
-      // First get the number of columns...
-      // And then find the index of the column that contains "User ID"
-      // Then ensure every nth element of that column only contains the desired User ID
-      // TODO: If we use this again, it should go in a helper
-      cy.get(".TableInteractive-headerCellData")
-        .its("length")
-        .then(columnCount => {
-          cy.contains(".TableInteractive-headerCellData", "User ID")
-            .invoke("index")
-            .then(userIDIndex => {
-              cy.get(".cellData")
-                .its("length")
-                .then(cellCountWithHeaders => {
-                  const range = (start, stop, step) =>
-                    Array.from(
-                      { length: (stop - start) / step + 1 },
-                      (_, i) => start + i * step,
-                    );
-                  // Loop over the columns starting at the zero-indexed second row (first row is headers)
-                  // userIDIndex is already zero-indexed, so we just add that to the number of columns
-                  const genArr = range(
-                    columnCount + userIDIndex,
-                    cellCountWithHeaders,
-                    columnCount,
-                  );
-                  cy.wrap(genArr).each(index => {
-                    cy.get(".cellData")
-                      .eq(index)
-                      .should("have.text", "3");
-                  });
-                });
-            });
         });
+        signOut();
+        signInAsNormalUser();
+      });
 
-      // Notebook filter
-      cy.get(".Icon-notebook").click();
-      cy.findByText("Summarize").click();
-      cy.findByText("Count of rows").click();
-      cy.findByText("Visualize").click();
-      cy.get(".ScalarValue");
-      cy.findByText("18,760").should("not.exist");
-      cy.findByText("10");
-    });
+      it("should be sandboxed with a filter (on normal table)", () => {
+        cy.visit("/browse/1");
+        cy.findByText("Orders").click();
 
-    // TODO: Restore before each test and avoid using hard coded question IDs
-    it("should be sandboxed with a filter (on a saved JOINed question)", () => {
-      signInAsNormalUser();
-      cy.visit("/question/5");
+        // TODO: Refactor - asserting on the number of rows proved to be risky.
+        // Table filter - only 10 rows should show up
+        cy.contains("Showing 10");
 
-      cy.wait(2000)
-        .get(".TableInteractive-cellWrapper--firstColumn")
-        .should("have.length", 11);
-    });
+        // And those rows should only show the User ID of 3
+        // First get the number of columns...
+        // And then find the index of the column that contains "User ID"
+        // Then ensure every nth element of that column only contains the desired User ID
+        // TODO: If we use this again, it should go in a helper
+        cy.get(".TableInteractive-headerCellData")
+          .its("length")
+          .then(columnCount => {
+            cy.contains(".TableInteractive-headerCellData", "User ID")
+              .invoke("index")
+              .then(userIDIndex => {
+                cy.get(".cellData")
+                  .its("length")
+                  .then(cellCountWithHeaders => {
+                    const range = (start, stop, step) =>
+                      Array.from(
+                        { length: (stop - start) / step + 1 },
+                        (_, i) => start + i * step,
+                      );
+                    // Loop over the columns starting at the zero-indexed second row (first row is headers)
+                    // userIDIndex is already zero-indexed, so we just add that to the number of columns
+                    const genArr = range(
+                      columnCount + userIDIndex,
+                      cellCountWithHeaders,
+                      columnCount,
+                    );
+                    cy.wrap(genArr).each(index => {
+                      cy.get(".cellData")
+                        .eq(index)
+                        .should("have.text", "3");
+                    });
+                  });
+              });
+          });
 
-    it("should be sandboxed with a filter (after applying a filter to a JOINed question)", () => {
-      signInAsNormalUser();
-      cy.visit("/question/5");
+        // Notebook filter
+        cy.get(".Icon-notebook").click();
+        cy.findByText("Summarize").click();
+        cy.findByText("Count of rows").click();
+        cy.findByText("Visualize").click();
+        cy.get(".ScalarValue");
+        cy.findByText("18,760").should("not.exist");
+        cy.findByText("10");
+      });
 
-      // Notebook filter
-      cy.get(".Icon-notebook").click();
-      cy.wait(2000)
-        .findByText("Filter")
-        .click();
-      cy.findAllByText("Total")
-        .last()
-        .click();
-      cy.findByText("Equal to").click();
-      cy.findByText("Greater than").click();
-      cy.findByPlaceholderText("Enter a number").type("100");
-      cy.findByText("Add filter").click();
-      cy.findByText("Visualize").click();
-      cy.wait(2000)
-        .get(".TableInteractive-cellWrapper--firstColumn")
-        .should("have.length", 7);
-    });
+      // TODO: Restore before each test and avoid using hard coded question IDs
+      it("should be sandboxed with a filter (on a saved JOINed question)", () => {
+        cy.visit("/question/5");
 
-    it("should filter categories on saved SQL question (for a new question - column number)", () => {
-      signInAsNormalUser();
-      openPeopleTable();
-      cy.get(".TableInteractive-cellWrapper--firstColumn").should(
-        "have.length",
-        2,
-      );
-    });
+        cy.wait(2000)
+          .get(".TableInteractive-cellWrapper--firstColumn")
+          .should("have.length", 11);
+      });
 
-    it("should filter categories on saved SQL question (for a new question - row number)", () => {
-      signInAsNormalUser();
-      openPeopleTable();
-      cy.get(".TableInteractive-headerCellData").should("have.length", 4);
+      it("should be sandboxed with a filter (after applying a filter to a JOINed question)", () => {
+        cy.visit("/question/5");
+
+        // Notebook filter
+        cy.get(".Icon-notebook").click();
+        cy.wait(2000)
+          .findByText("Filter")
+          .click();
+        cy.findAllByText("Total")
+          .last()
+          .click();
+        cy.findByText("Equal to").click();
+        cy.findByText("Greater than").click();
+        cy.findByPlaceholderText("Enter a number").type("100");
+        cy.findByText("Add filter").click();
+        cy.findByText("Visualize").click();
+        cy.wait(2000)
+          .get(".TableInteractive-cellWrapper--firstColumn")
+          .should("have.length", 7);
+      });
+
+      it("should filter categories on saved SQL question (for a new question - column number)", () => {
+        openPeopleTable();
+        cy.get(".TableInteractive-cellWrapper--firstColumn").should(
+          "have.length",
+          2,
+        );
+      });
+
+      it("should filter categories on saved SQL question (for a new question - row number)", () => {
+        openPeopleTable();
+        cy.get(".TableInteractive-headerCellData").should("have.length", 4);
+      });
     });
   });
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Restructures the way sandboxing tests are organized
- Makes all tests run in isolation (as part of #14339)
- Cuts down the tests running time from around 40-45 s to 20-25 s on average
- Introduces some of the Cypress official best practices
- Makes it easier to read
![image](https://user-images.githubusercontent.com/31325167/104130135-72f3fd00-536f-11eb-988f-8d5973ebf0d7.png)
vs.
![image](https://user-images.githubusercontent.com/31325167/104130179-a898e600-536f-11eb-9581-1c0bbc406d1b.png)


### Additional context:
- [Avoid writing “tiny” tests with a single assertion](https://docs.cypress.io/guides/references/best-practices.html#Creating-%E2%80%9Ctiny%E2%80%9D-tests-with-a-single-assertion)
> Cypress runs a series of async lifecycle events that reset state between tests
> Resetting tests is much slower than adding more assertions
```javascript
// before
it("should filter categories on saved SQL question (for a new question - column number)", () => {
  openPeopleTable();
  cy.get(".TableInteractive-cellWrapper--firstColumn").should(
    "have.length",
    2,
  );
});

it("should filter categories on saved SQL question (for a new question - row number)", () => {
  openPeopleTable();
  cy.get(".TableInteractive-headerCellData").should("have.length", 4);
});
```

```javascript
// after
describe("table sandboxed on a saved parametrized SQL question", () => {
  it("should show filtered categories", () => {
    openPeopleTable();
    cy.get(".TableInteractive-headerCellData").should("have.length", 4);
    cy.get(".TableInteractive-cellWrapper--firstColumn").should(
      "have.length",
      2,
    );
  });
});
```

- [Avoid writing tests that rely on the state of the previous tests](https://docs.cypress.io/guides/references/best-practices.html#Having-tests-rely-on-the-state-of-previous-tests)
> You only need to do one thing to know whether you’ve coupled your tests incorrectly, or if one test is relying on the state of a previous one.
> Put an .only on the test and refresh the browser.
> If this test can run by itself and pass - congratulations you have written a good test.
> If this is not the case, then you should refactor and change your approach. 

Trying to run any of the previously written tests would've resulted in a failure. They were relying on previously written tests (which shouldn't have been written as a test in the first place. Because they are setup steps, they should've been written inside of a `beforeEach()` hook ).
```javascript
describe("Setup for sandbox tests", () => {
  beforeEach(signInAsAdmin);

  it("should make SQL question", () => {
  ...
  });
});

// then we had a test in a separate `describe()` block that completely relied on the previously mentioned one
describe("Sandboxes should work", () => {
  beforeEach(signInAsNormalUser);

  it("should filter categories on saved SQL question (for a new question - row number)", () => {
  ...
  });
});
```

This is now contained within a `describe()` block that keeps the setup for all its tests inside of a `beforeEach()` hook. **Bonus:** Since we're using API to set up the desired state, the whole setup is done almost in an instant. All that without the danger of a flakes in UI-based setup, and without the need to manually wait.
It is also really easy (for the maintainer or even reviewer) to collapse the whole `beforeEach()` block and to focus strictly on tests: Please see the [GIF screenshot on this link](https://share.getcloudapp.com/GGu2jXW1).
```javascript
describe("normal user", () => {
  // Define all the constants that we are going to use in tests within this block
  // Bonus: Relationships between setup and tests are now clear - everything leads back to a single `const`, which makes it easier to maintain and update the test as needed.

  const FOO = "Bar";
  ...

  beforeEach(() => {
    restore();
    signInAsAdmin();

    // Lengthy but non-taxing setup made possible by using the series of API calls
    // 1. Create sandboxed user
    // 2. Create a question
    // 3. Sandbox DB table based on that question
    // 4. Repeat as needed...
    // 5. Update permissions graph

    signOut();
    signInAsNormalUser();
  });

  // Each of the following blocks AND/OR tests can be run in isolation (try adding `.only`)
  describe("block 1", () => {
    it("test 1", () => {
    ...
    });
  });

  describe("block n", () => {
    it("test 1", () => {
    ...
    });
  });
});
```

- [Avoid unnecessary waiting](https://docs.cypress.io/guides/references/best-practices.html#Unnecessary-Waiting)
> In Cypress, you almost never need to use `cy.wait()` for an arbitrary amount of time. If you are finding yourself doing this, there is likely a much simpler way.
```javascript
it("should make a JOINs table", () => {
  openOrdersTable();
  cy.wait(1000)
    .get(".Icon-notebook")
    .click();
  cy.wait(1000)
    .findByText("Join data")
    .click();
  ...
});

it("should be sandboxed with a filter (on a saved JOINed question)", () => {
  // Another issue here is visiting the hardcoded question id. This is brittle. If setup changes (or any other factor, for that matter), this test would've failed.
  cy.visit("/question/5");

  cy.wait(2000)
    .get(".TableInteractive-cellWrapper--firstColumn")
    .should("have.length", 11);
});
```