### PR TITLE
Remove extra column options from admin

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -369,7 +369,7 @@ const FieldSettingsPane = ({ field, onUpdateFieldSettings }) => (
       value={(field && field.settings) || {}}
       onChange={onUpdateFieldSettings}
       column={field}
-      blacklist={
+      denylist={
         new Set(
           ["column_title"].concat(isCurrency(field) ? ["number_style"] : []),
         )

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx
@@ -57,7 +57,7 @@ class FormattingWidget extends React.Component {
               value={value[type]}
               onChange={settings => onChange({ ...value, [type]: settings })}
               column={column}
-              whitelist={new Set(settings)}
+              allowlist={new Set(settings)}
             />
           </div>
         ))}

--- a/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
@@ -9,7 +9,7 @@ import type {
   ClickActionProps,
 } from "metabase-types/types/Visualization";
 
-const BLACKLIST_TYPES = [
+const DENYLIST_TYPES = [
   TYPE.PK,
   TYPE.SerializedJSON,
   TYPE.Description,
@@ -23,7 +23,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     clicked.value !== undefined ||
     clicked.column.source !== "fields" ||
     // $FlowFixMe: flow thinks `clicked` or `clicked.column` may be null even though we checked it above
-    _.any(BLACKLIST_TYPES, t => isa(clicked.column.special_type, t))
+    _.any(DENYLIST_TYPES, t => isa(clicked.column.special_type, t))
   ) {
     return [];
   }

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -129,7 +129,7 @@ describe("scenarios > admin > permissions", () => {
     });
   });
 
-  it.skip("should not display excessive options in localization tab (metabase#14426)", () => {
+  it("should not display excessive options in localization tab (metabase#14426)", () => {
     cy.visit("/admin/settings/localization");
     cy.findByText(/Instance language/i);
     cy.findByText(/Report timezone/i);


### PR DESCRIPTION
Fixes #14426

(Introduced in #14239)

As far as I know we don't have a documented bug for the change in `FieldApp`, but clearly that'd come back to bite us.