### PR TITLE
Default databases with auto_run_queries to true

### DIFF
--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -123,6 +123,7 @@ export const initializeDatabase = function(databaseId) {
     } else {
       const newDatabase = {
         name: "",
+        auto_run_queries: true,
         engine: Object.keys(MetabaseSettings.get("engines"))[0],
         details: {},
         created: false,

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -32,6 +32,14 @@ describe("scenarios > admin > databases > add", () => {
 
     cy.visit("/admin/databases/create");
 
+    // Instead of bloating our test suite with a separate repro, this line will do
+    cy.log(
+      "**Repro for [metabase#14334](https://github.com/metabase/metabase/issues/14334)**",
+    );
+    cy.findByLabelText(
+      "Automatically run queries when doing simple filtering and summarizing",
+    ).should("have.attr", "aria-checked", "true");
+
     typeField("Name", "Test db name");
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/14334

previously this was set in the
frontend/src/metabase/entities/databases/forms.js file with initial:
true but this did not affect form state, just the initial value of the
form. So what happened was we saved nil and regardless of the value,
the initial value of the form was checked. Meaning if you saved it as
false, subsequent page loads would show it as true due to the initial
form state. The db has a default of true for this column which is why
this seemingly worked in the past

Edit by Nemanja:
- This PR also includes a repro for #14334.
Instead of writing a separate test, I added a missing piece to already existing test. Note that the link inside Cypress runner is actually clickable and leads to the original issue directly from Cypress GUI.
![image](https://user-images.githubusercontent.com/31325167/104253077-ef700400-5473-11eb-9629-f73c4902de28.png)
