### PR TITLE
Custom expression: use i18n plural for giving error feedback

### DIFF
--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { ngettext, msgid } from "ttag";
 import { ExpressionVisitor } from "./visitor";
 import { CLAUSE_TOKENS } from "./lexer";
 
@@ -65,7 +65,11 @@ export function typeCheck(cst, rootType) {
       const name = functionToken.name;
       const expectedArgsLength = clause.args.length;
       if (!clause.multiple && clause.args.length !== args.length) {
-        const message = t`Function ${name} expects ${expectedArgsLength} arguments`;
+        const message = ngettext(
+          msgid`Function ${name} expects ${expectedArgsLength} argument`,
+          `Function ${name} expects ${expectedArgsLength} arguments`,
+          expectedArgsLength,
+        );
         this.errors.push({ message });
       }
       return args.map(arg => {


### PR DESCRIPTION
(this is a minor refinement, a follow-up to PR #14310)

How to verify:

1. Ask a question, Custom question.
2. Pick Sample Dataset, Products table
3. Summarize, Pick the metric you want to see, Custom Expression
4. Type `SUM(` into the text field

**Before** this PR:

![image](https://user-images.githubusercontent.com/7288/104202759-2c8ab680-53e0-11eb-8119-2c56a3afc9b4.png)

After this PR:

![image](https://user-images.githubusercontent.com/7288/104202779-344a5b00-53e0-11eb-9054-8cb528b3229f.png)
