### PR TITLE
Pivot table settings: restore the mouse-hover effect

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -333,8 +333,11 @@ class EmptyPartition extends React.Component {
 class Column extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { expanded: false };
+    this.state = { hover: false, expanded: false };
   }
+  mouseHover = hover => {
+    this.setState({ hover });
+  };
   toggleExpand = () => {
     const { expanded } = this.state;
     this.setState({ expanded: !expanded });
@@ -360,19 +363,20 @@ class Column extends React.Component {
       isDragging,
       partitionName,
     } = this.props;
-    const { expanded } = this.state;
+    const { hover, expanded } = this.state;
+    const shadowOffset = hover ? "5px" : "3px";
+    const shadowColor = lighten(colors["text-dark"], hover ? 1.3 : 1.5);
     const showOptionsPanel = expanded && !isDragging;
     return connectDropTarget(
       connectDragSource(
         <div
           className="mb1 bordered rounded"
+          onMouseEnter={() => this.mouseHover(true)}
+          onMouseLeave={() => this.mouseHover(false)}
           style={{
             padding: "12px 14px",
-            "box-shadow": `0 2px 3px ${lighten(colors["text-dark"], 1.5)}`,
-            "&:hover": {
-              "box-shadow": `0 2px 5px ${lighten(colors["text-dark"], 1.3)}`,
-              transition: "all 300ms linear",
-            },
+            "box-shadow": `0 2px ${shadowOffset} ${shadowColor}`,
+            transition: "all 300ms linear",
           }}
         >
           <div


### PR DESCRIPTION
ColumnDragger was migrated from a simple `<div/>` (via styled-component) to a more complex JSX. Thus, the previous `:hover` effect is reimplemented using mouse enter/leave event.

How to test: create any pivot table, e.g.

1. Ask a question, Simple question
2. Sample Dataset, Order
3. Summarize, Summarize by Count
4. Summarize, Group by Order.Created_At:Year and User.State
5. Visualization, Pivot Table
6. From this Pivot Table options, put the mouse cursor under any column (e.g "User State")

Expected: The column bar should change its shadow (rather subtle, pay attention closely).

![image](https://user-images.githubusercontent.com/7288/105879082-9bf2cf80-5fb6-11eb-9b8d-c9f1345af952.png)
