### PR TITLE
Use the right background color for ProfileLink's hover state in the Admin Panel

### DIFF
--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -94,6 +94,7 @@ export default class ProfileLink extends Component {
 
   render() {
     const { modalOpen } = this.state;
+    const adminContext = this.props.context === "admin";
     const { tag, date, ...versionExtra } = MetabaseSettings.get("version");
     // don't show trademark if application name is whitelabeled
     const showTrademark = t`Metabase` === "Metabase";
@@ -105,7 +106,9 @@ export default class ProfileLink extends Component {
           triggerIcon="gear"
           triggerProps={{
             hover: {
-              backgroundColor: darken(color("brand")),
+              backgroundColor: adminContext
+                ? darken(color("accent7"))
+                : darken(color("brand")),
               color: "white",
             },
           }}


### PR DESCRIPTION
This checks if the current context is the admin panel or not, and picks either the brand color or accent7 as the hover background accordingly.

## Before

![Screen Shot 2021-01-21 at 12 04 15 PM](https://user-images.githubusercontent.com/2223916/105922353-5d2d3b80-5fef-11eb-9ccc-f35ffe37abea.png)


## After

![image](https://user-images.githubusercontent.com/2223916/105922349-58688780-5fef-11eb-943d-10444e2a26a2.png)
