### PR TITLE
Add JDBC fetch size option for Redshift driver

### DIFF
--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -814,6 +814,14 @@ Since: 0.36.0
 
 Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS. Related [MB_SITE_URL](#mb_site_url)
 
+#### `MB_REDSHIFT_FETCH_SIZE`
+
+Type: integer<br>
+Default: `5000`
+
+Controls the fetch size used for Redshift queries (in `PreparedStatement`), via the `defaultRowFetchSize` JDBC URL
+parameter.
+
 #### `MB_REPORT_TIMEZONE`
 
 Type: string<br>

--- a/modules/drivers/redshift/project.clj
+++ b/modules/drivers/redshift/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/redshift-driver "1.0.0-SNAPSHOT-1.2.43.1067"
+(defproject metabase/redshift-driver "1.1.0-SNAPSHOT-2.0.0.3"
   :min-lein-version "2.5.0"
 
   :repositories
@@ -6,7 +6,7 @@
 
 
   :dependencies
-  [[com.amazon.redshift/redshift-jdbc42-no-awssdk "1.2.51.1078"]]
+  [[com.amazon.redshift/redshift-jdbc42 "2.0.0.3"]]
 
   :profiles
   {:provided

--- a/modules/drivers/redshift/resources/metabase-plugin.yaml
+++ b/modules/drivers/redshift/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase Redshift Driver
-  version: 1.0.0-SNAPSHOT-1.2.43.1067
+  version: 1.1.0-SNAPSHOT-2.0.0.3
   description: Allows Metabase to connect to Redshift databases.
 driver:
   name: redshift
@@ -27,4 +27,4 @@ init:
   - step: load-namespace
     namespace: metabase.driver.redshift
   - step: register-jdbc-driver
-    class: com.amazon.redshift.jdbc.Driver
+    class: com.amazon.redshift.jdbc42.Driver

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -7,6 +7,7 @@
             [honeysql.core :as hsql]
             [metabase.driver :as driver]
             [metabase.driver.common :as driver.common]
+            [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc.execute.legacy-impl :as legacy]
@@ -200,13 +201,15 @@
 
 (defmethod sql-jdbc.conn/connection-details->spec :redshift
   [_ {:keys [host port db], :as opts}]
-  (merge
-   {:classname                     "com.amazon.redshift.jdbc.Driver"
-    :subprotocol                   "redshift"
-    :subname                       (str "//" host ":" port "/" db)
-    :ssl                           true
-    :OpenSourceSubProtocolOverride false}
-   (dissoc opts :host :port :db)))
+  (sql-jdbc.common/handle-additional-options
+   (merge
+    {:classname                     "com.amazon.redshift.jdbc42.Driver"
+     :subprotocol                   "redshift"
+     :subname                       (str "//" host ":" port "/" db)
+     :ssl                           true
+     :OpenSourceSubProtocolOverride false
+     :additional-options            (str "defaultRowFetchSize=" (pubset/redshift-fetch-size))}
+    (dissoc opts :host :port :db))))
 
 (prefer-method
  sql-jdbc.execute/read-column-thunk

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -5,12 +5,11 @@
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.models.database :refer [Database]]
             [metabase.models.field :refer [Field]]
+            [metabase.models.setting :as setting]
             [metabase.models.table :refer [Table]]
             [metabase.plugins.jdbc-proxy :as jdbc-proxy]
             [metabase.public-settings :as pubset]
             [metabase.query-processor :as qp]
-            [metabase.query-processor.context.default :as context.default]
-            [metabase.query-processor.store :as qp.store]
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.data.interface :as tx]
@@ -18,7 +17,8 @@
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
             [toucan.db :as db])
-  (:import metabase.plugins.jdbc_proxy.ProxyDriver))
+  (:import (java.sql ResultSetMetaData ResultSet)
+           metabase.plugins.jdbc_proxy.ProxyDriver))
 
 (use-fixtures :once (fixtures/initialize :plugins))
 (use-fixtures :once (fixtures/initialize :db))
