### PR TITLE
#14426 Repro: Admin localization tab showing excessive options

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -81,6 +81,15 @@ describe("scenarios > admin > permissions", () => {
     cy.get(".axis.x").contains(/monday/i);
     cy.get(".axis.x").contains(/tuesday/i);
   });
+
+  it.skip("should not display excessive options in localization tab (metabase#14426)", () => {
+    cy.visit("/admin/settings/localization");
+    cy.findByText(/Instance language/i);
+    cy.findByText(/Report timezone/i);
+    cy.findByText(/First day of the week/i);
+    cy.findByText(/Localization options/i);
+    cy.contains(/Column title/i).should("not.exist");
+  });
 });
 
 function setFirstWeekDayTo(day) {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14426

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/104975290-987da800-59fa-11eb-9c72-c8b265e3290f.png)
