### PR TITLE
Refactor auditing Cypress tests

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -11,12 +11,10 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { PRODUCTS } = SAMPLE_DATASET;
 
 const year = new Date().getFullYear();
-const QUESTION = "question";
-const DASHBOARD = "dashboard";
 
 function generateQuestions(user) {
   cy.request("POST", `/api/card`, {
-    name: `${user} ${QUESTION}`,
+    name: `${user} question`,
     dataset_query: {
       type: "native",
       native: {
@@ -42,20 +40,20 @@ function generateQuestions(user) {
 
 function generateDashboards(user) {
   cy.request("POST", "/api/dashboard", {
-    name: `${user} ${DASHBOARD}`,
+    name: `${user} dashboard`,
   });
 }
 
 describeWithToken("audit > auditing", () => {
-  const userRoles = ["admin", "normal"];
-  const ADMIN_QUESTION = `${userRoles[0]} ${QUESTION}`;
-  const ADMIN_DASHBOARD = `${userRoles[0]} ${DASHBOARD}`;
-  const NORMAL_QUESTION = `${userRoles[1]} ${QUESTION}`;
-  const NORMAL_DASHBOARD = `${userRoles[1]} ${DASHBOARD}`;
+  const [admin, normal] = Object.keys(USERS);
+  const ADMIN_QUESTION = `${admin} question`;
+  const ADMIN_DASHBOARD = `${admin} dashboard`;
+  const NORMAL_QUESTION = `${normal} question`;
+  const NORMAL_DASHBOARD = `${normal} dashboard`;
 
   before(() => {
     restore();
-    userRoles.forEach(user => {
+    [admin, normal].forEach(user => {
       signIn(user);
       generateQuestions(user);
       generateDashboards(user);
@@ -68,7 +66,7 @@ describeWithToken("audit > auditing", () => {
 
     signIn("nodata");
 
-    cy.log(`**View ${userRoles[1]}'s dashboard**`);
+    cy.log(`**View ${normal}'s dashboard**`);
     cy.visit("/collection/root?type=dashboard");
     cy.findByText(NORMAL_DASHBOARD).click();
     cy.findByText("This dashboard is looking empty.");
@@ -78,7 +76,7 @@ describeWithToken("audit > auditing", () => {
     cy.visit("/question/2");
     cy.findByText("18,760");
 
-    cy.log(`**View newly created ${userRoles[0]}'s question**`);
+    cy.log(`**View newly created ${admin}'s question**`);
     cy.visit("/collection/root?type");
     cy.findByText(ADMIN_QUESTION).click();
     cy.findByPlaceholderText(/ID/i);

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -54,45 +54,34 @@ describeWithToken("audit > auditing", () => {
       generateQuestions(user);
       generateDashboards(user);
     });
+
+    cy.log("**Download a question**");
+    cy.visit("/question/3");
+    // cy.server();
+    cy.get(".Icon-download").click();
+    cy.request("POST", "/api/card/1/query/json");
+
+    signIn("nodata");
+
+    cy.log(`**View ${users[1]}'s dashboard**`);
+    cy.visit("/collection/root?type=dashboard");
+    cy.findByText(users[1] + " test dash").click();
+    cy.findByText("This dashboard is looking empty.");
+    cy.findByText("My personal collection").should("not.exist");
+
+    cy.log("**View old existing question**");
+    cy.visit("/question/2");
+    cy.findByText("18,760");
+
+    cy.log(`**View newly created ${users[0]}'s question**`);
+    cy.visit("/collection/root?type");
+    cy.findByText(users[0] + " test q").click();
+    cy.findByPlaceholderText(/ID/i);
   });
 
-  describe("Generate data to audit", () => {
-    beforeEach(signOut);
-
-    it("should view a dashboard", () => {
-      signIn("nodata");
-      cy.visit("/collection/root?type=dashboard");
-      cy.findByText(users[1] + " test dash").click();
-
-      cy.findByText("This dashboard is looking empty.");
-      cy.findByText("My personal collection").should("not.exist");
-    });
-
-    it("should view old question and new question", () => {
-      signIn("nodata");
-      cy.visit("/collection/root?type");
-      cy.findByText("Orders, Count").click();
-
-      cy.findByText("18,760");
-
-      cy.visit("/collection/root?type");
-      cy.findByText(users[0] + " test q").click();
-
-      cy.get('[placeholder="ID"]');
-    });
-
-    it("should download a question", () => {
-      signInAsNormalUser();
-      cy.visit("/question/3");
-      cy.server();
-      cy.get(".Icon-download").click();
-      cy.request("POST", "/api/card/1/query/json");
-    });
-  });
+  beforeEach(signInAsAdmin);
 
   describe("See expected info on team member pages", () => {
-    beforeEach(signInAsAdmin);
-
     const all_users = [
       USERS.admin,
       USERS.normal,
@@ -148,8 +137,6 @@ describeWithToken("audit > auditing", () => {
   });
 
   describe("See expected info on data pages", () => {
-    beforeEach(signInAsAdmin);
-
     it("should load both tabs in Databases", () => {
       // Overview tab
       cy.visit("/admin/audit/databases/overview");
@@ -209,8 +196,6 @@ describeWithToken("audit > auditing", () => {
   });
 
   describe("See expected info on item pages", () => {
-    beforeEach(signInAsAdmin);
-
     it("should load both tabs in Questions", () => {
       // Overview tab
       cy.visit("/admin/audit/questions/overview");

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -14,7 +14,7 @@ const year = new Date().getFullYear();
 const QUESTION = "question";
 const DASHBOARD = "dashboard";
 
-export function generateQuestions(user) {
+function generateQuestions(user) {
   cy.request("POST", `/api/card`, {
     name: `${user} ${QUESTION}`,
     dataset_query: {
@@ -39,7 +39,8 @@ export function generateQuestions(user) {
     visualization_settings: {},
   });
 }
-export function generateDashboards(user) {
+
+function generateDashboards(user) {
   cy.request("POST", "/api/dashboard", {
     name: `${user} ${DASHBOARD}`,
   });

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -50,15 +50,9 @@ export function generateQuestions(users) {
 export function generateDashboards(users) {
   users.forEach(user => {
     signIn(user);
-    cy.visit("/");
-    cy.get(".Icon-add").click();
-    cy.findByText("New dashboard").click();
-    cy.findByLabelText("Name").type(user + " test dash");
-    cy.get(".Icon-chevrondown").click();
-    cy.findAllByText("Our analytics")
-      .last()
-      .click();
-    cy.findByText("Create").click();
+    cy.request("POST", "/api/dashboard", {
+      name: user + " test dash",
+    });
   });
 }
 

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -14,45 +14,34 @@ const { PRODUCTS } = SAMPLE_DATASET;
 
 const year = new Date().getFullYear();
 
-export function generateQuestions(users) {
-  users.forEach(user => {
-    signIn(user);
-
-    cy.request("POST", `/api/card`, {
-      name: `${user} test q`,
-      dataset_query: {
-        type: "native",
-        native: {
-          query: "SELECT * FROM products WHERE {{ID}}",
-          "template-tags": {
-            ID: {
-              id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-              name: "ID",
-              display_name: "ID",
-              type: "dimension",
-              dimension: ["field-id", PRODUCTS.ID],
-              "widget-type": "category",
-              default: null,
-            },
+export function generateQuestions(user) {
+  cy.request("POST", `/api/card`, {
+    name: `${user} test q`,
+    dataset_query: {
+      type: "native",
+      native: {
+        query: "SELECT * FROM products WHERE {{ID}}",
+        "template-tags": {
+          ID: {
+            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+            name: "ID",
+            display_name: "ID",
+            type: "dimension",
+            dimension: ["field-id", PRODUCTS.ID],
+            "widget-type": "category",
+            default: null,
           },
         },
-        database: 1,
       },
-      display: "scalar",
-      description: null,
-      visualization_settings: {},
-      collection_id: null,
-      result_metadata: null,
-      metadata_checksum: null,
-    });
+      database: 1,
+    },
+    display: "scalar",
+    visualization_settings: {},
   });
 }
-export function generateDashboards(users) {
-  users.forEach(user => {
-    signIn(user);
-    cy.request("POST", "/api/dashboard", {
-      name: user + " test dash",
-    });
+export function generateDashboards(user) {
+  cy.request("POST", "/api/dashboard", {
+    name: `${user} test dash`,
   });
 }
 
@@ -60,8 +49,11 @@ describeWithToken("audit > auditing", () => {
   const users = ["admin", "normal"];
   before(() => {
     restore();
-    generateQuestions(users);
-    generateDashboards(users);
+    users.forEach(user => {
+      signIn(user);
+      generateQuestions(user);
+      generateDashboards(user);
+    });
   });
 
   describe("Generate data to audit", () => {

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -82,14 +82,6 @@ describeWithToken("audit > auditing", () => {
   beforeEach(signInAsAdmin);
 
   describe("See expected info on team member pages", () => {
-    const all_users = [
-      USERS.admin,
-      USERS.normal,
-      USERS.nodata,
-      USERS.nocollection,
-      USERS.none,
-    ];
-
     it("should load the Overview tab", () => {
       cy.visit("/admin/audit/members/overview");
 
@@ -116,8 +108,8 @@ describeWithToken("audit > auditing", () => {
     it("should load the All Members tab", () => {
       cy.visit("/admin/audit/members/all");
 
-      all_users.forEach(user => {
-        cy.findByText(user.first_name + " " + user.last_name);
+      Object.values(USERS).forEach(({ first_name, last_name }) => {
+        cy.findByText(`${first_name} ${last_name}`);
       });
       cy.get("tr")
         .last()

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -125,7 +125,7 @@ describeWithToken("audit > auditing", () => {
         .should("contain", year);
     });
 
-    it.skip("should load the Audit log (Audit log should display views of dashboards)", () => {
+    it.skip("audit log should display views of dashboards (metabase-enterprise#287)", () => {
       cy.visit("/admin/audit/members/log");
 
       cy.findAllByText("Orders, Count").should("have.length", 1);


### PR DESCRIPTION
### Status
READY

### What does this PR do?
- Restructures the way auditing tests are organized
- Makes all tests run in isolation (as part of #14339)
- Extracts setup into `before()` hook
- Introduces some of the Cypress official best practices

### How to test this manually?
- Put `.only` to **any** `describe()` block or any test within any `describe()` block
- Test(s) should pass