### PR TITLE
#13785 Repro: Clicking on a bar graph that represents a date range chooses only the start of the range

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -499,8 +499,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
         cy.wait("@cardQuery.2");
         cy.url().should("include", "2017-08-01~2017-08-31");
-        // For this to work, binning would have to change to "group by day"
-        cy.get(".bar").should("have.length", 9);
+        cy.get(".bar").should("have.length", 1);
+        // Since hover doesn't work in Cypress we can't assert on the popover that's shown when one hovers the bar
+        // But when this issue gets fixed, Y-axis should definitely show "12" (total count of reviews)
+        cy.get(".axis.y").contains("12");
       });
     });
   });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13785 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Filter did not update, and the graph is showing only one day (only the first day of the month)* 
![image](https://user-images.githubusercontent.com/31325167/106492181-ef35b800-64b7-11eb-842b-1e67b655cc54.png)

*_If month doesn't have any value at the first of the month, the visualization returns "No results"_

2. Sanity check: Let's skip the filter for now and assert on y-axis for local testing purposes only. Test still correctly fails:
![image](https://user-images.githubusercontent.com/31325167/106492356-2015ed00-64b8-11eb-8154-cafbf81daa8a.png)


