### PR TITLE
add cmd rotate-encryption-key

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -152,6 +152,11 @@
         {:keys [user]} (cmd-args->map args)]
     (cmd path user)))
 
+(defn ^:command rotate-keys
+  "Rotate the encryption of a metabase database."
+  [to-key]
+  (classloader/require 'metabase.cmd.rotate-encryption-key)
+  ((resolve 'metabase.cmd.rotate-encryption-key/rotate-keys!) to-key))
 
 ;;; ------------------------------------------------ Running Commands ------------------------------------------------
 

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -154,9 +154,9 @@
 
 (defn ^:command rotate-keys
   "Rotate the encryption of a metabase database."
-  [to-key]
+  [& args]
   (classloader/require 'metabase.cmd.rotate-encryption-key)
-  ((resolve 'metabase.cmd.rotate-encryption-key/rotate-keys!) to-key))
+  ((resolve 'metabase.cmd.rotate-encryption-key/rotate-keys!) (first args)))
 
 ;;; ------------------------------------------------ Running Commands ------------------------------------------------
 

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -152,11 +152,12 @@
         {:keys [user]} (cmd-args->map args)]
     (cmd path user)))
 
-(defn ^:command rotate-keys
-  "Rotate the encryption of a metabase database."
-  [& args]
+(defn ^:command rotate-encryption-key
+  "Rotate the encryption key of a metabase database. The MB_ENCRYPTION_SECRET_KEY environment variable has to be set to
+  the current key, and the parameter `new-key` has to be the new key. `new-key` has to be at least 16 chars."
+  [new-key]
   (classloader/require 'metabase.cmd.rotate-encryption-key)
-  ((resolve 'metabase.cmd.rotate-encryption-key/rotate-keys!) (first args)))
+  ((resolve 'metabase.cmd.rotate-encryption-key/rotate-encryption-key!) new-key))
 
 ;;; ------------------------------------------------ Running Commands ------------------------------------------------
 

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -52,8 +52,9 @@
   (let [options        {:keep-existing? (boolean (some #{"--keep-existing"} opts))
                         :dump-plaintext? (boolean (some #{"--dump-plaintext"} opts)) }
         return-code    ((resolve 'metabase.cmd.dump-to-h2/dump-to-h2!) h2-filename options)]
-    (when (pos-int? return-code)
-      (system-exit! return-code))))
+    (if (pos-int? return-code)
+      (system-exit! return-code)
+      (println "Dump complete"))))
 
 (defn ^:command profile
   "Start Metabase the usual way and exit. Useful for profiling Metabase launch time."

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -157,7 +157,9 @@
   the current key, and the parameter `new-key` has to be the new key. `new-key` has to be at least 16 chars."
   [new-key]
   (classloader/require 'metabase.cmd.rotate-encryption-key)
-  ((resolve 'metabase.cmd.rotate-encryption-key/rotate-encryption-key!) new-key))
+  (let [return-code ((resolve 'metabase.cmd.rotate-encryption-key/rotate-encryption-key!) new-key)]
+    (when (pos-int? return-code)
+      (system-exit! 1))))
 
 ;;; ------------------------------------------------ Running Commands ------------------------------------------------
 

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -17,6 +17,7 @@
   associated with each command's entrypoint function to generate descriptions for each command."
   (:refer-clojure :exclude [load])
   (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.config :as config]
             [metabase.plugins.classloader :as classloader]
@@ -55,8 +56,8 @@
       ((resolve 'metabase.cmd.dump-to-h2/dump-to-h2!) h2-filename options)
       (println "Dump complete")
       (system-exit! 0))
-    (catch Exception e
-      (println "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")
+    (catch Throwable e
+      (log/error e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")
       (system-exit! 1))))
 
 (defn ^:command profile

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -159,7 +159,7 @@
   [new-key]
   (classloader/require 'metabase.cmd.rotate-encryption-key)
   (let [return-code ((resolve 'metabase.cmd.rotate-encryption-key/rotate-encryption-key!) new-key)]
-    (when (pos-int? return-code)
+    (when (not return-code)
       (system-exit! 1))))
 
 ;;; ------------------------------------------------ Running Commands ------------------------------------------------

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -41,5 +41,5 @@
                  mdb.conn/*jdbc-spec* h2-jdbc-spec
                  db/*db-connection* h2-jdbc-spec
                  db/*quoting-style* :h2]
-         (rotate-encryption/rotate-keys! nil)))
+         (rotate-encryption/rotate-encryption-key! nil)))
      (println "Dump complete"))))

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -36,10 +36,12 @@
      (when-not keep-existing?
        (copy.h2/delete-existing-h2-database-files! h2-filename))
      (copy/copy!  (mdb.conn/db-type) (mdb.conn/jdbc-spec) :h2 h2-jdbc-spec)
-     (when dump-plaintext?
+     (if dump-plaintext?
        (binding [mdb.conn/*db-type* :h2
                  mdb.conn/*jdbc-spec* h2-jdbc-spec
                  db/*db-connection* h2-jdbc-spec
                  db/*quoting-style* :h2]
-         (rotate-encryption/rotate-encryption-key! nil)))
-     (println "Dump complete"))))
+         (if (rotate-encryption/rotate-encryption-key! nil)
+           (println "Dump complete")
+           1))
+       (println "Dump complete")))))

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -41,7 +41,5 @@
                  mdb.conn/*jdbc-spec* h2-jdbc-spec
                  db/*db-connection* h2-jdbc-spec
                  db/*quoting-style* :h2]
-         (if (rotate-encryption/rotate-encryption-key! nil)
-           (println "Dump complete")
-           1))
-       (println "Dump complete")))))
+         (when (not (rotate-encryption/rotate-encryption-key! nil))
+           1))))))

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -41,5 +41,4 @@
                  mdb.conn/*jdbc-spec* h2-jdbc-spec
                  db/*db-connection* h2-jdbc-spec
                  db/*quoting-style* :h2]
-         (when (not (rotate-encryption/rotate-encryption-key! nil))
-           1))))))
+         (rotate-encryption/rotate-encryption-key! nil))))))

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -9,31 +9,29 @@
 
 (defn rotate-keys!
   "Rotate the current configured db using the current MB_ENCRYPTION_SECRET_KEY env var and `to-key` argument."
-  ([] (rotate-keys! nil))
-  ([to-key]
-   (mdb/setup-db!)
-   (try
-     (let [encrypt-fn (if to-key
-                        (partial encrypt/maybe-encrypt
-                                 (encrypt/validate-and-hash-secret-key to-key))
-                        identity)]
-       (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
-         (doseq [[key value] (db/select-field->field :key :value Setting)]
-           (when (encrypt/possibly-encrypted-string? value)
-             (println key value)
-             (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
-           (jdbc/update! t-conn
-                         :setting
-                         {:value (encrypt-fn value)}
-                         ["setting.key = ?" key]))
-         (doseq [[id details] (db/select-id->field :details Database)]
-           (jdbc/update! t-conn
-                         :metabase_database
-                         {:details (encrypt-fn (json/encode details))}
-                         ["metabase_database.id = ?" id])
-           (when (encrypt/possibly-encrypted-string? details)
-             (println id details)
-             (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))))
-       true)
-     ;; (catch  e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")))
-     (catch Throwable e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data"))))))
+  [to-key]
+  (mdb/setup-db!)
+  (try
+    (let [encrypt-fn (if to-key
+                       (partial encrypt/maybe-encrypt
+                                (encrypt/validate-and-hash-secret-key to-key))
+                       identity)]
+      (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
+        (doseq [[key value] (db/select-field->field :key :value Setting)]
+          (when (encrypt/possibly-encrypted-string? value)
+            (println key value)
+            (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
+          (jdbc/update! t-conn
+                        :setting
+                        {:value (encrypt-fn value)}
+                        ["setting.key = ?" key]))
+        (doseq [[id details] (db/select-id->field :details Database)]
+          (jdbc/update! t-conn
+                        :metabase_database
+                        {:details (encrypt-fn (json/encode details))}
+                        ["metabase_database.id = ?" id])
+          (when (encrypt/possibly-encrypted-string? details)
+            (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))))
+      true)
+    ;; (catch  e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")))
+    (catch Throwable e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")))))

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -1,0 +1,31 @@
+(ns metabase.cmd.rotate-encryption-key
+  (:require [cheshire.core :as json]
+            [clojure.java.jdbc :as jdbc]
+            [environ.core :as env]
+            [metabase.db :as mdb]
+            [metabase.db.connection :as mdb.conn]
+            [metabase.models :refer [Database Setting]]
+            [metabase.util.encryption :as encrypt]
+            [toucan.db :as db]))
+
+(defn rotate-keys!
+  "Rotate the current configured db using the current MB_ENCRYPTION_SECRET_KEY env var and `to-key` argument."
+  [to-key]
+  ;; (mdb/setup-db!)
+  (let [hashed-key (encrypt/secret-key->hash to-key)]
+    (try
+      (db/transaction
+       (doseq [[key value] (db/select-field->field :key :value Setting)]
+         (when (encrypt/possibly-encrypted-string? value)
+           (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
+         (jdbc/update! (mdb.conn/jdbc-spec)
+                       :setting
+                       {:value (encrypt/maybe-encrypt hashed-key value)}
+                       ["key = ?" key]))
+       (doseq [[id details] (db/select-id->field :details Database)]
+         (jdbc/update! (mdb.conn/jdbc-spec)
+                       :metabase_database
+                       {:details (encrypt/maybe-encrypt hashed-key (json/encode details))}
+                       ["id = ?" id])))
+      true
+      (catch Throwable e nil))))

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -1,7 +1,6 @@
 (ns metabase.cmd.rotate-encryption-key
   (:require [cheshire.core :as json]
             [clojure.java.jdbc :as jdbc]
-            [environ.core :as env]
             [metabase.db :as mdb]
             [metabase.db.connection :as mdb.conn]
             [metabase.models :refer [Database Setting]]
@@ -10,22 +9,28 @@
 
 (defn rotate-keys!
   "Rotate the current configured db using the current MB_ENCRYPTION_SECRET_KEY env var and `to-key` argument."
-  [to-key]
-  ;; (mdb/setup-db!)
-  (let [hashed-key (encrypt/secret-key->hash to-key)]
-    (try
-      (db/transaction
-       (doseq [[key value] (db/select-field->field :key :value Setting)]
-         (when (encrypt/possibly-encrypted-string? value)
-           (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
-         (jdbc/update! (mdb.conn/jdbc-spec)
-                       :setting
-                       {:value (encrypt/maybe-encrypt hashed-key value)}
-                       ["key = ?" key]))
-       (doseq [[id details] (db/select-id->field :details Database)]
-         (jdbc/update! (mdb.conn/jdbc-spec)
-                       :metabase_database
-                       {:details (encrypt/maybe-encrypt hashed-key (json/encode details))}
-                       ["id = ?" id])))
-      true
-      (catch Throwable e nil))))
+  ([] (rotate-keys! nil))
+  ([to-key]
+   (mdb/setup-db!)
+   (try
+     (let [encrypt-fn (if to-key
+                        (partial encrypt/maybe-encrypt
+                                 (encrypt/validate-and-hash-secret-key to-key))
+                        identity)]
+       (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
+         (doseq [[key value] (db/select-field->field :key :value Setting)]
+           (when (encrypt/possibly-encrypted-string? value)
+             (println value)
+             (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
+           (jdbc/update! t-conn
+                         :setting
+                         {:value (encrypt-fn value)}
+                         ["key = ?" key]))
+         (doseq [[id details] (db/select-id->field :details Database)]
+           (jdbc/update! t-conn
+                         :metabase_database
+                         {:details (encrypt-fn (json/encode details))}
+                         ["id = ?" id])))
+       true)
+     ;; (catch  e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")))
+     (catch Throwable e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data"))))))

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -20,7 +20,7 @@
        (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
          (doseq [[key value] (db/select-field->field :key :value Setting)]
            (when (encrypt/possibly-encrypted-string? value)
-             (println value)
+             (println key value)
              (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
            (jdbc/update! t-conn
                          :setting
@@ -30,7 +30,10 @@
            (jdbc/update! t-conn
                          :metabase_database
                          {:details (encrypt-fn (json/encode details))}
-                         ["id = ?" id])))
+                         ["id = ?" id])
+           (when (encrypt/possibly-encrypted-string? details)
+             (println id details)
+             (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))))
        true)
      ;; (catch  e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")))
      (catch Throwable e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data"))))))

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -25,12 +25,12 @@
            (jdbc/update! t-conn
                          :setting
                          {:value (encrypt-fn value)}
-                         ["key = ?" key]))
+                         ["setting.key = ?" key]))
          (doseq [[id details] (db/select-id->field :details Database)]
            (jdbc/update! t-conn
                          :metabase_database
                          {:details (encrypt-fn (json/encode details))}
-                         ["id = ?" id])
+                         ["metabase_database.id = ?" id])
            (when (encrypt/possibly-encrypted-string? details)
              (println id details)
              (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))))

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -7,7 +7,7 @@
             [metabase.util.encryption :as encrypt]
             [toucan.db :as db]))
 
-(defn rotate-keys!
+(defn rotate-encryption-key!
   "Rotate the current configured db using the current MB_ENCRYPTION_SECRET_KEY env var and `to-key` argument."
   [to-key]
   (mdb/setup-db!)
@@ -19,7 +19,6 @@
       (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
         (doseq [[key value] (db/select-field->field :key :value Setting)]
           (when (encrypt/possibly-encrypted-string? value)
-            (println key value)
             (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
           (jdbc/update! t-conn
                         :setting
@@ -33,5 +32,4 @@
           (when (encrypt/possibly-encrypted-string? details)
             (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))))
       true)
-    ;; (catch  e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")))
-    (catch Throwable e (do (println e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")))))
+    (catch Throwable e (println "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data"))))

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -11,25 +11,22 @@
   "Rotate the current configured db using the current MB_ENCRYPTION_SECRET_KEY env var and `to-key` argument."
   [to-key]
   (mdb/setup-db!)
-  (try
-    (let [encrypt-fn (if to-key
-                       (partial encrypt/maybe-encrypt
-                                (encrypt/validate-and-hash-secret-key to-key))
-                       identity)]
-      (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
-        (doseq [[key value] (db/select-field->field :key :value Setting)]
-          (when (encrypt/possibly-encrypted-string? value)
-            (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
-          (jdbc/update! t-conn
-                        :setting
-                        {:value (encrypt-fn value)}
-                        ["setting.key = ?" key]))
-        (doseq [[id details] (db/select-id->field :details Database)]
-          (jdbc/update! t-conn
-                        :metabase_database
-                        {:details (encrypt-fn (json/encode details))}
-                        ["metabase_database.id = ?" id])
-          (when (encrypt/possibly-encrypted-string? details)
-            (throw  (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))))
-      true)
-    (catch Throwable e (println "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data"))))
+  (let [encrypt-fn (if to-key
+                     (partial encrypt/maybe-encrypt
+                              (encrypt/validate-and-hash-secret-key to-key))
+                     identity)]
+    (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
+      (doseq [[key value] (db/select-field->field :key :value Setting)]
+        (when (encrypt/possibly-encrypted-string? value)
+          (throw (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))
+        (jdbc/update! t-conn
+                      :setting
+                      {:value (encrypt-fn value)}
+                      ["setting.key = ?" key]))
+      (doseq [[id details] (db/select-id->field :details Database)]
+        (jdbc/update! t-conn
+                      :metabase_database
+                      {:details (encrypt-fn (json/encode details))}
+                      ["metabase_database.id = ?" id])
+        (when (encrypt/possibly-encrypted-string? details)
+          (throw (Exception. "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt files")))))))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -55,7 +55,8 @@
 (u/strict-extend (class Setting)
   models/IModel
   (merge models/IModelDefaults
-         {:types (constantly {:value :encrypted-text})}))
+         {:types (constantly {:value :encrypted-text})
+          :primary-key (constantly :key)}))
 
 
 (def ^:private Type

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -78,7 +78,7 @@
 (def ^:private ^:const aes256-tag-length 32)
 (def ^:private ^:const aes256-block-size 16)
 
-(defn- possibly-encrypted-string?
+(defn possibly-encrypted-string?
   "Returns true if it's likely that `s` is an encrypted string. Specifically we need `s` to be a non-blank, base64
   encoded string of the correct length. The correct length is determined by the cipher's type tag and the cipher's
   block size (AES+CBC). To compute this, we need the number of bytes in the input, subtract the bytes used by the

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -20,14 +20,19 @@
                               :iterations 100000}) ; 100,000 iterations takes about ~160ms on my laptop
                  64))
 
+(defn validate-and-hash-secret-key
+  "Check the minimum length of the key and hash it for internal usage."
+  [^String secret-key]
+  (when-let [secret-key secret-key]
+    (when (seq secret-key)
+      (assert (>= (count secret-key) 16)
+              (str (trs "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters.")))
+      (secret-key->hash secret-key))))
+
 ;; apperently if you're not tagging in an arglist, `^bytes` will set the `:tag` metadata to `clojure.core/bytes` (ick)
 ;; so you have to do `^{:tag 'bytes}` instead
 (defonce ^:private ^{:tag 'bytes} default-secret-key
-  (when-let [secret-key (env/env :mb-encryption-secret-key)]
-    (when (seq secret-key)
-      (assert (>= (count secret-key) 16)
-        (str (trs "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters.")))
-      (secret-key->hash secret-key))))
+  (validate-and-hash-secret-key (env/env :mb-encryption-secret-key)))
 
 ;; log a nice message letting people know whether DB details encryption is enabled
 (when-not *compile-files*

--- a/test/metabase/cmd/dump_to_h2_test.clj
+++ b/test/metabase/cmd/dump_to_h2_test.clj
@@ -44,7 +44,7 @@
               (io/delete-file file))))))))
 
 (deftest cmd-dump-to-h2-returns-code-from-dump-test
-  (with-redefs [dump-to-h2/dump-to-h2! (constantly 1)
+  (with-redefs [dump-to-h2/dump-to-h2! #(throw "err")
                 cmd/system-exit! identity]
     (is (= 1 (cmd/dump-to-h2 "file1")))))
 

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -1,0 +1,77 @@
+(ns metabase.cmd.rotate-encryption-key-test
+  (:require [clojure.java.io :as io]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.test :refer :all]
+            [metabase.cmd.load-from-h2 :as load-from-h2]
+            [metabase.cmd.rotate-encryption-key :refer [rotate-keys!]]
+            [metabase.db.connection :as mdb.connection]
+            [metabase.db.spec :as db.spec]
+            [metabase.driver :as driver]
+            [metabase.models :refer [Database Setting]]
+            [metabase.test :as mt]
+            [metabase.test.data.interface :as tx]
+            [metabase.util.encryption-test :as eu]
+            [toucan.db :as db]))
+
+(defn- persistent-jdbcspec
+  "Return a jdbc spec for the specified `db-type` on the db `db-name`. In case of H2, makes the connection persistent
+  10secs to give us time to fetch the results later."
+  [db-type db-name]
+  (case db-type
+    :h2 {:subprotocol "h2"
+         :subname     (format "mem:%s;DB_CLOSE_DELAY=10" db-name)
+         :classname   "org.h2.Driver"}
+    :postgres (db.spec/postgres (tx/dbdef->connection-details :postgres :db {:database-name db-name}))
+    :mysql (db.spec/mysql (tx/dbdef->connection-details :mysql :db {:database-name db-name}))))
+
+(defn- abs-path
+  [path]
+  (.getAbsolutePath (io/file path)))
+
+(defn- raw-value [key]
+  (:value (first (jdbc/query mdb.connection/*jdbc-spec* "select value from setting where key LIKE '';"))))
+
+(deftest rotate-keys!-test
+  (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
+        db-name (str "test_" (mt/random-name))
+        [k1 k2 k3] ["89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
+                    "yHa/6VEQuIItMyd5CNcgV9nXvzZcX6bWmiY0oOh6pLU="
+                    "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
+    (mt/test-drivers #{:mysql :postgres :h2}
+      (binding [mdb.connection/*db-type*   driver/*driver*
+                mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)
+                db/*db-connection* (persistent-jdbcspec driver/*driver* db-name)
+                db/*quoting-style* driver/*driver*]
+        (when-not (= driver/*driver* :h2)
+          (tx/create-db! driver/*driver* {:database-name db-name}))
+        (load-from-h2/load-from-h2! h2-fixture-db-file)
+        (db/insert! Setting {:key "setting0", :value "val0"})
+        (eu/with-secret-key k1
+          (db/insert! Setting {:key "setting1", :value "val1"})
+          (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"}))
+
+        (testing "rotating with the same key is a noop"
+          (eu/with-secret-key k1
+            (is (rotate-keys! k1))
+            ;; plain->newkey
+            (is (not (= "val0" (raw-value "setting0"))))
+            (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"])))))
+            ;; oldkey->newkey
+            (is (not (= "val1" (raw-value "setting1"))))
+            (is (= "val1" (:value (first (db/select Setting :key [:= "setting1"])))))))
+
+        (testing "rotating with a new key is recoverable"
+          (eu/with-secret-key k1 (is (rotate-keys! k2)))
+          (eu/with-secret-key k2 (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))
+          (eu/with-secret-key k1
+            (is (not (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))))
+
+        (testing "full rollback when a field looks encrypted with a differnt key than the current one"
+          (eu/with-secret-key k3
+            (db/insert! Setting {:key "setting3", :value "val3"}))
+          (eu/with-secret-key k2
+            (db/insert! Setting {:key "setting4", :value "val4"})
+            (is (not (rotate-keys! k3))))
+          (eu/with-secret-key k3
+            (is (not (= "val4" (:value (first (db/select Setting :key [:= "setting4"]))))))
+            (is (= "val3" (:value (first (db/select Setting :key [:= "setting3"])))))))))))

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -33,52 +33,53 @@
                              ["select value from setting where setting.key=?;" key]))))
 
 (deftest rotate-keys!-test
-  (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
-        db-name (str "test_" (mt/random-name))
-        [k1 k2 k3] ["89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
-                    "yHa/6VEQuIItMyd5CNcgV9nXvzZcX6bWmiY0oOh6pLU="
-                    "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
-    (mt/test-drivers #{:mysql :postgres :h2}
-      (binding [mdb.connection/*db-type*   driver/*driver*
-                mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)
-                db/*db-connection* (persistent-jdbcspec driver/*driver* db-name)
-                db/*quoting-style* driver/*driver*]
-        (when-not (= driver/*driver* :h2)
-          (tx/create-db! driver/*driver* {:database-name db-name}))
-        (load-from-h2/load-from-h2! h2-fixture-db-file)
-        (db/insert! Setting {:key "setting0", :value "val0"})
-        (eu/with-secret-key k1
-          (db/insert! Setting {:key "setting1", :value "val1"})
-          (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"}))
-
-        (testing "rotating with the same key is a noop"
+  (eu/with-secret-key nil
+    (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
+          db-name (str "test_" (mt/random-name))
+          [k1 k2 k3] ["89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
+                      "yHa/6VEQuIItMyd5CNcgV9nXvzZcX6bWmiY0oOh6pLU="
+                      "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
+      (mt/test-drivers #{:mysql :postgres :h2}
+        (binding [mdb.connection/*db-type*   driver/*driver*
+                  mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)
+                  db/*db-connection* (persistent-jdbcspec driver/*driver* db-name)
+                  db/*quoting-style* driver/*driver*]
+          (when-not (= driver/*driver* :h2)
+            (tx/create-db! driver/*driver* {:database-name db-name}))
+          (load-from-h2/load-from-h2! h2-fixture-db-file)
+          (db/insert! Setting {:key "setting0", :value "val0"})
           (eu/with-secret-key k1
-            (is (rotate-keys! k1))
-            ;; plain->newkey
-            (is (not (= "val0" (raw-value "setting0"))))
-            (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"])))))
-            ;; oldkey->newkey
-            (is (not (= "val1" (raw-value "setting1"))))
-            (is (= "val1" (:value (first (db/select Setting :key [:= "setting1"])))))))
+            (db/insert! Setting {:key "setting1", :value "val1"})
+            (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"}))
 
-        (testing "rotating with a new key is recoverable"
-          (eu/with-secret-key k1 (is (rotate-keys! k2)))
-          (eu/with-secret-key k2 (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))
-          (eu/with-secret-key k1
-            (is (not (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))))
+          (testing "rotating with the same key is a noop"
+            (eu/with-secret-key k1
+              (is (rotate-keys! k1))
+              ;; plain->newkey
+              (is (not (= "val0" (raw-value "setting0"))))
+              (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"])))))
+              ;; oldkey->newkey
+              (is (not (= "val1" (raw-value "setting1"))))
+              (is (= "val1" (:value (first (db/select Setting :key [:= "setting1"])))))))
 
-        (testing "full rollback when a field looks encrypted with a different key than the current one"
-          (eu/with-secret-key k3
-            (db/insert! Setting {:key "setting3", :value "val3"}))
-          (eu/with-secret-key k2
-            (db/insert! Setting {:key "setting2", :value "val2"})
-            (is (not (rotate-keys! k3))))
-          (eu/with-secret-key k3
-            (is (not (= "val2" (:value (first (db/select Setting :key [:= "setting2"]))))))
-            (is (= "val3" (:value (first (db/select Setting :key [:= "setting3"])))))))
+          (testing "rotating with a new key is recoverable"
+            (eu/with-secret-key k1 (is (rotate-keys! k2)))
+            (eu/with-secret-key k2 (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))
+            (eu/with-secret-key k1
+              (is (not (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))))
 
-        (testing "rotate-keys! to nil decrypts the encrypted keys"
-          (db/delete! Setting :key "setting3")
-          (eu/with-secret-key k2
-            (is (rotate-keys! nil)))
-          (is (= "val0" (raw-value "setting0"))))))))
+          (testing "full rollback when a field looks encrypted with a different key than the current one"
+            (eu/with-secret-key k3
+              (db/insert! Setting {:key "setting3", :value "val3"}))
+            (eu/with-secret-key k2
+              (db/insert! Setting {:key "setting2", :value "val2"})
+              (is (not (rotate-keys! k3))))
+            (eu/with-secret-key k3
+              (is (not (= "val2" (:value (first (db/select Setting :key [:= "setting2"]))))))
+              (is (= "val3" (:value (first (db/select Setting :key [:= "setting3"])))))))
+
+          (testing "rotate-keys! to nil decrypts the encrypted keys"
+            (db/delete! Setting :key "setting3")
+            (eu/with-secret-key k2
+              (is (rotate-keys! nil)))
+            (is (= "val0" (raw-value "setting0")))))))))

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.cmd.rotate-encryption-key-test
   (:require [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.cmd.load-from-h2 :as load-from-h2]
             [metabase.cmd.rotate-encryption-key :refer [rotate-keys!]]
@@ -35,7 +36,7 @@
 (deftest rotate-keys!-test
   (eu/with-secret-key nil
     (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
-          db-name (str "test_" (mt/random-name))
+          db-name (str "test_" (str/lower-case (mt/random-name)))
           [k1 k2 k3] ["89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
                       "yHa/6VEQuIItMyd5CNcgV9nXvzZcX6bWmiY0oOh6pLU="
                       "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -30,7 +30,7 @@
 
 (defn- raw-value [key]
   (:value (first (jdbc/query mdb.connection/*jdbc-spec*
-                             ["select value from setting where key=?;" key]))))
+                             ["select value from setting where setting.key=?;" key]))))
 
 (deftest rotate-keys!-test
   (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -5,6 +5,7 @@
             [clojure.test :refer :all]
             [metabase.cmd.load-from-h2 :as load-from-h2]
             [metabase.cmd.rotate-encryption-key :refer [rotate-keys!]]
+            [metabase.db :as mdb]
             [metabase.db.connection :as mdb.connection]
             [metabase.db.spec :as db.spec]
             [metabase.driver :as driver]
@@ -34,53 +35,68 @@
                              ["select value from setting where setting.key=?;" key]))))
 
 (deftest rotate-keys!-test
+  ;; (mdb/setup-db!)
+  ;; (metabase.test.data.env/set-test-drivers! #{:mysql})
   (eu/with-secret-key nil
     (let [h2-fixture-db-file (abs-path "frontend/test/__runner__/test_db_fixture.db")
           db-name (str "test_" (str/lower-case (mt/random-name)))
           [k1 k2 k3] ["89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
                       "yHa/6VEQuIItMyd5CNcgV9nXvzZcX6bWmiY0oOh6pLU="
                       "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
-      (mt/test-drivers #{:mysql :postgres :h2}
-        (binding [mdb.connection/*db-type*   driver/*driver*
-                  mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)
-                  db/*db-connection* (persistent-jdbcspec driver/*driver* db-name)
-                  db/*quoting-style* driver/*driver*]
-          (when-not (= driver/*driver* :h2)
-            (tx/create-db! driver/*driver* {:database-name db-name}))
-          (load-from-h2/load-from-h2! h2-fixture-db-file)
-          (db/insert! Setting {:key "setting0", :value "val0"})
-          (eu/with-secret-key k1
-            (db/insert! Setting {:key "setting1", :value "val1"})
-            (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"}))
+      (mt/test-drivers #{:postgres :h2 :mysql}
+        (with-redefs [metabase.models.interface/cached-encrypted-json-out #'metabase.models.interface/encrypted-json-out]
+          (binding [mdb.connection/*db-type*   driver/*driver*
+                   mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)
+                   db/*db-connection* (persistent-jdbcspec driver/*driver* db-name)
+                   db/*quoting-style* driver/*driver*]
+           (when-not (= driver/*driver* :h2)
+             (tx/create-db! driver/*driver* {:database-name db-name}))
+           (load-from-h2/load-from-h2! h2-fixture-db-file)
+           (db/insert! Setting {:key "setting0", :value "val0"})
+           (eu/with-secret-key k1
+             (db/insert! Setting {:key "setting1", :value "val1"})
+             (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"}))
 
-          (testing "rotating with the same key is a noop"
-            (eu/with-secret-key k1
-              (is (rotate-keys! k1))
-              ;; plain->newkey
-              (is (not (= "val0" (raw-value "setting0"))))
-              (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"])))))
-              ;; oldkey->newkey
-              (is (not (= "val1" (raw-value "setting1"))))
-              (is (= "val1" (:value (first (db/select Setting :key [:= "setting1"])))))))
+           (testing "rotating with the same key is a noop"
+             (eu/with-secret-key k1
+               (is (rotate-keys! k1))
+               ;; plain->newkey
+               (is (not (= "val0" (raw-value "setting0"))))
+               (is (= "val0" (db/select-one-field :value Setting :key "setting0")))
+               ;; oldkey->newkey
+               (is (not (= "val1" (raw-value "setting1"))))
+               (is (= "val1" (db/select-one-field :value Setting :key "setting1")))))
 
-          (testing "rotating with a new key is recoverable"
-            (eu/with-secret-key k1 (is (rotate-keys! k2)))
-            (eu/with-secret-key k2 (is (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))
-            (eu/with-secret-key k1
-              (is (not (= "val0" (:value (first (db/select Setting :key [:= "setting0"]))))))))
+           (testing "rotating with a new key is recoverable"
+             (eu/with-secret-key k1 (is (rotate-keys! k2)))
+             (eu/with-secret-key k2
+               (is (= "val0" (db/select-one-field :value Setting :key "setting0")))
+               (is (= {:db "/tmp/test.db"} (db/select-one-field :details Database :id 1))))
+             (eu/with-secret-key k1
+               (is (not (= "val0" (db/select-one-field :value Setting :key "setting0"))))
+               (is (not (= "{\"db\":\"/tmp/test.db\"}" (db/select-one-field :details Database :id 1))))))
 
-          (testing "full rollback when a field looks encrypted with a different key than the current one"
-            (eu/with-secret-key k3
-              (db/insert! Setting {:key "setting3", :value "val3"}))
-            (eu/with-secret-key k2
-              (db/insert! Setting {:key "setting2", :value "val2"})
-              (is (not (rotate-keys! k3))))
-            (eu/with-secret-key k3
-              (is (not (= "val2" (:value (first (db/select Setting :key [:= "setting2"]))))))
-              (is (= "val3" (:value (first (db/select Setting :key [:= "setting3"])))))))
+           (testing "full rollback when a setting looks encrypted with a different key than the current one"
+             (eu/with-secret-key k3
+               (db/insert! Setting {:key "setting3", :value "val3"}))
+             (eu/with-secret-key k2
+               (db/insert! Setting {:key "setting2", :value "val2"})
+               (is (not (rotate-keys! k3))))
+             (eu/with-secret-key k3
+               (is (not (= "val2" (:value (first (db/select Setting :key [:= "setting2"]))))))
+               (is (= "val3" (:value (first (db/select Setting :key [:= "setting3"])))))))
 
-          (testing "rotate-keys! to nil decrypts the encrypted keys"
-            (db/delete! Setting :key "setting3")
-            (eu/with-secret-key k2
-              (is (rotate-keys! nil)))
-            (is (= "val0" (raw-value "setting0")))))))))
+           (testing "full rollback when a database looks encrypted with a different key than the current one"
+             (eu/with-secret-key k3
+               (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"}))
+             (eu/with-secret-key k2
+               (is (not (rotate-keys! k3))))
+             (eu/with-secret-key k3
+               (is (= {:db "/tmp/test.db"} (db/select-one-field :details Database :id 1)))))
+
+           (testing "rotate-keys! to nil decrypts the encrypted keys"
+             (db/delete! Setting :key "setting3")
+             (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"})
+             (eu/with-secret-key k2
+               (is (rotate-keys! nil)))
+             (is (= "val0" (raw-value "setting0"))))))))))


### PR DESCRIPTION
This PR adds `rotate-encryption-key` command line to decrypt and reencrypt data with a new key.

The command is intended to be used on a stopped mb instance. After the command succeeds, metabase should be restarted with the new `MB_ENCRYPTION_SECRET_KEY`.

We don't allow to rotate to an empty key from the cli, although this functionality is used internally by `dump-to-h2 --dump-plaintext`.

TODO:
- [x] make sure dump-to-h2 --dump-plaintext notifies differently when it succeeds and when it doesn't 