### PR TITLE
Binary >ip address

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -310,8 +310,8 @@ export const field_special_types = [
     section: t`Other`,
   },
   {
-    id: TYPE.IPAddressString,
-    name: t`IP Address String`,
+    id: TYPE.BinaryIPAddress,
+    name: t`Binary IP Address as String`,
     section: t`Other`,
   }
 ];

--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -313,7 +313,7 @@ export const field_special_types = [
     id: TYPE.BinaryIPAddress,
     name: t`Binary IP Address as String`,
     section: t`Other`,
-  }
+  },
 ];
 
 export const field_special_types_map = field_special_types.reduce(

--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -309,6 +309,11 @@ export const field_special_types = [
     name: t`Field containing JSON`,
     section: t`Other`,
   },
+  {
+    id: TYPE.IPAddressString,
+    name: t`IP Address String`,
+    section: t`Other`,
+  }
 ];
 
 export const field_special_types_map = field_special_types.reduce(

--- a/frontend/test/metabase-bootstrap.js
+++ b/frontend/test/metabase-bootstrap.js
@@ -111,6 +111,8 @@ window.MetabaseBootstrap = {
     "type/DateTimeWithLocalTZ": ["type/DateTimeWithTZ"],
     "type/UNIXTimestamp": ["type/Integer", "type/Instant"],
     "type/Enum": ["type/Category", "type/*"],
+    "type/Binary": ["type/*"],
+    "type/IPAddressString": ["type/String"],
   },
   version: {
     tag: "v1",

--- a/frontend/test/metabase-bootstrap.js
+++ b/frontend/test/metabase-bootstrap.js
@@ -112,7 +112,7 @@ window.MetabaseBootstrap = {
     "type/UNIXTimestamp": ["type/Integer", "type/Instant"],
     "type/Enum": ["type/Category", "type/*"],
     "type/Binary": ["type/*"],
-    "type/IPAddressString": ["type/String"],
+    "type/BinaryIPAddress": ["type/String"],
   },
   version: {
     tag: "v1",

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -166,6 +166,10 @@
   [_driver _special_type expr]
   (hx/->datetime expr))
 
+(defmethod sql.qp/cast-ip-string [:mysql :type/IPAddressString]
+  [_driver _special_type expr]
+  (hsql/call :inet6_ntoa expr))
+
 (defn- date-format [format-str expr] (hsql/call :date_format expr (hx/literal format-str)))
 (defn- str-to-date [format-str expr] (hsql/call :str_to_date expr (hx/literal format-str)))
 
@@ -241,7 +245,7 @@
 (defmethod sql-jdbc.sync/database-type->base-type :mysql
   [_ database-type]
   ({:BIGINT     :type/BigInteger
-    :BINARY     :type/*
+    :BINARY     :type/Binary
     :BIT        :type/Boolean
     :BLOB       :type/*
     :CHAR       :type/Text
@@ -268,7 +272,7 @@
     :TINYBLOB   :type/*
     :TINYINT    :type/Integer
     :TINYTEXT   :type/Text
-    :VARBINARY  :type/*
+    :VARBINARY  :type/Binary
     :VARCHAR    :type/Text
     :YEAR       :type/Date}
    ;; strip off " UNSIGNED" from end if present

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -166,7 +166,7 @@
   [_driver _special_type expr]
   (hx/->datetime expr))
 
-(defmethod sql.qp/cast-ip-string [:mysql :type/IPAddressString]
+(defmethod sql.qp/cast-ip-string [:mysql :type/BinaryIPAddress]
   [_driver _special_type expr]
   (hsql/call :inet6_ntoa expr))
 

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -209,6 +209,12 @@
   (fn [driver special_type _] [(driver/dispatch-on-initialized-driver driver) special_type])
   :hierarchy #'driver/hierarchy)
 
+(defmulti cast-ip-string
+  "Cast an ip type to a string"
+  {:arglists '([driver special_type expr]), :added "0.38.0"}
+  (fn [driver special_type _] [(driver/dispatch-on-initialized-driver driver) special_type])
+  :hierarchy #'driver/hierarchy)
+
 (defmethod cast-temporal-string :default
   [driver special_type _expr]
   (throw (Exception. (tru "Driver {0} does not support {1}" driver special_type))))
@@ -280,10 +286,11 @@
   "Wrap a `field-identifier` in appropriate HoneySQL expressions if it refers to a UNIX timestamp Field."
   [driver field field-identifier]
   (match [(:base_type field) (:special_type field)]
-    [(:isa? :type/Number)   (:isa? :type/UNIXTimestamp)]  (unix-timestamp->honeysql driver
-                                                                                    (special-type->unix-timestamp-unit (:special_type field))
-                                                                                    field-identifier)
-    [:type/Text             (:isa? :type/TemporalString)] (cast-temporal-string driver (:special_type field) field-identifier)
+    [(:isa? :type/Number)   (:isa? :type/UNIXTimestamp)]   (unix-timestamp->honeysql driver
+                                                                                     (special-type->unix-timestamp-unit (:special_type field))
+                                                                                     field-identifier)
+    [:type/Text             (:isa? :type/TemporalString)]  (cast-temporal-string driver (:special_type field) field-identifier)
+    [:type/Binary           (:isa? :type/IPAddressString)] (cast-ip-string driver (:special_type field) field-identifier)
     :else field-identifier))
 
 ;; default implmentation is a no-op; other drivers can override it as needed

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -290,7 +290,7 @@
                                                                                      (special-type->unix-timestamp-unit (:special_type field))
                                                                                      field-identifier)
     [:type/Text             (:isa? :type/TemporalString)]  (cast-temporal-string driver (:special_type field) field-identifier)
-    [:type/Binary           (:isa? :type/IPAddressString)] (cast-ip-string driver (:special_type field) field-identifier)
+    [:type/Binary           (:isa? :type/BinaryIPAddress)] (cast-ip-string driver (:special_type field) field-identifier)
     :else field-identifier))
 
 ;; default implmentation is a no-op; other drivers can override it as needed

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -1,19 +1,45 @@
 (ns metabase.query-processor.middleware.format-rows
   "Middleware that formats the results of a query.
    Currently, the only thing this does is convert datetime types to ISO-8601 strings in the appropriate timezone."
-  (:require [clojure.tools.logging :as log]
+  (:require [buddy.core.codecs :as codecs]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [java-time :as t]
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [tru]]
             [potemkin.types :as p.types])
-  (:import [java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime ZoneId]))
+  (:import [java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime ZoneId]
+           org.apache.commons.codec.binary.Hex))
 
 (p.types/defprotocol+ FormatValue
   "Protocol for determining how QP results of various classes are serialized. Drivers can add implementations to support
   custom driver types as needed."
   (format-value [v ^ZoneId timezone-id]
     "Serialize a value in the QP results. You can add impementations for driver-specific types as needed."))
+
+(defmulti format-field-value (fn [value field] (:special_type field)))
+
+(defmethod format-field-value :default [value _] value)
+
+(defn convert-binary-ip [bytes]
+  (cond (not (seq bytes))
+        bytes
+
+        (= 4 (count bytes))
+        (str/join "." (map #(Byte/toUnsignedLong %) bytes))
+
+        :else
+        (let [hex-chunks (mapv #(apply str %) (partition-all 4 (codecs/bytes->hex bytes)))]
+          (str/replace (str (str/join ":" (pop hex-chunks)) "::" (peek hex-chunks))
+                       #":0000" ":0"))))
+
+(defmethod format-field-value :type/BinaryIPAddress
+  [value _field]
+  ;; mysql can convert in the db layer so its possible a string has already come out
+  (if (instance? (Class/forName "[B") value)
+    (convert-binary-ip value)
+    value))
 
 (extend-protocol FormatValue
   nil
@@ -53,7 +79,12 @@
   (format-value [t timezone-id]
     (t/format :iso-offset-date-time (u.date/with-time-zone-same-instant t timezone-id))))
 
-(defn- format-rows-xform [rf]
+(defn format-value* [v field timezone-id]
+  (-> v
+      (format-field-value field)
+      (format-value timezone-id)))
+
+(defn- format-rows-xform [metadata rf]
   {:pre [(fn? rf)]}
   (log/debug (tru "Formatting rows with results timezone ID {0}" (qp.timezone/results-timezone-id)))
   (let [timezone-id (t/zone-id (qp.timezone/results-timezone-id))]
@@ -65,7 +96,7 @@
        (rf result))
 
       ([result row]
-       (rf result (mapv #(format-value % timezone-id) row))))))
+       (rf result (mapv (fn [v col] (format-value* v col timezone-id)) row (:cols metadata)))))))
 
 (defn format-rows
   "Format individual query result values as needed.  Ex: format temporal values as ISO-8601 strings w/ timezone offset."
@@ -74,6 +105,6 @@
     (qp query
         (if format-rows?
           (fn [metadata]
-            (format-rows-xform (rff metadata)))
+            (format-rows-xform metadata (rff metadata)))
           rff)
         context)))

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -78,7 +78,7 @@
 
 (derive :type/PostgresEnum :type/Text)
 
-(derive :type/IPAddressString :type/Text)
+(derive :type/BinaryIPAddress :type/Text)
 
 ;;; DateTime Types
 

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -78,6 +78,8 @@
 
 (derive :type/PostgresEnum :type/Text)
 
+(derive :type/IPAddressString :type/Text)
+
 ;;; DateTime Types
 
 (derive :type/Temporal :type/*)
@@ -162,6 +164,8 @@
 (derive :type/TextLike :type/*)
 (derive :type/IPAddress :type/TextLike)
 (derive :type/MongoBSONID :type/TextLike)
+
+(derive :type/Binary :type/*)
 
 ;;; "Virtual" Types
 

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -64,7 +64,7 @@
             (tt/with-temp Database [database {:engine "mysql", :details details}]
               (sync/sync-database! database)
               (mt/with-db database
-                (db/update! Field (mt/id "network" :ip) :special_type :type/IPAddressString))
+                (db/update! Field (mt/id "network" :ip) :special_type :type/BinaryIPAddress))
               (mt/with-db database
                 (is (= #{["2001:4860:4860::8888"] ["67.51.210.110"]}
                        (set

--- a/test/metabase/query_processor/middleware/format_rows_test.clj
+++ b/test/metabase/query_processor/middleware/format_rows_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.format-rows-test
-  (:require [clojure.test :refer :all]
+  (:require [buddy.core.codecs :as codecs]
+            [clojure.test :refer :all]
             [java-time :as t]
             [metabase.driver :as driver]
             [metabase.query-processor-test :as qp.test]
@@ -182,3 +183,14 @@
                   results (mt/test-qp-middleware format-rows/format-rows query rows)]
               (is (= expected-rows
                      (:post results))))))))))
+
+; (0x4333D26E), (0x20014860486000000000000000008888)
+(deftest convert-binary-ip-test
+  (testing "handles ipv4 addresses"
+    (are [in ex] (= ex (-> in codecs/hex->bytes format-rows/convert-binary-ip))
+      "4333D26E"                         "67.51.210.110"
+      "20014860486000000000000000008888" "2001:4860:4860:0:0:0:0::8888"
+      ;; gibberish?
+      "ab"                               "::ab"
+      )
+    (is (nil? (format-rows/convert-binary-ip nil)))))


### PR DESCRIPTION
fixes #10640

binary field underneath can set special_type as BinaryIPAddress to get ui display

```
before:
ID IP
1  0x4333D26E
2  0x20014860

after
ID IP
1  67.51.210.110
2  2001:4860:4860::8888
```

Implemented only for mysql. Our dbs are:

- Amazon Redshift (basically pg which has a proper IP address type and doesn't have a good db native function for the conversion)
- Druid (no suitable binary type as far as i can tell)
- Google Analytics (did not investigate)
- Google BigQuery (has a binary type but the function `:net.ip_to_string` seems to treat the bytes as if they were string bytes)
- H2 (no suitable functions or db types)
- MongoDB (no suitable functions or db types)
- MySQL implemented
- Oracle (seems to have native URI type)
- PostgreSQL (native types and no suitable cast function)
- Presto (no suitable functions or db types)
- Snowflake (no suitable functions or db types)
- SparkSQL
- SQL Server (no suitable functions)
- SQLite (no suitable functions or db types)
- Vertica (has suitable type but no good casting function)
