### PR TITLE
Add Cypress coverage for the Cloud CTA in admin panel

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -12,6 +12,15 @@ describe("scenarios > admin > settings", () => {
     signInAsAdmin();
   });
 
+  it("should prompt admin to migrate to the hosted instance", () => {
+    cy.visit("/admin/settings/setup");
+    cy.findByText("Have your server maintained for you.");
+    cy.findByText("Migrate to Metabase Cloud.");
+    cy.findAllByRole("link", { name: "Learn more" })
+      .should("have.attr", "href")
+      .and("include", /migrate/);
+  });
+
   it("should surface an error when validation for any field fails (metabase#4506)", () => {
     const BASE_URL = Cypress.config().baseUrl;
     const DOMAIN_AND_PORT = BASE_URL.replace("http://", "");

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -18,7 +18,7 @@ describe("scenarios > admin > settings", () => {
     cy.findByText("Migrate to Metabase Cloud.");
     cy.findAllByRole("link", { name: "Learn more" })
       .should("have.attr", "href")
-      .and("include", /migrate/);
+      .and("include", "/migrate/");
   });
 
   it("should surface an error when validation for any field fails (metabase#4506)", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds Cypress coverage for the new prompt/CTA that lets admins know they can migrate to the hosted instance
- Asserts that the link contains `/migrate/` in it

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- All tests should pass

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/105787131-ab562680-5f7e-11eb-91eb-6d267770a75b.png)
