### PR TITLE
Make the rows/columns/values text in pivot table settings stand out more

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -20,21 +20,21 @@ const partitions = [
     name: "rows",
     columnFilter: isDimension,
     title: jt`Fields to use for the table ${(
-      <span className="text-dark text-heavy">rows</span>
+      <span className="text-dark text-heavy">{t`rows`}</span>
     )}`,
   },
   {
     name: "columns",
     columnFilter: isDimension,
     title: jt`Fields to use for the table ${(
-      <span className="text-dark text-heavy">columns</span>
+      <span className="text-dark text-heavy">{t`columns`}</span>
     )}`,
   },
   {
     name: "values",
     columnFilter: col => !isDimension(col),
     title: jt`Fields to use for the table ${(
-      <span className="text-dark text-heavy">values</span>
+      <span className="text-dark text-heavy">{t`values`}</span>
     )}`,
   },
 ];

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { t } from "ttag";
+import { t, jt } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 import { getIn } from "icepick";
@@ -19,17 +19,23 @@ const partitions = [
   {
     name: "rows",
     columnFilter: isDimension,
-    title: t`Fields to use for the table rows`,
+    title: jt`Fields to use for the table ${(
+      <span className="text-dark text-heavy">rows</span>
+    )}`,
   },
   {
     name: "columns",
     columnFilter: isDimension,
-    title: t`Fields to use for the table columns`,
+    title: jt`Fields to use for the table ${(
+      <span className="text-dark text-heavy">columns</span>
+    )}`,
   },
   {
     name: "values",
     columnFilter: col => !isDimension(col),
-    title: t`Fields to use for the table values`,
+    title: jt`Fields to use for the table ${(
+      <span className="text-dark text-heavy">values</span>
+    )}`,
   },
 ];
 

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -219,15 +219,15 @@ function assertOnPivotSettings() {
   cy.log("**-- Implicit side-bar assertions --**");
   cy.findByText(/Pivot Table options/i);
 
-  cy.findByText("Fields to use for the table rows");
+  cy.findAllByText("Fields to use for the table").eq(0);
   cy.get("@fieldOption")
     .eq(0)
     .contains(/Users? → Source/);
-  cy.findByText("Fields to use for the table columns");
+  cy.findAllByText("Fields to use for the table").eq(1);
   cy.get("@fieldOption")
     .eq(1)
     .contains(/Products? → Category/);
-  cy.findByText("Fields to use for the table values");
+  cy.findAllByText("Fields to use for the table").eq(2);
   cy.get("@fieldOption")
     .eq(2)
     .contains("Count");


### PR DESCRIPTION
See screenshot. This probably requires updating strings in Poeditor 'cause I've modified the string templates here, but I'm already going to have to quickly update strings because of https://github.com/metabase/metabase/pull/14413, so I figured I'd go ahead and make this change as well.

<img width="333" alt="Screen Shot 2021-01-15 at 9 36 10 AM" src="https://user-images.githubusercontent.com/2223916/104759765-3fb9c100-5715-11eb-8628-886c41830a7d.png">
