### PR TITLE
Disable the Sidebar component's Done button after click

### DIFF
--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -260,9 +260,9 @@ class SharingSidebar extends React.Component {
     cleanedPulse.name = dashboard.name;
     await this.props.updateEditingPulse(cleanedPulse);
 
-    await this.props.saveEditingPulse();
-
+    // The order below matters; it hides the "Done" button faster and prevents two pulses from being made if it's double-clicked
     this.setState({ editingMode: "list-pulses" });
+    await this.props.saveEditingPulse();
   };
 
   createSubscription = () => {


### PR DESCRIPTION
This prevents duplicate clicks

[Fixes #14397]