### PR TITLE
Include cards' SQL queries when searching

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -18,34 +18,19 @@
             [metabase.models.pulse :refer [Pulse]]
             [metabase.models.segment :refer [Segment]]
             [metabase.models.table :refer [Table]]
-            [metabase.search :as search]
+            [metabase.search.config :refer :all]
+            [metabase.search.scoring :as scoring]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
 
-(def ^:private ^:const search-max-results
-  "Absolute maximum number of search results to return. This number is in place to prevent massive application DB load
-  by returning tons of results; this number should probably be adjusted downward once we have UI in place to indicate
-  that results are truncated."
-  1000)
-
 (def ^:private SearchContext
   "Map with the various allowed search parameters, used to construct the SQL query"
   {:search-string      (s/maybe su/NonBlankString)
    :archived?          s/Bool
    :current-user-perms #{perms/UserPath}})
-
-(def ^:private searchable-models
-  "Models that can be searched. Results also come back in this order (i.e., all matching Cards, followed by all matching
-  Dashboards, etc.)"
-  [Card Dashboard Pulse Collection Segment Metric Table])
-
-(def ^:private model->sort-position
-  (into {} (map-indexed (fn [i model]
-                          [(str/lower-case (name model)) i])
-                        searchable-models)))
 
 (def ^:private SearchableModel
   (apply s/enum searchable-models))
@@ -87,71 +72,14 @@
    ;; returned for Card and Dashboard
    :collection_position :integer
    :favorite            :boolean
+   ;; returned for Card only
+   :dataset_query       :text
    ;; returned for Metric and Segment
    :table_id            :integer
    :database_id         :integer
    :table_schema        :text
    :table_name          :text
    :table_description   :text))
-
-;; below are the actual columns returned for any given entity
-
-(def ^:private default-columns
-  "Columns returned for all models."
-  [:id :name :description :archived])
-
-(def ^:private favorite-col
-  "Case statement to return boolean values of `:favorite` for Card and Dashboard."
-  [(hsql/call :case [:not= :fave.id nil] true :else false) :favorite])
-
-(def ^:private table-columns
-  "Columns containing information about the Table this model references. Returned for Metrics and Segments."
-  [:table_id
-   [:table.db_id       :database_id]
-   [:table.schema      :table_schema]
-   [:table.name        :table_name]
-   [:table.description :table_description]])
-
-(defmulti ^:private columns-for-model
-  "The columns that will be returned by the query for `model`, excluding `:model`, which is added automatically."
-  {:arglists '([model])}
-  class)
-
-(defmethod columns-for-model (class Card)
-  [_]
-  (conj default-columns :collection_id :collection_position [:collection.name :collection_name] favorite-col))
-
-(defmethod columns-for-model (class Dashboard)
-  [_]
-  (conj default-columns :collection_id :collection_position [:collection.name :collection_name] favorite-col))
-
-(defmethod columns-for-model (class Pulse)
-  [_]
-  [:id :name :collection_id [:collection.name :collection_name]])
-
-(defmethod columns-for-model (class Collection)
-  [_]
-  (conj default-columns [:id :collection_id] [:name :collection_name]))
-
-(defmethod columns-for-model (class Segment)
-  [_]
-  (into default-columns table-columns))
-
-(defmethod columns-for-model (class Metric)
-  [_]
-  (into default-columns table-columns))
-
-(defmethod columns-for-model (class Table)
-  [_]
-  [:id
-   :name
-   :display_name
-   :description
-   [:id :table_id]
-   [:db_id :database_id]
-   [:schema :table_schema]
-   [:name :table_name]
-   [:description :table_description]])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Shared Query Logic                                               |
@@ -235,7 +163,7 @@
   (when query
     (into [:or]
           (for [column searchable-columns
-                token (search/tokenize (search/normalize query))]
+                token (scoring/tokenize (scoring/normalize query))]
             [:like
              (hsql/call :lower column)
              (str "%" token "%")]))))
@@ -245,7 +173,7 @@
   (let [archived-clause (archived-where-clause model archived?)
         search-clause   (search-string-clause search-string
                                               (map (partial hsql/qualify (model->alias model))
-                                                   (search/searchable-columns-for-model model)))]
+                                                   (searchable-columns-for-model model)))]
     (if search-clause
       [:and archived-clause search-clause]
       archived-clause)))
@@ -380,17 +308,14 @@
                                      query)}
           _            (log/tracef "Searching with query:\n%s" (u/pprint-to-str search-query))
           results      (db/query search-query :max-rows search-max-results)]
