### PR TITLE
Reduce the verbose error message in the custom expression input field

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -235,6 +235,8 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   onInputBlur = () => {
     this.clearSuggestions();
+    const { compileError } = this.state;
+    this.setState({ displayCompileError: compileError });
 
     // whenever our input blurs we push the updated expression to our parent if valid
     if (this.state.expression) {
@@ -308,6 +310,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       expression,
       syntaxTree,
       compileError,
+      displayCompileError: null,
       suggestions: showSuggestions ? suggestions : [],
       helpText,
       highlightedSuggestionIndex: 0,
@@ -316,7 +319,13 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   render() {
     const { placeholder } = this.props;
-    const { compileError, source, suggestions, syntaxTree } = this.state;
+    const {
+      compileError,
+      displayCompileError,
+      source,
+      suggestions,
+      syntaxTree,
+    } = this.state;
 
     const inputClassName = cx("input text-bold text-monospace", {
       "text-dark": source,
@@ -354,7 +363,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           onClick={this.onInputClick}
           autoFocus
         />
-        <Errors compileError={compileError} />
+        <Errors compileError={displayCompileError} />
         <HelpText helpText={this.state.helpText} width={this.props.width} />
         <ExpressionEditorSuggestions
           suggestions={suggestions}

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -448,19 +448,25 @@ describe("scenarios > question > filter", () => {
     cy.findByText(AGGREGATED_FILTER);
   });
 
+  // This issue (#14341) has two problematic parts. We're testing for both:
+
   it.skip("in a simple question should display popup for custom expression options (metabase#14341)", () => {
     openProductsTable();
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();
 
-    // This issue has two problematic parts. We're testing for both:
-    cy.log("**--1. Popover should display all custom expression options--**");
+    cy.log("** Popover should display all custom expression options--**");
     // Popover shows up even without explicitly clicking the contenteditable field
     popover().within(() => {
       cy.findAllByRole("listitem").contains(/functions/i);
     });
+  });
 
-    cy.log("**--2. Should not display error prematurely--**");
+  it("in a simple question should not show verbose error while typing (metabase#14341)", () => {
+    openProductsTable();
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+    cy.log("** Should not display error prematurely--**");
     cy.get("[contenteditable='true']")
       .click()
       .type("contains(");


### PR DESCRIPTION
The error message is not shown while the user is still typing. If there is any error, it is shown once the focus leaves the input field. Basically this is refining the previous  PR #13724 (from @camsaul).

This fixes #14345 and the second half of #14341.

**Before** this PR:

![image](https://user-images.githubusercontent.com/7288/104792027-cb514300-5751-11eb-8fd2-6363dd80ae93.png)


**After** this PR:

![image](https://user-images.githubusercontent.com/7288/104791958-7e6d6c80-5751-11eb-9f7e-30a504166606.png)

