### PR TITLE
Fix #14327: Collapsed calendar prevented adding a date filter

### DIFF
--- a/frontend/src/metabase/components/ExpandingContent.jsx
+++ b/frontend/src/metabase/components/ExpandingContent.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import cx from "classnames";
 
 class ExpandingContent extends Component {
   constructor({ isInitiallyOpen }) {
@@ -59,8 +60,8 @@ class ExpandingContent extends Component {
           transition: `all ${duration}ms ease`,
           maxHeight: !animateHeight || isOpen ? maxHeight : 0,
           opacity: !animateOpacity || isOpen ? 1 : 0,
-          overflow: isOpen ? null : "hidden",
         }}
+        className={cx({ "overflow-hidden": !isOpen })}
       >
         {children}
       </div>

--- a/frontend/src/metabase/components/ExpandingContent.jsx
+++ b/frontend/src/metabase/components/ExpandingContent.jsx
@@ -59,6 +59,7 @@ class ExpandingContent extends Component {
           transition: `all ${duration}ms ease`,
           maxHeight: !animateHeight || isOpen ? maxHeight : 0,
           opacity: !animateOpacity || isOpen ? 1 : 0,
+          overflow: isOpen ? null : "hidden",
         }}
       >
         {children}

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -471,7 +471,7 @@ describe("scenarios > question > filter", () => {
     );
   });
 
-  it.skip("should be able to add date filter with calendar collapsed (metabase#14327)", () => {
+  it("should be able to add date filter with calendar collapsed (metabase#14327)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Filter").click();
     cy.findByText("Created At").click();


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes #14327 by setting a hidden overflow to the parent of a collapsed calendar

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- All tests should pass

*Alternatively, follow the steps from the original issue and try to add a filter when the calendar is collapsed.

### Additional notes:
- All tests in CI should pass

`frontend/src/metabase/components/ExpandingContent.jsx` is used in two files only:
- `frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx`
- `frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx`

It doesn't seem like this can introduce a greater risk of breaking something, but let's err on the side of caution.

The original issue wasn't only blocking a filter button. It was possible to actually click anywhere on the calendar without knowing it, because it was only "invisible" (opacity set to 0). 
Please see the following [GIF](https://share.getcloudapp.com/ApuRKnyy)

Calendar's parent was collapsed (with `max-height` set to 0), but because there wasn't an overflow control in place, its children were exposed.
