### PR TITLE
Build scripts should use oss/ee like everyone else instead of ce/ee

### DIFF
--- a/bin/build-drivers/src/build_drivers/build_driver.clj
+++ b/bin/build-drivers/src/build_drivers/build_driver.clj
@@ -62,8 +62,6 @@
       (build-driver! parent))
     (u/announce "%s parents built successfully." driver)))
 
-
-
 (defn- build-uberjar! [driver]
   (u/step (format "Build %s uberjar" driver)
     (u/delete-file-if-exists! (c/driver-target-directory driver))

--- a/bin/release/src/release/common.clj
+++ b/bin/release/src/release/common.clj
@@ -51,12 +51,12 @@
   (swap! build-options assoc :branch new-branch))
 
 (defn edition
-  "Either `:ce` (Community Edition) or `:ee` (Enterprise Edition)."
+  "Either `:oss` (Community Edition) or `:ee` (Enterprise Edition)."
   []
   (build-option-or-throw :edition))
 
 (defn set-edition! [new-edition]
-  (assert (#{:ce :ee} new-edition))
+  (assert (#{:oss :ee} new-edition))
   (swap! build-options assoc :edition new-edition))
 
 (defn pre-release-version?
@@ -75,12 +75,12 @@
 
 (defn docker-image-name []
   (case (edition)
-    :ce "metabase/metabase"
+    :oss "metabase/metabase"
     :ee "metabase/metabase-enterprise"))
 
 (defn downloads-url []
   (case (edition)
-    :ce "downloads.metabase.com"
+    :oss "downloads.metabase.com"
     :ee "downloads.metabase.com/enterprise"))
 
 (defn artifact-download-url
@@ -96,12 +96,12 @@
 
 (defn website-repo []
   (case (edition)
-    :ce "metabase/metabase.github.io"
+    :oss "metabase/metabase.github.io"
     nil))
 
 (defn heroku-buildpack-repo []
   (case (edition)
-    :ce "metabase/metabase-buildpack"
+    :oss "metabase/metabase-buildpack"
     nil))
 
 (defn metabase-repo
@@ -158,8 +158,8 @@
   []
   (->> ((requiring-resolve 'release.common.github/recent-tags))
        (filter (case (edition)
-                 :ee (partial re-matches #"v1(?:\.\d+){2,}$")
-                 :ce (partial re-matches #"v0(?:\.\d+){2,}$")))))
+                 :ee  (partial re-matches #"v1(?:\.\d+){2,}$")
+                 :oss (partial re-matches #"v0(?:\.\d+){2,}$")))))
 
 (defn- most-recent-tag
   "Given a set of release `tags`, return the most recent one."

--- a/bin/release/src/release/draft_release.clj
+++ b/bin/release/src/release/draft_release.clj
@@ -33,8 +33,8 @@
 
 (defn- release-title []
   (case (c/edition)
-    :ce (format "Metabase v%s" (c/version))
-    :ee (format "Metabase® Enterprise Edition™ v%s" (c/version))))
+    :oss (format "Metabase v%s" (c/version))
+    :ee  (format "Metabase® Enterprise Edition™ v%s" (c/version))))
 
 (defn- upload-draft-changelog! [changelog]
   (u/step "Upload draft changelog (create draft release)"

--- a/bin/release/src/release/set_build_options.clj
+++ b/bin/release/src/release/set_build_options.clj
@@ -9,7 +9,7 @@
       (let [version (u/read-line-with-prompt "What version are we building (e.g. 0.36.0)?")
             branch  current-branch
             edition (case (first version)
-                      \0 :ce
+                      \0 :oss
                       \1 :ee)]
         (if-not (u/yes-or-no-prompt (format "Building %s version %s from branch %s. Is this correct?"
                                             (pr-str edition) (pr-str version) (pr-str branch)))

--- a/bin/release/src/release/version_info.clj
+++ b/bin/release/src/release/version_info.clj
@@ -8,7 +8,7 @@
 
 (defn- version-info-url []
   (case (c/edition)
-    :ce "static.metabase.com/version-info.json"
+    :oss "static.metabase.com/version-info.json"
     nil))
 
 (def ^:private tmp-version-info-filename


### PR DESCRIPTION
We've basically standardized on using `:oss` and `:ee` to differentiate the two versions of Metabase elsewhere in the codebase e.g. Lein `project.clj`s and frontend config stuff. The Clojure build scripts predate this a bit and went with `:ce` and `:ee` instead. This PR changes them to use `:oss` and `:ee` like everyone else to reduce confusion and eliminate the need to convert between the two conventions