### PR TITLE
Support nested native query snippets

### DIFF
--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [metabase.driver :as driver]
             [metabase.driver.common.parameters :as i]
+            [metabase.driver.common.parameters.parse :as parse]
             [metabase.driver.sql.parameters.substitution :as substitution]
             [metabase.query-processor.error-type :as error-type]
             [metabase.util.i18n :refer [tru]]))
@@ -18,15 +19,28 @@
   (let [{:keys [replacement-snippet prepared-statement-args]} (substitution/->replacement-snippet-info driver/*driver* v)]
     [(str sql replacement-snippet) (concat args prepared-statement-args) missing]))
 
-(defn- substitute-native-query-snippet [[sql args missing] v]
-   (let [{:keys [replacement-snippet]} (substitution/->replacement-snippet-info driver/*driver* v)]
-     [(str sql replacement-snippet) args missing]))
+(declare substitute*)
 
-(defn- substitute-param [param->value [sql args missing] in-optional? {:keys [k]}]
+(defn- substitute-native-query-snippet [[sql args missing] v param->value in-optional? seen-params]
+   (let [{:keys [replacement-snippet]} (substitution/->replacement-snippet-info driver/*driver* v)
+         parsed-replacement (parse/parse replacement-snippet)]
+     (if (not-any? i/Param? parsed-replacement)
+       [(str sql replacement-snippet) args missing] ; no nested parameters, just splice in the SQL
+       (let [[recursive-query & _]
+             (substitute* param->value parsed-replacement in-optional? seen-params)]
+         [(str sql recursive-query) args missing]))))
+
+(defn- substitute-param [param->value [sql args missing] in-optional? {:keys [k]} seen-params]
   (if-not (contains? param->value k)
     [sql args (conj missing k)]
     (let [v (get param->value k)]
       (cond
+        (contains? seen-params k)
+        (throw (ex-info (tru "Cycle detected when resolving parameters")
+                        {:type         error-type/qp
+                         :params       param->value
+                         :sql          sql
+                         :seen-params  seen-params}))
         (i/FieldFilter? v)
         (substitute-field-filter [sql args missing] in-optional? k v)
 
@@ -34,7 +48,7 @@
         (substitute-card-query [sql args missing] v)
 
         (i/ReferencedQuerySnippet? v)
-        (substitute-native-query-snippet [sql args missing] v)
+        (substitute-native-query-snippet [sql args missing] v param->value in-optional? (conj seen-params k))
 
         (= i/no-value v)
         [sql args (conj missing k)]
@@ -43,7 +57,6 @@
         (let [{:keys [replacement-snippet prepared-statement-args]} (substitution/->replacement-snippet-info driver/*driver* v)]
           [(str sql replacement-snippet) (concat args prepared-statement-args) missing])))))
 
-(declare substitute*)
 
 (defn- substitute-optional [param->value [sql args missing] {subclauses :args}]
   (let [[opt-sql opt-args opt-missing] (substitute* param->value subclauses true)]
@@ -53,20 +66,22 @@
 
 (defn- substitute*
   "Returns a sequence of `[replaced-sql-string jdbc-args missing-parameters]`."
-  [param->value parsed in-optional?]
-  (reduce
-   (fn [[sql args missing] x]
-     (cond
-       (string? x)
-       [(str sql x) args missing]
+  ([param->value parsed in-optional?]
+   (substitute* param->value parsed in-optional? #{}))
+  ([param->value parsed in-optional? seen-params]
+   (reduce
+     (fn [[sql args missing] x]
+       (cond
+         (string? x)
+         [(str sql x) args missing]
 
-       (i/Param? x)
-       (substitute-param param->value [sql args missing] in-optional? x)
+         (i/Param? x)
+         (substitute-param param->value [sql args missing] in-optional? x seen-params)
 
-       (i/Optional? x)
-       (substitute-optional param->value [sql args missing] x)))
-   nil
-   parsed))
+         (i/Optional? x)
+         (substitute-optional param->value [sql args missing] x)))
+     nil
+     parsed)))
 
 (defn substitute
   "Substitute `Optional` and `Param` objects in a `parsed-query`, a sequence of parsed string fragments and tokens, with
@@ -81,9 +96,11 @@
                              (substitute* param->value parsed-query false)
                              (catch Throwable e
                                (throw (ex-info (tru "Unable to substitute parameters")
-                                        {:type         (or (:type (ex-data e)) error-type/qp)
-                                         :params       param->value
-                                         :parsed-query parsed-query}
+                                        (merge
+                                          (ex-data e)
+                                          {:type         (or (:type (ex-data e)) error-type/qp)
+                                           :params       param->value
+                                           :parsed-query parsed-query})
                                         e))))]
     (when (seq missing)
       (throw (ex-info (tru "Cannot run the query: missing required parameters: {0}" (set missing))

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -9,6 +9,7 @@
             [metabase.models :refer [Field]]
             [metabase.query-processor :as qp]
             [metabase.query-processor-test :as qp.test]
+            [metabase.query-processor.error-type :as error-type]
             [metabase.query-processor.middleware.parameters.native :as native]
             [metabase.query-processor.test-util :as qp.test-util]
             [metabase.test :as mt]
@@ -194,8 +195,23 @@
   (testing "Native query snippet substitution"
     (let [query ["SELECT * FROM test_scores WHERE " (param "snippet:symbol_is_A")]]
       (is (= ["SELECT * FROM test_scores WHERE symbol = 'A'" nil]
-             (substitute query {"snippet:symbol_is_A" (i/->ReferencedQuerySnippet 123 "symbol = 'A'")}))))))
-
+             (substitute query {"snippet:symbol_is_A" (i/->ReferencedQuerySnippet 123 "symbol = 'A'")})))))
+  (testing "Native query nested snippet substitution"
+    (let [query ["SELECT * FROM test_scores WHERE " (param "snippet:symbol_is_something")]
+          nested1 {"snippet:symbol_is_something" (i/->ReferencedQuerySnippet 123 "symbol = {{snippet:the_something}}")
+                   "snippet:the_something" (i/->ReferencedQuerySnippet 157 "'X'")}
+          nested2 {"snippet:symbol_is_something" (i/->ReferencedQuerySnippet 123 "symbol = {{snippet:the_something}}")
+                   "snippet:the_something" (i/->ReferencedQuerySnippet 157 "{{snippet:symbol_is_something}}")}]
+      ;; legal nested snippets (should resolve recursively)
+      (is (= ["SELECT * FROM test_scores WHERE symbol = 'X'" nil]
+             (substitute query nested1)))
+      ;; illegal nested snippets (cycle)
+      (is (thrown-with-info?
+           Exception
+           {:type         error-type/qp
+            :seen-params  #{"snippet:symbol_is_something"
+                            "snippet:the_something"}}
+           (substitute query nested2))))))
 
 ;;; ------------------------------------------ simple substitution — {{x}} ------------------------------------------
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -76,6 +76,24 @@
        :diffs    (when-not pass?#
                    [[actual# [(s/check schema# actual#) nil]]])})))
 
+(defmethod assert-expr 'thrown-with-info? [msg form]
+  ;; (is (thrown-with-info-entries? c info expr))
+  ;; Asserts that evaluating expr throws an exception of class c.
+  ;; Also asserts that the map within the ExceptionInfo contains all entries from info..
+  (let [klass        (nth form 1)
+        info-entries (nth form 2)
+        body         (nthnext form 3)]
+    `(try
+       ~@body
+       (do-report {:type :fail, :message ~msg, :expected '~body, :actual nil})
+       (catch ~klass e#
+         (let [ex-d#  (ex-data e#)
+               k#     (keys ~info-entries)]
+           (is
+             (=
+               ~info-entries
+               (select-keys ex-d# k#))))))))
+
 (defn- random-uppercase-letter []
   (char (+ (int \A) (rand-int 26))))
 

--- a/test/metabase/test/util_test.clj
+++ b/test/metabase/test/util_test.clj
@@ -5,8 +5,10 @@
             [metabase.models.setting :as setting]
             [metabase.test :as mt]
             [metabase.test.data :as data]
+            [metabase.test.util :as tu]
             [metabase.util :as u]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import (clojure.lang ExceptionInfo)))
 
 (deftest with-temp-vals-in-db-test
   (testing "let's make sure this acutally works right!"
@@ -41,3 +43,11 @@
       (test-util-test-setting))
     (is (= ["A" "B" "C"]
            (test-util-test-setting)))))
+
+(deftest thrown-with-info?-test
+  (testing "thrown-with-info? implementation"
+    (is
+      (thrown-with-info?
+        ExceptionInfo
+        {:a 1 :b "foo" :c [3 4 5]}
+        (throw (ex-info "Something bad happened" {:a 1 :b "foo" :c [3 4 5]}))))))


### PR DESCRIPTION
Calling the parser on snippet contents in order to detect nested snippets and handle them appropriately, depending on the context.

* From values, when building the query->params-map, via a new generic mechanism for handling nested tag values. Only implemented for :snippet type right now.
* From substitute, when performing param value substitution, in order to resolve nested snippet values recursively in the query. This expects that all nested snippets will have been populated in the param->value map.

Adding new thrown-with-info? assert-expr that can check for expected ex-data map entries

Adding tests for valid and cyclic cases in both contexts, and asserting on the exception data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/14529)
<!-- Reviewable:end -->
