### PR TITLE
abiltity to dump-to-h2 removing encryption

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -49,7 +49,8 @@
   Target H2 file is deleted before dump, unless the --keep-existing flag is given."
   [h2-filename & opts]
   (classloader/require 'metabase.cmd.dump-to-h2)
-  (let [options        {:keep-existing? (boolean (some #{"--keep-existing"} opts))}
+  (let [options        {:keep-existing? (boolean (some #{"--keep-existing"} opts))
+                        :dump-plaintext? (boolean (some #{"--dump-plaintext"} opts)) }
         return-code    ((resolve 'metabase.cmd.dump-to-h2/dump-to-h2!) h2-filename options)]
     (when (pos-int? return-code)
       (system-exit! return-code))))

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -26,12 +26,14 @@
   ([h2-filename]
    (dump-to-h2! h2-filename nil))
 
-  ([h2-filename {:keys [keep-existing?]
-                 :or   {keep-existing? false}}]
+  ([h2-filename {:keys [keep-existing? dump-plaintext?]
+                 :or   {keep-existing? false dump-plaintext? false}}]
    (let [h2-filename  (or h2-filename "metabase_dump.h2")
          h2-jdbc-spec (copy.h2/h2-jdbc-spec h2-filename)]
      (println "Dumping from configured Metabase db to H2 file" h2-filename)
      (when-not keep-existing?
        (copy.h2/delete-existing-h2-database-files! h2-filename))
      (copy/copy!  (mdb.conn/db-type) (mdb.conn/jdbc-spec) :h2 h2-jdbc-spec)
+     (when dump-plaintext?
+       (copy/overwrite-encrypted-fields-to-plaintext! (mdb.conn/db-type) (mdb.conn/jdbc-spec) :h2 h2-jdbc-spec))
      (println "Dump complete"))))

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -10,7 +10,7 @@
             [metabase.db.connection :as mdb.connection]
             [metabase.db.spec :as db.spec]
             [metabase.driver :as driver]
-            [metabase.models :refer [Setting]]
+            [metabase.models :refer [Setting Database]]
             [metabase.test :as mt]
             [metabase.test.data.interface :as tx]
             [metabase.util.encryption-test :as eu]
@@ -49,10 +49,10 @@
 (defn- persistent-jdbcspec
   "Return a jdbc spec for the specified `db-type` on the db `db-name`. In case of H2, makes the connection persistent
   10secs to give us time to fetch the results later."
-  [db-type db-name app-db]
+  [db-type db-name]
   (case db-type
     :h2 {:subprotocol "h2"
-         :subname     (format "mem:%s;DB_CLOSE_DELAY=10" app-db)
+         :subname     (format "mem:%s;DB_CLOSE_DELAY=10" db-name)
          :classname   "org.h2.Driver"}
     :postgres (db.spec/postgres (tx/dbdef->connection-details :postgres :db {:database-name db-name}))
     :mysql (db.spec/mysql (tx/dbdef->connection-details :mysql :db {:database-name db-name}))))
@@ -62,21 +62,43 @@
   (.getAbsolutePath (io/file path)))
 
 (deftest dump-to-h2-dump-plaintext-test
-  (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
-        app-db (mt/random-name)
-        h2-file (format "/tmp/out-%s.db" (mt/random-name))
-        db-name "test"]
-    (mt/test-drivers #{:h2 :postgres :mysql}
-     (binding [mdb.connection/*db-type*   driver/*driver*
-               mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name app-db)
-               db/*db-connection* (persistent-jdbcspec driver/*driver* db-name app-db)
-               db/*quoting-style* driver/*driver*]
-       (when-not (= driver/*driver* :h2)
-         (tx/create-db! driver/*driver* {:database-name db-name }))
-       (load-from-h2/load-from-h2! h2-fixture-db-file)
-       (eu/with-secret-key "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
-         (db/insert! Setting {:key "my-site-admin", :value "baz"})
-         (dump-to-h2/dump-to-h2! h2-file {:dump-plaintext? true}))
-       (jdbc/with-db-connection [target-conn (copy.h2/h2-jdbc-spec h2-file)]
-         (is (= "baz"
-                (:value (first (jdbc/query target-conn "select value from SETTING where key='my-site-admin';"))))))))))
+  (testing "dump-to-h2 --dump-plaintext"
+      (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
+            h2-file-plaintext (format "/tmp/out-%s.db" (mt/random-name))
+            h2-file-enc (format "/tmp/out-%s.db" (mt/random-name))
+            h2-file-default-enc (format "/tmp/out-%s.db" (mt/random-name))
+            db-name (str "test_" (mt/random-name))]
+     (mt/test-drivers #{:h2 :postgres :mysql}
+       (binding [mdb.connection/*db-type*   driver/*driver*
+                 mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)
+                 db/*db-connection* (persistent-jdbcspec driver/*driver* db-name)
+                 db/*quoting-style* driver/*driver*]
+         (when-not (= driver/*driver* :h2)
+           (tx/create-db! driver/*driver* {:database-name db-name}))
+         (load-from-h2/load-from-h2! h2-fixture-db-file)
+         (eu/with-secret-key "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
+           (db/insert! Setting {:key "my-site-admin", :value "baz"})
+           (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"})
+           (dump-to-h2/dump-to-h2! h2-file-plaintext {:dump-plaintext? true})
+           (dump-to-h2/dump-to-h2! h2-file-enc {:dump-plaintext? false})
+           (dump-to-h2/dump-to-h2! h2-file-default-enc))
+
+         (testing "decodes settings and dashboard.details"
+           (jdbc/with-db-connection [target-conn (copy.h2/h2-jdbc-spec h2-file-plaintext)]
+             (is (= "baz" (:value (first (jdbc/query target-conn "select value from SETTING where key='my-site-admin';")))))
+             (is (= "{\"db\":\"/tmp/test.db\"}"
+                    (:details (first (jdbc/query target-conn "select details from metabase_database where id=1;")))))))
+
+         (testing "when flag is set to false, encrypted settings and dashboard.details are still encrypted"
+           (jdbc/with-db-connection [target-conn (copy.h2/h2-jdbc-spec h2-file-enc)]
+             (is (not (= "baz"
+                         (:value (first (jdbc/query target-conn "select value from SETTING where key='my-site-admin';"))))))
+             (is (not (= "{\"db\":\"/tmp/test.db\"}"
+                         (:details (first (jdbc/query target-conn "select details from metabase_database where id=1;"))))))))
+
+         (testing "defaults to not decrypting"
+             (jdbc/with-db-connection [target-conn (copy.h2/h2-jdbc-spec h2-file-default-enc)]
+               (is (not (= "baz"
+                           (:value (first (jdbc/query target-conn "select value from SETTING where key='my-site-admin';"))))))
+               (is (not (= "{\"db\":\"/tmp/test.db\"}"
+                           (:details (first (jdbc/query target-conn "select details from metabase_database where id=1;")))))))))))))

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -1,11 +1,21 @@
 (ns metabase.cmd.dump-to-h2-test
   (:require [clojure.java.io :as io]
+            [clojure.java.jdbc :as jdbc]
             [clojure.test :refer :all]
-            [metabase.cmd
-             [copy :as copy]
-             [dump-to-h2 :as dump-to-h2]]
             [metabase.cmd :as cmd]
-            [metabase.util.files :as u.files]))
+            [metabase.cmd.copy :as copy]
+            [metabase.cmd.copy.h2 :as copy.h2]
+            [metabase.cmd.dump-to-h2 :as dump-to-h2]
+            [metabase.cmd.load-from-h2 :as load-from-h2]
+            [metabase.db.connection :as mdb.connection]
+            [metabase.db.spec :as db.spec]
+            [metabase.driver :as driver]
+            [metabase.models :refer [Setting]]
+            [metabase.test :as mt]
+            [metabase.test.data.interface :as tx]
+            [metabase.util.encryption-test :as eu]
+            [metabase.util.files :as u.files]
+            [toucan.db :as db]))
 
 (deftest dump-deletes-target-db-files-tests
   ;; test fails when the application db is anything but H2 presently
@@ -35,3 +45,38 @@
   (with-redefs [dump-to-h2/dump-to-h2! (constantly 1)
                 cmd/system-exit! identity]
     (is (= 1 (cmd/dump-to-h2 "file1")))))
+
+(defn- persistent-jdbcspec
+  "Return a jdbc spec for the specified `db-type` on the db `db-name`. In case of H2, makes the connection persistent
+  10secs to give us time to fetch the results later."
+  [db-type db-name app-db]
+  (case db-type
+    :h2 {:subprotocol "h2"
+         :subname     (format "mem:%s;DB_CLOSE_DELAY=10" app-db)
+         :classname   "org.h2.Driver"}
+    :postgres (db.spec/postgres (tx/dbdef->connection-details :postgres :db {:database-name db-name}))
+    :mysql (db.spec/mysql (tx/dbdef->connection-details :mysql :db {:database-name db-name}))))
+
+(defn- abs-path
+  [path]
+  (.getAbsolutePath (io/file path)))
+
+(deftest dump-to-h2-dump-plaintext-test
+  (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
+        app-db (mt/random-name)
+        h2-file (format "/tmp/out-%s.db" (mt/random-name))
+        db-name "test"]
+    (mt/test-drivers #{:h2 :postgres :mysql}
+     (binding [mdb.connection/*db-type*   driver/*driver*
+               mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name app-db)
+               db/*db-connection* (persistent-jdbcspec driver/*driver* db-name app-db)
+               db/*quoting-style* driver/*driver*]
+       (when-not (= driver/*driver* :h2)
+         (tx/create-db! driver/*driver* {:database-name db-name }))
+       (load-from-h2/load-from-h2! h2-fixture-db-file)
+       (eu/with-secret-key "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
+         (db/insert! Setting {:key "my-site-admin", :value "baz"})
+         (dump-to-h2/dump-to-h2! h2-file {:dump-plaintext? true}))
+       (jdbc/with-db-connection [target-conn (copy.h2/h2-jdbc-spec h2-file)]
+         (is (= "baz"
+                (:value (first (jdbc/query target-conn "select value from SETTING where key='my-site-admin';"))))))))))


### PR DESCRIPTION
This PR allows for all fields to be dumped to an h2 db in plaintext, using the current MB_ENCRYPTION_SECRET_KEY env var.

Note: Not using multi-statement update because h2 doesn't allow it on prepared statements: http://h2-database.66688.n3.nabble.com/Invalid-value-for-parameter-in-multi-expression-statement-td898455.html 
TODO:
- [x] add test for happy path
- [x] test some fields encrypted and some plaintext
- [x] --keep-existing + --dump-plaintext?
- [ ] naming the flag better 