### PR TITLE
Handle long body cells in pivot table

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -555,19 +555,18 @@ function Cell({
         ...style,
         ...(isSubtotal ? { backgroundColor: PIVOT_BG_DARK } : {}),
       }}
-      className={cx("flex-full flex-basis-none", className, {
-        "text-bold": isSubtotal,
-        "cursor-pointer": onClick,
-      })}
+      className={cx(
+        "shrink-below-content-size flex-full flex-basis-none",
+        className,
+        {
+          "text-bold": isSubtotal,
+          "cursor-pointer": onClick,
+        },
+      )}
       onClick={onClick}
     >
       <div className={cx("px1 flex align-center", { "justify-end": isBody })}>
-        {isBody ? (
-          // Ellipsified isn't really needed for body cells. Avoiding it helps performance.
-          value
-        ) : (
-          <Ellipsified>{value}</Ellipsified>
-        )}
+        <Ellipsified>{value}</Ellipsified>
         {icon && <div className="pl1">{icon}</div>}
       </div>
     </div>


### PR DESCRIPTION
Fixes #14574

I had set the flex-basis to 0 so adjacent cells with unequal contents would grow evenly. That breaks down when the content exceeds the size of the cell since flex-shrink was also set to 0.

I also added `Ellipsified` back to body cells so we can display longer values.

### Before
![image](https://user-images.githubusercontent.com/691495/106480405-613adc80-6479-11eb-99fa-2c9c8e2eafc9.png)

### After
![image](https://user-images.githubusercontent.com/691495/106480335-4a948580-6479-11eb-945a-2f90e6341b2f.png)