### PR TITLE
Add an error from SQLite

### DIFF
--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -151,6 +151,8 @@ Ensure that the file you are writing or reading from a file or folder that the u
 - if you are running Metabase as a `jar` file in your local machine or server, check the user that is running the java process
 - if you are running Metabase from the docker container, make sure that you are using the `/metabase.db` folder which is owned by the metabase user who is the one that runs the java process inside the container
 
+If you are running metabase from the jar file in any *nix (Unix like) operating system, in order to see which user is running metabase you have to open a terminal and type `ps -uA | grep metabase`.
+
 ## Helpful tidbits
 
 ### How to get to the shell in the Metabase container

--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -152,7 +152,7 @@ Ensure that the user who is running Metabase has permission to read and write to
 - If you are running Metabase as a JAR file in your local machine or server, check the user who is running the Java process.
 - If you're running Metabase from the Docker container, make sure you're using the `/metabase.db` directory.
 
-If you are running metabase from the jar file in any *nix (Unix like) operating system, in order to see which user is running metabase you have to open a terminal and type `ps -uA | grep metabase`.
+If you're running Metabase from the JAR in any *nix (Unix like) operating system, in order to see which user is running Metabase, you have to open a terminal and type `ps -uA | grep metabase`.
 
 ## Helpful tidbits
 

--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -139,17 +139,18 @@ Run `curl http://localhost:port-number-here/api/health`. This should return a re
 
 Make sure to include a `-p 3000:3000` or similar remapping in the `docker run` command you execute to start the Metabase container image.
 
-### Metabase is not able to write or read to/from a file or a folder
+### Metabase can't write or read to/from a file or directory
 
 #### How to detect this:
 
-A message in the logs will clearly indicate an IOError/Permission denied from Java or errors from SQLite with the `org.sqlite.core.NativeDB._open_utf8` form
+A message in the logs will clearly indicate an IOError/Permission denied from Java, or errors from SQLite with the `org.sqlite.core.NativeDB._open_utf8` form.
 
 #### How to fix this:
 
-Ensure that the file you are writing or reading from a file or folder that the user that runs Metabase has access to. E.g.:
-- if you are running Metabase as a `jar` file in your local machine or server, check the user that is running the java process
-- if you are running Metabase from the docker container, make sure that you are using the `/metabase.db` folder which is owned by the metabase user who is the one that runs the java process inside the container
+Ensure that the user who is running Metabase has permission to read and write to the file or directory:
+
+- If you are running Metabase as a JAR file in your local machine or server, check the user who is running the Java process.
+- If you're running Metabase from the Docker container, make sure you're using the `/metabase.db` directory.
 
 If you are running metabase from the jar file in any *nix (Unix like) operating system, in order to see which user is running metabase you have to open a terminal and type `ps -uA | grep metabase`.
 

--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -139,6 +139,18 @@ Run `curl http://localhost:port-number-here/api/health`. This should return a re
 
 Make sure to include a `-p 3000:3000` or similar remapping in the `docker run` command you execute to start the Metabase container image.
 
+### Metabase is not able to write or read to/from a file or a folder
+
+#### How to detect this:
+
+A message in the logs will clearly indicate an IOError/Permission denied from Java or errors from SQLite with the `org.sqlite.core.NativeDB._open_utf8` form
+
+#### How to fix this:
+
+Ensure that the file you are writing or reading from a file or folder that the user that runs Metabase has access to. E.g.:
+- if you are running Metabase as a `jar` file in your local machine or server, check the user that is running the java process
+- if you are running Metabase from the docker container, make sure that you are using the `/metabase.db` folder which is owned by the metabase user who is the one that runs the java process inside the container
+
 ## Helpful tidbits
 
 ### How to get to the shell in the Metabase container

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -27,6 +27,6 @@ If the Metabase instance starts and runs for a significant amount of time before
 
 The `-XX:HeapDumpPath` flag is optional, with the current directory being the default. When an `OutOfMemoryError` occurs, it will dump an `hprof` file to the directory specified. These can be large (i.e. the size of the `-Xmx` argument) so ensure your disk has enough space. These `hprof` files can be read with many different tools, such as `jhat` included with the JDK or the [Eclipse Memory Analyzer Tool](https://www.eclipse.org/mat/).
 
-### Metabase cannot read or write from a file or folder (IOError)
+### Metabase can't read or write from a file or directory (IOError)
 
 Check the issue [here](docker.md)

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -29,4 +29,4 @@ The `-XX:HeapDumpPath` flag is optional, with the current directory being the de
 
 ### Metabase cannot read or write from a file or folder (IOError)
 
-If you find an error regarding file permissions when using Metabase, like not being able to read a SQLite database or a custom GeoJSON, we also have you covered in this section about [Metabase not being able to read from a file or folder](docker.html)
+If you find an error regarding file permissions, like Metabase being unable to read a SQLite database or a custom GeoJSON, check out the section "Metabase can't read to/from a file or directory" in our [Docker troubleshooting guide](docker.md).

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -27,6 +27,6 @@ If the Metabase instance starts and runs for a significant amount of time before
 
 The `-XX:HeapDumpPath` flag is optional, with the current directory being the default. When an `OutOfMemoryError` occurs, it will dump an `hprof` file to the directory specified. These can be large (i.e. the size of the `-Xmx` argument) so ensure your disk has enough space. These `hprof` files can be read with many different tools, such as `jhat` included with the JDK or the [Eclipse Memory Analyzer Tool](https://www.eclipse.org/mat/).
 
-### Metabase can't read or write from a file or directory (IOError)
+### Metabase cannot read or write from a file or folder (IOError)
 
-Check the issue [here](docker.md)
+If you find an error regarding file permissions when using Metabase, like not being able to read a SQLite database or a custom GeoJSON, we also have you covered in this section about [Metabase not being able to read from a file or folder](docker.html)

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -26,3 +26,7 @@ If the Metabase instance starts and runs for a significant amount of time before
     java -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/path/to/a/directory -jar metabase-jar
 
 The `-XX:HeapDumpPath` flag is optional, with the current directory being the default. When an `OutOfMemoryError` occurs, it will dump an `hprof` file to the directory specified. These can be large (i.e. the size of the `-Xmx` argument) so ensure your disk has enough space. These `hprof` files can be read with many different tools, such as `jhat` included with the JDK or the [Eclipse Memory Analyzer Tool](https://www.eclipse.org/mat/).
+
+### Metabase cannot read or write from a file or folder (IOError)
+
+Check the issue [here](docker.md)


### PR DESCRIPTION
Added a few lines to make sure that users don't run on the IOError or using the /tmp dir inside the container for SQLite

https://github.com/metabase/metabase/issues/8084