### PR TITLE
Disable width on pivot table AutoSizer

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -439,7 +439,7 @@ export default class PivotTable extends Component {
               <div className="flex flex-full">
                 {/* left header */}
                 <div style={{ width: leftHeaderWidth }}>
-                  <AutoSizer>
+                  <AutoSizer disableWidth>
                     {({ height }) => (
                       <Collection
                         ref={e => (this.leftHeaderRef = e)}
@@ -459,7 +459,7 @@ export default class PivotTable extends Component {
                 </div>
                 {/* pivot table body */}
                 <div>
-                  <AutoSizer>
+                  <AutoSizer disableWidth>
                     {({ height }) => (
                       <Grid
                         width={width - leftHeaderWidth}


### PR DESCRIPTION
Fixes #14591

This PR adds `disableWidth` to the two `AutoSizer` in the pivot table. That's the right thing to do according to [the docs](https://github.com/bvaughn/react-virtualized/blob/master/docs/AutoSizer.md) since we're not using the width provided by `AutoSizer`.

I wasn't expecting it to fix the issue, and I'm still not sure why it does. The issue occurred when the height alone changed but correctly adding this prop seems to solve it both on dashboards and in the query builder.