### PR TITLE
#14482 Repro: UI should update when a collection changes parent

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -414,6 +414,40 @@ describe("scenarios > collection_defaults", () => {
         });
     });
 
+    it.skip("should update UI when nested child collection is moved to the root collection (metabase#14482)", () => {
+      cy.visit("/collection/root");
+      cy.log("**Move 'Second collection' to the root");
+      openDropdownFor("First collection");
+      cy.findByText("Second collection").click();
+      cy.get(".Icon-pencil").click();
+      cy.findByText("Edit this collection").click();
+      modal().within(() => {
+        // Open the select dropdown menu
+        cy.findByText("First collection").click();
+      });
+      popover().within(() => {
+        cy.findAllByText("Our analytics")
+          .last()
+          .click();
+      });
+      // Make sure the correct value is selected
+      cy.get(".AdminSelect-content").contains("Our analytics");
+      cy.findByText("Update")
+        .closest(".Button")
+        .should("not.be.disabled")
+        .click();
+      // Make sure modal closed
+      cy.findByText("Update").should("not.exist");
+
+      cy.get("[class*=CollectionSidebar]")
+        .as("sidebar")
+        .within(() => {
+          // This click just gives us time for an UI to update - nothing else worked (not even waiting for XHR)
+          cy.findByText("Second collection").click();
+          cy.findAllByText("Second collection").should("have.length", 1);
+        });
+    });
+
     it.skip("should suggest questions saved in collections with colon in their name (metabase#14287)", () => {
       cy.request("POST", "/api/collection", {
         name: "foo:bar",


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14482 (second part)

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Cypress runner
![image](https://user-images.githubusercontent.com/31325167/105429234-484c5300-5c51-11eb-9587-58892ca898fa.png)

2. UI
![image](https://user-images.githubusercontent.com/31325167/105429256-5ac68c80-5c51-11eb-9e4a-82c2d6b97a17.png)
