### PR TITLE
#14052 Repro: Cannot save to sub-collection when access to its parent is revoked

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -351,7 +351,7 @@ describe("scenarios > collection_defaults", () => {
           cy.findByText(/Our analytics/i);
           cy.findByText(/My personal collection/i);
           cy.log("**Reported failing from v0.34.3**");
-          cy.findByText(/Child collection/i);
+          cy.findByText("Child");
         });
       });
     });

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -350,6 +350,7 @@ describe("scenarios > collection_defaults", () => {
         popover().within(() => {
           cy.findByText(/Our analytics/i);
           cy.findByText(/My personal collection/i);
+          cy.findByText("Parent").should("not.exist");
           cy.log("**Reported failing from v0.34.3**");
           cy.findByText("Child");
         });

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -8,6 +8,7 @@ import {
   popover,
   USERS,
   USER_GROUPS,
+  openOrdersTable,
 } from "__support__/cypress";
 // Ported from initial_collection.e2e.spec.js
 
@@ -337,7 +338,22 @@ describe("scenarios > collection_defaults", () => {
         cy.findByText("Child");
       });
 
-      it.skip("should be able to choose a child collection when saving a question (metabase#14052)", () => {});
+      it.skip("should be able to choose a child collection when saving a question (metabase#14052)", () => {
+        const { first_name, last_name } = nocollection;
+
+        openOrdersTable();
+        cy.findByText("Save").click();
+        // Click to choose which collection should this question be saved to
+        cy.findByText(
+          `${first_name} ${last_name}'s Personal Collection`,
+        ).click();
+        popover().within(() => {
+          cy.findByText(/Our analytics/i);
+          cy.findByText(/My personal collection/i);
+          cy.log("**Reported failing from v0.34.3**");
+          cy.findByText(/Child collection/i);
+        });
+      });
     });
 
     it.skip("sub-collection should be available in save and move modals (#14122)", () => {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -3,6 +3,7 @@ import {
   signInAsAdmin,
   setupLocalHostEmail,
   signInAsNormalUser,
+  signIn,
   signOut,
   modal,
   popover,
@@ -327,8 +328,7 @@ describe("scenarios > collection_defaults", () => {
         });
 
         signOut();
-        cy.log("**--Sign in as `nocollection` user--**");
-        cy.request("POST", "/api/session", nocollection);
+        signIn("nocollection");
       });
 
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -334,8 +334,10 @@ describe("scenarios > collection_defaults", () => {
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {
         cy.visit("/");
         cy.findByText("Child");
+        cy.findByText("Parent").should("not.exist");
         cy.findByText("Browse all items").click();
         cy.findByText("Child");
+        cy.findByText("Parent").should("not.exist");
       });
 
       it.skip("should be able to choose a child collection when saving a question (metabase#14052)", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14052 
- Groups #14052 and #14114 under the same `describe` block because they are tightly connected/related
- Adds negative assertion to #14114 to prevent future regressions

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/106536780-5fb0f900-64f9-11eb-975d-b1942836a0bd.png)

