### PR TITLE
Update Python code snippet for Python 3.7

### DIFF
--- a/frontend/src/metabase/public/lib/code.js
+++ b/frontend/src/metabase/public/lib/code.js
@@ -173,7 +173,7 @@ payload = {
 }
 token = jwt.encode(payload, METABASE_SECRET_KEY, algorithm="HS256")
 
-iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token.decode("utf8")${
+iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token${
     optionsToHashParams(displayOptions)
       ? " + " + JSON.stringify(optionsToHashParams(displayOptions))
       : ""


### PR DESCRIPTION
This is the fastest resolution for this bug: https://github.com/metabase/metabase/issues/14423


As I mention in the bug ticket, we may want to specify the python version in the dropdown or support multiple versions. But for now, the python snippet is for a very old python version and should be updated.
