### PR TITLE
Update values and fix failing Cypress tests on `master`

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -129,7 +129,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
         .click();
 
       // confirm that the preview updated
-      cy.contains("Result: 18703");
+      cy.contains("Result: 18758");
 
       // update name and description, set a revision note, and save the update
       cy.get('[name="name"]').type("{selectall}orders > 10");

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -164,7 +164,7 @@ describe("scenarios > admin > datamodel > segments", () => {
         .click();
 
       // confirm that the preview updated
-      cy.contains("18703 rows");
+      cy.contains("18758 rows");
 
       // update name and description, set a revision note, and save the update
       cy.get('[name="name"]')

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -233,7 +233,7 @@ describe("scenarios > question > new", () => {
         cy.findByText("Done").click();
       });
       cy.findByText("Visualize").click();
-      cy.findByText("604.96");
+      cy.findByText("318.7");
     });
 
     it.skip("should keep manually entered parenthesis intact (metabase#13306)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -65,7 +65,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
 
       it("should result in a correct query result", () => {
         cy.location("pathname").should("eq", `/question/${Q2.id}`);
-        cy.findByText("5,995");
+        cy.findByText("5,755");
       });
     });
 

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -81,7 +81,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("Source is Affiliate");
     cy.findByText("Category is Doohickey");
     // data loads
-    cy.findByText("45.08");
+    cy.findByText("45.04");
   });
 
   it("should allow drill through on left/top header values", () => {
@@ -346,13 +346,13 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     // sort descending
     cy.get(".Icon-arrow_down").click();
-    cy.findByText("300 – 302.5");
-    cy.findByText("2.5 – 5").should("not.exist");
+    cy.findByText("158 – 160");
+    cy.findByText("8 – 10").should("not.exist");
 
     // sort ascending
     cy.get(".Icon-arrow_up").click();
-    cy.findByText("2.5 – 5");
-    cy.findByText("300 – 302.5").should("not.exist");
+    cy.findByText("8 – 10");
+    cy.findByText("158 – 160").should("not.exist");
   });
 
   it("should display an error message for native queries", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR acoomplish?
- Updates the values in Cypress tests according to the changes introduced in 595594357796c0b03669cc938716108d4a5656a4

### Additional notes:
- Caching mechanism prevented us from catching this failure prior to merging #14513 
- Failures started appearing in 6b1b4a1eb5980748db79d0f16a8a66bc3caffcac
- Example of failing tests in CI:
    - [CircleCi dashboard](https://dashboard.cypress.io/projects/a394u1/runs/4368/test-results?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D&utm_source=github)