### PR TITLE
Fix the tiny run button in the simple query builder

### DIFF
--- a/frontend/src/metabase/query_builder/components/RunButton.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.jsx
@@ -55,7 +55,7 @@ export default class RunButton extends Component {
         iconSize={16}
         className={cx(className, "RunButton", {
           "RunButton--hidden": hidden,
-          circular: circular,
+          "circular px2": circular,
         })}
         onClick={isRunning ? onCancel : onRun}
       >


### PR DESCRIPTION
Somehow, the run button in the Simple query builder got really tiny:

![image](https://user-images.githubusercontent.com/2223916/105929707-09295380-5ffd-11eb-938f-8f8877b9fa4b.png)

I want to dial this in a bit more, but it should look more along these lines:

![image](https://user-images.githubusercontent.com/2223916/105929745-1d6d5080-5ffd-11eb-87d3-2dcf6535cf5d.png)