-      ;; sort by [score model name]
-      (sort-by (juxt
-                (comp - (partial search/score (:search-string search-ctx)))
-                (comp model->sort-position :model)
-                :name)
-               (for [row results
-                     :when (check-permissions-for-model row)]
-                 ;; MySQL returns `:favorite` and `:archived` as `1` or `0` so convert those to boolean as needed
-                 (-> row
-                     (update :favorite bit->boolean)
-                     (update :archived bit->boolean)))))))
+      (scoring/sort-results
+       (:search-string search-ctx)
+       (for [row results
+             :when (check-permissions-for-model row)]
+         ;; MySQL returns `:favorite` and `:archived` as `1` or `0` so convert those to boolean as needed
+         (-> row
+             (update :favorite bit->boolean)
+             (update :archived bit->boolean)))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -1,0 +1,119 @@
+(ns metabase.search.config
+  (:require [cheshire.core :as json]
+            [clojure.string :as str]
+            [honeysql.core :as hsql]
+            [metabase.models :refer :all]))
+
+(def ^:const search-max-results
+  "Absolute maximum number of search results to return. This number is in place to prevent massive application DB load
+  by returning tons of results; this number should probably be adjusted downward once we have UI in place to indicate
+  that results are truncated."
+  1000)
+
+(def searchable-models
+  "Models that can be searched. The order of this list also influences the order of the results."
+  [Card Dashboard Pulse Collection Segment Metric Table])
+
+(defn model-name->class
+  "Given a model name as a string, return its Class."
+  [model-name]
+  (Class/forName (format "metabase.models.%s.%sInstance" model-name (str/capitalize model-name))))
+
+(defn- ->class
+  [class-or-instance]
+  (if (class? class-or-instance)
+    class-or-instance
+    (class class-or-instance)))
+
+(defmulti searchable-columns-for-model
+  "The columns that will be searched for the query."
+  {:arglists '([model])}
+  ->class)
+
+(defmethod searchable-columns-for-model :default
+  [x]
+  [:name])
+
+(defmethod searchable-columns-for-model (class Card)
+  [_]
+  [:name
+   :dataset_query])
+
+(defmethod searchable-columns-for-model (class Table)
+  [_]
+  [:name
+   :display_name])
+
+(def ^:private default-columns
+  "Columns returned for all models."
+  [:id :name :description :archived])
+
+(def ^:private favorite-col
+  "Case statement to return boolean values of `:favorite` for Card and Dashboard."
+  [(hsql/call :case [:not= :fave.id nil] true :else false) :favorite])
+
+(def ^:private table-columns
+  "Columns containing information about the Table this model references. Returned for Metrics and Segments."
+  [:table_id
+   [:table.db_id       :database_id]
+   [:table.schema      :table_schema]
+   [:table.name        :table_name]
+   [:table.description :table_description]])
+
+(defmulti columns-for-model
+  "The columns that will be returned by the query for `model`, excluding `:model`, which is added automatically."
+  {:arglists '([model])}
+  ->class)
+
+(defmethod columns-for-model (class Card)
+  [_]
+  (conj default-columns :collection_id :collection_position [:collection.name :collection_name] :dataset_query
+        favorite-col))
+
+(defmethod columns-for-model (class Dashboard)
+  [_]
+  (conj default-columns :collection_id :collection_position [:collection.name :collection_name] favorite-col))
+
+(defmethod columns-for-model (class Pulse)
+  [_]
+  [:id :name :collection_id [:collection.name :collection_name]])
+
+(defmethod columns-for-model (class Collection)
+  [_]
+  (conj default-columns [:id :collection_id] [:name :collection_name]))
+
+(defmethod columns-for-model (class Segment)
+  [_]
+  (into default-columns table-columns))
+
+(defmethod columns-for-model (class Metric)
+  [_]
+  (into default-columns table-columns))
+
+(defmethod columns-for-model (class Table)
+  [_]
+  [:id
+   :name
+   :display_name
+   :description
+   [:id :table_id]
+   [:db_id :database_id]
+   [:schema :table_schema]
+   [:name :table_name]
+   [:description :table_description]])
+
+(defmulti column->string
+  "Turn a complex column into a string"
+  (fn [_column-value model column-name]
+    [(keyword model) column-name]))
+
+(defmethod column->string :default
+  [value _ _]
+  value)
+
+(defmethod column->string [:card :dataset_query]
+  [value _ _]
+  (let [query (json/parse-string value true)]
+    (if (= "native" (:type query))
+      (-> query :native :query)
+      "")))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -4,11 +4,15 @@
             [honeysql.core :as hsql]
             [metabase.models :refer [Card Collection Dashboard Metric Pulse Segment Table]]))
 
-(def ^:const search-max-results
-  "Absolute maximum number of search results to return. This number is in place to prevent massive application DB load
-  by returning tons of results; this number should probably be adjusted downward once we have UI in place to indicate
+(def ^:const db-max-results
+  "Number of raw results to fetch from the database. This number is in place to prevent massive application DB load by
+  returning tons of results; this number should probably be adjusted downward once we have UI in place to indicate
   that results are truncated."
   1000)
+
+(def ^:const max-filtered-results
+  "Number of results to return in an API response"
+  50)
 
 (def searchable-models
   "Models that can be searched. The order of this list also influences the order of the results."

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -2,7 +2,7 @@
   (:require [cheshire.core :as json]
             [clojure.string :as str]
             [honeysql.core :as hsql]
-            [metabase.models :refer :all]))
+            [metabase.models :refer [Card Collection Dashboard Metric Pulse Segment Table]]))
 
 (def ^:const search-max-results
   "Absolute maximum number of search results to return. This number is in place to prevent massive application DB load
@@ -31,7 +31,7 @@
   ->class)
 
 (defmethod searchable-columns-for-model :default
-  [x]
+  [_]
   [:name])
 
 (defmethod searchable-columns-for-model (class Card)

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -1,7 +1,6 @@
 (ns metabase.search.scoring
   (:require [clojure.core.memoize :as memoize]
             [clojure.string :as str]
-            [metabase.models :refer :all]
             [metabase.search.config :refer :all]
             [schema.core :as s]))
 
@@ -61,14 +60,19 @@
 
 (defn- score-with
   [scoring-fns tokens result]
-  (apply max-key :score
-         (for [column (searchable-columns-for-model (model-name->class (:model result)))
-               :let [target (-> result
-                                  (get column)
-                                  (column->string (:model result) column))]]
-           {:score  (reduce + (score-ratios tokens (-> target normalize tokenize) scoring-fns))
-            :match  target
-            :column column})))
+  (let [scores (for [column (searchable-columns-for-model (model-name->class (:model result)))
+                     :let   [target (-> result
+                                        (get column)
+                                        (column->string (:model result) column))
+                             score (reduce + (score-ratios tokens
+                                                           (-> target normalize tokenize)
+                                                           scoring-fns))]
+                     :when (> score 0)]
+                 {:score  score
+                  :match  target
+                  :column column})]
+    (when (seq scores)
+      (apply max-key :score scores))))
 
 (def ^:private consecutivity-scorer
   (partial largest-common-subseq-length matches?))
