### PR TITLE
Support nested native query snippets

### DIFF
--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -11,6 +11,7 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.driver.common.parameters :as i]
+            [metabase.driver.common.parameters.parse :as parse]
             [metabase.models.card :refer [Card]]
             [metabase.models.field :refer [Field]]
             [metabase.models.native-query-snippet :refer [NativeQuerySnippet]]
@@ -39,6 +40,19 @@
   {:arglists '([tag params])}
   (fn [{tag-type :type} _]
     (keyword tag-type)))
+
+(defmulti resolve-nested-tag-values
+  "Parse any nested parameter value(s) for a given tag and its parsed value,
+  returning a map of nested param names to values (which are the appropriate
+  record type such as `metabase.driver.common.parameters.FieldFilter`)."
+  {:arglists '([tag tag-value])}
+  (fn [{tag-type :type} _]
+    (keyword tag-type)))
+
+(defmethod resolve-nested-tag-values :default
+  [_ _]
+  ;; by default, do not resolve any nested tag values
+  {})
 
 (defmethod parse-tag :default
   [{tag-type :type, :as tag} _]
@@ -159,6 +173,63 @@
                  :type              qp.error-type/invalid-parameter}
                 e))))))
 
+(defn ^:private get-snippet-name [param-key ex-attrs]
+  (let [[_ p-type p-name] (re-matches #"([^:]+):(.+)" param-key)]
+    (if (= (name :snippet) p-type)
+      p-name
+      (throw (ex-info (tru "Invalid nested parameter found in snippet {0}. Only other snippets can be nested."
+                           param-key)
+                      (assoc ex-attrs :type qp.error-type/invalid-parameter))))))
+
+(defn ^:private native-snippet-to-ref-map [native-snippet]
+  {(str "snippet:" (:name native-snippet))
+   (i/map->ReferencedQuerySnippet
+     {:snippet-id (:id native-snippet)
+      :content    (:content native-snippet)})})
+
+(defn ^:private find-all-nested-snippets [parent-tag level snippet-nm {:keys [snippet-id content], :as snippet} name-to-val]
+  (if
+    (contains? name-to-val snippet-nm)
+    (throw (ex-info (tru "Cycle detected in snippet definitions; name {0} already seen. Full chain: {1}."
+                         snippet-nm
+                         (pr-str name-to-val))
+                    {:snippet-id       snippet-id
+                     :snippet-name     snippet-nm
+                     :tag              parent-tag
+                     :nest-level       level
+                     :covered-snippets (keys name-to-val)
+                     :type             qp.error-type/invalid-parameter}))
+    (let [parsed-content (parse/parse content)
+          params (filter i/Param? parsed-content)
+          ret-map (if (> level 0) {snippet-nm snippet} {})
+          ex-attrs {:snippet-id   snippet-id
+                    :snippet-name snippet-nm
+                    :tag          parent-tag}]
+      (if (> (count params) 0)
+        (let [names               (map #(get-snippet-name (:k %) ex-attrs) params)
+              native-vals         (map #(db/select-one NativeQuerySnippet :name %) names)
+              name->ref           (map native-snippet-to-ref-map native-vals)
+              nested-refs-by-name (reduce
+                                    (fn [acc sub-snippets] ; TODO: pull out to separate fn
+                                      (merge
+                                        acc
+                                        (reduce-kv
+                                          (fn [sub-acc nested-name nested-snippet]
+                                            (merge
+                                              sub-acc
+                                              (find-all-nested-snippets
+                                                parent-tag
+                                                (inc level)
+                                                nested-name
+                                                nested-snippet
+                                                (assoc name-to-val snippet-nm snippet))))
+                                          {}
+                                          sub-snippets)))
+                                    {}
+                                    name->ref)]
+          (into ret-map nested-refs-by-name))
+        ret-map))))
+
 (s/defmethod parse-tag :snippet :- ReferencedQuerySnippet
   [{:keys [snippet-name snippet-id], :as tag} :- TagParam, _]
   (let [snippet-id (or snippet-id
@@ -174,6 +245,9 @@
      {:snippet-id (:id snippet)
       :content    (:content snippet)})))
 
+(s/defmethod resolve-nested-tag-values :snippet :- su/Map
+             [tag snippet-value]
+             (find-all-nested-snippets tag 0 (:name tag) snippet-value {}))
 
 ;;; Non-FieldFilter Params (e.g. WHERE x = {{x}})
 
@@ -325,13 +399,15 @@
   (log/tracef "Building params map out of tags %s and params %s" (pr-str tags) (pr-str params))
   (try
     (into {} (for [[k tag] tags
-                   :let    [v (value-for-tag tag params)]
+                   :let    [v (value-for-tag tag params)
+                            nested-v (resolve-nested-tag-values tag v)]
                    :when   v]
                ;; TODO - if V is `nil` *on purpose* this still won't give us a query like `WHERE field = NULL`. That
                ;; kind of query shouldn't be possible from the frontend anyway
                (do
                  (log/tracef "Value for tag %s %s -> %s" (pr-str k) (pr-str tag) (pr-str v))
-                 {k v})))
+                 (log/tracef "Nested values found: %s" (pr-str nested-v))
+                 (assoc nested-v k v))))
     (catch Throwable e
       (throw (ex-info (tru "Error building query parameter map")
                       {:type   (or (:type (ex-data e)) qp.error-type/invalid-parameter)

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [metabase.driver :as driver]
             [metabase.driver.common.parameters :as i]
+            [metabase.driver.common.parameters.parse :as parse]
             [metabase.driver.sql.parameters.substitution :as substitution]
             [metabase.query-processor.error-type :as error-type]
             [metabase.util.i18n :refer [tru]]))
@@ -18,15 +19,28 @@
   (let [{:keys [replacement-snippet]} (substitution/->replacement-snippet-info driver/*driver* v)]
     [(str sql replacement-snippet) args missing]))
 
-(defn- substitute-native-query-snippet [[sql args missing] v]
-   (let [{:keys [replacement-snippet]} (substitution/->replacement-snippet-info driver/*driver* v)]
-     [(str sql replacement-snippet) args missing]))
+(declare substitute*)
 
-(defn- substitute-param [param->value [sql args missing] in-optional? {:keys [k]}]
+(defn- substitute-native-query-snippet [[sql args missing] v param->value in-optional? seen-params]
+   (let [{:keys [replacement-snippet]} (substitution/->replacement-snippet-info driver/*driver* v)
+         parsed-replacement (parse/parse replacement-snippet)]
+     (if (not-any? i/Param? parsed-replacement)
+       [(str sql replacement-snippet) args missing] ; no nested parameters, just splice in the SQL
+       (let [[recursive-query & _]
+             (substitute* param->value parsed-replacement in-optional? seen-params)]
+         [(str sql recursive-query) args missing]))))
+
+(defn- substitute-param [param->value [sql args missing] in-optional? {:keys [k]} seen-params]
   (if-not (contains? param->value k)
     [sql args (conj missing k)]
     (let [v (get param->value k)]
       (cond
+        (contains? seen-params k)
+        (throw (ex-info (tru "Cycle detected when resolving parameters")
+                        {:type         error-type/qp
+                         :params       param->value
+                         :sql          sql
+                         :seen-params  seen-params}))
         (i/FieldFilter? v)
         (substitute-field-filter [sql args missing] in-optional? k v)
 
@@ -34,7 +48,7 @@
         (subsistute-card-query [sql args missing] v)
 
         (i/ReferencedQuerySnippet? v)
-        (substitute-native-query-snippet [sql args missing] v)
+        (substitute-native-query-snippet [sql args missing] v param->value in-optional? (conj seen-params k))
 
         (= i/no-value v)
         [sql args (conj missing k)]
@@ -43,7 +57,6 @@
         (let [{:keys [replacement-snippet prepared-statement-args]} (substitution/->replacement-snippet-info driver/*driver* v)]
           [(str sql replacement-snippet) (concat args prepared-statement-args) missing])))))
 
-(declare substitute*)
 
 (defn- substitute-optional [param->value [sql args missing] {subclauses :args}]
   (let [[opt-sql opt-args opt-missing] (substitute* param->value subclauses true)]
@@ -53,20 +66,22 @@
 
 (defn- substitute*
   "Returns a sequence of `[replaced-sql-string jdbc-args missing-parameters]`."
-  [param->value parsed in-optional?]
-  (reduce
-   (fn [[sql args missing] x]
-     (cond
-       (string? x)
-       [(str sql x) args missing]
+  ([param->value parsed in-optional?]
+   (substitute* param->value parsed in-optional? #{}))
+  ([param->value parsed in-optional? seen-params]
+   (reduce
+     (fn [[sql args missing] x]
+       (cond
+         (string? x)
+         [(str sql x) args missing]
 
-       (i/Param? x)
-       (substitute-param param->value [sql args missing] in-optional? x)
+         (i/Param? x)
+         (substitute-param param->value [sql args missing] in-optional? x seen-params)
 
-       (i/Optional? x)
-       (substitute-optional param->value [sql args missing] x)))
-   nil
-   parsed))
+         (i/Optional? x)
+         (substitute-optional param->value [sql args missing] x)))
+     nil
+     parsed)))
 
 (defn substitute
   "Substitute `Optional` and `Param` objects in a `parsed-query`, a sequence of parsed string fragments and tokens, with

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -284,14 +284,18 @@
              (values/query->params-map query)))))))
 
 (deftest snippet-test
-  (letfn [(query-with-snippet [& {:as snippet-properties}]
-            (assoc (mt/native-query "SELECT * FROM {{expensive-venues}}")
-                   :template-tags {"expensive-venues" (merge
-                                                       {:type         :snippet
-                                                        :name         "expensive-venues"
-                                                        :display-name "Expensive Venues"
-                                                        :snippet-name "expensive-venues"}
-                                                       snippet-properties)}))]
+  (letfn [(query-with-snippet* [snippet-name display-name snippet-properties]
+            (assoc (mt/native-query (str "SELECT * FROM {{" snippet-name "}}"))
+              :template-tags {snippet-name (merge
+                                             {:type         :snippet
+                                              :name         snippet-name
+                                              :display-name display-name
+                                              :snippet-name snippet-name}
+                                             snippet-properties)}))
+          (query-with-snippet [& {:as snippet-properties}]
+            (query-with-snippet* "expensive-venues" "Expensive venues" snippet-properties))
+          (nested-query-with-snippet [& {:as snippet-properties}]
+            (query-with-snippet* "expensive-nearby-venues" "Expensive nearby venues" snippet-properties))]
     (testing "`:snippet-id` should be required"
       (is (thrown?
            clojure.lang.ExceptionInfo
@@ -303,13 +307,42 @@
            (values/query->params-map (query-with-snippet :snippet-id Integer/MAX_VALUE)))))
 
     (testing "Snippet parsing should work correctly for a valid Snippet"
-      (mt/with-temp NativeQuerySnippet [{snippet-id :id} {:name    "expensive-venues"
-                                                          :content "venues WHERE price = 4"}]
+      (mt/with-temp* [NativeQuerySnippet [{snippet-id :id} {:name    "expensive-venues"
+                                                            :content "venues WHERE price = 4"}]
+                      NativeQuerySnippet [{snp-near-dist-amt :id} {:name    "near-distance-amt"
+                                                                   :content "10"}]
+                      NativeQuerySnippet [{snp-near-dist :id} {:name    "near-distance"
+                                                               :content "distance < {{snippet:near-distance-amt}}"}]
+                      NativeQuerySnippet [{snp-expensive-nearby :id}
+                                          {:name    "expensive-nearby-venues"
+                                           :content "{{snippet:expensive-venues}} AND {{snippet:near-distance}}"}]
+                      NativeQuerySnippet [{snp-circ-1 :id} {:name    "snp-circ-1"
+                                                            :content "venues WHERE price < 2 AND {{snippet:snp-circ-2}}"}]
+                      NativeQuerySnippet [{snp-circ-2 :id} {:name    "snp-circ-2"
+                                                            :content "distance = 1 AND {{snippet:snp-circ-1}}"}]]
         (let [expected {"expensive-venues" (i/map->ReferencedQuerySnippet {:snippet-id snippet-id
-                                                                           :content    "venues WHERE price = 4"})}]
+                                                                           :content    "venues WHERE price = 4"})}
+              expected-nested (assoc expected "expensive-nearby-venues"
+                                              (i/map->ReferencedQuerySnippet
+                                                {:snippet-id snp-expensive-nearby
+                                                 :content    "{{snippet:expensive-venues}} AND {{snippet:near-distance}}"})
+                                              "near-distance"
+                                              (metabase.driver.common.parameters/map->ReferencedQuerySnippet
+                                                {:content    "distance < {{snippet:near-distance-amt}}"
+                                                 :snippet-id snp-near-dist})
+                                              "near-distance-amt"
+                                              (metabase.driver.common.parameters/map->ReferencedQuerySnippet
+                                                {:content    "10"
+                                                 :snippet-id snp-near-dist-amt}))]
           (is (= expected
                  (values/query->params-map (query-with-snippet :snippet-id snippet-id))))
-
+          (testing "all nested snippets should be resolved and placed into param map correctly"
+            (is (= expected-nested
+                   (values/query->params-map (nested-query-with-snippet :snippet-id snp-expensive-nearby)))))
+          (testing "circular nested snippet definition should throw an exception"
+            (is (thrown?
+                  clojure.lang.ExceptionInfo
+                  (values/query->params-map (nested-query-with-snippet :snippet-id snp-circ-1)))))
           (testing "`:snippet-name` property in query shouldn't have to match `:name` of Snippet in DB"
             (is (= expected
                    (values/query->params-map (query-with-snippet :snippet-id snippet-id, :snippet-name "Old Name"))))))))))


### PR DESCRIPTION
WORK IN PROGRESS

Calling the parser from substitute when encountering a Param inside the snippet value

Adding generic cycle detection mechanism (based on Param key) to substitute-param

Adding test for valid and cyclic cases

TODO:
* Make changes in metabase.driver.common.parameters.values namespace and test
* Add stricter check to ensure only other snippets can be nested (as opposed to other param types)?

###### Before submitting the PR, please make sure you do the following

- [N/A] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [N/A] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [X] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

- [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
