### PR TITLE
Don't save site url on general settings page load

### DIFF
--- a/frontend/src/metabase/components/InputWithSelectPrefix.jsx
+++ b/frontend/src/metabase/components/InputWithSelectPrefix.jsx
@@ -18,37 +18,38 @@ type State = {
   rest: string,
 };
 
+function splitValue({
+  value,
+  prefixes,
+  defaultPrefix,
+  caseInsensitivePrefix = false,
+}) {
+  const prefix = prefixes.find(
+    caseInsensitivePrefix
+      ? p => value.toLowerCase().startsWith(p.toLowerCase())
+      : p => value.startsWith(p),
+  );
+
+  return prefix ? [prefix, value.slice(prefix.length)] : [defaultPrefix, value];
+}
+
 export default class InputWithSelectPrefix extends Component {
   props: Props;
   state: State;
 
   constructor(props: Props) {
     super(props);
-    this.state = { prefix: "", rest: "" };
-  }
 
-  componentDidMount() {
-    this.setPrefixAndRestFromValue();
+    const [prefix, rest] = splitValue(props);
+    this.state = { prefix, rest };
   }
 
   setPrefixAndRestFromValue() {
-    const {
-      value,
-      prefixes,
-      defaultPrefix,
-      caseInsensitivePrefix = false,
-    } = this.props;
+    const { value } = this.props;
+
     if (value) {
-      const prefix = prefixes.find(
-        caseInsensitivePrefix
-          ? p => value.toLowerCase().startsWith(p.toLowerCase())
-          : p => value.startsWith(p),
-      );
-      this.setState(
-        prefix
-          ? { prefix, rest: value.slice(prefix.length) }
-          : { prefix: defaultPrefix, rest: value },
-      );
+      const [prefix, rest] = splitValue(this.props);
+      this.setState({ prefix, rest });
     }
   }
 

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -36,15 +36,13 @@ describe("scenarios > admin > settings", () => {
       .type("foo", { delay: 100 })
       .blur();
 
-    cy.wait("@url")
-      .wait("@url") // cy.wait("@url.2") doesn't work for some reason
-      .should(xhr => {
-        expect(xhr.status).to.eq(500);
-        // Switching to regex match for assertions - the test was flaky because of the "typing" issue
-        // i.e. it sometimes doesn't type the whole string "foo", but only "oo".
-        // We only care that the `cause` is starting with "Invalid site URL"
-        expect(xhr.response.body.cause).to.match(/^Invalid site URL/);
-      });
+    cy.wait("@url").should(xhr => {
+      expect(xhr.status).to.eq(500);
+      // Switching to regex match for assertions - the test was flaky because of the "typing" issue
+      // i.e. it sometimes doesn't type the whole string "foo", but only "oo".
+      // We only care that the `cause` is starting with "Invalid site URL"
+      expect(xhr.response.body.cause).to.match(/^Invalid site URL/);
+    });
 
     // NOTE: This test is not concerned with HOW we style the error message - only that there is one.
     //       If we update UI in the future (for example: we show an error within a popup/modal), the test in current form could fail.


### PR DESCRIPTION
Fixes #13061 

**Description**
The site url input triggers a save of the form on page load when you navigate to `/admin/settings/general`.

We were calling `setState` in the `componentDidMount` method of the `InputWithSelectPrefix` component, triggering an unnecessary `componentDidUpdate` call. Fixed by setting the initial `prefix`/`rest` state values in the component constructor.

**Verification**
You can verify the fix by checking for an `/api/setting/site-url` PUT when the user navigates to the `/admin/settings/general` route. Can also verify by checking for the "Saved" indicator in the top right corner of the page. 
There's no usage of `InputWithSelectPrefix` outside of this input and the input still triggers a save on blur event.