### PR TITLE
Trim URLs generated using user input

### DIFF
--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -113,10 +113,22 @@ export const DEFAULT_SCHEDULES = {
   },
 };
 
+function concatURL(...urlParts) {
+  return urlParts.reduce(
+    (url, part) =>
+      typeof url !== "string" || typeof part !== "string"
+        ? undefined
+        : url + part.trim(),
+    "",
+  );
+}
+
 function getClientIdDescription(engine, details) {
   if (CREDENTIALS_URL_PREFIXES[engine]) {
-    const credentialsURL =
-      CREDENTIALS_URL_PREFIXES[engine] + (details["project-id"] || "");
+    const credentialsURL = concatURL(
+      CREDENTIALS_URL_PREFIXES[engine],
+      details["project-id"] || "",
+    );
     return (
       <span>
         {jt`${(
@@ -132,22 +144,24 @@ function getClientIdDescription(engine, details) {
 
 function getAuthCodeLink(engine, details) {
   if (AUTH_URL_PREFIXES[engine] && details["client-id"]) {
+    const authCodeURL = concatURL(
+      AUTH_URL_PREFIXES[engine],
+      details["client-id"],
+    );
+    const googleDriveAuthCodeURL = concatURL(
+      AUTH_URL_PREFIXES["bigquery_with_drive"],
+      details["client-id"],
+    );
     return (
       <span>
         {jt`${(
-          <ExternalLink href={AUTH_URL_PREFIXES[engine] + details["client-id"]}>
-            {t`Click here`}
-          </ExternalLink>
+          <ExternalLink href={authCodeURL}>{t`Click here`}</ExternalLink>
         )} to get an auth code.`}
         {engine === "bigquery" && (
           <span>
             {" "}
             ({t`or`}{" "}
-            <ExternalLink
-              href={
-                AUTH_URL_PREFIXES["bigquery_with_drive"] + details["client-id"]
-              }
-            >
+            <ExternalLink href={googleDriveAuthCodeURL}>
               {t`with Google Drive permissions`}
             </ExternalLink>
             )
@@ -167,7 +181,8 @@ function getAuthCodeEnableAPILink(engine, details) {
       details["client-id"] && (details["client-id"].match(/^\d+/) || [])[0];
     if (ENABLE_API_PREFIXES[engine] && projectID) {
       // URL looks like https://console.developers.google.com/apis/api/analytics.googleapis.com/overview?project=12343611585
-      const enableAPIURL = ENABLE_API_PREFIXES[engine] + projectID;
+      const enableAPIURL = concatURL(ENABLE_API_PREFIXES[engine], projectID);
+
       return (
         <span>
           {t`To use Metabase with this data you must enable API access in the Google Developers Console.`}{" "}

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -113,19 +113,13 @@ export const DEFAULT_SCHEDULES = {
   },
 };
 
-function concatURL(...urlParts) {
-  return urlParts.reduce(
-    (url, part) =>
-      typeof url !== "string" || typeof part !== "string"
-        ? undefined
-        : url + part.trim(),
-    "",
-  );
+function concatTrimmed(a, b) {
+  return (a || "").trim() + (b || "").trim();
 }
 
 function getClientIdDescription(engine, details) {
   if (CREDENTIALS_URL_PREFIXES[engine]) {
-    const credentialsURL = concatURL(
+    const credentialsURL = concatTrimmed(
       CREDENTIALS_URL_PREFIXES[engine],
       details["project-id"] || "",
     );
@@ -144,11 +138,11 @@ function getClientIdDescription(engine, details) {
 
 function getAuthCodeLink(engine, details) {
   if (AUTH_URL_PREFIXES[engine] && details["client-id"]) {
-    const authCodeURL = concatURL(
+    const authCodeURL = concatTrimmed(
       AUTH_URL_PREFIXES[engine],
       details["client-id"],
     );
-    const googleDriveAuthCodeURL = concatURL(
+    const googleDriveAuthCodeURL = concatTrimmed(
       AUTH_URL_PREFIXES["bigquery_with_drive"],
       details["client-id"],
     );
@@ -181,7 +175,10 @@ function getAuthCodeEnableAPILink(engine, details) {
       details["client-id"] && (details["client-id"].match(/^\d+/) || [])[0];
     if (ENABLE_API_PREFIXES[engine] && projectID) {
       // URL looks like https://console.developers.google.com/apis/api/analytics.googleapis.com/overview?project=12343611585
-      const enableAPIURL = concatURL(ENABLE_API_PREFIXES[engine], projectID);
+      const enableAPIURL = concatTrimmed(
+        ENABLE_API_PREFIXES[engine],
+        projectID,
+      );
 
       return (
         <span>

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -201,4 +201,34 @@ describe("scenarios > admin > databases > add", () => {
       cy.contains("generate a Client ID and Client Secret for your project");
     });
   });
+
+  describe("Google Analytics ", () => {
+    it("should generate well-formed external auth URLs", () => {
+      cy.route({
+        method: "GET",
+        url: "/api/database/123",
+        response: {
+          id: 123,
+          engine: "googleanalytics",
+          details: {
+            "account-id": "account-id",
+            "client-id": "client-id",
+            "client-secret": "client-secret",
+            "auth-code": "auth-code",
+          },
+        },
+        status: 200,
+        delay: 100,
+      });
+      cy.visit("/admin/databases/123");
+
+      typeField("Client ID", "   999  ");
+
+      cy.findAllByText("Click here").then(els => {
+        for (const el of els) {
+          expect(el.getAttribute("href").includes(" ")).to.be.false;
+        }
+      });
+    });
+  });
 });

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -215,11 +215,13 @@ describe("scenarios > admin > databases > add", () => {
 
       typeField("Client ID", "   999  ");
 
-      cy.findAllByText("Click here").then(els => {
-        for (const el of els) {
-          expect(el.getAttribute("href").includes(" ")).to.be.false;
-        }
-      });
+      cy.findByText("get an auth code", { exact: false })
+        .findByRole("link")
+        .then(el => {
+          expect(el.attr("href")).to.equal(
+            "https://accounts.google.com/o/oauth2/auth?access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=https://www.googleapis.com/auth/analytics.readonly&client_id=999",
+          );
+        });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -203,24 +203,15 @@ describe("scenarios > admin > databases > add", () => {
   });
 
   describe("Google Analytics ", () => {
-    it("should generate well-formed external auth URLs", () => {
-      cy.route({
-        method: "GET",
-        url: "/api/database/123",
-        response: {
-          id: 123,
-          engine: "googleanalytics",
-          details: {
-            "account-id": "account-id",
-            "client-id": "client-id",
-            "client-secret": "client-secret",
-            "auth-code": "auth-code",
-          },
-        },
-        status: 200,
-        delay: 100,
-      });
-      cy.visit("/admin/databases/123");
+    it.only("should generate well-formed external auth URLs", () => {
+      cy.visit("/admin/databases/create");
+      cy.contains("Database type")
+        .parents(".Form-field")
+        .find(".AdminSelect")
+        .click();
+      popover()
+        .contains("Google Analytics")
+        .click({ force: true });
 
       typeField("Client ID", "   999  ");
 


### PR DESCRIPTION
Fixes #9836

**Description**
I think at some point the "copy" button you'd click in the Google dev console added an errant space to the Client ID string causing our simple `a + b` string concatenation to generate a bad URL. I was unable to repro that behavior in the Google dev console but figured sprinkling some `.trim()` wouldn't hurt.

**Verification**
Can easily verify by going to create a Google Analytics database, copying or typing `"  123   "` in the Client ID input, and then checking the URLs for the links with text "Click here." Also verified via the Cypress test I added. In the below image you can see the URL for one of the links and there are no spaces before the "123" located at the end of the URL.

<img width="1182" alt="Screen Shot 2021-02-01 at 2 24 13 PM" src="https://user-images.githubusercontent.com/13057258/106525668-2fd20900-6499-11eb-8c09-cf1e2500ce13.png">
