### PR TITLE
Sync startup cleanups

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -28,6 +28,7 @@
                               (p/def-map-type '(2 nil nil (:defn)))
                               (p.types/defrecord+ '(2 nil nil (:defn)))
                               (tools.macro/macrolet '(1 (:defn))))))
+                  (clojure-indent-style . always-align)
                   ;; if you're using clj-refactor (highly recommended!)
                   (cljr-favor-prefix-notation . nil)
                   ;; prefer keeping source width about ~118, GitHub seems to cut off stuff at either 119 or 120 and

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -68,17 +68,19 @@
     ;; if the sync operation schedules have changed, we need to reschedule this DB
     (when (or new-metadata-schedule new-fieldvalues-schedule)
       (let [{old-metadata-schedule    :metadata_sync_schedule
-             old-fieldvalues-schedule :cache_field_values_schedule} (db/select-one [Database
-                                                                                    :metadata_sync_schedule
-                                                                                    :cache_field_values_schedule]
-                                                                      :id (u/get-id database))
+             old-fieldvalues-schedule :cache_field_values_schedule
+             existing-engine          :engine
+             existing-name            :name} (db/select-one [Database
+                                                             :metadata_sync_schedule
+                                                             :cache_field_values_schedule]
+                                               :id (u/the-id database))
             ;; if one of the schedules wasn't passed continue using the old one
-            new-metadata-schedule    (or new-metadata-schedule old-metadata-schedule)
-            new-fieldvalues-schedule (or new-fieldvalues-schedule old-fieldvalues-schedule)]
+            new-metadata-schedule            (or new-metadata-schedule old-metadata-schedule)
+            new-fieldvalues-schedule         (or new-fieldvalues-schedule old-fieldvalues-schedule)]
         (when-not (= [new-metadata-schedule new-fieldvalues-schedule]
                      [old-metadata-schedule old-fieldvalues-schedule])
           (log/info
-           (trs "{0} Database ''{1}'' sync/analyze schedules have changed!" (:engine database) (:name database))
+           (trs "{0} Database ''{1}'' sync/analyze schedules have changed!" existing-engine existing-name)
            "\n"
            (trs "Sync metadata was: ''{0}'' is now: ''{1}''" old-metadata-schedule new-metadata-schedule)
            "\n"

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -198,7 +198,7 @@
      ;; store is bound so DB timezone can be used in date coercion logic
      (qp.store/store-database! database)
      (reduce (fn [acc table]
-               (log-progress-fn (if *refingerprint?* "fingerprint-fields" "refingerprint-fields") table)
+               (log-progress-fn (if *refingerprint?* "refingerprint-fields" "fingerprint-fields") table)
                (let [results (if (= :googleanalytics (:engine database))
                                (empty-stats-map 0)
                                (fingerprint-fields! table))

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -249,7 +249,7 @@
   [database]
   (if-let [randomized-schedules (randomized-schedules database)]
     (u/prog1 (merge database randomized-schedules)
-             (db/update! Database (u/id database) randomized-schedules))
+      (db/update! Database (u/the-id database) randomized-schedules))
     database))
 
 (defmethod task/init! ::SyncDatabases


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/14411 and https://github.com/metabase/metabase/issues/14409

two trivial bugs. Both logging related:
- when updating a database, it would log when schedules changed, including the name and engine for context. The update doesn't necessarily have these values, yielding some nulls in the logs. However, it queries for the original schedule values so we can also just grab name and engine there
- when logging fingerprinting, the logic for logging it as refingerprinting vs fingerprinting was inverted