### PR TITLE
Work around Safari CSS issue by swapping visibility toggle to display

### DIFF
--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -238,7 +238,7 @@ export default class DimensionList extends Component {
         onChange={this.handleChange}
         itemIsSelected={this.itemIsSelected}
         renderItemExtra={this.renderItemExtra}
-        getItemClassName={() => "hover-parent hover--visibility"}
+        getItemClassName={() => "hover-parent hover--display"}
       />
     );
   }


### PR DESCRIPTION
Fixes #14131

I wasn't able to find any bugs or internet chatter about this issue. My best guess is that something changed in the hover detection since when I force `:hover` in inspector the `+` appears.

The fix was a shot in the dark but it seems to work 🤷.

I think using display to hide the UI where is fine, but let me know if I should check any edge cases. [Here's the relevant css file](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/css/core/hover.css). We're just swapping the `visibility: visible` for `display: block`.