@@ -35,13 +35,12 @@
                (.getName (class driver))))))))
 
 (defn- query->native [query]
-  (let [native-query (atom nil)]
-    (with-redefs [sql-jdbc.execute/prepared-statement (fn [_ _ sql _]
-                                                        (reset! native-query sql)
-                                                        (throw (Exception. "done")))
-                  execute/execute-statement! (fn [_ _ sql]
-                                               (reset! native-query sql)
-                                               (throw (Exception. "done")))]
+  (let [native-query (atom nil)
+        check-sql-fn (fn [_ _ sql & _]
+                       (reset! native-query sql)
+                       (throw (Exception. "done")))]
+    (with-redefs [sql-jdbc.execute/prepared-statement check-sql-fn
+                  sql-jdbc.execute/execute-statement! check-sql-fn]
       (u/ignore-exceptions
         (qp/process-query query))
       @native-query)))
@@ -201,27 +200,29 @@
                     (db/select [Field :name :database_type :base_type] :table_id table-id))))))))))
 
 (defn- assert-jdbc-url-fetch-size [db fetch-size]
-  (let [ds   (sql-jdbc.execute/datasource db)
-        conn (.getConnection ds)
-        md   (.getMetaData conn)
-        url  (.getURL md)]
-    (is (str/includes? url (str "defaultRowFetchSize=" fetch-size)))))
+  (with-open [conn (.getConnection (sql-jdbc.execute/datasource db))]
+    (let [md  (.getMetaData conn)
+          url (.getURL md)]
+      (is (str/includes? url (str "defaultRowFetchSize=" fetch-size))))))
 
 (deftest test-jdbc-fetch-size
   (testing "Redshift JDBC fetch size is set correctly in PreparedStatement"
     (mt/test-driver :redshift
-      (assert-jdbc-url-fetch-size (mt/db) 5000) ; the default value should always be picked up if nothing is set
-      (with-redefs [env/env (assoc env/env :mb-redshift-fetch-size "14")]
-        ; we have to create a new DB in order to pick up the change to the environment here
+      ;; the default value should always be picked up if nothing is set
+      (assert-jdbc-url-fetch-size (mt/db) (:default (setting/resolve-setting :redshift-fetch-size)))
+      (mt/with-temporary-setting-values [redshift-fetch-size "14"]
+        ;; create a new DB in order to pick up the change to the setting here
         (mt/with-temp Database [db {:engine :redshift, :details (:details (mt/db))}]
           (mt/with-db db
             ;; make sure the JDBC URL has the defaultRowFetchSize parameter set correctly
             (assert-jdbc-url-fetch-size db 14)
             ;; now, actually run a query and see if the PreparedStatement has the right fetchSize set
-            (qp.store/with-store
-              (qp.store/fetch-and-store-database! (u/the-id db))
-              (let [max-rows 10000
-                    q        "SELECT 1"
-                    ctx      (context.default/default-context)
-                    rs-fn    (fn [rs] (is (= 14 (.getFetchSize (.getStatement rs)))))]
-                   (#'sql-jdbc.execute/run-fn-with-result-set :redshift q {} max-rows ctx rs-fn)))))))))
+            (mt/with-everything-store
+              (let [orig-fn sql-jdbc.execute/reducible-rows
+                    new-fn  (fn [driver ^ResultSet rs ^ResultSetMetaData rsmeta canceled-chan]
+                              (is (= 14 (.getFetchSize (.getStatement rs))))
+                              (orig-fn driver rs rsmeta canceled-chan))]
+                (with-redefs [sql-jdbc.execute/reducible-rows new-fn]
+                  (= [1] (-> {:query "SELECT 1"}
+                             (mt/native-query)
+                             (qp/process-query))))))))))))

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -449,18 +449,6 @@
   (let [row-thunk (row-thunk driver rs rsmeta)]
     (qp.reducible/reducible-rows row-thunk canceled-chan)))
 
-(defn- run-fn-with-result-set
-  "Gets the JDBC ResultSet from running the given sql query with the given driver, params, max-rows, and context. Then,
-  executes the given rs-fn against it before closing."
-  [driver sql params max-rows context rs-fn]
-  (let [db (qp.store/database)
-        fs (:fetch-size (:details db))]
-    (with-open [conn (connection-with-timezone driver db (qp.timezone/report-timezone-id-if-supported))
-                stmt (doto (prepared-statement* driver conn sql params (context/canceled-chan context))
-                       (.setMaxRows max-rows))
-                rs   (execute-query! driver stmt)]
-        (rs-fn rs))))
-
 (defn execute-reducible-query
   "Default impl of `execute-reducible-query` for sql-jdbc drivers."
   {:added "0.35.0", :arglists '([driver query context respond] [driver sql params max-rows context respond])}

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -449,6 +449,18 @@
   (let [row-thunk (row-thunk driver rs rsmeta)]
     (qp.reducible/reducible-rows row-thunk canceled-chan)))
 
+(defn- run-fn-with-result-set
+  "Gets the JDBC ResultSet from running the given sql query with the given driver, params, max-rows, and context. Then,
+  executes the given rs-fn against it before closing."
+  [driver sql params max-rows context rs-fn]
+  (let [db (qp.store/database)
+        fs (:fetch-size (:details db))]
+    (with-open [conn (connection-with-timezone driver db (qp.timezone/report-timezone-id-if-supported))
+                stmt (doto (prepared-statement* driver conn sql params (context/canceled-chan context))
+                       (.setMaxRows max-rows))
+                rs   (execute-query! driver stmt)]
+        (rs-fn rs))))
+
 (defn execute-reducible-query
   "Default impl of `execute-reducible-query` for sql-jdbc drivers."
   {:added "0.35.0", :arglists '([driver query context respond] [driver sql params max-rows context respond])}

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -90,7 +90,7 @@
                 (log/error e (trs "site-url is invalid; returning nil for now. Will be reset on next request.")))))
   :setter (fn [new-value]
             (let [new-value (some-> new-value normalize-site-url)
-                  https?    (some-> new-value (str/starts-with?  "https:"))]
+                  https?    (some-> new-value (str/starts-with?  "https:" ))]
               ;; if the site URL isn't HTTPS then disable force HTTPS redirects if set
               (when-not https?
                 (redirect-all-requests-to-https false))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -90,7 +90,7 @@
                 (log/error e (trs "site-url is invalid; returning nil for now. Will be reset on next request.")))))
   :setter (fn [new-value]
             (let [new-value (some-> new-value normalize-site-url)
-                  https?    (some-> new-value (str/starts-with?  "https:" ))]
+                  https?    (some-> new-value (str/starts-with?  "https:"))]
               ;; if the site URL isn't HTTPS then disable force HTTPS redirects if set
               (when-not https?
                 (redirect-all-requests-to-https false))
@@ -395,3 +395,9 @@
   :visibility :public
   :type       :integer
   :default    180)
+
+(defsetting redshift-fetch-size
+  (deferred-tru "Controls the fetch size used for Redshift queries (in PreparedStatement), via defaultRowFetchSize.")
+  :visibility :public
+  :type       :integer
+  :default    5000)


### PR DESCRIPTION
Originally, this change added a generic option to set the fetch size for a variety of JDBC drivers, on the admin page.  After a lot of discussion (see below), it has been reworked significiantly.

Now, this change aims to (narrowly) solve [this problem](https://docs.aws.amazon.com/redshift/latest/dg/queries-troubleshooting.html#set-the-JDBC-fetch-size-parameter) with the Redshift driver, namely that the fetch size is left to "infinite", which can cause problems with large result sets.  It includes the following:

- A new setting (not exposed in the UI, only controllable via environment variable) called `redshift-fetch-size` that allows people to set the `fetchSize` that will be used for all Redshift queries
- Documentation on this new setting in the environment variables markdown file
- An update of the Redshift JDBC driver dependency to the latest version (2.0.0.3), which is necessary because [the JDBC URL parameter](https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-configuration-options.html#jdbc20-defaultrowfetchsize-option) we now use to control the fetchSize was only introduced in the 2.x version of the driver
- Updates to the Redshift Metabase driver itself to bring in the new version, and to set the URL parameter based on the setting
- Test to ensure that the new URL parameter is set, and also that it actually takes effect (i.e. that the underlying `PreparedStatement` does, in fact, have that value when `.getFetchSize` is called on it)