### PR TITLE
Pivot tables public/embed Cypress coverage and repro for #14447

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -10,6 +10,11 @@ const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE } = SAMPLE_DATASET;
 const QUESTION_NAME = "Cypress Pivot Table";
 const DASHBOARD_NAME = "Pivot Table Dashboard";
 
+const TEST_CASES = [
+  { case: "question", subject: QUESTION_NAME },
+  { case: "dashboard", subject: DASHBOARD_NAME },
+];
+
 describe("scenarios > visualizations > pivot tables", () => {
   beforeEach(() => {
     restore();
@@ -239,10 +244,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       });
     });
 
-    const TEST_CASES = [
-      { case: "question", subject: QUESTION_NAME },
-      { case: "dashboard", subject: DASHBOARD_NAME },
-    ].forEach(test => {
+    TEST_CASES.forEach(test => {
       describe(test.case, () => {
         beforeEach(() => {
           cy.visit("collection/root");

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -192,7 +192,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("Pivot tables can only be used with aggregated queries.");
   });
 
-  describe("sharing", () => {
+  describe.skip("sharing (metabase#14447)", () => {
     beforeEach(() => {
       cy.log("**--1. Create a question--**");
       cy.request("POST", "/api/card", {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -22,13 +22,16 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.findByText("Settings").click();
     assertOnPivotSettings();
-    assertOnPivotTable();
+    cy.get(".Visualization").within(() => {
+      assertOnPivotFields();
+    });
   });
 
   it("should correctly display saved question", () => {
     createAndVisitTestQuestion();
-
-    assertOnPivotTable();
+    cy.get(".Visualization").within(() => {
+      assertOnPivotFields();
+    });
 
     // Open Pivot table side-bar
     cy.findByText("Settings").click();
@@ -233,16 +236,15 @@ function assertOnPivotSettings() {
     .contains("Count");
 }
 
-function assertOnPivotTable() {
+function assertOnPivotFields() {
   cy.log("**-- Implicit assertions on a table itself --**");
-  cy.get(".Visualization").within(() => {
-    cy.findByText(/Users? → Source/);
-    cy.findByText(/Row totals/i);
-    cy.findByText(/Grand totals/i);
-    cy.findByText("3,520");
-    cy.findByText("4,784");
-    cy.findByText("18,760");
-  });
+
+  cy.findByText(/Users? → Source/);
+  cy.findByText(/Row totals/i);
+  cy.findByText(/Grand totals/i);
+  cy.findByText("3,520");
+  cy.findByText("4,784");
+  cy.findByText("18,760");
 }
 
 // Rely on native drag events, rather than on the coordinates


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Originally, it was supposed to add Cypress coverage to pivot tables in public/embedded context (https://github.com/metabase/metabase/issues/14262)
- Closes #14262
- Some commit broke the functionality in the meantime, so now this PR also serves as a repro for #14447

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/public/public.cy.spec.js`
- Replace `describe.skip()` with `describe.only()` to test this block in isolation
- Tests will fail until the related issue is solved

### Additional notes:
- There doesn't seem to be any error - the pivot table simply doesn't render.