### PR TITLE
Add Log4j2 config for containers :)

### DIFF
--- a/docs/operations-guide/log-configuration.md
+++ b/docs/operations-guide/log-configuration.md
@@ -10,10 +10,9 @@ The easiest way to get started customizing logging would be to use a copy of def
 
 # Using Log4j 2 with docker
 
-When using docker images you will need to pass the custom `log4j.configurationFile` argument _before_ Metabase runs. To do this add a `JAVA_OPTS=-Dlog4j.configurationFile=file:/path/to/custom/log4j2.xml` to the environment variables of the container. 
+Before running the Metabase docker image, you'll need to pass the custom `log4j.configurationFile` argument. Add a `JAVA_OPTS=-Dlog4j.configurationFile=file:/path/to/custom/log4j2.xml` to the environment variables of the container, like this:
 
-When using docker run:
-`docker run -p 3000:3000 -v $PWD/logging_config:/metabase.db -e JAVA_OPTS=-Dlog4j.configurationFile=file:///metabase.db/log4j2.xml metabase/metabase`
+        docker run -p 3000:3000 -v $PWD/logging_config:/metabase.db -e JAVA_OPTS=-Dlog4j.configurationFile=file:///metabase.db/log4j2.xml metabase/metabase`
 
 When using docker-compose:
 ```

--- a/docs/operations-guide/log-configuration.md
+++ b/docs/operations-guide/log-configuration.md
@@ -2,12 +2,35 @@
 
 By default, Metabase logs quite a bit of information. Luckily, Metabase uses [Log4j 2](https://logging.apache.org/log4j/2.x/) under the hood, meaning the logging is completely configurable.
 
-Metabase's default logging configuration can be found [here](https://github.com/metabase/metabase/blob/master/resources/log4j2.xml). You can override this XML file and tell
-Metabase to use your own logging configuration file by passing a `-Dlog4j.configurationFile` argument when running Metabase:
+Metabase's default logging configuration can be found [here](https://github.com/metabase/metabase/blob/master/resources/log4j2.xml). You can override this XML file and tell Metabase to use your own logging configuration file by passing a `-Dlog4j.configurationFile` argument when running Metabase:
 
     java -Dlog4j.configurationFile=file:/path/to/custom/log4j2.xml -jar metabase.jar
 
 The easiest way to get started customizing logging would be to use a copy of default `log4j2.xml` file linked to above and adjust that to meet your needs. Keep in mind that you'll need to restart Metabase for changes to the file to take effect.
+
+# Using Log4j 2 with docker
+
+When using docker images you will need to pass the custom `log4j.configurationFile` argument _before_ Metabase runs. To do this add a `JAVA_OPTS=-Dlog4j.configurationFile=file:/path/to/custom/log4j2.xml` to the environment variables of the container. 
+
+When using docker run:
+`docker run -p 3000:3000 -v $PWD/logging_config:/metabase.db -e JAVA_OPTS=-Dlog4j.configurationFile=file:///metabase.db/log4j2.xml metabase/metabase`
+
+When using docker-compose:
+```
+metabase:
+    image: metabase/metabase:v0.37.4
+    container_name: metabase
+    hostname: metabase
+    volumes: 
+    - /dev/urandom:/dev/random:ro
+    - $PWD/logging_config:/metabase.db
+    ports:
+      - 3000:3000
+    environment: 
+      - "JAVA_OPTS=-Dlog4j.configurationFile=file:///metabase.db/log4j2.xml"
+```
+
+**IMPORTANT**: when using containers, logs need to be written into /metabase.db directory as it is the only directory with write permissions for the metabase user which is the one that executes java inside the container.
 
 # Configuring Emoji Logging
 

--- a/docs/operations-guide/log-configuration.md
+++ b/docs/operations-guide/log-configuration.md
@@ -29,7 +29,7 @@ metabase:
       - "JAVA_OPTS=-Dlog4j.configurationFile=file:///metabase.db/log4j2.xml"
 ```
 
-**IMPORTANT**: when using containers, logs need to be written into /metabase.db directory as it is the only directory with write permissions for the metabase user which is the one that executes java inside the container.
+**IMPORTANT**: when using containers, logs need to be written into the /metabase.db directory. It's the only directory the Metabase user can write to (the user here being the one that executes that Metabase JAR inside the container).
 
 # Configuring Emoji Logging
 


### PR DESCRIPTION
Added a few lines in the documentation to cover and close [this issue](https://github.com/metabase/metabase/issues/8158)

the solution was already there but I managed to make it work with the container user permissions. Not a big issue but important to put it in the official documentation.

