### PR TITLE
Improve pivot table performance

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -117,12 +117,14 @@ export function multiLevelPivot(
       isGrandTotal: true,
     });
   }
-  console.log({ valueColumns });
+
+  const columnIndex = addEmptyIndexItem(
+    formattedColumnTreeWithoutValues.flatMap(enumerate),
+  );
   const formattedColumnTree = addValueColumnNodes(
     formattedColumnTreeWithoutValues,
     valueColumns,
   );
-  console.log({ formattedColumnTreeWithoutValues, formattedColumnTree });
 
   const formattedRowTreeWithoutSubtotals = formatValuesInTree(
     rowColumnTree,
@@ -142,13 +144,10 @@ export function multiLevelPivot(
     });
   }
 
-  console.log({ formattedRowTree, formattedColumnTree });
-  const columnIndex = addEmptyIndexItem(formattedColumnTree.flatMap(enumerate));
   const rowIndex = addEmptyIndexItem(formattedRowTree.flatMap(enumerate));
 
   const leftHeaderItems = treeToArray(formattedRowTree.flat());
   const topHeaderItems = treeToArray(formattedColumnTree.flat());
-  console.log({ columnIndex, rowIndex, leftHeaderItems, topHeaderItems });
 
   const getRowSection = createRowSectionGetter({
     valuesByKey,
@@ -201,7 +200,6 @@ function createRowSectionGetter({
   const getter = (columnIdx, rowIdx) => {
     const columnValues = columnIndex[columnIdx] || [];
     const rowValues = rowIndex[rowIdx] || [];
-    console.log({ columnIdx, rowIdx, columnValues, rowValues });
     const indexValues = columnValues.concat(rowValues);
     if (
       rowValues.length < rowColumnIndexes.length ||

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -312,21 +312,24 @@ function updateValueObject(row, indexes, seenValues, collapsedSubtotals = []) {
 
 function treeToArray(nodes) {
   const a = [];
-  function dfs(nodes, depth, offset) {
+  function dfs(nodes, depth, offset, path = []) {
     if (nodes.length === 0) {
       return { span: 1, maxDepth: 0 };
     }
     let totalSpan = 0;
     let maxDepth = 0;
-    for (const { children, ...rest } of nodes) {
+    for (const { children, rawValue, ...rest } of nodes) {
+      const pathWithValue = [...path, rawValue];
       const item = {
         ...rest,
+        rawValue,
         depth,
         offset,
         hasChildren: children.length > 0,
+        path: pathWithValue,
       };
       a.push(item);
-      const result = dfs(children, depth + 1, offset);
+      const result = dfs(children, depth + 1, offset, pathWithValue);
       item.span = result.span;
       item.maxDepthBelow = result.maxDepth;
       offset += result.span;

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -134,7 +134,7 @@ export function multiLevelPivot(
     formattedRowTreeWithoutSubtotals,
     leftIndexFormatters,
   );
-  if (formattedRowTree.length > 1) {
+  if (formattedRowTreeWithoutSubtotals.length > 1) {
     // if there are multiple columns, we should add another for row totals
     formattedRowTree.push({
       value: t`Grand totals`,
@@ -162,8 +162,8 @@ export function multiLevelPivot(
   return {
     leftHeaderItems,
     topHeaderItems,
-    rowIndex,
-    columnIndex,
+    rowCount: rowIndex.length,
+    columnCount: columnIndex.length,
     getRowSection,
   };
 }
@@ -318,8 +318,15 @@ function treeToArray(nodes) {
     }
     let totalSpan = 0;
     let maxDepth = 0;
-    for (const { children, rawValue, ...rest } of nodes) {
-      const pathWithValue = [...path, rawValue];
+    for (const {
+      children,
+      rawValue,
+      isGrandTotal,
+      isValueColumn,
+      ...rest
+    } of nodes) {
+      const pathWithValue =
+        isValueColumn || isGrandTotal ? null : [...path, rawValue];
       const item = {
         ...rest,
         rawValue,

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -269,23 +269,24 @@ function addSubtotals(rowColumnTree, formatters) {
 }
 
 function addSubtotal(item, [formatter, ...formatters]) {
-  const subtotal =
-    item.children.length > 1
-      ? [
-          {
-            value: t`Totals for ${formatter(item.value)}`,
-            rawValue: item.rawValue,
-            span: 1,
-            isSubtotal: true,
-            children: [],
-          },
-        ]
-      : [];
+  const hasSubtotal = item.children.length > 1;
+  const subtotal = hasSubtotal
+    ? [
+        {
+          value: t`Totals for ${formatter(item.value)}`,
+          rawValue: item.rawValue,
+          span: 1,
+          isSubtotal: true,
+          children: [],
+        },
+      ]
+    : [];
   if (item.isCollapsed) {
     return subtotal;
   }
   const node = {
     ...item,
+    hasSubtotal,
     children: item.children.flatMap(item =>
       // add subtotals until the last level
       item.children.length > 0 ? addSubtotal(item, formatters) : item,
@@ -330,6 +331,7 @@ function treeToArray(nodes) {
       const item = {
         ...rest,
         rawValue,
+        isGrandTotal,
         depth,
         offset,
         hasChildren: children.length > 0,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -212,8 +212,8 @@ export default class PivotTable extends Component {
       console.warn(e);
     }
     const {
-      leftHeaderItems: leftTreeList,
-      topHeaderItems: topTreeList,
+      leftHeaderItems,
+      topHeaderItems,
       rowCount,
       columnCount,
       getRowSection,
@@ -227,7 +227,7 @@ export default class PivotTable extends Component {
         hasChildren,
         depth,
         path,
-      } = leftTreeList[index];
+      } = leftHeaderItems[index];
       return (
         <div
           key={key}
@@ -256,7 +256,7 @@ export default class PivotTable extends Component {
       );
     };
     const leftCellSizeAndPositionGetter = ({ index }) => {
-      const { offset, span, depth, maxDepthBelow } = leftTreeList[index];
+      const { offset, span, depth, maxDepthBelow } = leftHeaderItems[index];
       return {
         height: span * CELL_HEIGHT,
         width:
@@ -269,11 +269,12 @@ export default class PivotTable extends Component {
       };
     };
 
-    const topHeaderHeight =
-      CELL_HEIGHT * (columnIndexes.length + (valueIndexes.length > 1 ? 1 : 0));
+    const topHeaderRows =
+      columnIndexes.length + (valueIndexes.length > 1 ? 1 : 0) || 1;
+    const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
 
     const topCellRenderer = ({ index, key, style }) => {
-      const { value, hasChildren } = topTreeList[index];
+      const { value, hasChildren } = topHeaderItems[index];
       return (
         <div
           key={key}
@@ -285,12 +286,12 @@ export default class PivotTable extends Component {
       );
     };
     const topCellSizeAndPositionGetter = ({ index }) => {
-      const { offset, span, maxDepthBelow } = topTreeList[index];
+      const { offset, span, maxDepthBelow } = topHeaderItems[index];
       return {
         height: CELL_HEIGHT,
         width: span * CELL_WIDTH,
         x: offset * CELL_WIDTH,
-        y: topHeaderHeight - (maxDepthBelow + 1) * CELL_HEIGHT,
+        y: (topHeaderRows - maxDepthBelow - 1) * CELL_HEIGHT,
       };
     };
 
@@ -363,7 +364,7 @@ export default class PivotTable extends Component {
                   className="scroll-hide-all text-medium"
                   width={width - leftHeaderWidth}
                   height={topHeaderHeight}
-                  cellCount={topTreeList.length}
+                  cellCount={topHeaderItems.length}
                   cellRenderer={topCellRenderer}
                   cellSizeAndPositionGetter={topCellSizeAndPositionGetter}
                   onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
@@ -371,7 +372,7 @@ export default class PivotTable extends Component {
                 />
                 {/* left header */}
                 <Collection
-                  cellCount={leftTreeList.length}
+                  cellCount={leftHeaderItems.length}
                   cellRenderer={leftCellRenderer}
                   cellSizeAndPositionGetter={leftCellSizeAndPositionGetter}
                   width={leftHeaderWidth}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -373,6 +373,7 @@ export default class PivotTable extends Component {
                 />
                 {/* left header */}
                 <Collection
+                  className="scroll-hide-all"
                   cellCount={leftHeaderItems.length}
                   cellRenderer={leftCellRenderer}
                   cellSizeAndPositionGetter={leftCellSizeAndPositionGetter}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -378,9 +378,9 @@ export default class PivotTable extends Component {
                   height={height - topHeaderHeight}
                   className="text-dark"
                   rowCount={rowCount}
-                  rowHeight={CELL_HEIGHT}
                   columnCount={columnCount}
-                  columnWidth={({ index }) => valueIndexes.length * CELL_WIDTH}
+                  rowHeight={CELL_HEIGHT}
+                  columnWidth={valueIndexes.length * CELL_WIDTH}
                   cellRenderer={bodyRenderer}
                   onScroll={({ scrollLeft, scrollTop }) =>
                     onScroll({ scrollLeft, scrollTop })

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -277,10 +277,10 @@ export default class PivotTable extends Component {
           })}
         >
           <div
-            className={cx("flex full-height align-center", {
+            className={cx("flex flex-full full-height align-center", {
               "border-bottom": hasChildren,
             })}
-            style={{ width: CELL_WIDTH }}
+            style={{ width: "100%" }}
           >
             <Ellipsified>{value}</Ellipsified>
           </div>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -226,6 +226,7 @@ export default class PivotTable extends Component {
         isGrandTotal,
         hasChildren,
         depth,
+        path,
       } = leftTreeList[index];
       return (
         <div
@@ -240,6 +241,16 @@ export default class PivotTable extends Component {
             value={value}
             isSubtotal={isSubtotal}
             isGrandTotal={isGrandTotal}
+            icon={
+              (isSubtotal || hasChildren) && (
+                <RowToggleIcon
+                  value={path}
+                  settings={settings}
+                  updateSettings={onUpdateVisualizationSettings}
+                  hideUnlessCollapsed={isSubtotal}
+                />
+              )
+            }
           />
         </div>
       );
@@ -424,54 +435,6 @@ function RowToggleIcon({
       onClick={update}
     >
       <Icon name={isCollapsed ? "add" : "dash"} size={8} />
-    </div>
-  );
-}
-
-function LeftHeaderSection({
-  item: { value, rawValue, isSubtotal, isGrandTotal, children },
-  settings,
-  onUpdateVisualizationSettings,
-  valuePath = [],
-  depth = 0,
-}) {
-  valuePath = [...valuePath, rawValue];
-  return (
-    <div className="flex justify-between">
-      {value === null ? null : (
-        <Cell
-          value={value}
-          isSubtotal={isSubtotal}
-          isGrandTotal={isGrandTotal}
-          baseWidth={LEFT_HEADER_CELL_WIDTH}
-          width={isSubtotal ? undefined : 1}
-          className={isSubtotal ? "flex-full" : ""}
-          style={{
-            ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
-          }}
-          icon={
-            (isSubtotal || children.length > 1) && (
-              <RowToggleIcon
-                value={valuePath}
-                settings={settings}
-                updateSettings={onUpdateVisualizationSettings}
-                hideUnlessCollapsed={isSubtotal}
-              />
-            )
-          }
-        />
-      )}
-      <div className="flex flex-column">
-        {children.map(child => (
-          <LeftHeaderSection
-            item={child}
-            depth={depth + 1}
-            valuePath={valuePath}
-            settings={settings}
-            onUpdateVisualizationSettings={onUpdateVisualizationSettings}
-          />
-        ))}
-      </div>
     </div>
   );
 }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -211,7 +211,7 @@ export default class PivotTable extends Component {
       getRowSection,
     } = pivoted;
 
-    const leftCellRenderer = ({ index, key, style }) => {
+    const leftHeaderCellRenderer = ({ index, key, style }) => {
       const {
         value,
         isSubtotal,
@@ -248,7 +248,7 @@ export default class PivotTable extends Component {
         </div>
       );
     };
-    const leftCellSizeAndPositionGetter = ({ index }) => {
+    const leftHeaderCellSizeAndPositionGetter = ({ index }) => {
       const { offset, span, depth, maxDepthBelow } = leftHeaderItems[index];
       return {
         height: span * CELL_HEIGHT,
@@ -266,7 +266,7 @@ export default class PivotTable extends Component {
       columnIndexes.length + (valueIndexes.length > 1 ? 1 : 0) || 1;
     const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
 
-    const topCellRenderer = ({ index, key, style }) => {
+    const topHeaderCellRenderer = ({ index, key, style }) => {
       const { value, hasChildren } = topHeaderItems[index];
       return (
         <div
@@ -287,7 +287,7 @@ export default class PivotTable extends Component {
         </div>
       );
     };
-    const topCellSizeAndPositionGetter = ({ index }) => {
+    const topHeaderCellSizeAndPositionGetter = ({ index }) => {
       const { offset, span, maxDepthBelow } = topHeaderItems[index];
       return {
         height: CELL_HEIGHT,
@@ -363,8 +363,8 @@ export default class PivotTable extends Component {
                   width={width - leftHeaderWidth}
                   height={topHeaderHeight}
                   cellCount={topHeaderItems.length}
-                  cellRenderer={topCellRenderer}
-                  cellSizeAndPositionGetter={topCellSizeAndPositionGetter}
+                  cellRenderer={topHeaderCellRenderer}
+                  cellSizeAndPositionGetter={topHeaderCellSizeAndPositionGetter}
                   onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
                   scrollLeft={scrollLeft}
                 />
@@ -372,8 +372,10 @@ export default class PivotTable extends Component {
                 <Collection
                   className="scroll-hide-all"
                   cellCount={leftHeaderItems.length}
-                  cellRenderer={leftCellRenderer}
-                  cellSizeAndPositionGetter={leftCellSizeAndPositionGetter}
+                  cellRenderer={leftHeaderCellRenderer}
+                  cellSizeAndPositionGetter={
+                    leftHeaderCellSizeAndPositionGetter
+                  }
                   width={leftHeaderWidth}
                   height={height - topHeaderHeight}
                   scrollTop={scrollTop}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -217,6 +217,7 @@ export default class PivotTable extends Component {
         isSubtotal,
         isGrandTotal,
         hasChildren,
+        hasSubtotal,
         depth,
         path,
       } = leftHeaderItems[index];
@@ -234,7 +235,7 @@ export default class PivotTable extends Component {
             isSubtotal={isSubtotal}
             isGrandTotal={isGrandTotal}
             icon={
-              (isSubtotal || hasChildren) && (
+              (isSubtotal || hasSubtotal) && (
                 <RowToggleIcon
                   value={path}
                   settings={settings}
@@ -271,9 +272,18 @@ export default class PivotTable extends Component {
         <div
           key={key}
           style={style}
-          className={cx({ "border-bottom border-medium": !hasChildren })}
+          className={cx("px1 flex align-center", {
+            "border-bottom border-medium": !hasChildren,
+          })}
         >
-          <Cell value={value} />
+          <div
+            className={cx("flex flex-full full-height align-center", {
+              "border-bottom": hasChildren,
+            })}
+            style={{ width: CELL_WIDTH }}
+          >
+            <Ellipsified>{value}</Ellipsified>
+          </div>
         </div>
       );
     };
@@ -297,14 +307,15 @@ export default class PivotTable extends Component {
     const bodyRenderer = ({ key, style, rowIndex, columnIndex }) => (
       <div key={key} style={style} className="flex">
         {getRowSection(columnIndex, rowIndex).map(
-          ({ value, isSubtotal, isGrandTotal, clicked }, index) => (
+          (
+            { value, hasChildren, isSubtotal, isGrandTotal, clicked },
+            index,
+          ) => (
             <Cell
               key={index}
               value={value}
               isSubtotal={isSubtotal}
               isGrandTotal={isGrandTotal}
-              width={1}
-              height={1}
               isBody
               onClick={
                 clicked &&
@@ -345,9 +356,7 @@ export default class PivotTable extends Component {
                   {rowIndexes.map(index => (
                     <Cell
                       value={formatColumn(columns[index])}
-                      baseWidth={LEFT_HEADER_CELL_WIDTH}
-                      width={1}
-                      height={1}
+                      style={{ width: LEFT_HEADER_CELL_WIDTH }}
                     />
                   ))}
                 </div>
@@ -436,10 +445,6 @@ function Cell({
   isSubtotal,
   isGrandTotal,
   onClick,
-  width,
-  height,
-  baseWidth = CELL_WIDTH,
-  baseHeight = CELL_HEIGHT,
   style,
   isBody = false,
   className,
@@ -448,13 +453,11 @@ function Cell({
   return (
     <div
       style={{
-        ...(width != null ? { width: baseWidth * width } : {}),
-        ...(height != null ? { height: baseHeight * height } : {}),
         lineHeight: `${CELL_HEIGHT}px`,
         ...(isGrandTotal ? { borderTop: "1px solid white" } : {}),
         ...style,
       }}
-      className={cx(className, {
+      className={cx("flex-full", className, {
         "bg-medium text-bold": isSubtotal,
         "cursor-pointer": onClick,
       })}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -225,7 +225,7 @@ export default class PivotTable extends Component {
         <div
           key={key}
           style={style}
-          className={cx("bg-light", {
+          className={cx("bg-light overflow-hidden", {
             "border-right border-medium": !hasChildren,
           })}
         >
@@ -277,7 +277,7 @@ export default class PivotTable extends Component {
           })}
         >
           <div
-            className={cx("flex flex-full full-height align-center", {
+            className={cx("flex full-height align-center", {
               "border-bottom": hasChildren,
             })}
             style={{ width: CELL_WIDTH }}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -163,14 +163,6 @@ export default class PivotTable extends Component {
   };
 
   render() {
-    // We need to tell the List/Grids to call the columnWidth/rowHeight functions again when data changes.
-    // Putting this in componentDidUpdate led the dimensions to be recomputed _after_ re-rendering the cells.
-    // According to the docs, recomputing dimensions should force a render but this didn't occur correctly.
-    // The downside of keeping it here is that the dimensions are computed twice per render.
-    this.bodyGrid && this.bodyGrid.recomputeGridSize();
-    this.topGrid && this.topGrid.recomputeGridSize();
-    this.leftList && this.leftList.recomputeRowHeights();
-
     const {
       settings,
       data,
@@ -382,7 +374,6 @@ export default class PivotTable extends Component {
                 />
                 {/* pivot table body */}
                 <Grid
-                  ref={e => (this.bodyGrid = e)}
                   width={width - leftHeaderWidth}
                   height={height - topHeaderHeight}
                   className="text-dark"

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -307,10 +307,7 @@ export default class PivotTable extends Component {
     const bodyRenderer = ({ key, style, rowIndex, columnIndex }) => (
       <div key={key} style={style} className="flex">
         {getRowSection(columnIndex, rowIndex).map(
-          (
-            { value, hasChildren, isSubtotal, isGrandTotal, clicked },
-            index,
-          ) => (
+          ({ value, isSubtotal, isGrandTotal, clicked }, index) => (
             <Cell
               key={index}
               value={value}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -214,8 +214,8 @@ export default class PivotTable extends Component {
     const {
       leftHeaderItems: leftTreeList,
       topHeaderItems: topTreeList,
-      rowIndex,
-      columnIndex,
+      rowCount,
+      columnCount,
       getRowSection,
     } = pivoted;
 
@@ -385,9 +385,9 @@ export default class PivotTable extends Component {
                   width={width - leftHeaderWidth}
                   height={height - topHeaderHeight}
                   className="text-dark"
-                  rowCount={rowIndex.length}
+                  rowCount={rowCount}
                   rowHeight={CELL_HEIGHT}
-                  columnCount={columnIndex.length}
+                  columnCount={columnCount}
                   columnWidth={({ index }) => valueIndexes.length * CELL_WIDTH}
                   cellRenderer={bodyRenderer}
                   onScroll={({ scrollLeft, scrollTop }) =>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -468,7 +468,7 @@ function Cell({
       })}
       onClick={onClick}
     >
-      <div className="px1 flex align-center">
+      <div className={cx("px1 flex align-center", { "justify-end": isBody })}>
         {isBody ? (
           // Ellipsified isn't really needed for body cells. Avoiding it helps performance.
           value

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -132,7 +132,7 @@ describe("data_grid", () => {
     });
   });
 
-  describe("multiLevelPivot", () => {
+  describe.skip("multiLevelPivot", () => {
     const extractValues = rows => rows.map(row => row.map(item => item.value));
 
     const data = makePivotData([

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -1,3 +1,5 @@
+import _ from "underscore";
+
 import { pivot, multiLevelPivot } from "metabase/lib/data_grid";
 
 import { TYPE } from "metabase/lib/types";
@@ -132,8 +134,10 @@ describe("data_grid", () => {
     });
   });
 
-  describe.skip("multiLevelPivot", () => {
-    const extractValues = rows => rows.map(row => row.map(item => item.value));
+  describe("multiLevelPivot", () => {
+    const getValues = items => _.pluck(items, "value");
+    const getPathsAndValues = items =>
+      items.map(item => _.pick(item, "path", "value"));
 
     const data = makePivotData([
       ["a", "x", 1],
@@ -143,94 +147,50 @@ describe("data_grid", () => {
       ["b", "y", 5],
       ["b", "z", 6],
     ]);
-    it("should produce multi-level top index", () => {
-      const { topIndex, leftIndex, rowCount, columnCount } = multiLevelPivot(
-        data,
-        [0, 1],
-        [],
-        [2],
-      );
-      expect(topIndex).toEqual([
-        [
-          [{ span: 3, value: "a" }],
-          [
-            { span: 1, value: "x" },
-            { span: 1, value: "y" },
-            { span: 1, value: "z" },
-          ],
-        ],
-        [
-          [{ span: 3, value: "b" }],
-          [
-            { span: 1, value: "x" },
-            { span: 1, value: "y" },
-            { span: 1, value: "z" },
-          ],
-        ],
-        [[{ span: 1, value: "Row totals" }]],
+    it("should produce multi-level top header", () => {
+      const {
+        topHeaderItems,
+        leftHeaderItems,
+        rowCount,
+        columnCount,
+      } = multiLevelPivot(data, [0, 1], [], [2]);
+      expect(getPathsAndValues(topHeaderItems)).toEqual([
+        { value: "a", path: ["a"] },
+        { value: "x", path: ["a", "x"] },
+        { value: "y", path: ["a", "y"] },
+        { value: "z", path: ["a", "z"] },
+        { value: "b", path: ["b"] },
+        { value: "x", path: ["b", "x"] },
+        { value: "y", path: ["b", "y"] },
+        { value: "z", path: ["b", "z"] },
+        { value: "Row totals", path: null },
       ]);
-      expect(leftIndex).toEqual([]);
+      expect(leftHeaderItems).toEqual([]);
       expect(rowCount).toEqual(1);
-      expect(columnCount).toEqual(3);
+      expect(columnCount).toEqual(7);
     });
-    it("should produce multi-level left index", () => {
-      const { topIndex, leftIndex, rowCount, columnCount } = multiLevelPivot(
-        data,
-        [],
-        [0, 1],
-        [2],
-      );
-      expect(leftIndex).toEqual([
-        [
-          {
-            children: [
-              { children: [], isCollapsed: false, rawValue: "x", value: "x" },
-              { children: [], isCollapsed: false, rawValue: "y", value: "y" },
-              { children: [], isCollapsed: false, rawValue: "z", value: "z" },
-            ],
-            isCollapsed: false,
-            rawValue: "a",
-            value: "a",
-          },
-          {
-            children: [],
-            isSubtotal: true,
-            rawValue: "a",
-            span: 1,
-            value: "Totals for a",
-          },
-        ],
-        [
-          {
-            children: [
-              { children: [], isCollapsed: false, rawValue: "x", value: "x" },
-              { children: [], isCollapsed: false, rawValue: "y", value: "y" },
-              { children: [], isCollapsed: false, rawValue: "z", value: "z" },
-            ],
-            isCollapsed: false,
-            rawValue: "b",
-            value: "b",
-          },
-          {
-            children: [],
-            isSubtotal: true,
-            rawValue: "b",
-            span: 1,
-            value: "Totals for b",
-          },
-        ],
-        [
-          {
-            children: [],
-            isGrandTotal: true,
-            isSubtotal: true,
-            span: 1,
-            value: "Grand totals",
-          },
-        ],
+    it("should produce multi-level left header", () => {
+      const {
+        topHeaderItems,
+        leftHeaderItems,
+        rowCount,
+        columnCount,
+      } = multiLevelPivot(data, [], [0, 1], [2]);
+      expect(getPathsAndValues(leftHeaderItems)).toEqual([
+        { value: "a", path: ["a"] },
+        { value: "x", path: ["a", "x"] },
+        { value: "y", path: ["a", "y"] },
+        { value: "z", path: ["a", "z"] },
+        { value: "Totals for a", path: ["a"] },
+        { value: "b", path: ["b"] },
+        { value: "x", path: ["b", "x"] },
+        { value: "y", path: ["b", "y"] },
+        { value: "z", path: ["b", "z"] },
+        { value: "Totals for b", path: ["b"] },
+        { value: "Grand totals", path: null },
       ]);
-      expect(topIndex).toEqual([[[{ value: "Metric", span: 1 }]]]);
-      expect(rowCount).toEqual(3);
+      expect(getValues(topHeaderItems)).toEqual(["Metric"]);
+      expect(rowCount).toEqual(9);
       expect(columnCount).toEqual(1);
     });
     it("should allow unspecified values", () => {
@@ -240,32 +200,15 @@ describe("data_grid", () => {
         ["b", "x", 3],
         // ["b", "y", ...], not present
       ]);
-      const { leftIndex, topIndex, getRowSection } = multiLevelPivot(
-        data,
-        [0],
-        [1],
-        [2],
-      );
-      expect(leftIndex).toEqual([
-        [{ children: [], isCollapsed: false, rawValue: "x", value: "x" }],
-        [{ children: [], isCollapsed: false, rawValue: "y", value: "y" }],
-        [
-          {
-            children: [],
-            isGrandTotal: true,
-            isSubtotal: true,
-            span: 1,
-            value: "Grand totals",
-          },
-        ],
-      ]);
-      expect(topIndex).toEqual([
-        [[{ value: "a", span: 1 }]],
-        [[{ value: "b", span: 1 }]],
-        [[{ span: 1, value: "Row totals" }]],
-      ]);
-      expect(extractValues(getRowSection(0, 0))).toEqual([["1"]]);
-      expect(extractValues(getRowSection(1, 1))).toEqual([[null]]);
+      const {
+        topHeaderItems,
+        leftHeaderItems,
+        getRowSection,
+      } = multiLevelPivot(data, [0], [1], [2]);
+      expect(getValues(leftHeaderItems)).toEqual(["x", "y", "Grand totals"]);
+      expect(getValues(topHeaderItems)).toEqual(["a", "b", "Row totals"]);
+      expect(getValues(getRowSection(0, 0))).toEqual(["1"]);
+      expect(getValues(getRowSection(1, 1))).toEqual([null]);
     });
     it("should handle multiple value columns", () => {
       const data = makePivotData(
@@ -278,22 +221,16 @@ describe("data_grid", () => {
         ],
       );
 
-      const { topIndex, leftIndex, getRowSection } = multiLevelPivot(
-        data,
-        [0],
-        [1],
-        [2, 3],
-      );
-      expect(topIndex).toEqual([
-        [
-          [{ value: "a", span: 2 }],
-          [{ value: "Metric 1", span: 1 }, { value: "Metric 2", span: 1 }],
-        ],
-      ]);
-      expect(leftIndex).toEqual([
-        [{ children: [], isCollapsed: false, rawValue: "b", value: "b" }],
-      ]);
-      expect(extractValues(getRowSection(0, 0))).toEqual([["1", "2"]]);
+      const {
+        topHeaderItems,
+        leftHeaderItems,
+        rowCount,
+        columnCount,
+        getRowSection,
+      } = multiLevelPivot(data, [0], [1], [2, 3]);
+      expect(getValues(topHeaderItems)).toEqual(["a", "Metric 1", "Metric 2"]);
+      expect(getValues(leftHeaderItems)).toEqual(["b"]);
+      expect(getValues(getRowSection(0, 0))).toEqual(["1", "2"]);
     });
     it("should work with three levels of row grouping", () => {
       // three was picked because there was a bug during development that showed up with at least three
@@ -321,11 +258,38 @@ describe("data_grid", () => {
         ],
       );
 
-      const { topIndex, leftIndex } = multiLevelPivot(data, [], [0, 1, 2], [3]);
-      expect(topIndex).toEqual([[[{ span: 1, value: "Metric" }]]]);
-      expect(leftIndex[0][0].value).toEqual("a1");
-      expect(leftIndex[0][0].children[0].value).toEqual("b1");
-      expect(leftIndex[0][0].children[0].children[0].value).toEqual("c1");
+      const {
+        rowCount,
+        columnCount,
+        topHeaderItems,
+        leftHeaderItems,
+      } = multiLevelPivot(data, [], [0, 1, 2], [3]);
+      expect(getValues(topHeaderItems)).toEqual(["Metric"]);
+      expect(getPathsAndValues(leftHeaderItems)).toEqual([
+        { path: ["a1"], value: "a1" },
+        { path: ["a1", "b1"], value: "b1" },
+        { path: ["a1", "b1", "c1"], value: "c1" },
+        { path: ["a1", "b1", "c2"], value: "c2" },
+        { path: ["a1", "b1"], value: "Totals for b1" },
+        { path: ["a1", "b2"], value: "b2" },
+        { path: ["a1", "b2", "c1"], value: "c1" },
+        { path: ["a1", "b2", "c2"], value: "c2" },
+        { path: ["a1", "b2"], value: "Totals for b2" },
+        { path: ["a1"], value: "Totals for a1" },
+        { path: ["a2"], value: "a2" },
+        { path: ["a2", "b1"], value: "b1" },
+        { path: ["a2", "b1", "c1"], value: "c1" },
+        { path: ["a2", "b1", "c2"], value: "c2" },
+        { path: ["a2", "b1"], value: "Totals for b1" },
+        { path: ["a2", "b2"], value: "b2" },
+        { path: ["a2", "b2", "c1"], value: "c1" },
+        { path: ["a2", "b2", "c2"], value: "c2" },
+        { path: ["a2", "b2"], value: "Totals for b2" },
+        { path: ["a2"], value: "Totals for a2" },
+        { path: null, value: "Grand totals" },
+      ]);
+      expect(rowCount).toEqual(15);
+      expect(columnCount).toEqual(1);
     });
     it("should format values", () => {
       const data = makePivotData(
@@ -353,19 +317,20 @@ describe("data_grid", () => {
         ],
       );
 
-      const { getRowSection } = multiLevelPivot(data, [0], [1], [2]);
-      expect(extractValues(getRowSection(0, 0))).toEqual([["1,000"]]);
+      const {
+        getRowSection,
+        topHeaderItems,
+        leftHeaderItems,
+      } = multiLevelPivot(data, [0], [1], [2]);
+      expect(getValues(topHeaderItems)).toEqual(["1  –  11"]);
+      expect(getValues(leftHeaderItems)).toEqual(["January 1, 2020, 12:00 AM"]);
+      expect(getValues(getRowSection(0, 0))).toEqual(["1,000"]);
     });
     it("should format values without a pivoted column or row", () => {
       const data = makePivotData(
         [[1, 1000]],
         [
-          {
-            name: "D1",
-            display_name: "Dimension 1",
-            base_type: TYPE.Float,
-            source: "breakout",
-          },
+          D1,
           {
             name: "M1",
             display_name: "Metric",
@@ -376,9 +341,9 @@ describe("data_grid", () => {
       );
       let getRowSection;
       ({ getRowSection } = multiLevelPivot(data, [0], [], [1]));
-      expect(extractValues(getRowSection(0, 0))).toEqual([["1,000"]]);
+      expect(getValues(getRowSection(0, 0))).toEqual(["1,000"]);
       ({ getRowSection } = multiLevelPivot(data, [], [0], [1]));
-      expect(extractValues(getRowSection(0, 0))).toEqual([["1,000"]]);
+      expect(getValues(getRowSection(0, 0))).toEqual(["1,000"]);
     });
     it("should format multiple values", () => {
       const data = makePivotData(
@@ -405,18 +370,18 @@ describe("data_grid", () => {
       );
 
       const { getRowSection } = multiLevelPivot(data, [0], [1], [2, 3]);
-      expect(extractValues(getRowSection(0, 0))).toEqual([
-        ["January 1, 2020, 12:00 AM", "1,000"],
+      expect(getValues(getRowSection(0, 0))).toEqual([
+        "January 1, 2020, 12:00 AM",
+        "1,000",
       ]);
-      expect(extractValues(getRowSection(1, 1))).toEqual([[null, null]]);
+      expect(getValues(getRowSection(1, 1))).toEqual([null, null]);
     });
 
     it("should return subtotals in each section", () => {
       const cols = [D1, D2, M];
       const primaryGroup = 0;
       const subtotalOne = 2;
-      const subtotalTwo = 1;
-      const subtotalThree = 3;
+      const subtotalTwo = 3;
       const rows = [
         ["a", "x", 1, primaryGroup],
         ["a", "y", 2, primaryGroup],
@@ -424,9 +389,7 @@ describe("data_grid", () => {
         ["b", "y", 4, primaryGroup],
         ["a", null, 3, subtotalOne],
         ["b", null, 7, subtotalOne],
-        [null, "x", 4, subtotalTwo],
-        [null, "y", 6, subtotalTwo],
-        [null, null, 10, subtotalThree],
+        [null, null, 10, subtotalTwo],
       ];
       const data = {
         rows,
@@ -438,11 +401,17 @@ describe("data_grid", () => {
         [0, 1],
         [2],
       );
-      expect(rowCount).toEqual(3);
+      expect(rowCount).toEqual(7);
       expect(columnCount).toEqual(1);
-      expect(extractValues(getRowSection(0, 0))).toEqual([["1"], ["2"], ["3"]]);
-      expect(extractValues(getRowSection(0, 1))).toEqual([["3"], ["4"], ["7"]]);
-      expect(extractValues(getRowSection(0, 2))).toEqual([["10"]]);
+      expect(_.range(rowCount).map(i => getRowSection(0, i)[0].value)).toEqual([
+        "1",
+        "2",
+        "3",
+        "3",
+        "4",
+        "7",
+        "10",
+      ]);
     });
 
     it("hide collapsed rows", () => {
@@ -457,32 +426,24 @@ describe("data_grid", () => {
         ["b", "y", 4, primaryGroup],
         ["a", null, 3, subtotalOne],
         ["b", null, 7, subtotalOne],
-        [null, "x", 4, subtotalTwo],
-        [null, "y", 6, subtotalTwo],
       ];
       const data = {
         rows,
         cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
       };
-      const { getRowSection, leftIndex, rowCount } = multiLevelPivot(
+      const { getRowSection, leftHeaderItems, rowCount } = multiLevelPivot(
         data,
         [],
         [0, 1],
         [2],
         ['["a"]'],
       );
-      expect(rowCount).toEqual(3);
-      expect(leftIndex[0][0]).toEqual({
-        children: [],
-        isSubtotal: true,
-        rawValue: "a",
-        span: 1,
-        value: "Totals for a",
-      });
-      expect(getRowSection(0, 0)).toEqual([[{ isSubtotal: true, value: "3" }]]);
+      expect(rowCount).toEqual(5);
+      expect(leftHeaderItems[0].value).toEqual("Totals for a"); // a is collapsed
+      expect(getRowSection(0, 0)).toEqual([{ isSubtotal: true, value: "3" }]);
     });
 
-    it("should return multiple levels of subtotals", () => {
+    it("should return multiple levels of subtotals in body cells", () => {
       const cols = [D1, D2, D3, D4, M];
       const primaryGroup = 0;
       const subtotalOne = 4;
@@ -497,19 +458,12 @@ describe("data_grid", () => {
         ["a", "i", "y", "t1", 2, primaryGroup],
         ["a", "j", "x", "t1", 3, primaryGroup],
         ["a", "j", "y", "t1", 4, primaryGroup],
-        ["b", "i", "x", "t1", 5, primaryGroup],
-        ["b", "i", "y", "t1", 6, primaryGroup],
-        ["b", "j", "x", "t1", 7, primaryGroup],
-        ["b", "j", "y", "t1", 8, primaryGroup],
         ["a", "i", "x", "t2", 0, primaryGroup],
 
         ["a", "i", null, "t1", 3, subtotalOne],
         ["a", "j", null, "t1", 7, subtotalOne],
-        ["b", "i", null, "t1", 11, subtotalOne],
-        ["b", "j", null, "t1", 15, subtotalOne],
         ["a", null, null, "t1", 10, subtotalTwo],
-        ["b", null, null, "t1", 26, subtotalTwo],
-        [null, null, null, "t1", 36, subtotalThree],
+        [null, null, null, "t1", 10, subtotalThree],
         ["a", "i", "x", null, 1, subtotalFour],
         ["a", "i", "y", null, 2, subtotalFour],
         ["a", "j", "x", null, 3, subtotalFour],
@@ -522,25 +476,20 @@ describe("data_grid", () => {
         rows,
         cols: [...cols, { name: "pivot-grouping", base_type: TYPE.Text }],
       };
-      const { getRowSection } = multiLevelPivot(data, [3], [0, 1, 2], [4]);
-      expect(extractValues(getRowSection(0, 0))).toEqual([
-        ["1"],
-        ["2"],
-        ["3"],
-        ["3"],
-        ["4"],
-        ["7"],
-        ["10"],
-      ]);
-      expect(extractValues(getRowSection(2, 0))).toEqual([
-        ["1"],
-        ["2"],
-        ["3"],
-        ["3"],
-        ["4"],
-        ["7"],
-        ["10"],
-      ]);
+      const { rowCount, columnCount, getRowSection } = multiLevelPivot(
+        data,
+        [3],
+        [0, 1, 2],
+        [4],
+      );
+      const firstColumn = ["1", "2", "3", "3", "4", "7", "10"];
+      const lastColumn = ["1", "2", "3", "3", "4", "7", "10"];
+      expect(_.range(rowCount).map(i => getRowSection(0, i)[0].value)).toEqual(
+        firstColumn,
+      );
+      expect(
+        _.range(rowCount).map(i => getRowSection(columnCount - 1, i)[0].value),
+      ).toEqual(lastColumn);
     });
   });
 });

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -224,8 +224,6 @@ describe("data_grid", () => {
       const {
         topHeaderItems,
         leftHeaderItems,
-        rowCount,
-        columnCount,
         getRowSection,
       } = multiLevelPivot(data, [0], [1], [2, 3]);
       expect(getValues(topHeaderItems)).toEqual(["a", "Metric 1", "Metric 2"]);
@@ -418,7 +416,6 @@ describe("data_grid", () => {
       const cols = [D1, D2, M];
       const primaryGroup = 0;
       const subtotalOne = 2;
-      const subtotalTwo = 1;
       const rows = [
         ["a", "x", 1, primaryGroup],
         ["a", "y", 2, primaryGroup],


### PR DESCRIPTION
Fixes #14336, Fixes #14443

What this PR changed:
Previously we rendered sections based on the _first_ value along each header. Those chunks could get too big if many columns were stacked on an axis. This PR changes to rendering sections for a single set of value columns.

Here's a video of scrolling on the example query from the issue:

https://user-images.githubusercontent.com/691495/104974351-b250c800-59c5-11eb-9fec-54ee26ae537e.mp4



Remaining work
- [x] add back row collapsing UI
- [x] fix unit tests
- [x] styling tweaks
  - [x] add back top header horizontal lines
  - [x] remove section borders when empty
  - [x] 1px misalignment with "Grand totals" row
