### PR TITLE
#14517 Repro: Regex escape characters shouldn't be removed

### DIFF
--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -56,4 +56,28 @@ describe("postgres > question > custom columns", () => {
     cy.findByText("Visualize").click();
     cy.findByText("Arnold Adams");
   });
+
+  it.skip("should not remove regex escape characters (metabase#14517)", () => {
+    // Ironically, both Prettier and Cypress remove escape characters from our code as well
+    // We're testing for the literal sting `(?<=\/\/)[^\/]*`, but we need to escape the escape characters to make it work
+    const ESCAPED_REGEX = "(?<=\\/\\/)[^\\/]*";
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText(PG_DB_NAME).click();
+    cy.findByText("People").click();
+
+    cy.log("**-- 1. Create custom column using `regexextract()` --**");
+
+    cy.get(".Icon-add_data").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']")
+        .type(`regexextract([State], "${ESCAPED_REGEX}")`)
+        .blur();
+
+      // It removes escaped characters already on blur
+      cy.log("**Reported failing on v0.36.4**");
+      cy.contains(ESCAPED_REGEX);
+    });
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14517

### How to test this manually?
- `yarn test-cypress-open --testFiles frontend/test/metabase-db/`
- `frontend/test/metabase-db/postgres/custom-column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to test this in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Test failure at the time of unfixed bug
![image](https://user-images.githubusercontent.com/31325167/105899493-08071f00-601b-11eb-90bf-8d0861dccc7d.png)

**Please note that Cypress test runner (incorrectly) visually shows escaped string `(?<=//)[^/]*` but it actually searches for `(?<=\/\/)[^\/]*`**

2. Sanity check (run the test without `.blur()`)
![image](https://user-images.githubusercontent.com/31325167/105900646-9f20a680-601c-11eb-961d-e108b9159232.png)

**It finds the string, although it is still showing it escaped in the test runner.**