### PR TITLE
When logging db, actually need to select name and engine

### DIFF
--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -72,8 +72,10 @@
              existing-engine          :engine
              existing-name            :name} (db/select-one [Database
                                                              :metadata_sync_schedule
-                                                             :cache_field_values_schedule]
-                                               :id (u/the-id database))
+                                                             :cache_field_values_schedule
+                                                             :engine
+                                                             :name]
+                                                            :id (u/the-id database))
             ;; if one of the schedules wasn't passed continue using the old one
             new-metadata-schedule            (or new-metadata-schedule old-metadata-schedule)
             new-fieldvalues-schedule         (or new-fieldvalues-schedule old-fieldvalues-schedule)]


### PR DESCRIPTION
had destructured them for logging but forgot to actually select them

this is in models.database to log when the sync schedules change. We originally assumed engine and name came in the update but this isn't a reliable assumption. There was already a db call to get the old values for comparison and logging of sync schedules, so just grab those values from the db rather than expect them to come in.