### PR TITLE
Fix `auditing` test failure on `master`

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -149,7 +149,8 @@ describeWithToken("audit > auditing", () => {
       cy.findByPlaceholderText("Database name");
       cy.findByText("No results!").should("not.exist");
       cy.findByText("Sample Dataset");
-      cy.findByText("Every hour");
+      cy.findByText(/Sync Schedule/i);
+      cy.contains(year);
     });
 
     it("should load both tabs in Schemas", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes a test failure on master that was introduced by 992f8475b4c68dd96032e99ee0cd1274204f12b8

### How to test this manually?
- `yarn test-cypress-open --testFiles enterprise/frontend/test/metabase-enterprise`
- `enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js`
- All tests should pass
_Alternatively, you can isolate this one test only (thanks to the changes introduced in #14339)_
- add `.only` to "should load both tabs in Databases" test
- it should pass consistently on every single run

### Additional context
- We now have randomized sync times so it's not possible to assert on the string "Every hour" anymore.
- Given that the sync time was not even crucial for this test, I have removed that assertion and added two new ones
```javascript
cy.findByText(/Sync Schedule/i); // Table header cell
cy.contains(year); // The current year (can be found in "Added On" column)
```
- The whole point of this test is simply to confirm that both "Overview" and "All databases" tabs load with proper info
- CI should pass consistently

### Examples of the previous failures:
- https://app.circleci.com/pipelines/github/metabase/metabase/11859/workflows/94930d8e-4b4d-4e8c-b5a1-63d8b1291739/jobs/437864 (when it was introduced)
- https://app.circleci.com/pipelines/github/metabase/metabase/11876/workflows/6b38776a-1d8a-4629-92f9-1d7dc695a3d3/jobs/438000 (on @kidd 's branch)

### Screenshot of a failed test (from the CI)
We can see that the sync time has been changed and we can't assert on "Every hour" anymore
![image](https://user-images.githubusercontent.com/31325167/104464660-7b3c7a00-55b3-11eb-8589-66e1a627a425.png)

### Screenshots of successful test run after the fix
1. Cypress runner
![image](https://user-images.githubusercontent.com/31325167/104464520-4fb98f80-55b3-11eb-88a0-34128331e178.png)

2. UI
![image](https://user-images.githubusercontent.com/31325167/104464556-5d6f1500-55b3-11eb-8842-6ce8e36fff6e.png)




