### PR TITLE
Sanitize URL substring used for determining if the instance is hosted

### DIFF
--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -88,7 +88,8 @@ class Settings {
   // Right now, all Metabase Cloud hosted instances run on *.metabaseapp.com
   // We plan on changing this to look at an envvar in the future instead.
   isHosted() {
-    return /.+\.metabaseapp.com$/i.test(this.get("site-url"));
+    // matches <custom>.metabaseapp.com and <custom>.metabaseapp.com/
+    return /.+\.metabaseapp.com\/?$/i.test(this.get("site-url"));
   }
 
   isTrackingEnabled() {

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -88,12 +88,7 @@ class Settings {
   // Right now, all Metabase Cloud hosted instances run on *.metabaseapp.com
   // We plan on changing this to look at an envvar in the future instead.
   isHosted() {
-    return (
-      this.get("site-url") &&
-      this.get("site-url")
-        .toLowerCase()
-        .includes("metabaseapp.com")
-    );
+    return /.+\.metabaseapp.com$/i.test(this.get("site-url"));
   }
 
   isTrackingEnabled() {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Sanitizes URL substring used for determining if the instance is hosted
- Simplifies `isHosted()` method by using regex
- Fixes the [CodeQL warning](https://github.com/metabase/metabase/pull/14511/checks?check_run_id=1770709190) from the previous PR #14511

### Additional notes:
- That warning was probably not super-important or even dangerous because (as @mazameli said), we're using `isHosted()` only to determine where to display CTA in UI. However, the fix was simple and it felt weird not to include it.