### PR TITLE
PivotTable scroll alignment fix

### DIFF
--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -27,13 +27,10 @@ export const IFRAMED_IN_SELF = (function() {
   }
 })();
 
-export const WINDOWS_SCROLL_BAR_X_HEIGHT = 20;
-export const MAC_SCROLL_BAR_X_HEIGHT = 10;
-
 // check whether scrollbars are visible to the user,
 // this is off by default on Macs, but can be changed
 // Always on on most other non mobile platforms
-export const areScrollbarsVisible = _.memoize(() => {
+export const getScrollBarSize = _.memoize(() => {
   const scrollableElem = document.createElement("div"),
     innerElem = document.createElement("div");
   scrollableElem.style.width = "30px";
@@ -46,7 +43,7 @@ export const areScrollbarsVisible = _.memoize(() => {
   document.body.appendChild(scrollableElem); // Elements only have width if they're in the layout
   const diff = scrollableElem.offsetWidth - scrollableElem.clientWidth;
   document.body.removeChild(scrollableElem);
-  return diff > 0;
+  return diff;
 });
 
 // check if we have access to localStorage to avoid handling "access denied"

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -1,3 +1,4 @@
+import _ from "underscore";
 // IE doesn't support scrollX/scrollY:
 export const getScrollX = () =>
   typeof window.scrollX === "undefined" ? window.pageXOffset : window.scrollX;
@@ -25,6 +26,28 @@ export const IFRAMED_IN_SELF = (function() {
     return false;
   }
 })();
+
+export const WINDOWS_SCROLL_BAR_X_HEIGHT = 20;
+export const MAC_SCROLL_BAR_X_HEIGHT = 10;
+
+// check whether scrollbars are visible to the user,
+// this is off by default on Macs, but can be changed
+// Always on on most other non mobile platforms
+export const areScrollbarsVisible = _.memoize(() => {
+  const scrollableElem = document.createElement("div"),
+    innerElem = document.createElement("div");
+  scrollableElem.style.width = "30px";
+  scrollableElem.style.height = "30px";
+  scrollableElem.style.overflow = "scroll";
+  scrollableElem.style.borderWidth = "0";
+  innerElem.style.width = "30px";
+  innerElem.style.height = "60px";
+  scrollableElem.appendChild(innerElem);
+  document.body.appendChild(scrollableElem); // Elements only have width if they're in the layout
+  const diff = scrollableElem.offsetWidth - scrollableElem.clientWidth;
+  document.body.removeChild(scrollableElem);
+  return diff > 0;
+});
 
 // check if we have access to localStorage to avoid handling "access denied"
 // exceptions

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -221,8 +221,6 @@ export default class PivotTable extends Component {
       const hasScrollbars =
         window.navigator.platform === "Win32" || areScrollbarsVisible();
 
-      console.log("hasScrollbars?", hasScrollbars);
-
       return scrollsHorizontally && scrollsVertically && hasScrollbars;
     }
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -224,7 +224,6 @@ export default class PivotTable extends Component {
       return scrollsHorizontally && scrollsVertically && hasScrollbars;
     }
 
-
     let pivoted;
     try {
       pivoted = multiLevelPivot(data, settings);

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -226,7 +226,6 @@ export default class PivotTable extends Component {
       return scrollsHorizontally && scrollsVertically && hasScrollbars;
     }
 
-    console.log(needsScrollbarOffset());
 
     let pivoted;
     try {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -5,6 +5,8 @@ import _ from "underscore";
 import { getIn, updateIn } from "icepick";
 import { Grid, Collection, ScrollSync } from "react-virtualized";
 
+import { areScrollbarsVisible } from "metabase/lib/dom";
+
 import Ellipsified from "metabase/components/Ellipsified";
 import Icon from "metabase/components/Icon";
 import { isDimension } from "metabase/lib/schema_metadata";
@@ -18,6 +20,7 @@ import { formatColumn } from "metabase/lib/formatting";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 
 import type { VisualizationProps } from "metabase-types/types/Visualization";
+import { findDOMNode } from "react-dom";
 
 const partitions = [
   {
@@ -178,6 +181,10 @@ export default class PivotTable extends Component {
     },
   };
 
+  setBodyRef = element => {
+    this.bodyRef = element;
+  };
+
   getColumnTitle(columnIndex) {
     const { data, settings } = this.props;
     const columns = data.cols.filter(col => !isPivotGroupColumn(col));
@@ -198,6 +205,28 @@ export default class PivotTable extends Component {
     if (data == null || !data.cols.some(isPivotGroupColumn)) {
       return null;
     }
+
+    const grid = this.bodyRef && findDOMNode(this.bodyRef);
+
+    // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
+    // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights
+    function needsScrollbarOffset() {
+      if (!grid) {
+        return false;
+      }
+      // check to see if the main data container has Y scrolling
+      const scrollsVertically = grid.scrollHeight > parseInt(grid.style.height);
+      const scrollsHorizontally = grid.scrollWidth > parseInt(grid.style.width);
+      // windows always has scrollbars, otherwise check for the Mac setting
+      const hasScrollbars =
+        window.navigator.platform === "Win32" || areScrollbarsVisible();
+
+      console.log("hasScrollbars?", hasScrollbars);
+
+      return scrollsHorizontally && scrollsVertically && hasScrollbars;
+    }
+
+    console.log(needsScrollbarOffset());
 
     let pivoted;
     try {
@@ -390,7 +419,11 @@ export default class PivotTable extends Component {
                     leftHeaderCellSizeAndPositionGetter
                   }
                   width={leftHeaderWidth}
-                  height={height - topHeaderHeight}
+                  height={
+                    needsScrollbarOffset()
+                      ? height - topHeaderHeight - 20
+                      : height - topHeaderHeight
+                  }
                   scrollTop={scrollTop}
                   onScroll={({ scrollTop }) => onScroll({ scrollTop })}
                 />
@@ -407,6 +440,7 @@ export default class PivotTable extends Component {
                   onScroll={({ scrollLeft, scrollTop }) =>
                     onScroll({ scrollLeft, scrollTop })
                   }
+                  ref={this.setBodyRef}
                   scrollTop={scrollTop}
                   scrollLeft={scrollLeft}
                 />

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { getIn, updateIn } from "icepick";
 import { Grid, Collection, ScrollSync } from "react-virtualized";
 
-import { areScrollbarsVisible } from "metabase/lib/dom";
+import { getScrollBarSize } from "metabase/lib/dom";
 
 import Ellipsified from "metabase/components/Ellipsified";
 import Icon from "metabase/components/Icon";
@@ -210,18 +210,19 @@ export default class PivotTable extends Component {
 
     // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
     // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights
-    function needsScrollbarOffset() {
+    function scrollBarOffsetSize() {
       if (!grid) {
-        return false;
+        return 0;
       }
-      // check to see if the main data container has Y scrolling
-      const scrollsVertically = grid.scrollHeight > parseInt(grid.style.height);
+      // get the size of the scrollbars
+      const scrollBarSize = getScrollBarSize();
       const scrollsHorizontally = grid.scrollWidth > parseInt(grid.style.width);
-      // windows always has scrollbars, otherwise check for the Mac setting
-      const hasScrollbars =
-        window.navigator.platform === "Win32" || areScrollbarsVisible();
 
-      return scrollsHorizontally && scrollsVertically && hasScrollbars;
+      if (scrollsHorizontally && scrollBarSize > 0) {
+        return scrollBarSize;
+      } else {
+        return 0;
+      }
     }
 
     let pivoted;
@@ -415,11 +416,7 @@ export default class PivotTable extends Component {
                     leftHeaderCellSizeAndPositionGetter
                   }
                   width={leftHeaderWidth}
-                  height={
-                    needsScrollbarOffset()
-                      ? height - topHeaderHeight - 20
-                      : height - topHeaderHeight
-                  }
+                  height={height - topHeaderHeight - scrollBarOffsetSize()}
                   scrollTop={scrollTop}
                   onScroll={({ scrollTop }) => onScroll({ scrollTop })}
                 />


### PR DESCRIPTION
Closes #14352 

## What this does
- Adds some special casing to the computed height of the PivotTable left column to prevent the presence of a horizontal scrollbar causing rows in the left sidebar and main content area getting out of sync. 