### PR TITLE
#14327 Repro: Cannot add date filter when calendar is collapsed

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -470,4 +470,19 @@ describe("scenarios > question > filter", () => {
       "not.exist",
     );
   });
+
+  it.skip("should be able to add date filter with calendar collapsed (metabase#14327)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Filter").click();
+    cy.findByText("Created At").click();
+    cy.findByText("Previous").click();
+    cy.findByText("Before").click();
+    // Collapse the calendar view
+    cy.get(".Icon-calendar").click();
+    cy.findByText("Add filter")
+      .closest(".Button")
+      .should("not.be.disabled")
+      .click();
+    cy.findByText(/^Created At is before/i);
+  });
 });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #14327 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

It is interesting that Cypress mechanics reveal the source of the bug in this repro. "Add filter" button is being covered by a calendar which is still in the DOM - only not visible.

### Screenshots
1. Cypress runner
![image](https://user-images.githubusercontent.com/31325167/104251050-314a7b80-546f-11eb-99d4-8980fdf80a46.png)

2. UI with the console
![image](https://user-images.githubusercontent.com/31325167/104251187-6fe03600-546f-11eb-96c5-396439577994.png)
