### PR TITLE
Fuzzy Search

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
    [joda-time/joda-time "2.10.8"]
    [org.clojure/core.logic "1.0.0"]
    [org.clojure/core.match "0.3.0"]                                   ; optimized pattern matching library for Clojure
-   [org.clojure/core.memoize "1.0.236"]                               ; needed by core.match; has useful FIFO, LRU, etc. caching mechanisms
+   [org.clojure/core.memoize "1.0.236"]                               ; needed by core.match and search; has useful FIFO, LRU, etc. caching mechanisms
    [org.clojure/data.csv "0.1.4"]                                     ; CSV parsing / generation
    [org.clojure/java.classpath "1.0.0"]                               ; examine the Java classpath from Clojure programs
    [org.clojure/java.jdbc "0.7.11"]                                   ; basic JDBC access from Clojure

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -379,12 +379,12 @@
                                          :when (seq query)]
                                      query)}
           _            (log/tracef "Searching with query:\n%s" (u/pprint-to-str search-query))
-          ;; sort results by [model name]
-          results      (sort-by (juxt (comp model->sort-position :model)
-                                      :name)
-                                (db/query search-query :max-rows search-max-results))]
-      ;; TODO: reconcile these two sorts
-      (sort-by (comp - (partial search/score (:search-string search-ctx)))
+          results      (db/query search-query :max-rows search-max-results)]
+      ;; sort by [score model name]
+      (sort-by (juxt
+                (comp - (partial search/score (:search-string search-ctx)))
+                (comp model->sort-position :model)
+                :name)
                (for [row results
                      :when (check-permissions-for-model row)]
                  ;; MySQL returns `:favorite` and `:archived` as `1` or `0` so convert those to boolean as needed

--- a/src/metabase/search.clj
+++ b/src/metabase/search.clj
@@ -2,6 +2,10 @@
   (:require [clojure.string :as str]
             [schema.core :as s]))
 
+(s/defn normalize :- s/Str
+  [query :- s/Str]
+  (str/lower-case query))
+
 (s/defn tokenize :- [s/Str]
   "Break a search `query` into its constituent tokens"
   [query :- s/Str]

--- a/src/metabase/search.clj
+++ b/src/metabase/search.clj
@@ -1,0 +1,9 @@
+(ns metabase.search
+  (:require [clojure.string :as str]
+            [schema.core :as s]))
+
+(s/defn tokenize :- [s/Str]
+  "Break a search `query` into its constituent tokens"
+  [query :- s/Str]
+  (filter seq
+          (str/split query #"\s+")))

--- a/src/metabase/search.clj
+++ b/src/metabase/search.clj
@@ -1,6 +1,10 @@
 (ns metabase.search
-  (:require [clojure.string :as str]
+  (:require [clojure.core.memoize :as memoize]
+            [clojure.string :as str]
+            [metabase.models.table :refer [Table]]
             [schema.core :as s]))
+
+;;; Utility functions
 
 (s/defn normalize :- s/Str
   [query :- s/Str]
@@ -11,3 +15,61 @@
   [query :- s/Str]
   (filter seq
           (str/split query #"\s+")))
+
+(def largest-common-subseq-length
+  (memoize/fifo
+   (fn
+     ([eq xs ys]
+      (largest-common-subseq-length eq xs ys 0))
+     ([eq xs ys tally]
+      (if (or (zero? (count xs))
+              (zero? (count ys)))
+        tally
+        (max
+         (if (eq (first xs)
+                 (first ys))
+           (largest-common-subseq-length eq (rest xs) (rest ys) (inc tally))
+           tally)
+         (largest-common-subseq-length eq xs (rest ys) 0)
+         (largest-common-subseq-length eq (rest xs) ys 0)))))))
+
+;;; Model setup
+
+(defn- model-name->class
+  [model-name]
+  (Class/forName (format "metabase.models.%s.%sInstance" model-name (str/capitalize model-name))))
+
+(defmulti searchable-columns-for-model
+  "The columns that will be searched for the query."
+  {:arglists '([model])}
+  class)
+
+(defmethod searchable-columns-for-model :default
+  [_]
+  [:name])
+
+(defmethod searchable-columns-for-model (class Table)
+  [_]
+  [:name
+   :display_name])
+
+;;; Scoring
+
+(defn- consecutivity-score
+  "Score in [0, 1] based on the length of the largest matching sub-expression"
+  [tokens result]
+  (->
+   (for [column (searchable-columns-for-model (model-name->class (:model result)))
+         :let [target (-> result
+                          (get column)
+                          normalize
+                          tokenize)]]
+     (largest-common-subseq-length #(str/includes? %2 %1) tokens target))
+   ((partial apply max))
+   (/ (count tokens))))
+
+(s/defn score :- s/Num
+  [query :- s/Str, result :- s/Any] ;; TODO. It's a map with result columns + :model
+  (let [query-tokens (tokenize query)]
+    (+
+     (consecutivity-score query-tokens result))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -301,9 +301,9 @@
                                     :name             nil}]]
         (is (= []
                (filter (fn [{:keys [model id]}]
-                         (and (= id (u/get-id pulse))
+                         (and (= id (u/the-id pulse))
                               (= "pulse" model)))
-                       ((mt/user->client :crowberto) :get 200 "search"))))))))
+                       (mt/user-http-request :crowberto :get 200 "search"))))))))
 
 (defn- default-table-search-row [table-name]
   (merge

--- a/test/metabase/search_test.clj
+++ b/test/metabase/search_test.clj
@@ -10,5 +10,7 @@
            (search/tokenize "                Rasta\tthe    \tToucan     ")))
     (is (= []
            (search/tokenize " \t\n\t ")))
+    (is (= []
+           (search/tokenize "")))
     (is (thrown-with-msg? Exception #"does not match schema"
                           (search/tokenize nil)))))

