### PR TITLE
Reduce the verbose error message in the custom expression input field

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -235,6 +235,8 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   onInputBlur = () => {
     this.clearSuggestions();
+    const { compileError } = this.state;
+    this.setState({ displayCompileError: compileError });
 
     // whenever our input blurs we push the updated expression to our parent if valid
     if (this.state.expression) {
@@ -308,15 +310,31 @@ export default class ExpressionEditorTextfield extends React.Component {
       expression,
       syntaxTree,
       compileError,
+      displayCompileError: null,
       suggestions: showSuggestions ? suggestions : [],
       helpText,
       highlightedSuggestionIndex: 0,
     });
+
+    if (!source || source.length <= 0) {
+      const { suggestions } = this._processSource({
+        source,
+        targetOffset,
+        ...this._getParserOptions(),
+      });
+      this.setState({ suggestions });
+    }
   }
 
   render() {
     const { placeholder } = this.props;
-    const { compileError, source, suggestions, syntaxTree } = this.state;
+    const {
+      compileError,
+      displayCompileError,
+      source,
+      suggestions,
+      syntaxTree,
+    } = this.state;
 
     const inputClassName = cx("input text-bold text-monospace", {
       "text-dark": source,
@@ -354,7 +372,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           onClick={this.onInputClick}
           autoFocus
         />
-        <Errors compileError={compileError} />
+        <Errors compileError={displayCompileError} />
         <HelpText helpText={this.state.helpText} width={this.props.width} />
         <ExpressionEditorSuggestions
           suggestions={suggestions}

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -448,7 +448,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText(AGGREGATED_FILTER);
   });
 
-  it.skip("in a simple question should display popup for custom expression options (metabase#14341)", () => {
+  it("in a simple question should display popup for custom expression options (metabase#14341)", () => {
     openProductsTable();
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();


### PR DESCRIPTION
(This is a more complete fix, compared to PR #14433)

The error message is not shown while the user is still typing. If there is any error, it is shown once the focus leaves the input field. Basically this is refining the previous  PR #13724 (from @camsaul).

Also, when the input is empty, show any useful suggestions instead of displaying nothing.

This fixes #14345 and #14341.


**Before** this PR:

![image](https://user-images.githubusercontent.com/7288/104792027-cb514300-5751-11eb-8fd2-6363dd80ae93.png)


**After** this PR:

![image](https://user-images.githubusercontent.com/7288/104791958-7e6d6c80-5751-11eb-9f7e-30a504166606.png)