@@ -101,18 +105,18 @@
 
 (defn- score-with-match
   [query-string result]
-  (if (seq query-string)
+  (when (seq query-string)
     (score-with match-based-scorers
                 (tokenize (normalize query-string))
-                result)
-    {:score 0}))
+                result)))
 
 (defn sort-results
   "Sorts the given results based on internal scoring. Returns them in order, with `:matched_column` and
   `matched_text` injected in"
   [query-string results]
   (let [scores-and-results (for [result results
-                                 :let [{:keys [score column match]} (score-with-match query-string result)]]
+                                 :let [{:keys [score column match] :as hit} (score-with-match query-string result)]
+                                 :when hit]
                              [[(- score)
                                (model->sort-position (:model result))
                                (:name result)]

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -1,7 +1,7 @@
 (ns metabase.search.scoring
   (:require [clojure.core.memoize :as memoize]
             [clojure.string :as str]
-            [metabase.search.config :refer :all]
+            [metabase.search.config :as search-config]
             [schema.core :as s]))
 
 ;;; Utility functions
@@ -60,10 +60,10 @@
 
 (defn- score-with
   [scoring-fns tokens result]
-  (let [scores (for [column (searchable-columns-for-model (model-name->class (:model result)))
+  (let [scores (for [column (search-config/searchable-columns-for-model (search-config/model-name->class (:model result)))
                      :let   [target (-> result
                                         (get column)
-                                        (column->string (:model result) column))
+                                        (search-config/column->string (:model result) column))
                              score (reduce + (score-ratios tokens
                                                            (-> target normalize tokenize)
                                                            scoring-fns))]
@@ -101,7 +101,7 @@
 (def ^:private model->sort-position
   (into {} (map-indexed (fn [i model]
                           [(str/lower-case (name model)) i])
-                        searchable-models)))
+                        search-config/searchable-models)))
 
 (defn- score-with-match
   [query-string result]

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -87,7 +87,7 @@
         coll-data-map (fn [instance-name collection]
                         (merge (data-map instance-name)
                                (when-not in-root-collection?
-                                 {:collection_id (u/get-id collection)})))]
+                                 {:collection_id (u/the-id collection)})))]
     (mt/with-temp* [Collection [coll      (data-map "collection %s collection")]
                     Card       [card      (coll-data-map "card %s card" coll)]
                     Dashboard  [dashboard (coll-data-map "dashboard %s dashboard" coll)]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -1,6 +1,6 @@
-(ns metabase.search-test
+(ns metabase.search.scoring-test
   (:require [clojure.test :refer :all]
-            [metabase.search :as search]))
+            [metabase.search.scoring :as search]))
 
 (defn- result-row
   ([name]
@@ -22,8 +22,13 @@
     (is (thrown-with-msg? Exception #"does not match schema"
                           (search/tokenize nil)))))
 
+(defn scorer->score
+  [scorer]
+  (comp :score
+        (partial #'search/score-with [scorer])))
+
 (deftest consecutivity-scorer-test
-  (let [score (partial #'search/score-with [#'search/consecutivity-scorer])]
+  (let [score (scorer->score #'search/consecutivity-scorer)]
     (testing "partial matches"
       (is (= 1/3
              (score ["rasta" "el" "tucan"]
@@ -53,7 +58,7 @@
                     (result-row "")))))))
 
 (deftest total-occurrences-scorer-test
-  (let [score (partial #'search/score-with [#'search/total-occurrences-scorer])]
+  (let [score (scorer->score #'search/total-occurrences-scorer)]
     (testing "partial matches"
       (is (= 1/3
              (score ["rasta" "el" "tucan"]
@@ -83,7 +88,7 @@
                     (result-row "")))))))
 
 (deftest exact-match-scorer-test
-  (let [score (partial #'search/score-with [#'search/exact-match-scorer])]
+  (let [score (scorer->score #'search/exact-match-scorer)]
     (is (= 0
            (score ["rasta" "the" "toucan"]
                   (result-row "Crowberto el tucan"))))

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -50,12 +50,12 @@
              (score ["rasta"]
                     (result-row "Rasta")))))
     (testing "misses"
-      (is (= 0
-             (score ["rasta"]
-                    (result-row "just a straight-up imposter")))
-          (= 0
-             (score ["rasta" "the" "toucan"]
-                    (result-row "")))))))
+      (is (nil?
+           (score ["rasta"]
+                  (result-row "just a straight-up imposter")))
+          (nil?
+           (score ["rasta" "the" "toucan"]
+                  (result-row "")))))))
 
 (deftest total-occurrences-scorer-test
   (let [score (scorer->score #'search/total-occurrences-scorer)]
@@ -80,18 +80,18 @@
              (score ["rasta" "the" "toucan"]
                     (result-row "Rasta may be my favorite of the toucans")))))
     (testing "misses"
-      (is (= 0
-             (score ["rasta"]
-                    (result-row "just a straight-up imposter"))))
-      (is (= 0
-             (score ["rasta" "the" "toucan"]
-                    (result-row "")))))))
+      (is (nil?
+           (score ["rasta"]
+                  (result-row "just a straight-up imposter"))))
+      (is (nil?
+           (score ["rasta" "the" "toucan"]
+                  (result-row "")))))))
 
 (deftest exact-match-scorer-test
   (let [score (scorer->score #'search/exact-match-scorer)]
-    (is (= 0
-           (score ["rasta" "the" "toucan"]
-                  (result-row "Crowberto el tucan"))))
+    (is (nil?
+         (score ["rasta" "the" "toucan"]
+                (result-row "Crowberto el tucan"))))
     (is (= 1/3
            (score ["rasta" "the" "toucan"]
                   (result-row "Rasta el tucan"))))


### PR DESCRIPTION
[Fixes #4227] by searching a `Card`'s native SQL query. This was a Trojan horse of a feature that also required:

* Providing better match information to the frontend (the `matched_column` and `matched_text` keys), which will be used to display the results differently depending on the match

* Logic to only search parts of a column (we don't want to search all of `dataset_query`, just the native query part)

* Logic to only return results whose search score is greater than 0. The base architecture here is that we use SQL to get a very wide set of results and then score and sort them in Clojure. With the above changes, the results could be _too_ wide, so now we pare them down.

* Recognizing that `api/search.clj` was doing _a lot_ and that we should start organizing the code better. There's still more moving around to do, but this seems like a good first stab.

* Fixing a ton of tests to add the new keys to the results :expressionless: 