### PR TITLE
SchedulePicker gets null day of the week

### DIFF
--- a/frontend/src/metabase/components/SchedulePicker.jsx
+++ b/frontend/src/metabase/components/SchedulePicker.jsx
@@ -63,6 +63,8 @@ export default class SchedulePicker extends Component {
     minutesOnHourPicker: PropTypes.bool,
   };
 
+  DEFAULT_DAY = "mon";
+
   handleChangeProperty(name, value) {
     let newSchedule = {
       ...this.props.schedule,
@@ -102,7 +104,7 @@ export default class SchedulePicker extends Component {
       if (value === "weekly") {
         newSchedule = {
           ...newSchedule,
-          schedule_day: "mon",
+          schedule_day: this.DEFAULT_DAY,
           schedule_frame: null,
         };
       }
@@ -112,13 +114,19 @@ export default class SchedulePicker extends Component {
         newSchedule = {
           ...newSchedule,
           schedule_frame: "first",
-          schedule_day: "mon",
+          schedule_day: this.DEFAULT_DAY,
         };
       }
     } else if (name === "schedule_frame") {
       // when the monthly schedule frame is the 15th, clear out the schedule_day
       if (value === "mid") {
         newSchedule = { ...newSchedule, schedule_day: null };
+      } else {
+        // first or last, needs a day of the week
+        newSchedule = {
+          ...newSchedule,
+          schedule_day: newSchedule.schedule_day || this.DEFAULT_DAY,
+        };
       }
     }
 

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -77,7 +77,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         });
     });
 
-    it.skip("should not display 'null' day of the week (metabase#14405)", () => {
+    it("should not display 'null' day of the week (metabase#14405)", () => {
       assignRecipient();
       cy.findByText("To:").click();
       cy.get(".AdminSelect")


### PR DESCRIPTION
Fixes #14405

I looked into writing some unit tests for `handleChangeProperty`, but as far as I can tell we're not set up for that. It seems a little heavy to render stuff onto the screen and poke at it with `click` events, but React Testing Library seems to not support method-level testing by design (in contrast to Enzyme).

@nemanjaglumac any thoughts?