### PR TITLE
Allow minutes and hours for dashboard relative date filter

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/RelativeDatePicker.jsx
@@ -22,13 +22,13 @@ export const DATE_PERIODS: RelativeDatetimeUnit[] = [
 
 const TIME_PERIODS: RelativeDatetimeUnit[] = ["minute", "hour"];
 
-const ALL_PERIODS = DATE_PERIODS.concat(TIME_PERIODS);
+// define ALL_PERIODS in increasing order of duration
+const ALL_PERIODS = TIME_PERIODS.concat(DATE_PERIODS);
 
 type Props = {
   filter: TimeIntervalFilter,
   onFilterChange: (filter: TimeIntervalFilter) => void,
   formatter: (value: any) => any,
-  hideTimeSelectors?: boolean,
   className?: string,
 };
 
@@ -83,7 +83,7 @@ export default class RelativeDatePicker extends Component {
             }
             intervals={intervals}
             formatter={formatter}
-            periods={this.props.hideTimeSelectors ? DATE_PERIODS : ALL_PERIODS}
+            periods={ALL_PERIODS}
           />
         </div>
       </div>

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -534,6 +534,32 @@ describe("scenarios > dashboard", () => {
       cy.contains(/revert/i);
     });
   });
+
+  it("should show sub-day resolutions in relative date filter (metabase#6660)", () => {
+    cy.visit("/dashboard/1");
+    cy.get(".Icon-pencil").click();
+    cy.get(".Icon-filter").click();
+    popover().within(() => {
+      cy.findByText("Time").click();
+      cy.findByText("All Options").click();
+    });
+    cy.findByText("No default").click();
+    // click on Previous, to expand the relative date filter type dropdown
+    cy.findByText("Previous").click();
+    // choose Next, under which the new options should be available
+    cy.findByText("Next").click();
+    // click on Days (the default value), which should open the resolution dropdown
+    cy.findByText("Days").click();
+    // Hours should appear in the selection box (don't click it)
+    cy.findByText("Hours");
+    // Minutes should appear in the selection box; click it
+    cy.findByText("Minutes").click();
+    // also check the "Include this minute" checkbox
+    // which is actually "Include" followed by "this minute" wrapped in <strong>, so has to be clicked this way
+    cy.contains("Include this minute").click();
+    // make sure the checkbox was checked
+    cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
+  });
 });
 
 function checkOptionsForFilter(filter) {

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -37,12 +37,27 @@
 
 (defn- comparison-range
   ([t unit]
-   (comparison-range t t unit))
+   (comparison-range t t unit :day))
 
   ([start end unit]
+   (comparison-range start end unit :day))
+
+  ([start end unit resolution]
    (merge
-    (u.date/comparison-range start unit :>= {:resolution :day})
-    (u.date/comparison-range end   unit :<= {:resolution :day, :end :inclusive}))))
+    (u.date/comparison-range start unit :>= {:resolution resolution})
+    (u.date/comparison-range end   unit :<= {:resolution resolution, :end :inclusive}))))
+
+(defn- second-range
+  [start end]
+  (comparison-range start end :second :second))
+
+(defn- minute-range
+  [start end]
+  (comparison-range start end :minute :minute))
+
+(defn- hour-range
+  [start end]
+  (comparison-range start end :hour :hour))
 
 (defn- week-range [start end]
   (comparison-range start end :week))
@@ -64,15 +79,27 @@
      :end   (.atEndOfQuarter year-quarter)}))
 
 (def ^:private operations-by-date-unit
-  {"day"   {:unit-range day-range
-            :to-period  t/days}
-   "week"  {:unit-range week-range
-            :to-period  t/weeks}
-   "month" {:unit-range month-range
-            :to-period  t/months}
-   "year"  {:unit-range year-range
-            :to-period  t/years}})
+  {"second" {:unit-range second-range
+             :to-period  t/seconds}
+   "minute" {:unit-range minute-range
+             :to-period  t/minutes}
+   "hour"   {:unit-range hour-range
+             :to-period  t/hours}
+   "day"    {:unit-range day-range
+             :to-period  t/days}
+   "week"   {:unit-range week-range
+             :to-period  t/weeks}
+   "month"  {:unit-range month-range
+             :to-period  t/months}
+   "year"   {:unit-range year-range
+             :to-period  t/years}})
 
