### PR TITLE
#11183 Repro: Missing Time series filter and granularity widgets

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -148,6 +148,36 @@ describe("scenarios > question > new", () => {
       // this step is maybe redundant since it fails to even find "by month"
       cy.findByText("Hour of day");
     });
+
+    it.skip("should display granularity widgets at the bottom of the screen for timeseries filter (metabase#11183)", () => {
+      cy.request("POST", "/api/card", {
+        name: "11183",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["sum", ["field-id", ORDERS.SUBTOTAL]]],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+            ],
+          },
+          type: "query",
+        },
+        display: "line",
+        visualization_settings: {},
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.server();
+        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+
+        cy.visit(`/question/${QUESTION_ID}`);
+      });
+
+      cy.wait("@cardQuery");
+      cy.get(".AdminSelect")
+        .as("select")
+        .contains(/All Time/i);
+      cy.get("@select").contains(/Month/i);
+    });
   });
 
   describe("ask a (custom) question", () => {

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -149,7 +149,7 @@ describe("scenarios > question > new", () => {
       cy.findByText("Hour of day");
     });
 
-    it.skip("should display granularity widgets at the bottom of the screen for timeseries filter (metabase#11183)", () => {
+    it.skip("should display timeseries filter and granularity widgets at the bottom of the screen (metabase#11183)", () => {
       cy.request("POST", "/api/card", {
         name: "11183",
         dataset_query: {
@@ -173,6 +173,7 @@ describe("scenarios > question > new", () => {
       });
 
       cy.wait("@cardQuery");
+      cy.log("**Reported missing in v0.33.1**");
       cy.get(".AdminSelect")
         .as("select")
         .contains(/All Time/i);


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?

- Reproduces #11183 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/new.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/105115771-b534e100-5ac9-11eb-89ea-4c9a509e98f9.png)
