### PR TITLE
Allow for `quick` parameter on `notify/db/:id` for quick syncing

### DIFF
--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -9,7 +9,9 @@
 
 (api/defendpoint POST "/db/:id"
   "Notification about a potential schema change to one of our `Databases`.
-  Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single `Table`."
+  Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single
+  `Table`. Optional Parameter `:scan` can be `\"full\" or \"schema\" for a full sync or a schema sync, available
+  regardless if a `:table_id` or `:table_name` is passed."
   [id :as {{:keys [table_id table_name scan]} :body}]
   (when scan
     (or (contains? #{"full" :full "schema" :schema} scan)

--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -11,14 +11,15 @@
   "Notification about a potential schema change to one of our `Databases`.
   Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single `Table`."
   [id :as {{:keys [table_id table_name quick]} :body}]
-  (let [sync-fn (if quick sync-metadata/sync-table-metadata! sync/sync-table!)]
+  (let [table-sync-fn (if quick sync-metadata/sync-table-metadata! sync/sync-table!)
+        db-sync-fn (if quick sync-metadata/sync-db-metadata! sync/sync-database!)]
     (api/let-404 [database (Database id)]
       (cond
         table_id (when-let [table (Table :db_id id, :id (int table_id))]
-                   (future (sync-fn table)))
+                   (future (table-sync-fn table)))
         table_name (when-let [table (Table :db_id id, :name table_name)]
-                     (future (sync-fn table)))
-        :else (future (sync/sync-database! database)))))
+                     (future (table-sync-fn table)))
+        :else (future (db-sync-fn database)))))
   {:success true})
 
 

--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -11,11 +11,6 @@
 
 (def ^:private ^:dynamic *execute-asynchronously* true)
 
-(defmacro ^:private execute
-  "Emit a runtime check whether to run off thread or on thread. Intended to remove race conditions from tests."
-  [form]
-  `(if *execute-asynchronously* (future ~form) ~form))
-
 (api/defendpoint POST "/db/:id"
   "Notification about a potential schema change to one of our `Databases`.
   Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single
@@ -27,14 +22,18 @@
    scan       (s/maybe (s/enum "full" "schema"))}
   (let [schema?       (when scan (#{"schema" :schema} scan))
         table-sync-fn (if schema? sync-metadata/sync-table-metadata! sync/sync-table!)
-        db-sync-fn    (if schema? sync-metadata/sync-db-metadata! sync/sync-database!)]
+        db-sync-fn    (if schema? sync-metadata/sync-db-metadata! sync/sync-database!)
+        execute!      (fn [thunk]
+                        (if *execute-asynchronously*
+                          (future (thunk))
+                          (thunk)))]
     (api/let-404 [database (Database id)]
       (cond
         table_id   (when-let [table (Table :db_id id, :id (int table_id))]
-                     (execute (table-sync-fn table)))
+                     (execute! #(table-sync-fn table)))
         table_name (when-let [table (Table :db_id id, :name table_name)]
-                     (execute (table-sync-fn table)))
-        :else      (execute (db-sync-fn database)))))
+                     (execute! #(table-sync-fn table)))
+        :else      (execute! #(db-sync-fn database)))))
   {:success true})
 
 

--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -40,7 +40,11 @@
   reject the request and return a 403 Forbidden response."
   [handler]
   (fn [{:keys [metabase-api-key], :as request} respond raise]
-    (if (= (api-key) metabase-api-key)
-      (handler request respond raise)
-      ;; default response is 403
-      (respond middleware.u/response-forbidden))))
+    (cond (not metabase-api-key)
+          (respond middleware.u/response-forbidden)
+
+          (= (api-key) metabase-api-key)
+          (handler request respond raise)
+
+          :else
+          (respond middleware.u/response-forbidden))))

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -1,8 +1,10 @@
 (ns metabase.api.notify-test
-  (:require [clj-http.client :as client]
+  (:require [cheshire.core :as json]
+            [clj-http.client :as client]
             [clojure.test :refer :all]
             [metabase.http-client :as http]
-            [metabase.models.database :as database :refer [Database]]
+            [metabase.models.database :as database]
+            [metabase.server.middleware.auth :as auth]
             [metabase.server.middleware.util :as middleware.u]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
@@ -23,7 +25,7 @@
               :body   "Not found."}
              (try (client/post (http/build-url (format "notify/db/%d" Integer/MAX_VALUE) {})
                                {:accept  :json
-                                :headers {"X-METABASE-APIKEY" "test-api-key"
+                                :headers {"X-METABASE-APIKEY" (auth/api-key)
                                           "Content-Type"      "application/json"}})
                   (catch clojure.lang.ExceptionInfo e
                     (select-keys (:object (ex-data e)) [:status :body]))))))))
