### PR TITLE
Force user to type database name to delete the database

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
@@ -32,6 +32,7 @@ export default class DeleteDatabaseModal extends Component {
 
   render() {
     const { confirmValue } = this.state;
+    const { database } = this.props;
 
     let formError;
     if (this.state.error) {
@@ -46,14 +47,12 @@ export default class DeleteDatabaseModal extends Component {
       formError = <span className="text-error px2">{errorMessage}</span>;
     }
 
-    // allow English or localized
     const confirmed =
-      confirmValue.toUpperCase() === "DELETE" ||
-      confirmValue.toUpperCase() === t`DELETE`;
+      confirmValue.trim().toLowerCase() === database.name.trim().toLowerCase();
 
     return (
       <ModalContent
-        title={t`Delete this database?`}
+        title={t`Delete the ${database.name} database?`}
         onClose={this.props.onClose}
       >
         <div className="mb4">
@@ -62,7 +61,7 @@ export default class DeleteDatabaseModal extends Component {
             <strong>{t`This cannot be undone.`}</strong>
           </p>
           <p className="text-paragraph">
-            {t`If you're sure, please type`} <strong>{t`DELETE`}</strong>{" "}
+            {t`If you're sure, please type`} <strong>{database.name}</strong>{" "}
             {t`in this box:`}
           </p>
           <input

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -197,7 +197,7 @@ describe("scenarios > admin > databases > edit", () => {
       cy.visit("/admin/databases/1");
       cy.findByText("Remove this database").click();
       modal().within(() => {
-        cy.get("input").type("DELETE");
+        cy.get("input").type("Sample Dataset");
         cy.get(".Button.Button--danger").click();
       });
 

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -50,6 +50,13 @@ describe("scenarios > admin > databases > list", () => {
     cy.get(".ModalBody input").type("DELETE");
     cy.get(".ModalBody")
       .contains("button", "Delete")
+      .should("be.disabled");
+    cy.get(".ModalBody input")
+      .clear()
+      .type("Sample Dataset");
+
+    cy.get(".ModalBody")
+      .contains("button", "Delete")
       .click();
     cy.wait("@delete");
 


### PR DESCRIPTION
Fixes #12883

**Description**
I liked the suggestions from @nemanjaglumac and @xPaw so I've taken the liberty to combine their ideas into the simplest change that avoids the need for a localization update. I've added the database name to the modal title and am also forcing the user to type the database name to delete the database. Happy to go in a different direction if preferred.

What do you think, @kdoh & @mazameli?

**Verification**
The updated Cypress test covers the logic change -- the "Delete" button is disabled until you type in the full database name. Here's what it looks like:
<img width="714" alt="Screen Shot 2021-02-01 at 4 18 14 PM" src="https://user-images.githubusercontent.com/13057258/106536767-ecce6080-64ad-11eb-807a-e9eafa4883a6.png">


