### PR TITLE
#14341 Repro: Custom expression filter doesn't display options [REGRESSION]

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -447,4 +447,27 @@ describe("scenarios > question > filter", () => {
     );
     cy.findByText(AGGREGATED_FILTER);
   });
+
+  it.skip("in a simple question should display popup for custom expression options (metabase#14341)", () => {
+    openProductsTable();
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+
+    // This issue has two problematic parts. We're testing for both:
+    cy.log("**--1. Popover should display all custom expression options--**");
+    // Popover shows up even without explicitly clicking the contenteditable field
+    popover().within(() => {
+      cy.findAllByRole("listitem").contains(/functions/i);
+    });
+
+    cy.log("**--2. Should not display error prematurely--**");
+    cy.get("[contenteditable='true']")
+      .click()
+      .type("contains(");
+    cy.findByText(/Checks to see if string1 contains string2 within it./i);
+    cy.get(".text-error").should("not.exist");
+    cy.findAllByText(/Expected one of these possible Token sequences:/i).should(
+      "not.exist",
+    );
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14341

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshot:
- 1st Error (popup doesn't show up)
![image](https://user-images.githubusercontent.com/31325167/104216860-eb73c000-543a-11eb-86c3-1f35aaf03604.png)

- 2nd Error (will not be visible by default - it'd show up only if the first one is fixed, but this one still persists for some reason)
![image](https://user-images.githubusercontent.com/31325167/104217191-5e7d3680-543b-11eb-870f-d0f24263252b.png)
![image](https://user-images.githubusercontent.com/31325167/104217223-6b9a2580-543b-11eb-8587-a39abd25e5f5.png)

