### PR TITLE
Modify color utility classes in night mode dashboards

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -83,6 +83,25 @@
   fill: currentColor;
 }
 
+.Dashboard.Dashboard--night .bg-light {
+  background-color: var(--color-bg-black);
+}
+
+.Dashboard.Dashboard--night .bg-medium {
+  background-color: var(--color-bg-dark);
+}
+
+.Dashboard.Dashboard--night .text-dark {
+  color: var(--color-bg-light);
+}
+
+.Dashboard.Dashboard--night .border-top,
+.Dashboard.Dashboard--night .border-left,
+.Dashboard.Dashboard--night .border-bottom,
+.Dashboard.Dashboard--night .border-right {
+  border-color: var(--color-bg-dark);
+}
+
 /* Night mode transition */
 .Dashboard.Dashboard--fullscreen,
 .Dashboard.Dashboard--fullscreen .DashCard .Card {

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -88,7 +88,7 @@
 }
 
 .Dashboard.Dashboard--night .bg-medium {
-  background-color: var(--color-bg-dark);
+  background-color: #596269;
 }
 
 .Dashboard.Dashboard--night .text-dark {


### PR DESCRIPTION
Closes #14326 

## What this does
- Modifies some of our `bg-*` and `border-*` util classes to use dark colors when in night mode. I went with the "modify the css classes themselves" approach instead of adding different classes in the viz type itself based on an `isNightmode` to make sure this would apply to other visualizations in the future as well.

I don't love this as a long term solution, since it doesn't cover every possible case or class, but it helps clean up the big legibility issue with our new PivotTables when in night mode.

Showing the effect on pivot tables

Before:
![image](https://user-images.githubusercontent.com/5248953/104369334-49f87700-54eb-11eb-8fa8-4a07c35e615b.png)

After:
![image](https://user-images.githubusercontent.com/5248953/104369304-3a792e00-54eb-11eb-84d2-78008536ee3b.png)
