### PR TITLE
#14405 Repro: Dashboard subscription should not display "null" day of the week

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -34,7 +34,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
   });
 
-  describe("with email and slack set up", () => {
+  describe("with email and/or slack set up", () => {
     beforeEach(() => {
       setupDummySMTP();
     });
@@ -75,6 +75,26 @@ describe("scenarios > dashboard > subscriptions", () => {
         .within(() => {
           cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
         });
+    });
+
+    it.skip("should not display 'null' day of the week (metabase#14405)", () => {
+      assignRecipient();
+      cy.findByText("To:").click();
+      cy.get(".AdminSelect")
+        .contains("Daily")
+        .click();
+      cy.findByText("Monthly").click();
+      cy.get(".AdminSelect")
+        .contains("First")
+        .click();
+      cy.findByText("15th (Midpoint)").click();
+      cy.get(".AdminSelect")
+        .contains("15th (Midpoint)")
+        .click();
+      cy.findByText("First").click();
+      clickButton("Done");
+      // Implicit assertion (word mustn't contain string "null")
+      cy.findByText(/^Emailed monthly on the first (?!null)/);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -34,7 +34,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
   });
 
-  describe("with email and/or slack set up", () => {
+  describe("with email set up", () => {
     beforeEach(() => {
       setupDummySMTP();
     });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14405

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

*To reviewers:
**Although I made some sanity checks, please make sure I used the correct regex [(negative lookahead)](https://superuser.com/a/477467)**


### Screenshots:
1. Cypress runner
![image](https://user-images.githubusercontent.com/31325167/105530050-91e77d00-5ce7-11eb-945e-32a78211c7e7.png)

2. UI
![image](https://user-images.githubusercontent.com/31325167/105530079-99a72180-5ce7-11eb-9bf1-1a5aa3220e04.png)

3. Sanity check (make sure regex works as expected for alternate case):
![image](https://user-images.githubusercontent.com/31325167/105530313-e68af800-5ce7-11eb-87db-718063f5665f.png)

