### PR TITLE
Pivot tables - Display more levels of subtotals

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -144,7 +144,6 @@ export function multiLevelPivot(
     topIndex,
     leftIndex,
     topIndexFormatters,
-    rowColumnTree,
     leftIndexFormatters,
     columnCount,
     rowCount,
@@ -251,7 +250,7 @@ function enumerate(
   const childPaths = children.flatMap(child =>
     enumerate(child, { includeSubtotals }, pathWithValue),
   );
-  return includeSubtotals
+  return includeSubtotals && children.length > 1
     ? // follow children with their subtotal
       [...childPaths, pathWithValue]
     : childPaths;
@@ -297,7 +296,7 @@ function addSubtotals(rowColumnTree, formatters) {
 
 function addSubtotal(item, [formatter, ...formatters]) {
   const subtotal =
-    item.children.length > 0
+    item.children.length > 1
       ? [
           {
             value: t`Totals for ${formatter(item.value)}`,

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -119,26 +119,21 @@ export function multiLevelPivot(
     }
   }
 
-  const leftIndexWithoutSubtotals = getIndex(rowColumnTree, {});
-  const leftIndexUncollapsed = addSubtotalRowsToIndex(
-    leftIndexWithoutSubtotals,
-    leftIndexFormatters[0],
+  const formattedRowTree = formatValuesInTree(
+    rowColumnTree,
+    leftIndexFormatters,
   );
-  const leftIndex = collapseRows(rowColumnTree, leftIndexUncollapsed);
-
+  const leftIndex = addSubtotals(formattedRowTree, leftIndexFormatters);
   if (leftIndex.length > 1) {
     // if there are multiple rows, we should add another for grand totals
     leftIndex.push([
-      [
-        [
-          {
-            value: t`Grand totals`,
-            span: 1,
-            isSubtotal: true,
-            isGrandTotal: true,
-          },
-        ],
-      ],
+      {
+        value: t`Grand totals`,
+        span: 1,
+        isSubtotal: true,
+        isGrandTotal: true,
+        children: [],
+      },
     ]);
   }
 
@@ -149,6 +144,7 @@ export function multiLevelPivot(
     topIndex,
     leftIndex,
     topIndexFormatters,
+    rowColumnTree,
     leftIndexFormatters,
     columnCount,
     rowCount,
@@ -193,9 +189,7 @@ function createRowSectionGetter({
     const rows =
       rowIndex >= rowColumnTree.length
         ? [[]]
-        : enumerate(rowColumnTree[rowIndex]);
-    const initialRowValue =
-      rowColumnTree[rowIndex] && rowColumnTree[rowIndex].value;
+        : enumerate(rowColumnTree[rowIndex], { includeSubtotals: true });
     const columns =
       columnIndex >= columnColumnTree.length
         ? [[]]
@@ -221,56 +215,46 @@ function createRowSectionGetter({
 
     // "row totals" on the right
     if (rightColumn) {
-      const subtotalRows =
-        rowColumnIndexes.length > 1
-          ? [
-              columns.flatMap(col =>
-                getSubtotals(rowColumnIndexes.slice(0, 1), [initialRowValue]),
-              ),
-            ]
-          : [];
-
-      return rows
-        .map(row => getSubtotals(rowColumnIndexes, row))
-        .concat(subtotalRows);
+      return rows.map(row =>
+        getSubtotals(rowColumnIndexes.slice(0, row.length), row),
+      );
     }
 
-    const subtotalRows =
-      rowColumnIndexes.length > 1
-        ? [
-            columns.flatMap(col =>
-              getSubtotals(
-                columnColumnIndexes.concat(rowColumnIndexes.slice(0, 1)),
-                col.concat(initialRowValue),
-              ),
-            ),
-          ]
-        : [];
-
-    return rows
-      .map(row =>
-        columns.flatMap(col => {
-          const { values, data } =
-            valuesByKey[JSON.stringify(col.concat(row))] || {};
-          return formatValues(values).map(o =>
-            data === undefined ? o : { ...o, clicked: { data } },
+    return rows.map(row =>
+      columns.flatMap(col => {
+        if (row.length < rowColumnIndexes.length) {
+          const indexes = columnColumnIndexes.concat(
+            rowColumnIndexes.slice(0, row.length),
           );
-        }),
-      )
-      .concat(subtotalRows);
+          return getSubtotals(indexes, col.concat(row));
+        }
+        const { values, data } =
+          valuesByKey[JSON.stringify(col.concat(row))] || {};
+        return formatValues(values).map(o =>
+          data === undefined ? o : { ...o, clicked: { data } },
+        );
+      }),
+    );
   };
   return _.memoize(getter, (i1, i2) => [i1, i2].join());
 }
 
-function enumerate({ value, isCollapsed, children }, path = []) {
-  if (isCollapsed) {
-    return [];
-  }
+function enumerate(
+  { value, isCollapsed, children },
+  { includeSubtotals = false } = {},
+  path = [],
+) {
   const pathWithValue = [...path, value];
-  if (children.length === 0) {
+  if (isCollapsed || children.length === 0) {
     return [pathWithValue];
   }
-  return children.flatMap(child => enumerate(child, pathWithValue));
+  const childPaths = children.flatMap(child =>
+    enumerate(child, { includeSubtotals }, pathWithValue),
+  );
+  return includeSubtotals
+    ? // follow children with their subtotal
+      [...childPaths, pathWithValue]
+    : childPaths;
 }
 
 function getIndex(
@@ -298,30 +282,44 @@ function getIndex(
   });
 }
 
-// This wraps all items in the left index to accomodate a possible "Totals for" row.
-// If there are multiple levels in the index, each gets a "Totals for" row
-function addSubtotalRowsToIndex(leftIndex, subtotalFormatter) {
-  const shouldAddSubtotalRows = leftIndex.some(val => val.length > 1);
-  return leftIndex.map(row => {
-    if (!shouldAddSubtotalRows) {
-      return [row];
-    }
-    const rawValue = row[0][0].value;
-    const subtotal = {
-      value: t`Totals for ${subtotalFormatter(rawValue)}`,
-      rawValue,
-      span: 1,
-      isSubtotal: true,
-    };
-    return [row, [[subtotal]]];
-  });
+function formatValuesInTree(rowColumnTree, [formatter, ...formatters]) {
+  return rowColumnTree.map(item => ({
+    ...item,
+    value: formatter(item.value),
+    rawValue: item.value,
+    children: formatValuesInTree(item.children, formatters),
+  }));
 }
 
-function collapseRows(rowColumnTree, leftIndex) {
-  return leftIndex.map((item, index) => {
-    const { isCollapsed } = rowColumnTree[index];
-    return isCollapsed ? item.slice(1) : item;
-  });
+function addSubtotals(rowColumnTree, formatters) {
+  return rowColumnTree.map(item => addSubtotal(item, formatters));
+}
+
+function addSubtotal(item, [formatter, ...formatters]) {
+  const subtotal =
+    item.children.length > 0
+      ? [
+          {
+            value: t`Totals for ${formatter(item.value)}`,
+            rawValue: item.value,
+            span: 1,
+            isSubtotal: true,
+            children: [],
+          },
+        ]
+      : [];
+  if (item.isCollapsed) {
+    return subtotal;
+  }
+  const node = {
+    ...item,
+    children: item.children.flatMap(item =>
+      // add subtotals until the last level
+      item.children.length > 0 ? addSubtotal(item, formatters) : item,
+    ),
+  };
+
+  return [node, ...subtotal];
 }
 
 function updateValueObject(row, indexes, seenValues, collapsedSubtotals = []) {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -183,7 +183,8 @@ export default class PivotTable extends Component {
       rowCount,
       columnCount,
     } = pivoted;
-    const topHeaderHeight = (columnIndexes.length || 1) * CELL_HEIGHT;
+
+    const topHeaderHeight = (topIndex[0].length || 1) * CELL_HEIGHT;
     const leftHeaderWidth =
       rowIndexes.length > 0
         ? LEFT_HEADER_LEFT_SPACING + rowIndexes.length * LEFT_HEADER_CELL_WIDTH
@@ -438,7 +439,7 @@ function LeftHeaderSection({
             ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
           }}
           icon={
-            (isSubtotal || children.length > 0) && (
+            (isSubtotal || children.length > 1) && (
               <RowToggleIcon
                 value={valuePath}
                 settings={settings}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -179,7 +179,6 @@ export default class PivotTable extends Component {
       topIndex,
       leftIndex,
       topIndexFormatters,
-      leftIndexFormatters,
       getRowSection,
       rowCount,
       columnCount,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -135,7 +135,13 @@ export default class PivotTable extends Component {
     this.topGrid && this.topGrid.recomputeGridSize();
     this.leftList && this.leftList.recomputeRowHeights();
 
-    const { settings, data, width, height } = this.props;
+    const {
+      settings,
+      data,
+      width,
+      height,
+      onUpdateVisualizationSettings,
+    } = this.props;
     if (data == null || !data.cols.some(isPivotGroupColumn)) {
       return null;
     }
@@ -180,7 +186,9 @@ export default class PivotTable extends Component {
     } = pivoted;
     const topHeaderHeight = (columnIndexes.length || 1) * CELL_HEIGHT;
     const leftHeaderWidth =
-      LEFT_HEADER_LEFT_SPACING + rowIndexes.length * LEFT_HEADER_CELL_WIDTH;
+      rowIndexes.length > 0
+        ? LEFT_HEADER_LEFT_SPACING + rowIndexes.length * LEFT_HEADER_CELL_WIDTH
+        : 0;
 
     function columnWidth({ index }) {
       if (topIndex.length === 0) {
@@ -190,14 +198,16 @@ export default class PivotTable extends Component {
       return indexItem[indexItem.length - 1].length * CELL_WIDTH;
     }
 
+    function getSpan(children) {
+      return children.length === 0
+        ? 1
+        : children.reduce((sum, child) => sum + getSpan(child.children), 0);
+    }
     function rowHeight({ index }) {
       if (leftIndex.length === 0) {
         return CELL_HEIGHT;
       }
-      const span = leftIndex[index].reduce(
-        (sum, row) => row[0][0].span + sum,
-        0,
-      );
+      const span = getSpan(leftIndex[index]);
       return span * CELL_HEIGHT;
     }
 
@@ -241,67 +251,14 @@ export default class PivotTable extends Component {
         <div
           key={key}
           style={style}
-          className="flex flex-column border-right border-medium"
+          className="border-right border-medium bg-light"
         >
-          {leftIndex[index].map((row, rowIndex) => (
-            <div
-              className="flex"
-              style={{ height: row[0][0].span * CELL_HEIGHT }}
-            >
-              {row.map((col, index) =>
-                col[0].isSubtotal ? (
-                  <Cell
-                    value={col[0].value}
-                    isSubtotal
-                    isGrandTotal={col[0].isGrandTotal}
-                    style={{
-                      paddingLeft: LEFT_HEADER_LEFT_SPACING,
-                      width: leftHeaderWidth,
-                    }}
-                    icon={
-                      !col[0].isGrandTotal && (
-                        <RowToggleIcon
-                          value={col[0].rawValue}
-                          settings={this.props.settings}
-                          updateSettings={
-                            this.props.onUpdateVisualizationSettings
-                          }
-                          hideUnlessCollapsed
-                        />
-                      )
-                    }
-                  />
-                ) : (
-                  <div
-                    className="flex flex-column bg-light flex-basis-none flex-full"
-                    style={{
-                      paddingLeft: index === 0 ? LEFT_HEADER_LEFT_SPACING : 0,
-                    }}
-                  >
-                    {col.map(({ value, span = 1, isSubtotal }) => (
-                      <Cell
-                        value={leftIndexFormatters[index](value)}
-                        isSubtotal={isSubtotal}
-                        height={span}
-                        icon={
-                          index === 0 &&
-                          rowIndex === 0 &&
-                          row.length > 1 && (
-                            <RowToggleIcon
-                              value={value}
-                              settings={this.props.settings}
-                              updateSettings={
-                                this.props.onUpdateVisualizationSettings
-                              }
-                            />
-                          )
-                        }
-                      />
-                    ))}
-                  </div>
-                ),
-              )}
-            </div>
+          {(leftIndex[index] || []).map(item => (
+            <LeftHeaderSection
+              item={item}
+              settings={settings}
+              onUpdateVisualizationSettings={onUpdateVisualizationSettings}
+            />
           ))}
         </div>
       ),
@@ -434,7 +391,7 @@ function RowToggleIcon({
   hideUnlessCollapsed,
 }) {
   const setting = settings[COLLAPSED_ROWS_SETTING] || [];
-  const rowRef = JSON.stringify([value]);
+  const rowRef = JSON.stringify(value);
   const isCollapsed = setting.includes(rowRef);
   if (hideUnlessCollapsed && !isCollapsed) {
     // subtotal rows shouldn't have an icon unless the section is collapsed
@@ -456,6 +413,54 @@ function RowToggleIcon({
       onClick={update}
     >
       <Icon name={isCollapsed ? "add" : "dash"} size={8} />
+    </div>
+  );
+}
+
+function LeftHeaderSection({
+  item: { value, rawValue, isSubtotal, isGrandTotal, children },
+  settings,
+  onUpdateVisualizationSettings,
+  valuePath = [],
+  depth = 0,
+}) {
+  valuePath = [...valuePath, rawValue];
+  return (
+    <div className="flex justify-between">
+      {value === null ? null : (
+        <Cell
+          value={value}
+          isSubtotal={isSubtotal}
+          isGrandTotal={isGrandTotal}
+          baseWidth={LEFT_HEADER_CELL_WIDTH}
+          width={isSubtotal ? undefined : 1}
+          className={isSubtotal ? "flex-full" : ""}
+          style={{
+            ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
+          }}
+          icon={
+            (isSubtotal || children.length > 0) && (
+              <RowToggleIcon
+                value={valuePath}
+                settings={settings}
+                updateSettings={onUpdateVisualizationSettings}
+                hideUnlessCollapsed={isSubtotal}
+              />
+            )
+          }
+        />
+      )}
+      <div className="flex flex-column">
+        {children.map(child => (
+          <LeftHeaderSection
+            item={child}
+            depth={depth + 1}
+            valuePath={valuePath}
+            settings={settings}
+            onUpdateVisualizationSettings={onUpdateVisualizationSettings}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { pivot, multiLevelPivot } from "metabase/lib/data_grid";
 
 import { TYPE } from "metabase/lib/types";
@@ -17,19 +15,6 @@ const D3 = dimension(3);
 const D4 = dimension(4);
 
 const M = { name: "M", display_name: "Metric", base_type: TYPE.Integer };
-
-const GRAND_TOTALS_ROW = [
-  [
-    [
-      {
-        isGrandTotal: true,
-        isSubtotal: true,
-        span: 1,
-        value: "Grand totals",
-      },
-    ],
-  ],
-];
 
 function makeData(rows) {
   return {
@@ -465,7 +450,6 @@ describe("data_grid", () => {
       const primaryGroup = 0;
       const subtotalOne = 2;
       const subtotalTwo = 1;
-      const subtotalThree = 3;
       const rows = [
         ["a", "x", 1, primaryGroup],
         ["a", "y", 2, primaryGroup],
@@ -495,6 +479,7 @@ describe("data_grid", () => {
         span: 1,
         value: "Totals for a",
       });
+      expect(getRowSection(0, 0)).toEqual([[{ isSubtotal: true, value: "3" }]]);
     });
 
     it("should return multiple levels of subtotals", () => {
@@ -537,12 +522,7 @@ describe("data_grid", () => {
         rows,
         cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
       };
-      const { getRowSection, rowCount, columnCount } = multiLevelPivot(
-        data,
-        [3],
-        [0, 1, 2],
-        [4],
-      );
+      const { getRowSection } = multiLevelPivot(data, [3], [0, 1, 2], [4]);
       expect(extractValues(getRowSection(0, 0))).toEqual([
         ["1"],
         ["2"],

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -1,19 +1,21 @@
+import _ from "underscore";
+
 import { pivot, multiLevelPivot } from "metabase/lib/data_grid";
 
 import { TYPE } from "metabase/lib/types";
 
-const D1 = {
-  name: "D1",
-  display_name: "Dimension 1",
+const dimension = i => ({
+  name: "D" + i,
+  display_name: "Dimension " + i,
   base_type: TYPE.Text,
   source: "breakout",
-};
-const D2 = {
-  name: "D2",
-  display_name: "Dimension 2",
-  base_type: TYPE.Text,
-  source: "breakout",
-};
+});
+
+const D1 = dimension(1);
+const D2 = dimension(2);
+const D3 = dimension(3);
+const D4 = dimension(4);
+
 const M = { name: "M", display_name: "Metric", base_type: TYPE.Integer };
 
 const GRAND_TOTALS_ROW = [
@@ -195,46 +197,52 @@ describe("data_grid", () => {
       );
       expect(leftIndex).toEqual([
         [
-          [
-            [{ value: "a", span: 3 }],
-            [
-              { value: "x", span: 1 },
-              { value: "y", span: 1 },
-              { value: "z", span: 1 },
+          {
+            children: [
+              { children: [], isCollapsed: false, rawValue: "x", value: "x" },
+              { children: [], isCollapsed: false, rawValue: "y", value: "y" },
+              { children: [], isCollapsed: false, rawValue: "z", value: "z" },
             ],
-          ],
-          [
-            [
-              {
-                isSubtotal: true,
-                span: 1,
-                value: "Totals for a",
-                rawValue: "a",
-              },
-            ],
-          ],
+            isCollapsed: false,
+            rawValue: "a",
+            value: "a",
+          },
+          {
+            children: [],
+            isSubtotal: true,
+            rawValue: "a",
+            span: 1,
+            value: "Totals for a",
+          },
         ],
         [
-          [
-            [{ value: "b", span: 3 }],
-            [
-              { value: "x", span: 1 },
-              { value: "y", span: 1 },
-              { value: "z", span: 1 },
+          {
+            children: [
+              { children: [], isCollapsed: false, rawValue: "x", value: "x" },
+              { children: [], isCollapsed: false, rawValue: "y", value: "y" },
+              { children: [], isCollapsed: false, rawValue: "z", value: "z" },
             ],
-          ],
-          [
-            [
-              {
-                isSubtotal: true,
-                span: 1,
-                value: "Totals for b",
-                rawValue: "b",
-              },
-            ],
-          ],
+            isCollapsed: false,
+            rawValue: "b",
+            value: "b",
+          },
+          {
+            children: [],
+            isSubtotal: true,
+            rawValue: "b",
+            span: 1,
+            value: "Totals for b",
+          },
         ],
-        GRAND_TOTALS_ROW,
+        [
+          {
+            children: [],
+            isGrandTotal: true,
+            isSubtotal: true,
+            span: 1,
+            value: "Grand totals",
+          },
+        ],
       ]);
       expect(topIndex).toEqual([[[{ value: "Metric", span: 1 }]]]);
       expect(rowCount).toEqual(3);
@@ -254,9 +262,17 @@ describe("data_grid", () => {
         [2],
       );
       expect(leftIndex).toEqual([
-        [[[{ value: "x", span: 1 }]]],
-        [[[{ value: "y", span: 1 }]]],
-        GRAND_TOTALS_ROW,
+        [{ children: [], isCollapsed: false, rawValue: "x", value: "x" }],
+        [{ children: [], isCollapsed: false, rawValue: "y", value: "y" }],
+        [
+          {
+            children: [],
+            isGrandTotal: true,
+            isSubtotal: true,
+            span: 1,
+            value: "Grand totals",
+          },
+        ],
       ]);
       expect(topIndex).toEqual([
         [[{ value: "a", span: 1 }]],
@@ -289,7 +305,9 @@ describe("data_grid", () => {
           [{ value: "Metric 1", span: 1 }, { value: "Metric 2", span: 1 }],
         ],
       ]);
-      expect(leftIndex).toEqual([[[[{ value: "b", span: 1 }]]]]);
+      expect(leftIndex).toEqual([
+        [{ children: [], isCollapsed: false, rawValue: "b", value: "b" }],
+      ]);
       expect(extractValues(getRowSection(0, 0))).toEqual([["1", "2"]]);
     });
     it("should work with three levels of row grouping", () => {
@@ -320,53 +338,9 @@ describe("data_grid", () => {
 
       const { topIndex, leftIndex } = multiLevelPivot(data, [], [0, 1, 2], [3]);
       expect(topIndex).toEqual([[[{ span: 1, value: "Metric" }]]]);
-      expect(leftIndex).toEqual([
-        [
-          [
-            [{ span: 4, value: "a1" }],
-            [{ span: 2, value: "b1" }, { span: 2, value: "b2" }],
-            [
-              { span: 1, value: "c1" },
-              { span: 1, value: "c2" },
-              { span: 1, value: "c1" },
-              { span: 1, value: "c2" },
-            ],
-          ],
-          [
-            [
-              {
-                isSubtotal: true,
-                span: 1,
-                value: "Totals for a1",
-                rawValue: "a1",
-              },
-            ],
-          ],
-        ],
-        [
-          [
-            [{ span: 4, value: "a2" }],
-            [{ span: 2, value: "b1" }, { span: 2, value: "b2" }],
-            [
-              { span: 1, value: "c1" },
-              { span: 1, value: "c2" },
-              { span: 1, value: "c1" },
-              { span: 1, value: "c2" },
-            ],
-          ],
-          [
-            [
-              {
-                isSubtotal: true,
-                span: 1,
-                value: "Totals for a2",
-                rawValue: "a2",
-              },
-            ],
-          ],
-        ],
-        GRAND_TOTALS_ROW,
-      ]);
+      expect(leftIndex[0][0].value).toEqual("a1");
+      expect(leftIndex[0][0].children[0].value).toEqual("b1");
+      expect(leftIndex[0][0].children[0].children[0].value).toEqual("c1");
     });
     it("should format values", () => {
       const data = makePivotData(
@@ -501,7 +475,6 @@ describe("data_grid", () => {
         ["b", null, 7, subtotalOne],
         [null, "x", 4, subtotalTwo],
         [null, "y", 6, subtotalTwo],
-        [null, null, 10, subtotalThree],
       ];
       const data = {
         rows,
@@ -515,10 +488,79 @@ describe("data_grid", () => {
         ['["a"]'],
       );
       expect(rowCount).toEqual(3);
-      expect(leftIndex[0]).toEqual([
-        [[{ isSubtotal: true, span: 1, value: "Totals for a", rawValue: "a" }]],
+      expect(leftIndex[0][0]).toEqual({
+        children: [],
+        isSubtotal: true,
+        rawValue: "a",
+        span: 1,
+        value: "Totals for a",
+      });
+    });
+
+    it("should return multiple levels of subtotals", () => {
+      const cols = [D1, D2, D3, D4, M];
+      const primaryGroup = 0;
+      const subtotalOne = 4;
+      const subtotalTwo = 6;
+      const subtotalThree = 7;
+      const subtotalFour = 8;
+      const subtotalFive = 12;
+      const subtotalSix = 14;
+      const rows = [
+        // primary rows
+        ["a", "i", "x", "t1", 1, primaryGroup],
+        ["a", "i", "y", "t1", 2, primaryGroup],
+        ["a", "j", "x", "t1", 3, primaryGroup],
+        ["a", "j", "y", "t1", 4, primaryGroup],
+        ["b", "i", "x", "t1", 5, primaryGroup],
+        ["b", "i", "y", "t1", 6, primaryGroup],
+        ["b", "j", "x", "t1", 7, primaryGroup],
+        ["b", "j", "y", "t1", 8, primaryGroup],
+        ["a", "i", "x", "t2", 0, primaryGroup],
+
+        ["a", "i", null, "t1", 3, subtotalOne],
+        ["a", "j", null, "t1", 7, subtotalOne],
+        ["b", "i", null, "t1", 11, subtotalOne],
+        ["b", "j", null, "t1", 15, subtotalOne],
+        ["a", null, null, "t1", 10, subtotalTwo],
+        ["b", null, null, "t1", 26, subtotalTwo],
+        [null, null, null, "t1", 36, subtotalThree],
+        ["a", "i", "x", null, 1, subtotalFour],
+        ["a", "i", "y", null, 2, subtotalFour],
+        ["a", "j", "x", null, 3, subtotalFour],
+        ["a", "j", "y", null, 4, subtotalFour],
+        ["a", "i", null, null, 3, subtotalFive],
+        ["a", "j", null, null, 7, subtotalFive],
+        ["a", null, null, null, 10, subtotalSix],
+      ];
+      const data = {
+        rows,
+        cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
+      };
+      const { getRowSection, rowCount, columnCount } = multiLevelPivot(
+        data,
+        [3],
+        [0, 1, 2],
+        [4],
+      );
+      expect(extractValues(getRowSection(0, 0))).toEqual([
+        ["1"],
+        ["2"],
+        ["3"],
+        ["3"],
+        ["4"],
+        ["7"],
+        ["10"],
       ]);
-      expect(extractValues(getRowSection(0, 0))).toEqual([["3"]]);
+      expect(extractValues(getRowSection(2, 0))).toEqual([
+        ["1"],
+        ["2"],
+        ["3"],
+        ["3"],
+        ["4"],
+        ["7"],
+        ["10"],
+      ]);
     });
   });
 });


### PR DESCRIPTION
Fixes #14245

Note: The code is ready for review, but it isn't ready to be merged until I test it with a fix for #14329. The missing data in the gif below will appear when it's returned from the server.

![more subtotals](https://user-images.githubusercontent.com/691495/104392926-2cd69f00-5511-11eb-9e61-b055479bb809.gif)

### What does this PR do?

To accommodate more subtotals, I updated the data structure that describes the left header (`leftIndex`) and updated the component to recursively render nodes of that tree. That lets us nest more than the single level of subtotals and align things correctly in the DOM.
