### PR TITLE
#12600 Repro: Crash in ObjectDetail when parsing invalid JSON

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -7,7 +7,7 @@ import {
 } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+const { ORDERS, ORDERS_ID, REVIEWS } = SAMPLE_DATASET;
 
 describe("scenarios > admin > datamodel > metadata", () => {
   beforeEach(() => {
@@ -109,5 +109,22 @@ describe("scenarios > admin > datamodel > metadata", () => {
       cy.log("**Reported failing in v0.37.2**");
       cy.findByText(/^3:00 AM$/);
     });
+  });
+
+  it("object details should handle non-json data even if field is set to JSON (metabase#12600)", () => {
+    // Fixed in #13633
+
+    cy.log("**-- Set Reviews.BODY to `Field containing JSON` --**");
+    cy.request("PUT", `/api/field/${REVIEWS.BODY}`, {
+      special_type: "type/SerializedJSON",
+    });
+
+    openReviewsTable();
+    cy.get(".TableInteractive-cellWrapper--firstColumn")
+      .eq(2)
+      .click();
+    // Text is broken into elements - cannot use cy.findByText() here
+    cy.contains("This Review is connected to:");
+    cy.findByText(/xavier/i);
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #12600 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #13633

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/105405485-7dde4580-5c2b-11eb-85da-7009f57c1f02.png)

