### PR TITLE
Run Cypress OSS tests in isolation

### DIFF
--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -8,7 +8,7 @@ import {
 const PG_DB_NAME = "QA Postgres12";
 
 describe("postgres > question > custom columns", () => {
-  before(() => {
+  beforeEach(() => {
     restore();
     signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -15,9 +15,8 @@ function toggleFieldWithDisplayName(displayName) {
 }
 
 describe("scenarios > admin > databases > add", () => {
-  before(restore);
-
   beforeEach(() => {
+    restore();
     signInAsAdmin();
     cy.server();
   });

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -1,9 +1,8 @@
 import { signInAsAdmin, restore, popover, modal } from "__support__/cypress";
 
 describe("scenarios > admin > databases > edit", () => {
-  before(restore);
-
   beforeEach(() => {
+    restore();
     signInAsAdmin();
     cy.server();
     cy.route("GET", "/api/database/*").as("databaseGet");
@@ -65,13 +64,23 @@ describe("scenarios > admin > databases > edit", () => {
   });
 
   describe("Scheduling tab", () => {
+    beforeEach(() => {
+      // Turn on scheduling without relying on the previous test(s)
+      cy.request("PUT", "/api/database/1", {
+        details: {
+          "let-user-control-scheduling": true,
+        },
+        engine: "h2",
+      });
+    });
+
     it("shows the initial scheduling settings correctly", () => {
       cy.visit("/admin/databases/1");
 
       cy.findByText("Scheduling").click();
 
       cy.findByText("Database syncing")
-        .parent()
+        .closest(".Form-field")
         .findByText("Hourly");
 
       cy.findByText("Regularly, on a schedule")
@@ -85,7 +94,7 @@ describe("scenarios > admin > databases > edit", () => {
       cy.findByText("Scheduling").click();
 
       cy.findByText("Database syncing")
-        .parent()
+        .closest(".Form-field")
         .as("sync");
 
       cy.get("@sync")

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -1,9 +1,8 @@
 import { signInAsAdmin, restore } from "__support__/cypress";
 
 describe("scenarios > admin > databases > list", () => {
-  before(restore);
-
   beforeEach(() => {
+    restore();
     signInAsAdmin();
     cy.server();
   });
@@ -60,6 +59,7 @@ describe("scenarios > admin > databases > list", () => {
   it("should let you bring back the sample dataset", () => {
     cy.route("POST", "/api/database/sample_dataset").as("sample_dataset");
 
+    cy.request("DELETE", "/api/database/1").as("delete");
     cy.visit("/admin/databases");
     cy.contains("Bring the sample dataset back").click();
     cy.wait("@sample_dataset");

--- a/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
@@ -7,7 +7,7 @@ import {
 const ORDERS_URL = "/admin/datamodel/database/1/table/2";
 
 describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => {
-  before(restore);
+  beforeEach(restore);
 
   it("can hide a table and not show up in 'Our Data'", () => {
     cy.server();

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -1,11 +1,11 @@
 import { restore, signInAsAdmin, popover, modal } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
-const { ORDERS_ID } = SAMPLE_DATASET;
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > admin > datamodel > metrics", () => {
-  before(restore);
   beforeEach(() => {
+    restore();
     signInAsAdmin();
     cy.viewport(1400, 860);
   });
@@ -43,50 +43,23 @@ describe("scenarios > admin > datamodel > metrics", () => {
   });
 
   describe("with metrics", () => {
-    before(() => {
+    beforeEach(() => {
       // CREATE METRIC
-      signInAsAdmin();
-      cy.visit("/admin");
-      cy.contains("Data Model").click();
-      cy.contains("Metrics").click();
-      cy.contains("New metric").click();
-      cy.contains("Select a table").click();
-      popover()
-        .contains("Orders")
-        .click({ force: true }); // this shouldn't be needed, but there were issues with reordering as loads happeend
-
-      cy.url().should("match", /metric\/create$/);
-      cy.contains("Create Your Metric");
-
-      // filter to orders with total under 100
-      cy.contains("Add filters").click();
-      cy.contains("Total").click();
-      cy.contains("Equal to").click();
-      cy.contains("Less than").click();
-      cy.get('[placeholder="Enter a number"]').type("100");
-      popover()
-        .contains("Add filter")
-        .click();
-
-      //
-      cy.contains("Result: 12765");
-
-      // fill in name/description
-      cy.get('[name="name"]').type("orders <100");
-      cy.get('[name="description"]').type(
-        "Count of orders with a total under $100.",
-      );
-
-      // saving bounces you back and you see new metric in the list
-      cy.contains("Save changes").click();
-      cy.url().should("match", /datamodel\/metrics$/);
-      cy.contains("orders <100");
-      cy.contains("Count, Filtered by Total");
+      cy.request("POST", "/api/metric", {
+        definition: {
+          aggregation: ["count"],
+          filter: ["<", ["field-id", ORDERS.TOTAL], 100],
+          "source-table": ORDERS_ID,
+        },
+        name: "orders < 100",
+        description: "Count of orders with a total under $100.",
+        table_id: ORDERS_ID,
+      });
     });
 
     it("should show no questions based on a new metric", () => {
       cy.visit("/reference/metrics/1/questions");
-      cy.findAllByText("Questions about orders <100");
+      cy.findAllByText("Questions about orders < 100");
       cy.findByText("Loading...");
       cy.findByText("Loading...").should("not.exist");
       cy.findByText(
@@ -115,8 +88,8 @@ describe("scenarios > admin > datamodel > metrics", () => {
       // Check the list
       cy.visit("/reference/metrics/1/questions");
       cy.findByText("Our analysis").should("not.exist");
-      cy.findAllByText("Questions about orders <100");
-      cy.findByText("Orders, orders <100, Filtered by Total");
+      cy.findAllByText("Questions about orders < 100");
+      cy.findByText("Orders, orders < 100, Filtered by Total");
     });
 
     it("should show the metric detail view for a specific id", () => {
@@ -130,7 +103,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.contains("Data Model").click();
       cy.contains("Metrics").click();
 
-      cy.contains("orders <100")
+      cy.contains("orders < 100")
         .parent()
         .parent()
         .find(".Icon-ellipsis")
@@ -158,7 +131,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.contains("Result: 18703");
 
       // update name and description, set a revision note, and save the update
-      cy.get('[name="name"]').type("{selectall}orders >10");
+      cy.get('[name="name"]').type("{selectall}orders > 10");
       cy.get('[name="description"]').type(
         "{selectall}Count of orders with a total over $10.",
       );
@@ -167,10 +140,10 @@ describe("scenarios > admin > datamodel > metrics", () => {
 
       // get redirected to previous page and see the new metric name
       cy.url().should("match", /datamodel\/metrics$/);
-      cy.contains("orders >10");
+      cy.contains("orders > 10");
 
       // clean up
-      cy.contains("orders >10")
+      cy.contains("orders > 10")
         .parent()
         .parent()
         .find(".Icon-ellipsis")
@@ -196,7 +169,14 @@ describe("scenarios > admin > datamodel > metrics", () => {
           aggregation: [
             [
               "aggregation-options",
-              ["sum", ["*", ["field-id", 9], ["field-id", 10]]],
+              [
+                "sum",
+                [
+                  "*",
+                  ["field-id", ORDERS.DISCOUNT],
+                  ["field-id", ORDERS.QUANTITY],
+                ],
+              ],
               { "display-name": "CE" },
             ],
           ],

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -12,8 +12,8 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > admin > datamodel > segments", () => {
-  before(restore);
   beforeEach(() => {
+    restore();
     signInAsAdmin();
     cy.viewport(1400, 860);
   });
@@ -52,9 +52,7 @@ describe("scenarios > admin > datamodel > segments", () => {
   describe("with segment", () => {
     const SEGMENT_NAME = "Orders < 100";
 
-    before(() => {
-      signInAsAdmin();
-
+    beforeEach(() => {
       // Create a segment through API
       cy.request("POST", "/api/segment", {
         name: SEGMENT_NAME,

--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -2,8 +2,10 @@ import { signInAsAdmin, restore } from "__support__/cypress";
 // Ported from `databases.e2e.spec.js`
 
 describe("scenarios > admin > databases > table", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should see four tables in sample database", () => {
     cy.visit("/admin/datamodel/database/1");

--- a/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
@@ -1,8 +1,10 @@
 import { restore, signInAsAdmin } from "__support__/cypress";
 
 describe("scenarios > admin > permissions", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should display error on failed save", () => {
     // revoke some permissions

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -7,8 +7,10 @@ import {
 } from "__support__/cypress";
 
 describe("scenarios > admin > settings", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should surface an error when validation for any field fails (metabase#4506)", () => {
     const BASE_URL = Cypress.config().baseUrl;
@@ -280,6 +282,15 @@ describe("scenarios > admin > settings", () => {
       cy.findByText("Changes saved!");
     });
     it("should show an error if test email fails", () => {
+      // Reuse Email setup without relying on the previous test
+      cy.request("PUT", "/api/setting", {
+        "email-from-address": "admin@metabase.com",
+        "email-smtp-host": "localhost",
+        "email-smtp-password": null,
+        "email-smtp-port": "1234",
+        "email-smtp-security": "none",
+        "email-smtp-username": null,
+      });
       cy.visit("/admin/settings/email");
       cy.findByText("Send test email").click();
       cy.findByText("Sorry, something went wrong. Please try again.");

--- a/frontend/test/metabase/scenarios/admin/settings/spinner.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/spinner.cy.spec.js
@@ -1,8 +1,10 @@
 import { restore, signInAsAdmin } from "__support__/cypress";
 
 describe("scenarios > admin > spinner", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   describe("API request", () => {
     it("should return correct DB", () => {

--- a/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
@@ -27,12 +27,12 @@ export function setGoal(number) {
 }
 
 describe("scenarios > alert", () => {
-  beforeEach(() => {
-    restore();
-    signInAsAdmin();
-  });
-
   describe("with nothing set", () => {
+    beforeEach(() => {
+      restore();
+      signInAsAdmin();
+    });
+
     it("should prompt you to add email/slack credentials", () => {
       cy.visit("/question/1");
       cy.get(".Icon-bell").click();
@@ -40,6 +40,7 @@ describe("scenarios > alert", () => {
         "To send alerts, you'll need to set up email or Slack integration.",
       );
     });
+
     it("should say to non-admins that admin must add email credentials", () => {
       signInAsNormalUser();
       cy.visit("/question/1");

--- a/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
@@ -27,8 +27,10 @@ export function setGoal(number) {
 }
 
 describe("scenarios > alert", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   describe("with nothing set", () => {
     it("should prompt you to add email/slack credentials", () => {

--- a/frontend/test/metabase/scenarios/auth/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/search.cy.spec.js
@@ -6,7 +6,7 @@ import {
 } from "__support__/cypress";
 
 describe("scenarios > auth > search", () => {
-  before(restore);
+  beforeEach(restore);
 
   describe("universal search", () => {
     it("should work for admin", () => {

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -3,8 +3,10 @@ import { restore, signIn, signOut, USERS } from "__support__/cypress";
 const sizes = [[1280, 800], [640, 360]];
 
 describe("scenarios > auth > signin", () => {
-  before(restore);
-  beforeEach(signOut);
+  beforeEach(() => {
+    restore();
+    signOut();
+  });
 
   it("should redirect to  /auth/login", () => {
     cy.visit("/");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -11,8 +11,10 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { REVIEWS, REVIEWS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > dashboard > dashboard drill", () => {
-  before(restore);
-  beforeEach(signIn);
+  beforeEach(() => {
+    restore();
+    signIn();
+  });
 
   it("should handle URL click through on a table", () => {
     createDashboardWithQuestion({}, dashboardId =>

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -25,7 +25,7 @@ function filterDashboard(suggests = true) {
 }
 
 describe("support > permissions (metabase#8472)", () => {
-  before(() => {
+  beforeEach(() => {
     restore();
     signIn("admin");
 
@@ -48,7 +48,6 @@ describe("support > permissions (metabase#8472)", () => {
   });
 
   it("should allow an admin user to select the filter", () => {
-    signIn("admin");
     filterDashboard();
   });
 

--- a/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
@@ -1,8 +1,10 @@
 import { signInAsAdmin, restore, popover, modal } from "__support__/cypress";
 
 describe("scenarios > dashboard > embed", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should have the correct embed snippet", () => {
     cy.visit("/dashboard/1");

--- a/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
@@ -1,8 +1,10 @@
 import { signIn, restore, popover } from "__support__/cypress";
 
 describe("scenarios > dashboard > nested cards", () => {
-  before(restore);
-  beforeEach(signIn);
+  beforeEach(() => {
+    restore();
+    signIn();
+  });
 
   it("should show fields on nested cards", () => {
     createDashboardWithNestedCard(dashId => {
@@ -32,9 +34,7 @@ function createDashboardWithNestedCard(callback) {
       database: 1,
     },
     display: "table",
-    description: null,
     visualization_settings: {},
-    collection_id: null,
   }).then(({ body }) =>
     cy
       .request("POST", "/api/card", {

--- a/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
@@ -19,7 +19,7 @@ const DASHBOARD_JWT_TOKEN =
 describe("scenarios > dashboard > parameters-embedded", () => {
   let dashboardId, questionId, dashcardId;
 
-  before(() => {
+  beforeEach(() => {
     restore();
     signInAsAdmin();
 
@@ -86,8 +86,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
 
   describe("public question", () => {
     let uuid;
-    before(() => {
-      signInAsAdmin();
+    beforeEach(() => {
       cy.request("POST", `/api/card/${questionId}/public_link`).then(
         res => (uuid = res.body.uuid),
       );
@@ -103,8 +102,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
   });
 
   describe("embedded question", () => {
-    before(() => {
-      signInAsAdmin();
+    beforeEach(() => {
       cy.request("PUT", `/api/card/${questionId}`, {
         embedding_params: {
           id: "enabled",
@@ -138,8 +136,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
 
   describe("public dashboard", () => {
     let uuid;
-    before(() => {
-      signInAsAdmin();
+    beforeEach(() => {
       cy.request("POST", `/api/dashboard/${dashboardId}/public_link`).then(
         res => (uuid = res.body.uuid),
       );
@@ -155,8 +152,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
   });
 
   describe("embedded dashboard", () => {
-    before(() => {
-      signInAsAdmin();
+    beforeEach(() => {
       cy.request("PUT", `/api/dashboard/${dashboardId}`, {
         embedding_params: {
           id: "enabled",

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -1,10 +1,10 @@
 import { signInAsAdmin, signIn, restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > permissions", () => {
-  before(restore);
   let dashboardId;
 
-  it("should let admins view all cards in a dashboard", () => {
+  beforeEach(() => {
+    restore();
     // This first test creates a dashboard with two questions.
     // One is in Our Analytics the other is in a more locked down collection.
     signInAsAdmin();
@@ -87,7 +87,9 @@ describe("scenarios > dashboard > permissions", () => {
         cy.visit(`/dashboard/${dashId}`);
       },
     );
+  });
 
+  it("should let admins view all cards in a dashboard", () => {
     // Admin can see both questions
     cy.findByText("First Question");
     cy.findByText("foo");

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -9,13 +9,13 @@ function addTextBox(string) {
 }
 
 describe("scenarios > dashboard > text-box", () => {
-  before(restore);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   describe("Editing", () => {
     beforeEach(() => {
-      restore();
-      signInAsAdmin();
-
       // Create text box card
       cy.visit("/dashboard/1");
       addTextBox("Text *text* __text__");
@@ -45,8 +45,6 @@ describe("scenarios > dashboard > text-box", () => {
 
   describe("when text-box is the only element on the dashboard", () => {
     beforeEach(() => {
-      restore(); // restore before each so we can reuse dashboard id
-      signInAsAdmin();
       // Create dashboard
       cy.server();
       cy.request("POST", "/api/dashboard", {

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,8 +1,10 @@
 import { signIn, restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > title drill", () => {
-  before(restore);
-  beforeEach(signIn);
+  beforeEach(() => {
+    restore();
+    signIn();
+  });
 
   it("should let you click through the title to the query builder", () => {
     createDashboard(dashId => {

--- a/frontend/test/metabase/scenarios/home/activity-page.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/activity-page.cy.spec.js
@@ -8,8 +8,10 @@ import {
 //Replaces HomepageApp.e2e.spec.js
 
 describe("metabase > scenarios > home > activity-page", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should show test startup activity ", () => {
     cy.visit("/activity");

--- a/frontend/test/metabase/scenarios/home/overworld.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/overworld.cy.spec.js
@@ -5,7 +5,7 @@ import {
 } from "__support__/cypress";
 
 describe("scenarios > home > overworld", () => {
-  before(restore);
+  beforeEach(restore);
 
   describe("content management", () => {
     describe("as admin", () => {

--- a/frontend/test/metabase/scenarios/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions.cy.spec.js
@@ -1,7 +1,7 @@
 import { signIn, restore } from "__support__/cypress";
 
 describe("scenarios > permissions", () => {
-  before(restore);
+  beforeEach(restore);
 
   const PATHS = [
     "/dashboard/1",

--- a/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
+++ b/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
@@ -14,8 +14,10 @@ const MOCK_PULSE_FORM_INPUT = {
 };
 
 describe("scenarios > pulse", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
   it("should be able get to the new pulse page from the nav bar", () => {
     cy.visit("/");
 
@@ -31,8 +33,8 @@ describe("scenarios > pulse", () => {
 
     cy.visit("/pulse/create");
 
-    cy.get('[placeholder="Important metrics"]')
-      .wait(100)
+    cy.findByPlaceholderText("Important metrics")
+      .click()
       .type("pulse title");
 
     cy.contains("Select a question").click();
@@ -47,20 +49,44 @@ describe("scenarios > pulse", () => {
     cy.contains("pulse title");
   });
 
-  it("should load existing pulses", () => {
-    cy.visit("/collection/root");
-    cy.contains("pulse title").click({ force: true });
-    cy.contains("18,760");
-  });
+  describe("existing pulses", () => {
+    beforeEach(() => {
+      cy.server();
+      // Create new pulse without relying on the previous test
+      cy.request("POST", "/api/pulse", {
+        name: "pulse title",
+        cards: [{ id: 2, include_csv: false, include_xls: false }],
+        channels: [
+          {
+            channel_type: "email",
+            details: {},
+            enabled: true,
+            recipients: [],
+            schedule_day: "mon",
+            schedule_frame: "first",
+            schedule_hour: 8,
+            schedule_type: "daily",
+          },
+        ],
+        skip_if_empty: false,
+      });
+    });
 
-  it("should edit existing pulses", () => {
-    cy.visit("/pulse/1");
-    cy.get('[placeholder="Important metrics"]')
-      .clear()
-      .type("new pulse title");
+    it("should load existing pulses", () => {
+      cy.visit("/collection/root");
+      cy.contains("pulse title").click({ force: true });
+      cy.contains("18,760");
+    });
 
-    cy.contains("Save changes").click();
-    cy.url().should("match", /\/collection\/root$/);
-    cy.contains("new pulse title");
+    it("should edit existing pulses", () => {
+      cy.visit("/pulse/1");
+      cy.get('[placeholder="Important metrics"]')
+        .clear()
+        .type("new pulse title");
+
+      cy.contains("Save changes").click();
+      cy.url().should("match", /\/collection\/root$/);
+      cy.contains("new pulse title");
+    });
   });
 });

--- a/frontend/test/metabase/scenarios/question/data_ref.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/data_ref.cy.spec.js
@@ -1,8 +1,10 @@
 import { signInAsAdmin, restore } from "__support__/cypress";
 
 describe("scenarios > question > data reference sidebar", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should load needed data", () => {
     cy.visit("/question/new");

--- a/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
@@ -9,8 +9,8 @@ const testCases = [
 ];
 
 describe("scenarios > question > download", () => {
-  before(restore);
   beforeEach(() => {
+    restore();
     signInAsAdmin();
   });
 

--- a/frontend/test/metabase/scenarios/question/loading.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/loading.cy.spec.js
@@ -1,8 +1,10 @@
 import { signInAsAdmin, restore } from "__support__/cypress";
 
 describe("scenarios > question > loading behavior", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should preload tables on the new question page", () => {
     cy.server();

--- a/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
@@ -1,8 +1,10 @@
 import { signInAsAdmin, restore, signIn } from "__support__/cypress";
 
 describe("scenarios > question > native subquery", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should allow a user with no data access to execute a native subquery", () => {
     // Create the initial SQL question and followup nested question

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -11,7 +11,7 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
 
 describe("scenarios > question > nested (metabase#12568)", () => {
-  before(() => {
+  beforeEach(() => {
     restore();
     signInAsAdmin();
 
@@ -45,11 +45,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
         database: 1,
       },
       display: "scalar",
-      description: null,
       visualization_settings: {},
-      collection_id: null,
-      result_metadata: null,
-      metadata_checksum: null,
     });
 
     // Create a complex native question
@@ -87,15 +83,9 @@ describe("scenarios > question > nested (metabase#12568)", () => {
         database: 1,
       },
       display: "scalar",
-      description: null,
       visualization_settings: {},
-      collection_id: null,
-      result_metadata: null,
-      metadata_checksum: null,
     });
   });
-
-  beforeEach(signInAsAdmin);
 
   it("should allow Distribution on a Saved Simple Question", () => {
     cy.visit("/question/new");
@@ -154,7 +144,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
 });
 
 describe("scenarios > question > nested", () => {
-  before(() => {
+  beforeEach(() => {
     restore();
     signInAsAdmin();
   });

--- a/frontend/test/metabase/scenarios/question/operators.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/operators.cy.spec.js
@@ -1,8 +1,10 @@
 import { restore, signInAsNormalUser, popover } from "__support__/cypress";
 
 describe("operators in questions", () => {
-  before(restore);
-  beforeEach(signInAsNormalUser);
+  beforeEach(() => {
+    restore();
+    signInAsNormalUser();
+  });
 
   const expected = {
     text: {

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -1,8 +1,10 @@
 import { signInAsAdmin, restore, openOrdersTable } from "__support__/cypress";
 
 describe("scenarios > question > settings", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   describe("column settings", () => {
     it("should allow you to remove a column and add two foreign columns", () => {

--- a/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
@@ -18,44 +18,61 @@ function _clearAndIterativelyTypeUsingLabel(label, string) {
 //       - There is a related issue: https://github.com/metabase/metabase-enterprise/issues/543
 // TODO: Once the above issue is (re)solved, change back to `signInAsNormalUser`
 describe("scenarios > question > snippets", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should let you create and use a snippet", () => {
     cy.visit("/question/new");
     cy.contains("Native query").click();
 
-    // type a query and highlight some of the text
-    cy.get(".ace_content").as("ace");
-    cy.get("@ace").type(
+    // Type a query and highlight some of the text
+    cy.get(".ace_content").as("editor");
+    cy.get("@editor").type(
       "select 'stuff'" + "{shift}{leftarrow}".repeat("'stuff'".length),
     );
 
-    // add a snippet of that text
+    // Add a snippet of that text
     cy.get(".Icon-snippet").click();
     cy.contains("Create a snippet").click();
 
-    modal()
-      .find("input[name=name]")
-      .type("stuff-snippet");
-    modal()
-      .contains("Save")
-      .click();
+    modal().within(() => {
+      cy.findByLabelText("Give your snippet a name").type("stuff-snippet");
+      cy.findByText("Save").click();
+    });
 
     // SQL editor should get updated automatically
-    cy.get("@ace").contains("select {{snippet: stuff-snippet}}");
+    cy.get("@editor").contains("select {{snippet: stuff-snippet}}");
 
-    // run the query and check the displayed scalar
+    // Run the query and check the value
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.get(".ScalarValue").contains("stuff");
   });
 
   it("should let you edit snippet", () => {
-    // open the snippet edit modal
+    // Re-create the above snippet via API without the need to rely on the previous test
+    cy.request("POST", "/api/native-query-snippet", {
+      name: "stuff-snippet",
+      content: "stuff",
+    });
+
+    cy.visit("/question/new");
+    cy.findByText("Native query").click();
+
+    // Populate the native editor first
+    // 1. select
+    cy.get(".ace_content").as("editor");
+    cy.get("@editor").type("select ");
+    // 2. snippet
+    cy.get(".Icon-snippet").click();
+    cy.findByText("stuff-snippet").click();
+
+    // Open the snippet edit modal
     cy.get(".Icon-chevrondown").click({ force: true });
     cy.findByText("Edit").click();
 
-    // update the name and content
+    // Update the name and content
     modal().within(() => {
       cy.findByText("Editing stuff-snippet");
 
@@ -69,9 +86,9 @@ describe("scenarios > question > snippets", () => {
     });
 
     // SQL editor should get updated automatically
-    cy.get(".ace_content").contains("select {{snippet: Math}}");
+    cy.get("@editor").contains("select {{snippet: Math}}");
 
-    // run the query and check the displayed scalar
+    // Run the query and check the new value
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.get(".ScalarValue").contains("2");
   });

--- a/frontend/test/metabase/scenarios/question/trendline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/trendline.cy.spec.js
@@ -6,8 +6,10 @@ import {
 } from "__support__/cypress";
 
 describe("scenarios > question > trendline", () => {
-  before(restore);
-  beforeEach(signInAsNormalUser);
+  beforeEach(() => {
+    restore();
+    signInAsNormalUser();
+  });
 
   it.skip("displays trendline when there are multiple numeric outputs (for simple question) (metabase#12781)", () => {
     // Create question: orders summarized with "Average of Subtotal" and "Sum of Total" by CreatedAt:Year

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -11,8 +11,10 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { PRODUCTS } = SAMPLE_DATASET;
 
 describe("scenarios > question > view", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   describe("summarize sidebar", () => {
     it("should summarize by category and show a bar chart", () => {
@@ -92,10 +94,9 @@ describe("scenarios > question > view", () => {
     });
   });
 
-  describe.only("apply filters without data permissions", () => {
-    before(() => {
+  describe("apply filters without data permissions", () => {
+    beforeEach(() => {
       // All users upgraded to collection view access
-      signInAsAdmin();
       cy.visit("/admin/permissions/collections");
       cy.get(".Icon-close")
         .first()

--- a/frontend/test/metabase/scenarios/reference/databases.cy.spec.js
+++ b/frontend/test/metabase/scenarios/reference/databases.cy.spec.js
@@ -1,8 +1,10 @@
 import { signInAsAdmin, restore } from "__support__/cypress";
 
 describe("scenarios > reference > databases", () => {
-  before(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+  });
 
   it("should see the listing", () => {
     cy.visit("/reference/databases");

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -331,9 +331,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   describe("for an unsaved question", () => {
-    before(() => {
-      restore();
-      signInAsAdmin();
+    beforeEach(() => {
       // Build a question without saving
       openProductsTable();
       cy.findByText("Summarize").click();

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -12,13 +12,14 @@ const Q2 = {
 
 describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
   describe("card title click action", () => {
+    beforeEach(() => {
+      restore();
+      signInAsAdmin();
+    });
     describe("from a scalar card", () => {
       const DASHBOARD_NAME = "Scalar Dash";
 
-      before(() => {
-        restore();
-        signInAsAdmin();
-
+      beforeEach(() => {
         // Convert the second question to a scalar (Orders, summarized by count)
         cy.request("PUT", `/api/card/${Q2.id}`, {
           display: "scalar",
@@ -41,10 +42,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
     describe("from a scalar with active filter applied", () => {
       const DASHBOARD_NAME = "Scalar w Filter Dash";
 
-      before(() => {
-        restore();
-        signInAsAdmin();
-
+      beforeEach(() => {
         // Convert Q2 to a scalar with a filter applied
         cy.request("PUT", `/api/card/${Q2.id}`, {
           dataset_query: {
@@ -75,10 +73,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       const DASHBOARD_NAME = "Multiscalar Dash";
       const CARD_NAME = "Multiscalar Question";
 
-      before(() => {
-        restore();
-        signInAsAdmin();
-
+      beforeEach(() => {
         // Create muliscalar card
         cy.request("POST", "/api/card", {
           name: CARD_NAME,
@@ -131,11 +126,6 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
     });
 
     describe("saved visualizations", () => {
-      beforeEach(() => {
-        restore();
-        signInAsAdmin();
-      });
-
       it.skip("should respect visualization type when entering a question from a dashboard (metabase#13415)", () => {
         const QUESTION_NAME = "13415";
 
@@ -159,7 +149,6 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
             type: "query",
           },
           display: "table",
-          description: null,
           visualization_settings: {
             "table.pivot_column": "CATEGORY",
             "table.cell_column": "count",


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Refactors OSS Cypress tests in such a way that they can run in complete isolation (the same way #14339 did with the EE tests)

### Which files were not affected/touched?
- `collections_default.cy.spec.js` was converted some time ago into `collections.cy.spec.js` in `master` (I converted that file separately in https://github.com/metabase/metabase/pull/14383)
- Smoke tests (because of the idea that they should run sequentially)
- Any of the skipped files of describe blocks (mostly documented here: https://github.com/metabase/metabase/issues/13682) - I'll deal with them separately because they require far greater attention

### Additional notes:
- Most of the files had a simple change (therefore it didn't require a bunch of separate PRs)
```javascript
//from
before(restore);
beforeEeach(()=> {
  signIn();
  doWhateverElse();
})

// to 
beforeEeach(()=> {
  restore();
  signIn();
  doWhateverElse();
})
```
- Because of the sheer number of OSS Cypress test files, I wasn't able to go into detailed refactoring (like I did with the EE tests). This PR is concerned **only** with isolating tests from each other. Any further improvements will be a subject of subsequent PRs.
- Simple reorganization and extracting the common logic in before/beforeEach hooks was enough to isolate tests
- In a very few occasions I had to use API to mimic to set up the state for the test in such a way that it doesn't depend on the previous test(s). That is documented with comments.