+(defn- maybe-reduce-resolution [unit dt]
+  (if
+    (contains? #{"second" "minute" "hour"} unit)
+    dt
+    ; for units that are a day or longer, convert back to LocalDate
+    (t/local-date dt)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              DATE STRING DECODERS                                              |
@@ -110,43 +137,48 @@
 (def ^:private relative-date-string-decoders
   [{:parser #(= % "today")
     :range  (fn [_ dt]
-              {:start dt,
-               :end   dt})
+              (let [dt-res (t/local-date dt)]
+                {:start dt-res,
+                 :end   dt-res}))
     :filter (fn [_ field] [:= [:datetime-field field :day] [:relative-datetime :current]])}
 
    {:parser #(= % "yesterday")
     :range  (fn [_ dt]
-              {:start (t/minus dt (t/days 1))
-               :end   (t/minus dt (t/days 1))})
+              (let [dt-res (t/local-date dt)]
+                {:start (t/minus dt-res (t/days 1))
+                 :end   (t/minus dt-res (t/days 1))}))
     :filter (fn [_ field] [:= [:datetime-field field :day] [:relative-datetime -1 :day]])}
 
    ;; adding a tilde (~) at the end of a past<n><unit> filter means we should include the current day/etc.
    ;; e.g. past30days  = past 30 days, not including partial data for today ({:include-current false})
    ;;      past30days~ = past 30 days, *including* partial data for today   ({:include-current true})
-   {:parser (regex->parser #"past([0-9]+)(day|week|month|year)s(~?)", [:int-value :unit :include-current?])
+   {:parser (regex->parser #"past([0-9]+)(second|minute|hour|day|week|month|year)s(~?)", [:int-value :unit :include-current?])
     :range  (fn [{:keys [unit int-value unit-range to-period include-current?]} dt]
-              (unit-range (t/minus dt (to-period int-value))
-                          (t/minus dt (to-period (if (seq include-current?) 0 1)))))
+              (let [dt-res (maybe-reduce-resolution unit dt)]
+                (unit-range (t/minus dt-res (to-period int-value))
+                            (t/minus dt-res (to-period (if (seq include-current?) 0 1))))))
     :filter (fn [{:keys [unit int-value include-current?]} field]
               [:time-interval field (- int-value) (keyword unit) {:include-current (boolean (seq include-current?))}])}
 
-   {:parser (regex->parser #"next([0-9]+)(day|week|month|year)s(~?)" [:int-value :unit :include-current?])
+   {:parser (regex->parser #"next([0-9]+)(second|minute|hour|day|week|month|year)s(~?)" [:int-value :unit :include-current?])
     :range  (fn [{:keys [unit int-value unit-range to-period include-current?]} dt]
-              (unit-range (t/plus dt (to-period (if (seq include-current?) 0 1)))
-                          (t/plus dt (to-period int-value))))
+              (let [dt-res (maybe-reduce-resolution unit dt)]
+                (unit-range (t/plus dt-res (to-period (if (seq include-current?) 0 1)))
+                            (t/plus dt-res (to-period int-value)))))
     :filter (fn [{:keys [unit int-value]} field]
               [:time-interval field int-value (keyword unit)])}
 
-   {:parser (regex->parser #"last(day|week|month|year)" [:unit])
-    :range  (fn [{:keys [unit-range to-period]} dt]
-              (let [last-unit (t/minus dt (to-period 1))]
+   {:parser (regex->parser #"last(second|minute|hour|day|week|month|year)" [:unit])
+    :range  (fn [{:keys [unit unit-range to-period]} dt]
+              (let [last-unit (t/minus (maybe-reduce-resolution unit dt) (to-period 1))]
                 (unit-range last-unit last-unit)))
     :filter (fn [{:keys [unit]} field]
               [:time-interval field :last (keyword unit)])}
 
-   {:parser (regex->parser #"this(day|week|month|year)" [:unit])
-    :range  (fn [{:keys [unit-range]} dt]
-              (unit-range dt dt))
+   {:parser (regex->parser #"this(second|minute|hour|day|week|month|year)" [:unit])
+    :range  (fn [{:keys [unit unit-range]} dt]
+              (let [dt-adj (maybe-reduce-resolution unit dt)]
+                (unit-range dt-adj dt-adj)))
     :filter (fn [{:keys [unit]} field]
               [:time-interval field :current (keyword unit)])}])
 
@@ -260,10 +292,10 @@
   ([date-string  :- s/Str, {:keys [inclusive-start? inclusive-end?]
                             :or   {inclusive-start? true, inclusive-end? true}}]
    (let [options {:inclusive-start? inclusive-start?, :inclusive-end? inclusive-end?}
-         today   (t/local-date)]
+         now (t/local-date-time)]
      ;; Relative dates respect the given time zone because a notion like "last 7 days" might mean a different range of
      ;; days depending on the user timezone
-     (or (->> (execute-decoders relative-date-string-decoders :range today date-string)
+     (or (->> (execute-decoders relative-date-string-decoders :range now date-string)
               (adjust-inclusive-range-if-needed options)
               (m/map-vals u.date/format))
          ;; Absolute date ranges don't need the time zone conversion because in SQL the date ranges are compared

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -35,7 +35,7 @@
              (dates/date-string->filter "2019-04-01~" [:field-literal "field" :type/DateTime]))))))
 
 (deftest date-string->range-test
-  (t/with-clock (t/mock-clock #t "2016-06-07T12:00Z")
+  (t/with-clock (t/mock-clock #t "2016-06-07T12:13:55Z")
     (doseq [[group s->expected]
             {"absolute datetimes"         {"Q1-2016"               {:end "2016-03-31", :start "2016-01-01"}
                                            "2016-02"               {:end "2016-02-29", :start "2016-02-01"}
@@ -43,33 +43,45 @@
                                            "2016-04-18~2016-04-23" {:end "2016-04-23", :start "2016-04-18"}
                                            "2016-04-18~"           {:start "2016-04-18"}
                                            "~2016-04-18"           {:end "2016-04-18"}}
-             "relative (past)"            {"past3days"    {:end "2016-06-06", :start "2016-06-04"}
-                                           "past3days~"   {:end "2016-06-07", :start "2016-06-04"}
-                                           "past7days"    {:end "2016-06-06", :start "2016-05-31"}
-                                           "past30days"   {:end "2016-06-06", :start "2016-05-08"}
-                                           "past2months"  {:end "2016-05-31", :start "2016-04-01"}
-                                           "past2months~" {:end "2016-06-30", :start "2016-04-01"}
-                                           "past13months" {:end "2016-05-31", :start "2015-05-01"}
-                                           "past1years"   {:end "2015-12-31", :start "2015-01-01"}
-                                           "past1years~"  {:end "2016-12-31", :start "2015-01-01"}
-                                           "past16years"  {:end "2015-12-31", :start "2000-01-01"}}
-             "relative (next)"            {"next3days"    {:end "2016-06-10", :start "2016-06-08"}
-                                           "next3days~"   {:end "2016-06-10", :start "2016-06-07"}
-                                           "next7days"    {:end "2016-06-14", :start "2016-06-08"}
-                                           "next30days"   {:end "2016-07-07", :start "2016-06-08"}
-                                           "next2months"  {:end "2016-08-31", :start "2016-07-01"}
-                                           "next2months~" {:end "2016-08-31", :start "2016-06-01"}
-                                           "next13months" {:end "2017-07-31", :start "2016-07-01"}
-                                           "next1years"   {:end "2017-12-31", :start "2017-01-01"}
-                                           "next1years~"  {:end "2017-12-31", :start "2016-01-01"}
-                                           "next16years"  {:end "2032-12-31", :start "2017-01-01"}}
-             "relative (this)"            {"thisday"   {:end "2016-06-07", :start "2016-06-07"}
-                                           "thisweek"  {:end "2016-06-11", :start "2016-06-05"}
-                                           "thismonth" {:end "2016-06-30", :start "2016-06-01"}
-                                           "thisyear"  {:end "2016-12-31", :start "2016-01-01"}}
-             "relative (last)"            {"lastweek"  {:end "2016-06-04", :start "2016-05-29"}
-                                           "lastmonth" {:end "2016-05-31", :start "2016-05-01"}
-                                           "lastyear"  {:end "2015-12-31", :start "2015-01-01"}}
+             "relative (past)"            {"past30seconds" {:end "2016-06-07T12:13:54", :start "2016-06-07T12:13:25"}
+                                           "past5minutes~" {:end "2016-06-07T12:13:00", :start "2016-06-07T12:08:00"}
+                                           "past3hours"    {:end "2016-06-07T11:00:00", :start "2016-06-07T09:00:00"}
+                                           "past3days"     {:end "2016-06-06", :start "2016-06-04"}
+                                           "past3days~"    {:end "2016-06-07", :start "2016-06-04"}
+                                           "past7days"     {:end "2016-06-06", :start "2016-05-31"}
+                                           "past30days"    {:end "2016-06-06", :start "2016-05-08"}
+                                           "past2months"   {:end "2016-05-31", :start "2016-04-01"}
+                                           "past2months~"  {:end "2016-06-30", :start "2016-04-01"}
+                                           "past13months"  {:end "2016-05-31", :start "2015-05-01"}
+                                           "past1years"    {:end "2015-12-31", :start "2015-01-01"}
+                                           "past1years~"   {:end "2016-12-31", :start "2015-01-01"}
+                                           "past16years"   {:end "2015-12-31", :start "2000-01-01"}}
+             "relative (next)"            {"next45seconds" {:end "2016-06-07T12:14:40", :start "2016-06-07T12:13:56"}
+                                           "next20minutes" {:end "2016-06-07T12:33:00", :start "2016-06-07T12:14:00"}
+                                           "next6hours"    {:end "2016-06-07T18:00:00", :start "2016-06-07T13:00:00"}
+                                           "next3days"     {:end "2016-06-10", :start "2016-06-08"}
+                                           "next3days~"    {:end "2016-06-10", :start "2016-06-07"}
+                                           "next7days"     {:end "2016-06-14", :start "2016-06-08"}
+                                           "next30days"    {:end "2016-07-07", :start "2016-06-08"}
+                                           "next2months"   {:end "2016-08-31", :start "2016-07-01"}
+                                           "next2months~"  {:end "2016-08-31", :start "2016-06-01"}
+                                           "next13months"  {:end "2017-07-31", :start "2016-07-01"}
+                                           "next1years"    {:end "2017-12-31", :start "2017-01-01"}
+                                           "next1years~"   {:end "2017-12-31", :start "2016-01-01"}
+                                           "next16years"   {:end "2032-12-31", :start "2017-01-01"}}
+             "relative (this)"            {"thissecond" {:end "2016-06-07T12:13:55", :start "2016-06-07T12:13:55"}
+                                           "thisminute" {:end "2016-06-07T12:13:00", :start "2016-06-07T12:13:00"}
+                                           "thishour"   {:end "2016-06-07T12:00:00", :start "2016-06-07T12:00:00"}
+                                           "thisday"    {:end "2016-06-07", :start "2016-06-07"}
+                                           "thisweek"   {:end "2016-06-11", :start "2016-06-05"}
+                                           "thismonth"  {:end "2016-06-30", :start "2016-06-01"}
+                                           "thisyear"   {:end "2016-12-31", :start "2016-01-01"}}
+             "relative (last)"            {"lastsecond" {:end "2016-06-07T12:13:54", :start "2016-06-07T12:13:54"}
+                                           "lastminute" {:end "2016-06-07T12:12:00", :start "2016-06-07T12:12:00"}
+                                           "lasthour"   {:end "2016-06-07T11:00:00", :start "2016-06-07T11:00:00"}
+                                           "lastweek"   {:end "2016-06-04", :start "2016-05-29"}
+                                           "lastmonth"  {:end "2016-05-31", :start "2016-05-01"}
+                                           "lastyear"   {:end "2015-12-31", :start "2015-01-01"}}
              "relative (today/yesterday)" {"yesterday" {:end "2016-06-06", :start "2016-06-06"}
                                            "today"     {:end "2016-06-07", :start "2016-06-07"}}}]
       (testing group


### PR DESCRIPTION
Allow seconds, minutes, and hours for relative date strings for “past” and “next”, in the backend

Add “minutes” and “hours” options to the frontend widget for relative date picker

Adding tests for new options