### PR TITLE
Add autofocus to username input

### DIFF
--- a/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
+++ b/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
@@ -36,6 +36,7 @@ export default class LdapAndEmailForm extends Component {
               }
               placeholder={t`youlooknicetoday@email.com`}
               validate={ldapEnabled ? validate.required() : validate.email()}
+              autoFocus
             />
             <FormField
               name="password"

--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -2,13 +2,20 @@ import React from "react";
 
 import { formDomOnlyProps } from "metabase/lib/redux";
 
-const FormInputWidget = ({ type = "text", placeholder, field, readOnly }) => (
+const FormInputWidget = ({
+  type = "text",
+  placeholder,
+  field,
+  readOnly,
+  autoFocus,
+}) => (
   <input
     className="Form-input full"
     type={type}
     placeholder={placeholder}
     aria-labelledby={`${field.name}-label`}
     readOnly={readOnly}
+    autoFocus={autoFocus}
     {...formDomOnlyProps(field)}
   />
 );

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -31,7 +31,9 @@ describe("scenarios > auth > signin", () => {
 
   it("should greet users after successful login", () => {
     cy.visit("/auth/login");
-    cy.findByLabelText("Email address").type(USERS.admin.username);
+    cy.findByLabelText("Email address")
+      .should("be.focused")
+      .type(USERS.admin.username);
     cy.findByLabelText("Password").type(USERS.admin.password);
     cy.findByText("Sign in").click();
     cy.contains(/[a-z ]+, Bob/i);


### PR DESCRIPTION
Resolves #14505 

**Description**
Visiting `/auth/login` should autofocus the username input

**Verification**
1. Visit the login route while logged out -- `/auth/login` -- on a metabase instance with email/password signin.
2. See that the username input field has focus and the user can immediately type

<img width="437" alt="Screen Shot 2021-01-28 at 2 04 35 PM" src="https://user-images.githubusercontent.com/13057258/106204776-5b3fb580-6172-11eb-81b5-8c4159b100b7.png">

