### PR TITLE
Add support for the "CHARACTER VARYING" and NUMERIC Redshift type

### DIFF
--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -1,14 +1,23 @@
 (ns metabase.driver.redshift-test
-  (:require [clojure.string :as str]
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [clojure.test :refer :all]
+            [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as execute]
+            [metabase.models.database :refer [Database]]
+            [metabase.models.field :refer [Field]]
+            [metabase.models.table :refer [Table]]
             [metabase.plugins.jdbc-proxy :as jdbc-proxy]
             [metabase.public-settings :as pubset]
             [metabase.query-processor :as qp]
+            [metabase.sync :as sync]
             [metabase.test :as mt]
+            [metabase.test.data :as td]
+            [metabase.test.data.interface :as tx]
             [metabase.test.data.redshift :as rstest]
             [metabase.test.fixtures :as fixtures]
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [toucan.db :as db])
   (:import metabase.plugins.jdbc_proxy.ProxyDriver))
 
 (use-fixtures :once (fixtures/initialize :plugins))
@@ -149,3 +158,36 @@
                :parameters [{:type :date/all-options
                              :target [:dimension [:template-tag "date"]]
                              :value "past30years"}]}))))))
+
+(deftest redshift-types-test
+  (mt/test-driver
+    :redshift
+    (testing "Redshift specific types should be synced correctly"
+      (let [db-details   (tx/dbdef->connection-details :redshift)
+            tbl-nm       "redshift_specific_types"
+            qual-tbl-nm  (str rstest/session-schema-name "." tbl-nm)
+            view-nm      "late_binding_view"
+            qual-view-nm (str rstest/session-schema-name "." view-nm)]
+        (mt/with-temp
+          Database
+          [database {:engine :redshift, :details db-details}]
+          ;; create a table with a CHARACTER VARYING and a NUMERIC column, and a late bound view that selects from it
+          (rstest/execute!
+            (str "DROP TABLE IF EXISTS %1$s;%n"
+                 "CREATE TABLE %1$s(weird_varchar CHARACTER VARYING(50), numeric_col NUMERIC(10,2));%n"
+                 "CREATE OR REPLACE VIEW %2$s AS SELECT * FROM %1$s WITH NO SCHEMA BINDING;")
+            qual-tbl-nm
+            qual-view-nm)
+          ;; sync the schema again to pick up the new view (and table, though we aren't checking that)
+          (sync/sync-database! database)
+          (is
+            (contains?
+              (db/select-field :name Table :db_id (u/get-id database)) ; the new view should have been synced
+              view-nm))
+          (let [table-id (db/select-one-id Table :db_id (u/get-id database), :name view-nm)]
+            (is
+              ;; and its columns' :base_type should have been identified correctly
+              (=
+                [{:name "weird_varchar", :database_type "character varying(50)", :base_type :type/Text}
+                 {:name "numeric_col", :database_type "numeric(10,2)", :base_type :type/Decimal}]
+                (td/get-field-definitions table-id)))))))))

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -80,7 +80,10 @@
 
 ;;; Create + destroy the schema used for this test session
 
-(defn- execute! [format-string & args]
+(defn execute!
+  "Executes SQL statements against the current test session's schema. format-string is the statement(s) (formatted)
+   and any format args follow."
+  [format-string & args]
   (let [sql  (apply format format-string args)
         spec (sql-jdbc.conn/connection-details->spec :redshift @db-connection-details)]
     (println (u/format-color 'blue "[redshift] %s" sql))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -38,6 +38,7 @@
             [medley.core :as m]
             [metabase.driver.util :as driver.u]
             [metabase.models.dimension :refer [Dimension]]
+            [metabase.models.field :refer [Field]]
             [metabase.models.field-values :refer [FieldValues]]
             [metabase.query-processor :as qp]
             [metabase.test.data.dataset-definitions :as defs]
@@ -45,6 +46,7 @@
             [metabase.test.data.interface :as tx]
             [metabase.test.data.mbql-query-impl :as mbql-query-impl]
             [metabase.util :as u]
+            [toucan.db :as db]
             [toucan.util.test :as tt]))
 
 ;;; ------------------------------------------ Dataset-Independent Data Fns ------------------------------------------
@@ -301,3 +303,9 @@
 
 (defmacro with-venue-category-fk-remapping [remapping-name & body]
   `(do-with-venue-category-fk-remapping ~remapping-name (fn [] ~@body)))
+
+(defn get-field-definitions
+  "Gets the field definitions for the given table-id"
+  [table-id]
+  (map (partial into {})
+       (db/select [Field :name :database_type :base_type] :table_id table-id)))


### PR DESCRIPTION
CHARACTER VARYING seems to be an official Redshift type; see: https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html#r_Character_types-varchar-or-character-varying

It doesn't always seem to show up.  For example, in a plain CREATE TABLE then that DDL actually is seen by Metabase as "varchar" still.  But if a late binding view is created pointing to that table, then it can show up thusly

Using the database-type->base-type mechanism to recognize this type name and treat it as :type/Text

Adding a test that creates a table and late binding view, and asserts the correct type is synced

Adding test utility function to check whether field definitions match for a given table (since this pattern seems to be used in several places)
