### PR TITLE
Skip repro for EE_520

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -505,7 +505,9 @@ describeWithToken("formatting > sandboxes", () => {
         });
       });
 
-      it("advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)", () => {
+      // Quarantined until further notice
+      // Related issues: #10474, #14629
+      it.skip("advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)", () => {
         cy.log("**-- 1. Create the first native question with a filter --**");
 
         cy.request("POST", "/api/card", {


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Skips repro for https://github.com/metabase/metabase-enterprise/issues/520 again (that issue has been reopened)

### Additional context:
- This repro has been flaking all over CI. Potential cause: https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159
- It was first unskipped as part of #14014 (merged as 6312927aa5631b1c6bb5c3c99f80933d2b3f61ff)