### PR TITLE
CI: include sample-dataset.db.mv.db in frontend checksums

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,7 +495,7 @@ jobs:
       # .FRONTEND-CHECKSUMS is every JavaScript source file as well as dependency files like yarn.lock
       - create-checksum-file:
           filename: .FRONTEND-CHECKSUMS
-          find-args: ". -type f -name '*.js' -or -name '*.jsx' -or -name '*.json' -or -name yarn.lock"
+          find-args: ". -type f -name '*.js' -or -name '*.jsx' -or -name '*.json' -or -name yarn.lock -or -name sample-dataset.db.mv.db"
       # .MODULES-CHECKSUMS is every Clojure source file in the modules/ directory as well as plugin manifests
       - create-checksum-file:
           filename: .MODULES-CHECKSUMS


### PR DESCRIPTION
We recently changed this file and it's causing unpredictable test failures when things are incorrectly using the old cached version of stuff like the uberjar