### PR TITLE
Auto-retry ssh test

### DIFF
--- a/test/metabase/util/ssh_test.clj
+++ b/test/metabase/util/ssh_test.clj
@@ -180,23 +180,24 @@
   (testing "ssh tunnel can properly tunnel"
     ;; Sometimes the port is already in use
     (u/auto-retry 5
-      ;; this will try to open a TCP connection via the tunnel.
-       (sshu/with-ssh-tunnel [details-with-tunnel {:tunnel-enabled                true
-                                                   :tunnel-user                   ssh-username
-                                                   :tunnel-host                   "127.0.0.1"
-                                                   :tunnel-port                   ssh-mock-server-with-publickey-passphrase-port
-                                                   :tunnel-private-key            (slurp ssh-key-with-passphrase)
-                                                   :tunnel-private-key-passphrase ssh-key-passphrase
-                                                   :host                          "127.0.0.1"
-                                                   :port                          41414}]
-         (with-open [server (doto (ServerSocket. 41414)
-                              (.setSoTimeout 10000))
-                     socket (Socket.)]
-           (let [server-thread (future (with-open [client-socket (.accept server)
-                                                   out-server    (PrintWriter. (.getOutputStream client-socket) true)]
-                                         (.println out-server "hello from the ssh tunnel")))]
-             (.connect socket (InetSocketAddress. "127.0.0.1" ^Integer (:tunnel-entrance-port details-with-tunnel)) 3000)
-             ;; cause our future to run to completion
-             (u/deref-with-timeout server-thread 12000)
-             (with-open [in-client (BufferedReader. (InputStreamReader. (.getInputStream socket)))]
-               (is (= "hello from the ssh tunnel" (.readLine in-client))))))))))
+      (let [port (+ 41414 (rand-int 20))]
+        ;; this will try to open a TCP connection via the tunnel.
+        (sshu/with-ssh-tunnel [details-with-tunnel {:tunnel-enabled                true
+                                                    :tunnel-user                   ssh-username
+                                                    :tunnel-host                   "127.0.0.1"
+                                                    :tunnel-port                   ssh-mock-server-with-publickey-passphrase-port
+                                                    :tunnel-private-key            (slurp ssh-key-with-passphrase)
+                                                    :tunnel-private-key-passphrase ssh-key-passphrase
+                                                    :host                          "127.0.0.1"
+                                                    :port                          port}]
+          (with-open [server (doto (ServerSocket. port)
+                               (.setSoTimeout 10000))
+                      socket (Socket.)]
+            (let [server-thread (future (with-open [client-socket (.accept server)
+                                                    out-server    (PrintWriter. (.getOutputStream client-socket) true)]
+                                          (.println out-server "hello from the ssh tunnel")))]
+              (.connect socket (InetSocketAddress. "127.0.0.1" ^Integer (:tunnel-entrance-port details-with-tunnel)) 3000)
+              ;; cause our future to run to completion
+              (u/deref-with-timeout server-thread 12000)
+              (with-open [in-client (BufferedReader. (InputStreamReader. (.getInputStream socket)))]
+                (is (= "hello from the ssh tunnel" (.readLine in-client)))))))))))

--- a/test/metabase/util/ssh_test.clj
+++ b/test/metabase/util/ssh_test.clj
@@ -178,6 +178,7 @@
 
 (deftest ssh-tunnel-works
   (testing "ssh tunnel can properly tunnel"
+    ;; Sometimes the port is already in use
     (u/auto-retry 5
       ;; this will try to open a TCP connection via the tunnel.
        (sshu/with-ssh-tunnel [details-with-tunnel {:tunnel-enabled                true

--- a/test/metabase/util/ssh_test.clj
+++ b/test/metabase/util/ssh_test.clj
@@ -178,23 +178,24 @@
 
 (deftest ssh-tunnel-works
   (testing "ssh tunnel can properly tunnel"
-    ;; this will try to open a TCP connection via the tunnel.
-    (sshu/with-ssh-tunnel [details-with-tunnel {:tunnel-enabled                true
-                                                :tunnel-user                   ssh-username
-                                                :tunnel-host                   "127.0.0.1"
-                                                :tunnel-port                   ssh-mock-server-with-publickey-passphrase-port
-                                                :tunnel-private-key            (slurp ssh-key-with-passphrase)
-                                                :tunnel-private-key-passphrase ssh-key-passphrase
-                                                :host                          "127.0.0.1"
-                                                :port                          41414}]
-      (with-open [server (doto (ServerSocket. 41414)
-                           (.setSoTimeout 10000))
-                  socket (Socket.)]
-        (let [server-thread (future (with-open [client-socket (.accept server)
-                                                out-server    (PrintWriter. (.getOutputStream client-socket) true)]
-                                      (.println out-server "hello from the ssh tunnel")))]
-          (.connect socket (InetSocketAddress. "127.0.0.1" ^Integer (:tunnel-entrance-port details-with-tunnel)) 3000)
-          ;; cause our future to run to completion
-          (u/deref-with-timeout server-thread 12000)
-          (with-open [in-client (BufferedReader. (InputStreamReader. (.getInputStream socket)))]
-            (is (= "hello from the ssh tunnel" (.readLine in-client)))))))))
+    (u/auto-retry 5
+      ;; this will try to open a TCP connection via the tunnel.
+       (sshu/with-ssh-tunnel [details-with-tunnel {:tunnel-enabled                true
+                                                   :tunnel-user                   ssh-username
+                                                   :tunnel-host                   "127.0.0.1"
+                                                   :tunnel-port                   ssh-mock-server-with-publickey-passphrase-port
+                                                   :tunnel-private-key            (slurp ssh-key-with-passphrase)
+                                                   :tunnel-private-key-passphrase ssh-key-passphrase
+                                                   :host                          "127.0.0.1"
+                                                   :port                          41414}]
+         (with-open [server (doto (ServerSocket. 41414)
+                              (.setSoTimeout 10000))
+                     socket (Socket.)]
+           (let [server-thread (future (with-open [client-socket (.accept server)
+                                                   out-server    (PrintWriter. (.getOutputStream client-socket) true)]
+                                         (.println out-server "hello from the ssh tunnel")))]
+             (.connect socket (InetSocketAddress. "127.0.0.1" ^Integer (:tunnel-entrance-port details-with-tunnel)) 3000)
+             ;; cause our future to run to completion
+             (u/deref-with-timeout server-thread 12000)
+             (with-open [in-client (BufferedReader. (InputStreamReader. (.getInputStream socket)))]
+               (is (= "hello from the ssh tunnel" (.readLine in-client))))))))))


### PR DESCRIPTION
Banishes the uber-annoying "bind: address already in use" intermittent fail.