### PR TITLE
Fix test from #13015 not running against Redshift

### DIFF
--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -106,3 +106,19 @@
     (is (= [{:t #t "2020-05-28T18:06-07:00"}]
            (jdbc/query (db.spec/h2 {:db "mem:test_db"})
                        "SELECT TIMESTAMP WITH TIME ZONE '2020-05-28 18:06:00.000 America/Los_Angeles' AS t")))))
+
+(deftest native-query-parameters-test
+  (testing "Native query parameters should work with filters."
+    (is (= [[693 "2015-12-29T00:00:00Z" 10 90]]
+           (mt/rows
+             (qp/process-query
+              {:database   (mt/id)
+               :type       :native
+               :native     {:query         "select * from checkins where {{date}} order by date desc limit 1;"
+                            :template-tags {"date" {:name         "date"
+                                                    :display-name "date"
+                                                    :type         :dimension
+                                                    :dimension    [:field-id (mt/id :checkins :date)]}}}
+               :parameters [{:type :date/all-options
+                             :target [:dimension [:template-tag "date"]]
+                             :value "past30years"}]}))))))


### PR DESCRIPTION
Test added in #13015 to `redshift-test` to fix a Redshift-specific issue was actually testing against H2. 

I moved the old test into `h2-test` because throwing out a perfectly good test seemed like a waste