@@ -31,22 +33,24 @@
 (deftest post-db-id-test
   (mt/test-drivers (mt/normal-drivers)
     (let [table-name (->> (mt/db) database/tables first :name)
-          post (fn [quick]
-                 (try
-                   (mt/user-http-request :rasta :post (format "notify/db/%d" (u/the-id (mt/db)))
-                                         {:quick quick, :table_name table-name})
-                   (catch clojure.lang.ExceptionInfo e
-                     (select-keys (:object (ex-data e)) [:status :body]))))]
+          post       (fn [quick]
+                       (mt/user-http-request :crowberto
+                                             :post
+                                             (format "notify/db/%d" (u/the-id (mt/db)))
+                                             {:request-options
+                                              {:headers {"X-METABASE-APIKEY" (auth/api-key)
+                                                         "Content-Type"      "application/json"}}}
+                                             {:quick quick, :table_name table-name}))]
       (testing "sync just table when table is provided"
         (let [long-sync-called? (atom false), short-sync-called? (atom false)]
-          (with-redefs [metabase.sync/sync-table! (fn [_table] (reset! long-sync-called? true))
+          (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
                         metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
             (is (= {:success true} (post false)))
             (is @long-sync-called?)
             (is (not @short-sync-called?)))))
       (testing "only a quick sync when quick parameter is provided"
         (let [long-sync-called? (atom false), short-sync-called? (atom false)]
-          (with-redefs [metabase.sync/sync-table! (fn [_table] (reset! long-sync-called? true))
+          (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
                         metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
             (is (= {:success true} (post true)))
             (is (not @long-sync-called?))

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -34,13 +34,11 @@
   (mt/test-drivers (mt/normal-drivers)
     (let [table-name (->> (mt/db) database/tables first :name)
           post       (fn [quick]
-                       (mt/user-http-request :crowberto
-                                             :post
-                                             (format "notify/db/%d" (u/the-id (mt/db)))
-                                             {:request-options
-                                              {:headers {"X-METABASE-APIKEY" (auth/api-key)
-                                                         "Content-Type"      "application/json"}}}
-                                             {:quick quick, :table_name table-name}))]
+                       (mt/client :post 200 (format "notify/db/%d" (u/the-id (mt/db)))
+                                  {:request-options
+                                   {:headers {"X-METABASE-APIKEY" (auth/api-key)
+                                              "Content-Type"      "application/json"}}}
+                                  {:quick quick, :table_name table-name}))]
       (testing "sync just table when table is provided"
         (let [long-sync-called? (atom false), short-sync-called? (atom false)]
           (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -33,25 +33,38 @@
 (deftest post-db-id-test
   (mt/test-drivers (mt/normal-drivers)
     (let [table-name (->> (mt/db) database/tables first :name)
-          post       (fn [quick]
+          post       (fn [payload]
                        (mt/client :post 200 (format "notify/db/%d" (u/the-id (mt/db)))
                                   {:request-options
                                    {:headers {"X-METABASE-APIKEY" (auth/api-key)
                                               "Content-Type"      "application/json"}}}
-                                  {:quick quick, :table_name table-name}))]
+                                  payload))]
       (testing "sync just table when table is provided"
         (let [long-sync-called? (atom false), short-sync-called? (atom false)]
           (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
                         metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
-            (is (= {:success true} (post false)))
+            (is (= {:success true} (post {:quick false, :table_name table-name})))
             (is @long-sync-called?)
             (is (not @short-sync-called?)))))
       (testing "only a quick sync when quick parameter is provided"
         (let [long-sync-called? (atom false), short-sync-called? (atom false)]
           (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
                         metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
-            (is (= {:success true} (post true)))
+            (is (= {:success true} (post {:quick true, :table_name table-name})))
             (is (not @long-sync-called?))
-            (is @short-sync-called?)))))))
+            (is @short-sync-called?))))
+      (testing "full db sync by default"
+        (let [full-sync? (atom false)]
+          (with-redefs [metabase.sync/sync-database! (fn [_db] (reset! full-sync? true))]
+            (post {})
+            (is @full-sync?))))
+      (testing "simple sync with params"
+        (let [full-sync?   (atom false)
+              smaller-sync (atom true)]
+          (with-redefs [metabase.sync/sync-database!                  (fn [_db] (reset! full-sync? true))
+                        metabase.sync.sync-metadata/sync-db-metadata! (fn [_db] (reset! smaller-sync true))]
+            (post {:quick true})
+            (is (not @full-sync?))
+            (is @smaller-sync)))))))
 
 ;; TODO - how can we validate the normal scenario given that it just kicks off a background job?

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -3,6 +3,7 @@
             [clj-http.client :as client]
             [clojure.test :refer :all]
             [environ.core :as env]
+            [metabase.api.notify :as notify]
             [metabase.http-client :as http]
             [metabase.models.database :as database]
             [metabase.server.middleware.util :as middleware.u]
@@ -40,45 +41,46 @@
                       (select-keys (:object (ex-data e)) [:status :body])))))))))
 
 (deftest post-db-id-test
-  (with-api-key "testing-api-key"
-    (mt/test-drivers (mt/normal-drivers)
-      (let [table-name (->> (mt/db) database/tables first :name)
-            post       (fn post-api
-                         ([payload] (post-api payload 200))
-                         ([payload expected-code]
-                          (mt/client :post expected-code (format "notify/db/%d" (u/the-id (mt/db)))
-                                     {:request-options
-                                      {:headers {"X-METABASE-APIKEY" "testing-api-key"
-                                                 "Content-Type"      "application/json"}}}
-                                     payload)))]
-        (testing "sync just table when table is provided"
-          (let [long-sync-called? (atom false), short-sync-called? (atom false)]
-            (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
-                          metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
-              (post {:scan :full, :table_name table-name})
-              (is @long-sync-called?)
-              (is (not @short-sync-called?)))))
-        (testing "only a quick sync when quick parameter is provided"
-          (let [long-sync-called? (atom false), short-sync-called? (atom false)]
-            (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
-                          metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
-              (post {:scan :schema, :table_name table-name})
-              (is (not @long-sync-called?))
-              (is @short-sync-called?))))
-        (testing "full db sync by default"
-          (let [full-sync? (atom false)]
-            (with-redefs [metabase.sync/sync-database! (fn [_db] (reset! full-sync? true))]
-              (post {})
-              (is @full-sync?))))
-        (testing "simple sync with params"
-          (let [full-sync?   (atom false)
-                smaller-sync (atom true)]
-            (with-redefs [metabase.sync/sync-database!                  (fn [_db] (reset! full-sync? true))
-                          metabase.sync.sync-metadata/sync-db-metadata! (fn [_db] (reset! smaller-sync true))]
-              (post {:scan :schema})
-              (is (not @full-sync?))
-              (is @smaller-sync))))
-        (testing "errors on unrecognized scan options"
-          (is (= {:errors
-                  {:scan "value may be nil, or if non-nil, value must be one of: `full`, `schema`."}}
-                 (post {:scan :unrecognized} 400))))))))
+  (binding [notify/*execute-asynchronously* false]
+    (with-api-key "testing-api-key"
+      (mt/test-drivers (mt/normal-drivers)
+        (let [table-name (->> (mt/db) database/tables first :name)
+              post       (fn post-api
+                           ([payload] (post-api payload 200))
+                           ([payload expected-code]
+                            (mt/client :post expected-code (format "notify/db/%d" (u/the-id (mt/db)))
+                                       {:request-options
+                                        {:headers {"X-METABASE-APIKEY" "testing-api-key"
+                                                   "Content-Type"      "application/json"}}}
+                                       payload)))]
+          (testing "sync just table when table is provided"
+            (let [long-sync-called? (atom false), short-sync-called? (atom false)]
+              (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
+                            metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
+                (post {:scan :full, :table_name table-name})
+                (is @long-sync-called?)
+                (is (not @short-sync-called?)))))
+          (testing "only a quick sync when quick parameter is provided"
+            (let [long-sync-called? (atom false), short-sync-called? (atom false)]
+              (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
+                            metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
+                (post {:scan :schema, :table_name table-name})
+                (is (not @long-sync-called?))
+                (is @short-sync-called?))))
+          (testing "full db sync by default"
+            (let [full-sync? (atom false)]
+              (with-redefs [metabase.sync/sync-database! (fn [_db] (reset! full-sync? true))]
+                (post {})
+                (is @full-sync?))))
+          (testing "simple sync with params"
+            (let [full-sync?   (atom false)
+                  smaller-sync (atom true)]
+              (with-redefs [metabase.sync/sync-database!                  (fn [_db] (reset! full-sync? true))
+                            metabase.sync.sync-metadata/sync-db-metadata! (fn [_db] (reset! smaller-sync true))]
+                (post {:scan :schema})
+                (is (not @full-sync?))
+                (is @smaller-sync))))
+          (testing "errors on unrecognized scan options"
+            (is (= {:errors
+                    {:scan "value may be nil, or if non-nil, value must be one of: `full`, `schema`."}}
+                   (post {:scan :unrecognized} 400)))))))))

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -79,5 +79,6 @@
               (is (not @full-sync?))
               (is @smaller-sync))))
         (testing "errors on unrecognized scan options"
-          (is (= "Optional scan parameter must be either \"full\" or \"scan\""
+          (is (= {:errors
+                  {:scan "value may be nil, or if non-nil, value must be one of: `full`, `schema`."}}
                  (post {:scan :unrecognized} 400))))))))

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -2,6 +2,7 @@
   (:require [cheshire.core :as json]
             [clj-http.client :as client]
             [clojure.test :refer :all]
+            [environ.core :as env]
             [metabase.http-client :as http]
             [metabase.models.database :as database]
             [metabase.server.middleware.auth :as auth]
@@ -12,59 +13,70 @@
 
 (use-fixtures :once (fixtures/initialize :db :web-server))
 
+(defn- do-with-api-key [api-key thunk]
+  (with-redefs [env/env (assoc env/env :mb-api-key api-key)]
+    (thunk)))
+
+(defmacro ^:private with-api-key [api-key & body]
+  `(do-with-api-key ~api-key (fn [] ~@body)))
+
 (deftest unauthenticated-test
-  (testing "POST /api/notify/db/:id"
-    (testing "endpoint should require authentication"
-      (is (= (get middleware.u/response-forbidden :body)
-             (http/client :post 403 "notify/db/100"))))))
+  (with-api-key "testing-api-key"
+    (testing "POST /api/notify/db/:id"
+      (testing "endpoint should require authentication"
+        (is (= (get middleware.u/response-forbidden :body)
+               (http/client :post 403 "notify/db/100")))))))
 
 (deftest not-found-test
-  (testing "POST /api/notify/db/:id"
-    (testing "database must exist or we get a 404"
-      (is (= {:status 404
-              :body   "Not found."}
-             (try (client/post (http/build-url (format "notify/db/%d" Integer/MAX_VALUE) {})
-                               {:accept  :json
-                                :headers {"X-METABASE-APIKEY" (auth/api-key)
-                                          "Content-Type"      "application/json"}})
-                  (catch clojure.lang.ExceptionInfo e
-                    (select-keys (:object (ex-data e)) [:status :body]))))))))
+  (with-api-key "testing-api-key"
+    (testing "POST /api/notify/db/:id"
+      (testing "database must exist or we get a 404"
+        (is (= {:status 404
+                :body   "Not found."}
+               (try (client/post (http/build-url (format "notify/db/%d" Integer/MAX_VALUE) {})
+                                 {:accept  :json
+                                  :headers {"X-METABASE-APIKEY" "testing-api-key"
+                                            "Content-Type"      "application/json"}})
+                    (catch clojure.lang.ExceptionInfo e
+                      (select-keys (:object (ex-data e)) [:status :body])))))))))
 
-(deftest post-db-id-test
-  (mt/test-drivers (mt/normal-drivers)
-    (let [table-name (->> (mt/db) database/tables first :name)
-          post       (fn [payload]
-                       (mt/client :post 200 (format "notify/db/%d" (u/the-id (mt/db)))
-                                  {:request-options
-                                   {:headers {"X-METABASE-APIKEY" (auth/api-key)
-                                              "Content-Type"      "application/json"}}}
-                                  payload))]
-      (testing "sync just table when table is provided"
-        (let [long-sync-called? (atom false), short-sync-called? (atom false)]
-          (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
-                        metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
-            (is (= {:success true} (post {:quick false, :table_name table-name})))
-            (is @long-sync-called?)
-            (is (not @short-sync-called?)))))
-      (testing "only a quick sync when quick parameter is provided"
-        (let [long-sync-called? (atom false), short-sync-called? (atom false)]
-          (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
-                        metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
-            (is (= {:success true} (post {:quick true, :table_name table-name})))
-            (is (not @long-sync-called?))
-            (is @short-sync-called?))))
-      (testing "full db sync by default"
-        (let [full-sync? (atom false)]
-          (with-redefs [metabase.sync/sync-database! (fn [_db] (reset! full-sync? true))]
-            (post {})
-            (is @full-sync?))))
-      (testing "simple sync with params"
-        (let [full-sync?   (atom false)
-              smaller-sync (atom true)]
-          (with-redefs [metabase.sync/sync-database!                  (fn [_db] (reset! full-sync? true))
-                        metabase.sync.sync-metadata/sync-db-metadata! (fn [_db] (reset! smaller-sync true))]
-            (post {:quick true})
-            (is (not @full-sync?))
-            (is @smaller-sync)))))))
 
 ;; TODO - how can we validate the normal scenario given that it just kicks off a background job?
+
+(deftest post-db-id-test
+  (with-api-key "testing-api-key"
+    (mt/test-drivers (mt/normal-drivers)
+      (let [table-name (->> (mt/db) database/tables first :name)
+            post       (fn [payload]
+                         (mt/client :post 200 (format "notify/db/%d" (u/the-id (mt/db)))
+                                    {:request-options
+                                     {:headers {"X-METABASE-APIKEY" "testing-api-key"
+                                                "Content-Type"      "application/json"}}}
+                                    payload))]
+        (testing "sync just table when table is provided"
+          (let [long-sync-called? (atom false), short-sync-called? (atom false)]
+            (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
+                          metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
+              (post {:quick false, :table_name table-name})
+              (is @long-sync-called?)
+              (is (not @short-sync-called?)))))
+        (testing "only a quick sync when quick parameter is provided"
+          (let [long-sync-called? (atom false), short-sync-called? (atom false)]
+            (with-redefs [metabase.sync/sync-table!                        (fn [_table] (reset! long-sync-called? true))
+                          metabase.sync.sync-metadata/sync-table-metadata! (fn [_table] (reset! short-sync-called? true))]
+              (post {:quick true, :table_name table-name})
+              (is (not @long-sync-called?))
+              (is @short-sync-called?))))
+        (testing "full db sync by default"
+          (let [full-sync? (atom false)]
+            (with-redefs [metabase.sync/sync-database! (fn [_db] (reset! full-sync? true))]
+              (post {})
+              (is @full-sync?))))
+        (testing "simple sync with params"
+          (let [full-sync?   (atom false)
+                smaller-sync (atom true)]
+            (with-redefs [metabase.sync/sync-database!                  (fn [_db] (reset! full-sync? true))
+                          metabase.sync.sync-metadata/sync-db-metadata! (fn [_db] (reset! smaller-sync true))]
+              (post {:quick true})
+              (is (not @full-sync?))
+              (is @smaller-sync))))))))

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -5,7 +5,6 @@
             [environ.core :as env]
             [metabase.http-client :as http]
             [metabase.models.database :as database]
-            [metabase.server.middleware.auth :as auth]
             [metabase.server.middleware.util :as middleware.u]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -40,9 +40,6 @@
                     (catch clojure.lang.ExceptionInfo e
                       (select-keys (:object (ex-data e)) [:status :body])))))))))
 
-
-;; TODO - how can we validate the normal scenario given that it just kicks off a background job?
-
 (deftest post-db-id-test
   (with-api-key "testing-api-key"
     (mt/test-drivers (mt/normal-drivers)

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -128,4 +128,14 @@
     (testing "invalid apikey, expect 403"
       (is (= middleware.u/response-forbidden
              (api-key-enforced-handler
-              (request-with-api-key "foobar")))))))
+              (request-with-api-key "foobar"))))))
+
+  (testing "no apikey is set, expect 403"
+    (mt/with-temporary-setting-values [api-key nil]
+      (is (= middleware.u/response-forbidden
+             (api-key-enforced-handler
+              (mock/request :get "/anyurl")))))
+    (mt/with-temporary-setting-values [api-key ""]
+      (is (= middleware.u/response-forbidden
+             (api-key-enforced-handler
+              (mock/request :get "/anyurl")))))))


### PR DESCRIPTION
fixes #14634.

Allows for a post of `{:table-name "CATEGORIES" :scan schema}` to indicate a quick sync rather than the full sync, analysis, and field-values that `notify/db/:id` normally does.

Also extended so that just posting to `notify/db/<id>` with `{:scan schema}` allows for just the metadata sync rather than a full sync.