### PR TITLE
Refactor whitelabel Cypress tests

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
@@ -2,9 +2,11 @@ import { signIn, signInAsAdmin, restore, modal } from "__support__/cypress";
 
 // Drill-through support has been replaced with custom dashboard destinations
 describe.skip("drill through", () => {
-  before(restore);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
-  beforeEach(signInAsAdmin);
   it("sets drill through link for dots in a line graph", () => {
     cy.visit("/question/3");
     cy.contains("Settings").click();

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -92,34 +92,36 @@ describeWithToken("formatting > whitelabel", () => {
   });
 
   describe("company name", () => {
+    const COMPANY_NAME = "Test Co";
+
     beforeEach(() => {
       cy.log("**Change company name**");
       cy.visit("/admin/settings/whitelabel");
       cy.findByPlaceholderText("Metabase")
         .clear()
-        .type("Test Co");
+        .type(COMPANY_NAME);
       // Helps scroll the page up in order to see "Saved" notification
       cy.findByText("Application Name").click();
       cy.findByText("Saved");
-      cy.findByDisplayValue("Test Co");
+      cy.findByDisplayValue(COMPANY_NAME);
       cy.log("Company name has been updated!");
     });
 
-    it("changes should reflect", () => {
+    it("changes should reflect in different parts of UI", () => {
       cy.log("**--1. New company should show up on activity page--**");
       cy.visit("/activity");
-      cy.findByText("Test Co is up and running.");
+      cy.findByText(`${COMPANY_NAME} is up and running.`);
       cy.findByText("Metabase is up and running.").should("not.exist");
 
       cy.log("**--2. New company should show up when logged out--**");
       signOut();
       cy.visit("/");
-      cy.findByText("Sign in to Test Co");
+      cy.findByText(`Sign in to ${COMPANY_NAME}`);
 
       cy.log("**--3. New company should show up for a normal user--**");
       signInAsNormalUser();
       cy.visit("/activity");
-      cy.findByText("Test Co is up and running.");
+      cy.findByText(`${COMPANY_NAME} is up and running.`);
       cy.findByText("Metabase is up and running.").should("not.exist");
     });
   });

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -53,25 +53,23 @@ describeWithToken("formatting > whitelabel", () => {
     cy.findByPlaceholderText("Metabase")
       .clear()
       .type("Test Co");
-    // *** In html, is not text, only value
+    // Helps scroll the page up in order to see "Saved" notification
     cy.findByText("Application Name").click();
-
     cy.findByText("Saved");
-    cy.get("input").should("have.value", "Test Co");
-    cy.log("Company name has been updated");
+    cy.findByDisplayValue("Test Co");
+    cy.log("Company name has been updated!");
 
-    cy.log("New company show show up on activity page");
-    // signInAsAdmin();
+    cy.log("**--1. New company should show up on activity page--**");
     cy.visit("/activity");
     cy.findByText("Test Co is up and running.");
     cy.findByText("Metabase is up and running.").should("not.exist");
 
-    cy.log("New company should show up when logged out");
+    cy.log("**--2. New company should show up when logged out--**");
     signOut();
     cy.visit("/");
     cy.findByText("Sign in to Test Co");
 
-    cy.log("new company should show up as a normal user");
+    cy.log("**--3. New company should show up for a normal user--**");
     signInAsNormalUser();
     cy.visit("/activity");
     cy.findByText("Test Co is up and running.");

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -76,56 +76,62 @@ describeWithToken("formatting > whitelabel", () => {
     cy.findByText("Metabase is up and running.").should("not.exist");
   });
 
+  it("should be able to set colors using color-picker dialog", () => {
+    signInAsAdmin();
+    cy.visit("/admin/settings/whitelabel");
+
+    cy.log("**--1. Select color with squares--**");
+    changeThemeColor(1, colors.primary.hex);
+
+    cy.log("**--2. Select color by entering rgb value--**");
+    cy.get("td")
+      .eq(5)
+      .click();
+    cy.get(".sketch-picker")
+      .find("input")
+      .eq(1)
+      .clear()
+      .type(colors.nav.rgb[0]);
+    cy.get(".sketch-picker")
+      .find("input")
+      .eq(2)
+      .clear()
+      .type(colors.nav.rgb[1]);
+    cy.get(".sketch-picker")
+      .find("input")
+      .eq(3)
+      .clear()
+      .type(colors.nav.rgb[2]);
+    cy.findByText("Done").click();
+
+    cy.log("**--3. Select color by typing hex code--**");
+    cy.get("td")
+      .eq(29)
+      .click();
+    cy.get(".sketch-picker")
+      .find("input")
+      .first()
+      .clear()
+      .type(colors.additional4.hex);
+    cy.findByText("Done").click();
+  });
+
   describe("Changes to theme colors work", () => {
-    it("should change theme colors in admin panel", () => {
+    beforeEach(() => {
       signInAsAdmin();
-      cy.visit("/admin/settings/whitelabel");
-
-      // Select color with squares
-      changeThemeColor(1, colors.primary.hex);
-
-      // Select color by entering rgb
-      cy.get("td")
-        .eq(5)
-        .click();
-      cy.get(".sketch-picker")
-        .find("input")
-        .eq(1)
-        .clear()
-        .type(colors.nav.rgb[0]);
-      cy.get(".sketch-picker")
-        .find("input")
-        .eq(2)
-        .clear()
-        .type(colors.nav.rgb[1]);
-      cy.get(".sketch-picker")
-        .find("input")
-        .eq(3)
-        .clear()
-        .type(colors.nav.rgb[2]);
-      cy.findByText("Done").click();
-
-      // Select colors with squares
-      changeThemeColor(9, colors.accent1.hex);
-      changeThemeColor(13, colors.accent2.hex);
-      changeThemeColor(17, colors.additional1.hex);
-      changeThemeColor(21, colors.additional2.hex);
-      changeThemeColor(25, colors.additional3.hex);
-
-      // Select color by typing hex code
-      cy.get("td")
-        .eq(29)
-        .click();
-      cy.get(".sketch-picker")
-        .find("input")
-        .first()
-        .clear()
-        .type(colors.additional4.hex);
-      cy.findByText("Done").click();
-
-      changeThemeColor(33, colors.additional5.hex);
-
-      cy.get(".Icon-close").should("have.length", 10);
+      cy.request("PUT", "/api/setting/application-colors", {
+        value: {
+          accent1: "#417505",
+          accent2: "#7ed321",
+          accent3: "#b8e986",
+          accent4: "#50e3c2",
+          accent5: "#4a90e2",
+          accent6: "#082cbe",
+          accent7: "#f8e71c",
+          brand: "#8b572a",
+          nav: "#284e07",
+        },
+      });
     });
 
     it("should show color changes", () => {

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -214,17 +214,7 @@ describeWithToken("formatting > whitelabel", () => {
         "base64",
       ).then(logo_data => {
         cy.request("PUT", "/api/setting/application-logo-url", {
-          placeholder:
-            "enterprise/frontend/test/metabase-enterprise/_support_/logo.jpeg",
-          default: "app/assets/img/logo.svg",
-          description:
-            "For best results, use an SVG file with a transparent background.",
-          display_name: "Logo",
-          env_name: "MB_APPLICATION_LOGO_URL",
-          is_env_setting: false,
-          type: "string",
           value: `data:image/jpeg;base64,${logo_data}`,
-          originalValue: null,
         });
       });
     });

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -45,7 +45,7 @@ function checkLogo() {
 }
 
 describeWithToken("formatting > whitelabel", () => {
-  before(restore);
+  beforeEach(restore);
 
   it("should be able to change company name", () => {
     signInAsAdmin();

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -45,104 +45,110 @@ function checkLogo() {
 }
 
 describeWithToken("formatting > whitelabel", () => {
-  beforeEach(restore);
-
-  it("should be able to change company name", () => {
+  beforeEach(() => {
+    restore();
     signInAsAdmin();
-    cy.visit("/admin/settings/whitelabel");
-    cy.findByPlaceholderText("Metabase")
-      .clear()
-      .type("Test Co");
-    // Helps scroll the page up in order to see "Saved" notification
-    cy.findByText("Application Name").click();
-    cy.findByText("Saved");
-    cy.findByDisplayValue("Test Co");
-    cy.log("Company name has been updated!");
-
-    cy.log("**--1. New company should show up on activity page--**");
-    cy.visit("/activity");
-    cy.findByText("Test Co is up and running.");
-    cy.findByText("Metabase is up and running.").should("not.exist");
-
-    cy.log("**--2. New company should show up when logged out--**");
-    signOut();
-    cy.visit("/");
-    cy.findByText("Sign in to Test Co");
-
-    cy.log("**--3. New company should show up for a normal user--**");
-    signInAsNormalUser();
-    cy.visit("/activity");
-    cy.findByText("Test Co is up and running.");
-    cy.findByText("Metabase is up and running.").should("not.exist");
   });
 
-  it("should be able to set colors using color-picker dialog", () => {
-    signInAsAdmin();
-    cy.visit("/admin/settings/whitelabel");
+  describe("admin", () => {
+    it("should be able to set colors using color-picker dialog", () => {
+      cy.visit("/admin/settings/whitelabel");
 
-    cy.log("**--1. Select color with squares--**");
-    changeThemeColor(1, colors.primary.hex);
+      cy.log("**--1. Select color with squares--**");
+      changeThemeColor(1, colors.primary.hex);
 
-    cy.log("**--2. Select color by entering rgb value--**");
-    cy.get("td")
-      .eq(5)
-      .click();
-    cy.get(".sketch-picker")
-      .find("input")
-      .eq(1)
-      .clear()
-      .type(colors.nav.rgb[0]);
-    cy.get(".sketch-picker")
-      .find("input")
-      .eq(2)
-      .clear()
-      .type(colors.nav.rgb[1]);
-    cy.get(".sketch-picker")
-      .find("input")
-      .eq(3)
-      .clear()
-      .type(colors.nav.rgb[2]);
-    cy.findByText("Done").click();
+      cy.log("**--2. Select color by entering rgb value--**");
+      cy.get("td")
+        .eq(5)
+        .click();
+      cy.get(".sketch-picker")
+        .find("input")
+        .eq(1)
+        .clear()
+        .type(colors.nav.rgb[0]);
+      cy.get(".sketch-picker")
+        .find("input")
+        .eq(2)
+        .clear()
+        .type(colors.nav.rgb[1]);
+      cy.get(".sketch-picker")
+        .find("input")
+        .eq(3)
+        .clear()
+        .type(colors.nav.rgb[2]);
+      cy.findByText("Done").click();
 
-    cy.log("**--3. Select color by typing hex code--**");
-    cy.get("td")
-      .eq(29)
-      .click();
-    cy.get(".sketch-picker")
-      .find("input")
-      .first()
-      .clear()
-      .type(colors.additional4.hex);
-    cy.findByText("Done").click();
+      cy.log("**--3. Select color by typing hex code--**");
+      cy.get("td")
+        .eq(29)
+        .click();
+      cy.get(".sketch-picker")
+        .find("input")
+        .first()
+        .clear()
+        .type(colors.additional4.hex);
+      cy.findByText("Done").click();
+    });
   });
 
-  describe("Changes to theme colors work", () => {
+  describe("company name", () => {
     beforeEach(() => {
-      signInAsAdmin();
+      cy.log("**Change company name**");
+      cy.visit("/admin/settings/whitelabel");
+      cy.findByPlaceholderText("Metabase")
+        .clear()
+        .type("Test Co");
+      // Helps scroll the page up in order to see "Saved" notification
+      cy.findByText("Application Name").click();
+      cy.findByText("Saved");
+      cy.findByDisplayValue("Test Co");
+      cy.log("Company name has been updated!");
+    });
+
+    it("changes should reflect", () => {
+      cy.log("**--1. New company should show up on activity page--**");
+      cy.visit("/activity");
+      cy.findByText("Test Co is up and running.");
+      cy.findByText("Metabase is up and running.").should("not.exist");
+
+      cy.log("**--2. New company should show up when logged out--**");
+      signOut();
+      cy.visit("/");
+      cy.findByText("Sign in to Test Co");
+
+      cy.log("**--3. New company should show up for a normal user--**");
+      signInAsNormalUser();
+      cy.visit("/activity");
+      cy.findByText("Test Co is up and running.");
+      cy.findByText("Metabase is up and running.").should("not.exist");
+    });
+  });
+
+  describe("company color theme", () => {
+    beforeEach(() => {
       cy.request("PUT", "/api/setting/application-colors", {
         value: {
-          accent1: "#417505",
-          accent2: "#7ed321",
-          accent3: "#b8e986",
-          accent4: "#50e3c2",
-          accent5: "#4a90e2",
-          accent6: "#082cbe",
-          accent7: "#f8e71c",
-          brand: "#8b572a",
-          nav: "#284e07",
+          accent1: `#${colors.accent1.hex}`,
+          accent2: `#${colors.accent2.hex}`,
+          accent3: `#${colors.additional1.hex}`,
+          accent4: `#${colors.additional2.hex}`,
+          accent5: `#${colors.additional3.hex}`,
+          accent6: `#${colors.additional4.hex}`,
+          accent7: `#${colors.additional5.hex}`,
+          brand: `#${colors.primary.hex}`,
+          nav: `#${colors.nav.hex}`,
         },
       });
     });
 
-    it("should show color changes", () => {
+    it("should reflect color changes", () => {
       signOut();
       cy.visit("/");
-      cy.contains("Sign in");
 
       // Note that if we have modified the logo, the entire background turns the brand color.
       // But if we _haven't_, as is the case now, then the existing logo is branded
       // As is the "Remember me" and "Sign in" inputs
-      cy.get(".Icon").should(
+      cy.get(".Icon.text-brand").should(
         "have.css",
         "color",
         `rgb(${colors.primary.rgb.join(", ")})`,
@@ -198,10 +204,8 @@ describeWithToken("formatting > whitelabel", () => {
     });
   });
 
-  describe("Logo customization", () => {
+  describe("company logo", () => {
     beforeEach(() => {
-      signInAsAdmin();
-
       cy.log("**Add a logo**");
       cy.readFile(
         "enterprise/frontend/test/metabase-enterprise/_support_/logo.jpeg",
@@ -223,42 +227,44 @@ describeWithToken("formatting > whitelabel", () => {
       });
     });
 
-    it("should reflect logo change on admin's dashboard", () => {
+    it("changes should reflect on admin's dashboard", () => {
       cy.visit("/");
       checkLogo();
     });
 
-    it("should reflect logo change while signed out", () => {
+    it("changes should reflect while signed out", () => {
       signOut();
       cy.visit("/");
       checkLogo();
     });
 
-    it("should reflect logo change on user's dashboard", () => {
+    it("changes should reflect on user's dashboard", () => {
       signInAsNormalUser();
       cy.visit("/");
       checkLogo();
     });
   });
 
-  it("should add a custom favicon", () => {
-    signInAsAdmin();
-    cy.visit("/admin/settings/whitelabel");
+  describe("favicon", () => {
+    beforeEach(() => {
+      cy.visit("/admin/settings/whitelabel");
 
-    cy.findByPlaceholderText("frontend_client/favicon.ico").type(
-      "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
-    );
-    cy.get("ul")
-      .eq(2)
-      .click("right");
-    cy.findByText("Saved");
-    checkFavicon();
-
-    cy.log("New favicon should show up in user's HTML");
-    signInAsNormalUser();
-    cy.visit("/");
-    cy.get('head link[rel="icon"]')
-      .get('[href="https://cdn.ecosia.org/assets/images/ico/favicon.ico"]')
-      .should("have.length", 1);
+      cy.log("**Add favicon**");
+      cy.findByPlaceholderText("frontend_client/favicon.ico").type(
+        "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
+      );
+      cy.get("ul")
+        .eq(2)
+        .click("right");
+      cy.findByText("Saved");
+      checkFavicon();
+    });
+    it("should show up in user's HTML", () => {
+      signInAsNormalUser();
+      cy.visit("/");
+      cy.get('head link[rel="icon"]')
+        .get('[href="https://cdn.ecosia.org/assets/images/ico/favicon.ico"]')
+        .should("have.length", 1);
+    });
   });
 });

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -192,12 +192,11 @@ describeWithToken("formatting > whitelabel", () => {
     });
   });
 
-  describe("Changes to logo work", () => {
-    it("should add a logo", () => {
+  describe("Logo customization", () => {
+    beforeEach(() => {
       signInAsAdmin();
-      cy.visit("/admin/settings/whitelabel");
 
-      cy.server();
+      cy.log("**Add a logo**");
       cy.readFile(
         "enterprise/frontend/test/metabase-enterprise/_support_/logo.jpeg",
         "base64",
@@ -219,12 +218,12 @@ describeWithToken("formatting > whitelabel", () => {
     });
 
     it("should reflect logo change on admin's dashboard", () => {
-      signInAsAdmin();
       cy.visit("/");
       checkLogo();
     });
 
     it("should reflect logo change while signed out", () => {
+      signOut();
       cy.visit("/");
       checkLogo();
     });
@@ -239,8 +238,6 @@ describeWithToken("formatting > whitelabel", () => {
   it("should add a custom favicon", () => {
     signInAsAdmin();
     cy.visit("/admin/settings/whitelabel");
-
-    cy.server();
 
     cy.findByPlaceholderText("frontend_client/favicon.ico").type(
       "https://cdn.ecosia.org/assets/images/ico/favicon.ico",

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -5,7 +5,7 @@ import {
   signInAsNormalUser,
   openOrdersTable,
   describeWithToken,
-} from "../../../../../frontend/test/__support__/cypress";
+} from "__support__/cypress";
 
 // Define colors that we use for whitelabeling
 // If rbg values exist, it's because we explicit test those
@@ -28,11 +28,13 @@ function changeThemeColor(location, colorhex) {
   cy.get(`div[title='#${colorhex}']`).click();
   cy.findByText("Done").click();
 }
+
 function checkFavicon() {
   cy.request("/api/setting/application-favicon-url")
     .its("body")
     .should("include", "https://cdn.ecosia.org/assets/images/ico/favicon.ico");
 }
+
 function checkLogo() {
   cy.readFile(
     "enterprise/frontend/test/metabase-enterprise/_support_/logo.jpeg",

--- a/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
@@ -9,8 +9,10 @@ import {
 } from "__support__/cypress";
 
 describeWithToken("scenarios > question > snippets", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("can create a snippet", () => {
     cy.visit("/question/new");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Restructures the way whitelabel tests are organized
- Makes all tests run in isolation (as part of #14339)
- Cuts down the tests running time by a third - from around 95s to 60-65s on average
- Introduces some of the Cypress official best practices
- Makes it easier to read:
![image](https://user-images.githubusercontent.com/31325167/104248294-84b9cb00-5469-11eb-9648-0a81dee8c638.png)
vs.
![image](https://user-images.githubusercontent.com/31325167/104247898-ddd52f00-5468-11eb-95b7-904a17360628.png)


### Additional context
For some unknown reason, I managed to include two other commits in this PR.
- Run all tests in isolation for `drill_through.cy.spec.js` (https://github.com/metabase/metabase/pull/14346/commits/827b5939821b9b84a0948204cf783ef178bb479e) and
- Run all tests in isolation for `snippet-permissions.cy.spec.js` (https://github.com/metabase/metabase/pull/14346/commits/5fa8d998eba0bc5967eb059a5007200c0d79105c)

However, they don't have any significant code changes so I'll leave them here. The simple CI check should confirm that they are working as intended.