### PR TITLE
#14604 Repro: Custom columns break pivot tables

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -376,6 +376,8 @@ describe("scenarios > visualizations > pivot tables", () => {
 
   it.skip("should work with custom columns (metabase#14604)", () => {
     const CC_NAME = "Mooooar Taxes!";
+
+    // Create a starting point the using API ("normal" question with a custom column)
     cy.request("POST", "/api/card", {
       name: "14604",
       dataset_query: {
@@ -401,15 +403,20 @@ describe("scenarios > visualizations > pivot tables", () => {
       cy.visit(`/question/${QUESTION_ID}`);
     });
 
+    // Open the "notebook" editor to edit this question
     cy.get(".Icon-notebook").click();
 
+    // This is tricky and a bit fragile - last "plus" icon is used to add one more aggregation option
+    // which is exactly what we need for this test - add custom column as the third field for aggregation
     cy.get(".Icon-add")
       .last()
       .click();
     popover().within(() => {
       cy.findByText(CC_NAME).click();
     });
+    // One is "Custom column" and the other one is an aggregation field/option
     cy.findAllByText(CC_NAME).should("have.length", 2);
+    // Choose pivot table as a visualization
     cy.findByText("Visualize").click();
     cy.findByText("Visualization").click();
     cy.get(".Icon-pivot_table").click({ force: true });

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -7,7 +7,7 @@ import {
 } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE } = SAMPLE_DATASET;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATASET;
 
 const QUESTION_NAME = "Cypress Pivot Table";
 const DASHBOARD_NAME = "Pivot Table Dashboard";
@@ -374,7 +374,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("Pivot tables can only be used with aggregated queries.");
   });
 
-  it.skip("should work with custom columns (metabase#14604)", () => {
+  it.skip("should work with custom columns as values (metabase#14604)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         database: 1,
@@ -405,6 +405,29 @@ describe("scenarios > visualizations > pivot tables", () => {
     // check grand totals
     cy.findByText("1,510,621.68"); // sum of total grand total
     cy.findByText("3,021,243.37"); // sum of "twice total" grand total
+  });
+
+  it.skip("should work with custom columns as pivoted columns (metabase#14604)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": PRODUCTS_ID,
+          expressions: {
+            category_foo: ["concat", ["field-id", PRODUCTS.CATEGORY], "foo"],
+          },
+          aggregation: [["count"]],
+          breakout: [["expression", "category_foo"]],
+        },
+        database: 1,
+      },
+      display: "pivot",
+    });
+
+    cy.findByText("category_foo");
+    cy.findByText("Doohickeyfoo");
+    cy.findByText("42"); // count of Doohickeyfoo
+    cy.findByText("200"); // grand total
   });
 
   describe("dashboards", () => {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -374,60 +374,64 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("Pivot tables can only be used with aggregated queries.");
   });
 
-  it.skip("should work with custom columns as values (metabase#14604)", () => {
-    visitQuestionAdhoc({
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          expressions: { "Twice Total": ["*", ["field-id", ORDERS.TOTAL], 2] },
-          aggregation: [
-            ["sum", ["field-id", ORDERS.TOTAL]],
-            ["sum", ["expression", "Twice Total"]],
-          ],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-          ],
-        },
-        type: "query",
-      },
-      display: "pivot",
-    });
-
-    // value headings
-    cy.findByText("Sum of Total");
-    cy.findByText("Sum of Twice Total");
-
-    // check values in the table
-    cy.findByText("42,156.87"); // sum of total for 2016
-    cy.findByText("84,313.74"); // sum of "twice total" for 2016
-
-    // check grand totals
-    cy.findByText("1,510,621.68"); // sum of total grand total
-    cy.findByText("3,021,243.37"); // sum of "twice total" grand total
-  });
-
-  it.skip("should work with custom columns as pivoted columns (metabase#14604)", () => {
-    visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": PRODUCTS_ID,
-          expressions: {
-            category_foo: ["concat", ["field-id", PRODUCTS.CATEGORY], "foo"],
+  describe("custom columns (metabase#14604)", () => {
+    it.skip("should work with custom columns as values", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": ORDERS_ID,
+            expressions: {
+              "Twice Total": ["*", ["field-id", ORDERS.TOTAL], 2],
+            },
+            aggregation: [
+              ["sum", ["field-id", ORDERS.TOTAL]],
+              ["sum", ["expression", "Twice Total"]],
+            ],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+            ],
           },
-          aggregation: [["count"]],
-          breakout: [["expression", "category_foo"]],
+          type: "query",
         },
-        database: 1,
-      },
-      display: "pivot",
+        display: "pivot",
+      });
+
+      // value headings
+      cy.findByText("Sum of Total");
+      cy.findByText("Sum of Twice Total");
+
+      // check values in the table
+      cy.findByText("42,156.87"); // sum of total for 2016
+      cy.findByText("84,313.74"); // sum of "twice total" for 2016
+
+      // check grand totals
+      cy.findByText("1,510,621.68"); // sum of total grand total
+      cy.findByText("3,021,243.37"); // sum of "twice total" grand total
     });
 