--- a/test/metabase/search_test.clj
+++ b/test/metabase/search_test.clj
@@ -1,0 +1,14 @@
+(ns metabase.search-test
+  (:require [clojure.test :refer :all]
+            [metabase.search :as search]))
+
+(deftest tokenize-test
+  (testing "basic tokenization"
+    (is (= ["Rasta" "the" "Toucan's" "search"]
+           (search/tokenize "Rasta the Toucan's search")))
+    (is (= ["Rasta" "the" "Toucan"]
+           (search/tokenize "                Rasta\tthe    \tToucan     ")))
+    (is (= []
+           (search/tokenize " \t\n\t ")))
+    (is (thrown-with-msg? Exception #"does not match schema"
+                          (search/tokenize nil)))))

--- a/test/metabase/search_test.clj
+++ b/test/metabase/search_test.clj
@@ -23,7 +23,7 @@
                           (search/tokenize nil)))))
 
 (deftest consecutivity-scorer-test
-  (let [score (comp first (partial #'search/score-with [#'search/consecutivity-scorer]))]
+  (let [score (partial #'search/score-with [#'search/consecutivity-scorer])]
     (testing "partial matches"
       (is (= 1/3
              (score ["rasta" "el" "tucan"]
@@ -53,7 +53,7 @@
                     (result-row "")))))))
 
 (deftest total-occurrences-scorer-test
-  (let [score (comp first (partial #'search/score-with [#'search/total-occurrences-scorer]))]
+  (let [score (partial #'search/score-with [#'search/total-occurrences-scorer])]
     (testing "partial matches"
       (is (= 1/3
              (score ["rasta" "el" "tucan"]
@@ -81,3 +81,18 @@
       (is (= 0
              (score ["rasta" "the" "toucan"]
                     (result-row "")))))))
+
+(deftest exact-match-scorer-test
+  (let [score (partial #'search/score-with [#'search/exact-match-scorer])]
+    (is (= 0
+           (score ["rasta" "the" "toucan"]
+                  (result-row "Crowberto el tucan"))))
+    (is (= 1/3
+           (score ["rasta" "the" "toucan"]
+                  (result-row "Rasta el tucan"))))
+    (is (= 2/3
+           (score ["rasta" "the" "toucan"]
+                  (result-row "Crowberto the toucan"))))
+    (is (= 1
+           (score ["rasta" "the" "toucan"]
+                  (result-row "Rasta the toucan"))))))

--- a/test/metabase/search_test.clj
+++ b/test/metabase/search_test.clj
@@ -2,6 +2,13 @@
   (:require [clojure.test :refer :all]
             [metabase.search :as search]))
 
+(defn- result-row
+  ([name]
+   (result-row name "card"))
+  ([name model]
+   {:model model
+    :name name}))
+
 (deftest tokenize-test
   (testing "basic tokenization"
     (is (= ["Rasta" "the" "Toucan's" "search"]
@@ -14,3 +21,33 @@
            (search/tokenize "")))
     (is (thrown-with-msg? Exception #"does not match schema"
                           (search/tokenize nil)))))
+
+(deftest consecutivity-score-test
+  (let [score #'search/consecutivity-score]
+    (testing "partial matches"
+      (is (= 1/3
+             (score ["rasta" "el" "tucan"]
+                    (result-row "Rasta the Toucan"))))
+      (is (= 1/3
+             (score ["rasta" "el" "tucan"]
+                    (result-row "Here is Rasta the hero of many lands"))))
+      (is (= 2/3
+             (score ["Imposter" "the" "toucan"]
+                    (result-row "Rasta the Toucan"))))
+      (is (= 2/3 ;; substring matching; greedy choice does not work (i.e., don't match on Rasta)
+             (score ["rasta" "the" "toucan"]
+                    (result-row "Rasta may be my favorite of the toucans")))))
+    (testing "exact matches"
+      (is (= 1
+             (score ["rasta" "the" "toucan"]
+                    (result-row "Rasta the Toucan"))))
+      (is (= 1
+             (score ["rasta"]
+                    (result-row "Rasta")))))
+    (testing "misses"
+      (is (= 0
+             (score ["rasta"]
+                    (result-row "just a straight-up imposter")))
+          (= 0
+             (score ["rasta" "the" "toucan"]
+                    (result-row "")))))))

--- a/test/metabase/search_test.clj
+++ b/test/metabase/search_test.clj
@@ -22,8 +22,8 @@
     (is (thrown-with-msg? Exception #"does not match schema"
                           (search/tokenize nil)))))
 
-(deftest consecutivity-score-test
-  (let [score #'search/consecutivity-score]
+(deftest consecutivity-scorer-test
+  (let [score (comp first (partial #'search/score-with [#'search/consecutivity-scorer]))]
     (testing "partial matches"
       (is (= 1/3
              (score ["rasta" "el" "tucan"]
@@ -49,5 +49,35 @@
              (score ["rasta"]
                     (result-row "just a straight-up imposter")))
           (= 0
+             (score ["rasta" "the" "toucan"]
+                    (result-row "")))))))
+
+(deftest total-occurrences-scorer-test
+  (let [score (comp first (partial #'search/score-with [#'search/total-occurrences-scorer]))]
+    (testing "partial matches"
+      (is (= 1/3
+             (score ["rasta" "el" "tucan"]
+                    (result-row "Rasta the Toucan"))))
+      (is (= 1/3
+             (score ["rasta" "el" "tucan"]
+                    (result-row "Here is Rasta the hero of many lands"))))
+      (is (= 2/3
+             (score ["Imposter" "the" "toucan"]
+                    (result-row "Rasta the Toucan")))))
+    (testing "full matches"
+      (is (= 1
+             (score ["rasta" "the" "toucan"]
+                    (result-row "Rasta the Toucan"))))
+      (is (= 1
+             (score ["rasta"]
+                    (result-row "Rasta"))))
+      (is (= 1
+             (score ["rasta" "the" "toucan"]
+                    (result-row "Rasta may be my favorite of the toucans")))))
+    (testing "misses"
+      (is (= 0
+             (score ["rasta"]
+                    (result-row "just a straight-up imposter"))))
+      (is (= 0
              (score ["rasta" "the" "toucan"]
                     (result-row "")))))))


### PR DESCRIPTION
[Fixes #14337]

Enlarges the search results by searching for each of the search tokens separately, then sorts them with several heuristics.

The heuristics seem ~fine on my machine, but the real test will be on stats or somewhere else with a much larger dataset. There's no One Right Answer, just our perception of whether things seem to be in the right order.

If they are, then great.

If they're not, the more sophisticated (industry-standard) approach is [tf-idf](https://en.wikipedia.org/wiki/Tf%E2%80%93idf), which has the downside of needing to maintain a frequency list of how many occurrences of a given term we have. I think we could do that no problem, but it is another table / more storage required / engineering effort to make it stay in sync. If we did have such a table it would pave the way for "did you mean"-style spelling suggestions.