### PR TITLE
add a link to store.metabase.com for hosted instances

### DIFF
--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -88,9 +88,12 @@ class Settings {
   // Right now, all Metabase Cloud hosted instances run on *.metabaseapp.com
   // We plan on changing this to look at an envvar in the future instead.
   isHosted() {
-    return this.get("site-url")
-      .toLowerCase()
-      .includes("metabaseapp.com");
+    return (
+      this.get("site-url") &&
+      this.get("site-url")
+        .toLowerCase()
+        .includes("metabaseapp.com")
+    );
   }
 
   isTrackingEnabled() {

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -45,14 +45,15 @@ export default class ProfileLink extends Component {
         link: Urls.accountSettings(),
         event: `Navbar;Profile Dropdown;Edit Profile`,
       },
-      ...(MetabaseSettings.isHosted() &&[
-        {
-          title: t`Manage hosting`,
-          icon: 'external',
-          link: 'https://store.metabase.com/login',
-          event: `Navbar;Profile Dropdown;ManageHosting ${tag}`
-        }
-      ]),
+      ...(MetabaseSettings.isHosted() &&
+        admin && [
+          {
+            title: t`Manage hosting`,
+            icon: "external",
+            link: "https://store.metabase.com/login",
+            event: `Navbar;Profile Dropdown;ManageHosting ${tag}`,
+          },
+        ]),
       ...(admin && [
         {
           title: adminContext ? t`Exit admin` : t`Admin`,

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -48,7 +48,7 @@ export default class ProfileLink extends Component {
       ...(MetabaseSettings.isHosted() &&
         admin && [
           {
-            title: t`Manage hosting`,
+            title: t`Manage Metabase Cloud`,
             link: "https://store.metabase.com/login",
             event: `Navbar;Profile Dropdown;ManageHosting ${tag}`,
             externalLink: true,

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -45,6 +45,14 @@ export default class ProfileLink extends Component {
         link: Urls.accountSettings(),
         event: `Navbar;Profile Dropdown;Edit Profile`,
       },
+      ...(MetabaseSettings.isHosted() &&[
+        {
+          title: t`Manage hosting`,
+          icon: 'external',
+          link: 'https://store.metabase.com/login',
+          event: `Navbar;Profile Dropdown;ManageHosting ${tag}`
+        }
+      ]),
       ...(admin && [
         {
           title: adminContext ? t`Exit admin` : t`Admin`,

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -49,9 +49,9 @@ export default class ProfileLink extends Component {
         admin && [
           {
             title: t`Manage hosting`,
-            icon: "external",
             link: "https://store.metabase.com/login",
             event: `Navbar;Profile Dropdown;ManageHosting ${tag}`,
+            externalLink: true,
           },
         ]),
       ...(admin && [

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -4,57 +4,66 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import MetabaseSettings from "metabase/lib/settings";
 import ProfileLink from "metabase/nav/components/ProfileLink";
 
-const OPTIONS = [
+const REGULAR_ITEMS = [
   "Account settings",
   "Activity",
   "Help",
   "About Metabase",
   "Sign out",
 ];
-const ADMIN_OPTIONS = [...OPTIONS, "Admin"];
+const ADMIN_ITEMS = [...REGULAR_ITEMS, "Admin"];
+const HOSTED_ITEMS = [...ADMIN_ITEMS, "Manage hosting"];
 
 describe("ProfileLink", () => {
   describe("options", () => {
-    beforeEach(() => {
-      jest.spyOn(MetabaseSettings, "isHosted");
-      MetabaseSettings.isHosted = jest.fn(() => false);
-    });
-
-    afterEach(() => {
-      MetabaseSettings.isHosted.mockRestore();
-    });
-    describe("normal user", () => {
-      it("should show the proper set of items", () => {
-        const normalUser = { is_superuser: false };
-        render(<ProfileLink user={normalUser} context={""} />);
-
-        const SETTINGS = screen.getByRole("img", { name: /gear/i });
-        fireEvent.click(SETTINGS);
-
-        OPTIONS.forEach(title => {
-          screen.getByText(title);
+    ["regular", "hosted"].forEach(testCase => {
+      describe(`${testCase} instance`, () => {
+        beforeEach(() => {
+          jest.spyOn(MetabaseSettings, "isHosted");
+          MetabaseSettings.isHosted = jest.fn(() => false);
         });
 
-        expect(screen.getAllByRole("listitem").length).toEqual(OPTIONS.length);
-      });
-    });
-
-    describe("admin", () => {
-      it("should show the proper set of items", () => {
-        const admin = { is_superuser: true };
-        render(<ProfileLink user={admin} context={""} />);
-
-        const SETTINGS = screen.getByRole("img", { name: /gear/i });
-        fireEvent.click(SETTINGS);
-
-        ADMIN_OPTIONS.forEach(title => {
-          screen.getByText(title);
+        afterEach(() => {
+          MetabaseSettings.isHosted.mockRestore();
         });
 
-        expect(screen.getAllByRole("listitem").length).toEqual(
-          ADMIN_OPTIONS.length,
-        );
+        if (testCase === "hosted") {
+          beforeEach(() => {
+            MetabaseSettings.isHosted = jest.fn(() => true);
+          });
+        }
+
+        describe("normal user", () => {
+          it("should show the proper set of items", () => {
+            const normalUser = { is_superuser: false };
+            render(<ProfileLink user={normalUser} context={""} />);
+
+            assertOn(REGULAR_ITEMS);
+          });
+        });
+
+        describe("admin", () => {
+          it("should show the proper set of items", () => {
+            const admin = { is_superuser: true };
+            render(<ProfileLink user={admin} context={""} />);
+
+            testCase === "hosted"
+              ? assertOn(HOSTED_ITEMS)
+              : assertOn(ADMIN_ITEMS);
+          });
+        });
       });
     });
   });
 });
+
+function assertOn(items) {
+  const SETTINGS = screen.getByRole("img", { name: /gear/i });
+  fireEvent.click(SETTINGS);
+
+  items.forEach(title => {
+    screen.getByText(title);
+  });
+
+  expect(screen.getAllByRole("listitem").length).toEqual(items.length);
+}

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -4,6 +4,15 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import MetabaseSettings from "metabase/lib/settings";
 import ProfileLink from "metabase/nav/components/ProfileLink";
 
+const OPTIONS = [
+  "Account settings",
+  "Activity",
+  "Help",
+  "About Metabase",
+  "Sign out",
+];
+const ADMIN_OPTIONS = [...OPTIONS, "Admin"];
+
 describe("ProfileLink", () => {
   describe("options", () => {
     beforeEach(() => {
@@ -22,13 +31,7 @@ describe("ProfileLink", () => {
         const SETTINGS = screen.getByRole("img", { name: /gear/i });
         fireEvent.click(SETTINGS);
 
-        [
-          "Account settings",
-          "Activity",
-          "Help",
-          "About Metabase",
-          "Sign out",
-        ].forEach(title => {
+        OPTIONS.forEach(title => {
           screen.getByText(title);
         });
       });
@@ -42,14 +45,7 @@ describe("ProfileLink", () => {
         const SETTINGS = screen.getByRole("img", { name: /gear/i });
         fireEvent.click(SETTINGS);
 
-        [
-          "Account settings",
-          "Admin",
-          "Activity",
-          "Help",
-          "About Metabase",
-          "Sign out",
-        ].forEach(title => {
+        ADMIN_OPTIONS.forEach(title => {
           screen.getByText(title);
         });
       });

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -12,7 +12,7 @@ const REGULAR_ITEMS = [
   "Sign out",
 ];
 const ADMIN_ITEMS = [...REGULAR_ITEMS, "Admin"];
-const HOSTED_ITEMS = [...ADMIN_ITEMS, "Manage hosting"];
+const HOSTED_ITEMS = [...ADMIN_ITEMS, "Manage Metabase Cloud"];
 
 describe("ProfileLink", () => {
   describe("options", () => {

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -34,6 +34,8 @@ describe("ProfileLink", () => {
         OPTIONS.forEach(title => {
           screen.getByText(title);
         });
+
+        expect(screen.getAllByRole("listitem").length).toEqual(OPTIONS.length);
       });
     });
 
@@ -48,6 +50,10 @@ describe("ProfileLink", () => {
         ADMIN_OPTIONS.forEach(title => {
           screen.getByText(title);
         });
+
+        expect(screen.getAllByRole("listitem").length).toEqual(
+          ADMIN_OPTIONS.length,
+        );
       });
     });
   });

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -1,10 +1,19 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 
+import MetabaseSettings from "metabase/lib/settings";
 import ProfileLink from "metabase/nav/components/ProfileLink";
 
 describe("ProfileLink", () => {
   describe("options", () => {
+    beforeEach(() => {
+      jest.spyOn(MetabaseSettings, "isHosted");
+      MetabaseSettings.isHosted = jest.fn(() => false);
+    });
+
+    afterEach(() => {
+      MetabaseSettings.isHosted.mockRestore();
+    });
     describe("normal user", () => {
       it("should show the proper set of items", () => {
         const normalUser = { is_superuser: false };


### PR DESCRIPTION
Closes https://github.com/metabase/harbormaster/issues/1139

## What this does
- Adds an item to the user profile dropdown if the instance is hosted to make it easy to get back to store.metabase.com to manage instance details.