-    cy.findByText("category_foo");
-    cy.findByText("Doohickeyfoo");
-    cy.findByText("42"); // count of Doohickeyfoo
-    cy.findByText("200"); // grand total
+    it.skip("should work with custom columns as pivoted columns", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": PRODUCTS_ID,
+            expressions: {
+              category_foo: ["concat", ["field-id", PRODUCTS.CATEGORY], "foo"],
+            },
+            aggregation: [["count"]],
+            breakout: [["expression", "category_foo"]],
+          },
+          database: 1,
+        },
+        display: "pivot",
+      });
+
+      cy.findByText("category_foo");
+      cy.findByText("Doohickeyfoo");
+      cy.findByText("42"); // count of Doohickeyfoo
+      cy.findByText("200"); // grand total
+    });
   });
 
   describe("dashboards", () => {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -375,54 +375,36 @@ describe("scenarios > visualizations > pivot tables", () => {
   });
 
   it.skip("should work with custom columns (metabase#14604)", () => {
-    const CC_NAME = "Mooooar Taxes!";
-
-    // Create a starting point the using API ("normal" question with a custom column)
-    cy.request("POST", "/api/card", {
-      name: "14604",
+    visitQuestionAdhoc({
       dataset_query: {
         database: 1,
         query: {
           "source-table": ORDERS_ID,
-          expressions: { [CC_NAME]: ["*", ["field-id", ORDERS.TAX], 2] },
-          aggregation: [["count"]],
+          expressions: { "Twice Total": ["*", ["field-id", ORDERS.TOTAL], 2] },
+          aggregation: [
+            ["sum", ["field-id", ORDERS.TOTAL]],
+            ["sum", ["expression", "Twice Total"]],
+          ],
           breakout: [
-            ["fk->", ["field-id", ORDERS.USER_ID], ["field-id", PEOPLE.SOURCE]],
-            [
-              "fk->",
-              ["field-id", ORDERS.PRODUCT_ID],
-              ["field-id", PRODUCTS.CATEGORY],
-            ],
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
           ],
         },
         type: "query",
       },
-      display: "table",
-      visualization_settings: {},
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
+      display: "pivot",
     });
 
-    // Open the "notebook" editor to edit this question
-    cy.get(".Icon-notebook").click();
+    // value headings
+    cy.findByText("Sum of Total");
+    cy.findByText("Sum of Twice Total");
 
-    // This is tricky and a bit fragile - last "plus" icon is used to add one more aggregation option
-    // which is exactly what we need for this test - add custom column as the third field for aggregation
-    cy.get(".Icon-add")
-      .last()
-      .click();
-    popover().within(() => {
-      cy.findByText(CC_NAME).click();
-    });
-    // One is "Custom column" and the other one is an aggregation field/option
-    cy.findAllByText(CC_NAME).should("have.length", 2);
-    // Choose pivot table as a visualization
-    cy.findByText("Visualize").click();
-    cy.findByText("Visualization").click();
-    cy.get(".Icon-pivot_table").click({ force: true });
-    cy.findAllByRole("button", { name: "Done" }).click();
+    // check values in the table
+    cy.findByText("42,156.87"); // sum of total for 2016
+    cy.findByText("84,313.74"); // sum of "twice total" for 2016
 
-    cy.findAllByText(CC_NAME);
+    // check grand totals
+    cy.findByText("1,510,621.68"); // sum of total grand total
+    cy.findByText("3,021,243.37"); // sum of "twice total" grand total
   });
 
   describe("dashboards", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14604

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/106533231-07c2c400-64f2-11eb-9a00-e82db68661dd.png)
