### PR TITLE
Don't run visualization auto-selection when drilling from dashboard

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -67,6 +67,14 @@ import {
   ALERT_TYPE_TIMESERIES_GOAL,
 } from "metabase-lib/lib/Alert";
 
+const EMPTY_METADATA = new Metadata({
+  databases: {},
+  tables: {},
+  fields: {},
+  metrics: {},
+  segments: {},
+});
+
 type QuestionUpdateFn = (q: Question) => ?Promise<void>;
 
 /**
@@ -106,7 +114,7 @@ export default class Question {
     update?: ?QuestionUpdateFn,
   ) {
     this._card = card;
-    this._metadata = metadata || new Metadata({});
+    this._metadata = metadata || EMPTY_METADATA;
     this._parameterValues = parameterValues || {};
     this._update = update;
   }

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -67,14 +67,6 @@ import {
   ALERT_TYPE_TIMESERIES_GOAL,
 } from "metabase-lib/lib/Alert";
 
-const EMPTY_METADATA = new Metadata({
-  databases: {},
-  tables: {},
-  fields: {},
-  metrics: {},
-  segments: {},
-});
-
 type QuestionUpdateFn = (q: Question) => ?Promise<void>;
 
 /**
@@ -114,7 +106,15 @@ export default class Question {
     update?: ?QuestionUpdateFn,
   ) {
     this._card = card;
-    this._metadata = metadata || EMPTY_METADATA;
+    this._metadata =
+      metadata ||
+      new Metadata({
+        databases: {},
+        tables: {},
+        fields: {},
+        metrics: {},
+        segments: {},
+      });
     this._parameterValues = parameterValues || {};
     this._update = update;
   }

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -101,12 +101,12 @@ export default class Question {
    */
   constructor(
     card: CardObject,
-    metadata: Metadata,
+    metadata?: Metadata,
     parameterValues?: ParameterValues,
     update?: ?QuestionUpdateFn,
   ) {
     this._card = card;
-    this._metadata = metadata;
+    this._metadata = metadata || new Metadata({});
     this._parameterValues = parameterValues || {};
     this._update = update;
   }

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -974,8 +974,7 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       previousCard,
     );
 
-    const cardWithVizSettings = new Question()
-      .setCard(cardAfterClick)
+    const cardWithVizSettings = new Question(cardAfterClick)
       .setDisplay(cardAfterClick.display || previousCard.display)
       .setSettings(
         cardAfterClick.visualization_settings ||

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -974,14 +974,15 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       previousCard,
     );
 
-    // clicking graph title with a filter applied loses display type and visualization settings; see #5278
-    const cardWithVizSettings = {
-      ...cardAfterClick,
-      display: cardAfterClick.display || previousCard.display,
-      visualization_settings:
+    const cardWithVizSettings = new Question()
+      .setCard(cardAfterClick)
+      .setDisplay(cardAfterClick.display || previousCard.display)
+      .setSettings(
         cardAfterClick.visualization_settings ||
-        previousCard.visualization_settings,
-    };
+          previousCard.visualization_settings,
+      )
+      .lockDisplay()
+      .card();
 
     const url = questionUrlWithParameters(
       cardWithVizSettings,

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -50,10 +50,7 @@ export function maybeUsePivotEndpoint(
     return ref;
   }
 
-  const question = new Question(
-    card,
-    metadata || new Metadata({ databases: {} }),
-  );
+  const question = new Question(card, metadata);
 
   function wrap(api) {
     return (params: ?Data, ...rest: any) => {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -357,7 +357,6 @@ function makeBrushChangeFunctions({ series, onChangeCardAndRun }) {
     if (range) {
       const column = series[0].data.cols[0];
       const card = series[0].card;
-      // $FlowFixMe: Question requires Metadata but we don't actually need it in this case
       const query = new Question(card).query();
       const [start, end] = range;
       if (isDimensionTimeseries(series)) {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -486,6 +486,16 @@ describe("scenarios > visualizations > pivot tables", () => {
     it("should display a pivot table on a dashboard (metabase#14465)", () => {
       assertOnPivotFields();
     });
+
+    it("should allow filtering drill through (metabase#14632)", () => {
+      assertOnPivotFields();
+      cy.findByText("Google").click(); // open actions menu
+      popover().within(() => cy.findByText("=").click()); // drill with additional filter
+      cy.findByText("Source is Google"); // filter was added
+      cy.findByText("Row totals"); // it's still a pivot table
+      cy.findByText("1,027"); // primary data value
+      cy.findByText("3,798"); // subtotal value
+    });
   });
 
   describe("sharing (metabase#14447)", () => {


### PR DESCRIPTION
Fixes #14632

This bug occurred when drilling into a pivot table. We jumped you from the dashboard into the query builder, and the visualization auto-selection logic switched away from a pivot table _after_ the query was run. The direct cause was that we didn't rerun the non-pivot query after switching types. This led to displaying "pivot-grouping" in the UI.

I fixed it by preventing the auto-selection. That seemed like a better solution than allowing auto-selection but making sure we rerun the query. If you're drilling into a dashboard card, I expect to see the same visualization when I land in the QB.