### PR TITLE
Fix custom columns in pivot tables

### DIFF
--- a/backend/mbql/src/metabase/mbql/schema.clj
+++ b/backend/mbql/src/metabase/mbql/schema.clj
@@ -869,7 +869,7 @@
     (s/optional-key :source-table) SourceTable
     (s/optional-key :aggregation)  (su/non-empty [Aggregation])
     (s/optional-key :breakout)     (su/non-empty [Field])
-    ;; TODO - expressions keys should be strings; fix this when we get a chance
+    ;; TODO - expressions keys should be strings; fix this when we get a chance (#14647)
     (s/optional-key :expressions)  {s/Keyword FieldOrExpressionDef}
     (s/optional-key :fields)       Fields
     (s/optional-key :filter)       Filter

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -447,7 +447,7 @@ describe("scenarios > visualizations > pivot tables", () => {
   });
 
   describe("custom columns (metabase#14604)", () => {
-    it.skip("should work with custom columns as values", () => {
+    it("should work with custom columns as values", () => {
       visitQuestionAdhoc({
         dataset_query: {
           database: 1,
@@ -482,7 +482,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       cy.findByText("3,021,243.37"); // sum of "twice total" grand total
     });
 
-    it.skip("should work with custom columns as pivoted columns", () => {
+    it("should work with custom columns as pivoted columns", () => {
       visitQuestionAdhoc({
         dataset_query: {
           type: "query",

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -96,7 +96,7 @@
     (update-in query [:query :expressions] assoc :pivot-grouping [:abs bitmask])
     ;; in PostgreSQL and most other databases, all the expressions must be present in the breakouts. Add a pivot
     ;; grouping expression ref to the breakouts
-    (update-in query [:query :breakout] concat [[:expression "pivot-grouping"]])
+    (assoc-in query [:query :breakout] (concat breakout [[:expression "pivot-grouping"]]))
     (do
       (log/tracef "Added pivot-grouping expression to query\n%s" (u/pprint-to-str 'yellow query))
       query)))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -1,12 +1,14 @@
 (ns metabase.query-processor.pivot
   "Pivot table actions for the query processor"
   (:require [clojure.core.async :as a]
+            [clojure.tools.logging :as log]
             [metabase.mbql.normalize :as mbql.normalize]
             [metabase.query-processor :as qp]
             [metabase.query-processor.context :as qp.context]
             [metabase.query-processor.context.default :as context.default]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
+            [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]))
 
 (defn powerset
@@ -84,29 +86,30 @@
         ;; bottom right corner [_ _ _ _] => 1111 => Group #15
         [[]]))))))
 
-(defn add-grouping-field
+(defn- add-grouping-field
   "Add the grouping field and expression to the query"
   [query breakout bitmask]
-  (let [new-query (-> query
-                      ;;TODO: `pivot-grouping` is not "magic" enough to mark it as an internal thing
-                      (update-in [:query :fields]
-                                 #(conj % [:expression "pivot-grouping"]))
-                      ;;TODO: replace this value with a bitmask or something to indicate the source better
-                      (update-in [:query :expressions]
-                                 #(assoc % "pivot-grouping" [:abs bitmask])))]
-    ;; in PostgreSQL and most other databases, all the expressions must be present in the breakouts
-    (assoc-in new-query [:query :breakout]
-              (concat breakout (map (fn [expr] [:expression (name expr)])
-                                    (keys (get-in new-query [:query :expressions])))))))
+  (as-> query query
+    ;;TODO: `pivot-grouping` is not "magic" enough to mark it as an internal thing
+    (update-in query [:query :fields] concat [[:expression "pivot-grouping"]])
+    ;;TODO: replace this value with a bitmask or something to indicate the source better
+    (update-in query [:query :expressions] assoc :pivot-grouping [:abs bitmask])
+    ;; in PostgreSQL and most other databases, all the expressions must be present in the breakouts. Add a pivot
+    ;; grouping expression ref to the breakouts
+    (update-in query [:query :breakout] concat [[:expression "pivot-grouping"]])
+    (do
+      (log/tracef "Added pivot-grouping expression to query\n%s" (u/pprint-to-str 'yellow query))
+      query)))
 
 (defn- generate-queries
   "Generate the additional queries to perform a generic pivot table"
   [{{all-breakouts :breakout} :query, :keys [pivot-rows pivot-cols query], :as outer-query}]
   (try
-    (for [breakout-indices (breakout-combinations (count all-breakouts) pivot-rows pivot-cols)
-          :let             [group-bitmask    (group-bitmask (count all-breakouts) breakout-indices)
+    (for [breakout-indices (u/prog1 (breakout-combinations (count all-breakouts) pivot-rows pivot-cols)
+                             (log/tracef "Using breakout combinations: %s" (pr-str <>)))
+          :let             [group-bitmask (group-bitmask (count all-breakouts) breakout-indices)
                             new-breakouts (for [i breakout-indices]
-                                             (nth all-breakouts i))]]
+                                            (nth all-breakouts i))]]
       (add-grouping-field outer-query new-breakouts group-bitmask))
     (catch Throwable e
       (throw (ex-info (tru "Error generating pivot queries")

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -374,12 +374,12 @@
 
             (let [cols (get-in result [:data :cols])]
               (is (= 7 (count cols)))
-              (is (= {:base_type "type/Text"
-                      :special_type nil
-                      :name "test-expr"
-                      :display_name "test-expr"
-                      :expression_name "test-expr"
-                      :field_ref ["expression" "test-expr"]
+              (is (= {:base_type "type/Integer"
+                      :special_type "type/Number"
+                      :name "pivot-grouping"
+                      :display_name "pivot-grouping"
+                      :expression_name "pivot-grouping"
+                      :field_ref ["expression" "pivot-grouping"]
                       :source "breakout"}
                      (nth cols 3))))
 

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -189,13 +189,14 @@
 (deftest return-correct-columns-test
   (let [results (pivot/run-pivot-query (pivot.test-utils/pivot-query))
         rows    (mt/rows results)]
-    (is (= ["User → State"
-            "User → Source"
-            "Product → Category"
-            "pivot-grouping"
-            "Count"
-            "Sum of Quantity"]
-           (map :display_name (mt/cols results))))
+    (testing "Columns should come back in the expected order"
+      (is (= ["User → State"
+              "User → Source"
+              "Product → Category"
+              "pivot-grouping"
+              "Count"
+              "Sum of Quantity"]
+             (map :display_name (mt/cols results)))))
     (testing "Rows should have the correct shape"
       (let [Row [(s/one (s/maybe (apply s/enum (distinct-values :people   :state)))    "state")
                  (s/one (s/maybe (apply s/enum (distinct-values :people   :source)))   "source")
@@ -224,14 +225,34 @@
 
 (deftest pivots-should-not-return-expressions-test
   (mt/dataset sample-dataset
-    (testing "Pivots should not return expression columns in the results (#14604)"
-      (let [query (assoc (mt/mbql-query orders
-                           {:aggregation [[:count]]
-                            :breakout    [$user_id->people.source $product_id->products.category]})
-                         :pivot-rows [0]
-                         :pivot-cols [1])]
+    (let [query (assoc (mt/mbql-query orders
+                         {:aggregation [[:count]]
+                          :breakout    [$user_id->people.source $product_id->products.category]})
+                       :pivot-rows [0]
+                       :pivot-cols [1])]
+      (testing (str "Pivots should not return expression columns in the results if they are not explicitly included in "
+                    "`:fields` (#14604)")
         (is (= (pivot/run-pivot-query query)
-               (pivot/run-pivot-query (assoc-in query [:query :expressions] {"Don't include me pls" [:+ 1 1]}))))))
+               (pivot/run-pivot-query (assoc-in query [:query :expressions] {"Don't include me pls" [:+ 1 1]})))))
+
+      (testing "If the expression is *explicitly* included in `:fields`, then return it, I guess"
+        ;; I'm not sure this behavior makes sense -- it seems liable to result in a query the FE can't handle
+        ;; correctly, like #14604. The difference here is that #14064 was including expressions that weren't in
+        ;; `:fields` at all, which was a clear bug -- while returning expressions that are referenced in `:fields` is
+        ;; how the QP normally works in non-pivot-mode.
+        ;;
+        ;; I do not think there are any situations where the frontend actually explicitly specifies `:fields` in a
+        ;; pivot query, so we can revisit this behavior at a later date if needed.
+        (is (= ["User → Source"
+                "Product → Category"
+                "pivot-grouping"
+                "Count"
+                "test-expr"]
+               (map :display_name
+                    (mt/cols
+                      (pivot/run-pivot-query (-> query
+                                                 (assoc-in [:query :fields] [[:expression "test-expr"]])
+                                                 (assoc-in [:query :expressions] {:test-expr [:ltrim "wheeee"]})))))))))
 
     (testing "We should still be able to use expressions inside the aggregations"
       (is (schema= {:status   (s/eq :completed)

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -118,23 +118,23 @@
                                                  [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
                                                  [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
                                                  [:expression "pivot-grouping"]]
-                                   :expressions {"pivot-grouping" [:abs 0]}}}
+                                   :expressions {:pivot-grouping [:abs 0]}}}
                           {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
                                                  [:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
                                                  [:expression "pivot-grouping"]]
-                                   :expressions {"pivot-grouping" [:abs 1]}}}
+                                   :expressions {:pivot-grouping [:abs 1]}}}
                           {:query {:breakout    [[:fk-> (mt/$ids $orders.product_id) (mt/$ids $products.category)]
                                                  [:expression "pivot-grouping"]]
-                                   :expressions {"pivot-grouping" [:abs 3]}}}
+                                   :expressions {:pivot-grouping [:abs 3]}}}
                           {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
                                                  [:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.state)]
                                                  [:expression "pivot-grouping"]]
-                                   :expressions {"pivot-grouping" [:abs 4]}}}
+                                   :expressions {:pivot-grouping [:abs 4]}}}
                           {:query {:breakout    [[:fk-> (mt/$ids $orders.user_id) (mt/$ids $people.source)]
                                                  [:expression "pivot-grouping"]]
-                                   :expressions {"pivot-grouping" [:abs 5]}}}
+                                   :expressions {:pivot-grouping [:abs 5]}}}
                           {:query {:breakout    [[:expression "pivot-grouping"]]
-                                   :expressions {"pivot-grouping" [:abs 7]}}}]
+                                   :expressions {:pivot-grouping [:abs 7]}}}]
                 expected (map (fn [expected-val] (-> expected-val
                                                      (assoc :type       :query
                                                             :parameters []

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -215,6 +215,13 @@
     (is (= (count (mt/rows (pivot/run-pivot-query (pivot.test-utils/pivot-query))))
            (pivot/run-pivot-query (pivot.test-utils/pivot-query) nil {:rff rff})))))
 
+(deftest parameters-query-test
+  (mt/dataset sample-dataset
+    (is (schema= {:status    (s/eq :completed)
+                  :row_count (s/eq 137)
+                  s/Keyword  s/Any}
+                 (pivot/run-pivot-query (pivot.test-utils/parameters-query))))))
+
 (deftest pivots-should-not-return-expressions-test
   (mt/dataset sample-dataset
     (testing "Pivots should not return expression columns in the results (#14604)"

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -2,6 +2,7 @@
   "Tests for pivot table actions for the query processor"
   (:require [clojure.set :as set]
             [clojure.test :refer :all]
+            [medley.core :as m]
             [metabase.api.pivots :as pivot.test-utils]
             [metabase.query-processor :as qp]
             [metabase.query-processor.pivot :as pivot]
@@ -232,8 +233,10 @@
                        :pivot-cols [1])]
       (testing (str "Pivots should not return expression columns in the results if they are not explicitly included in "
                     "`:fields` (#14604)")
-        (is (= (pivot/run-pivot-query query)
-               (pivot/run-pivot-query (assoc-in query [:query :expressions] {"Don't include me pls" [:+ 1 1]})))))
+        (is (= (m/dissoc-in (pivot/run-pivot-query query)
+                            [:data :results_metadata :checksum])
+               (m/dissoc-in (pivot/run-pivot-query (assoc-in query [:query :expressions] {"Don't include me pls" [:+ 1 1]}))
+                            [:data :results_metadata :checksum]))))
 
       (testing "If the expression is *explicitly* included in `:fields`, then return it, I guess"
         ;; I'm not sure this behavior makes sense -- it seems liable to result in a query the FE can't handle

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [java-time :as t]
+            [medley.core :as m]
             [metabase.driver :as driver]
             [metabase.query-processor :as qp]
             [metabase.query-processor-test :as qp.test]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -5,6 +5,7 @@
             [clojure.test :refer :all]
             [java-time :as t]
             [metabase.driver :as driver]
+            [metabase.query-processor :as qp]
             [metabase.query-processor-test :as qp.test]
             [metabase.sync :as sync]
             [metabase.test :as mt]
@@ -84,6 +85,37 @@
                   :fields      [[:expression :x]]
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
+
+(deftest dont-return-expressions-if-fields-is-explicit-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
+    (let [query (mt/mbql-query venues
+                  {:expressions {"Price + 1" [:+ $price 1]
+                                 "1 + 1"     [:+ 1 1]}
+                   :fields      [$price [:expression "1 + 1"]]
+                   :order-by    [[:asc $id]]
+                   :limit       3})]
+      (testing "If an explicit `:fields` clause is present, expressions *not* in that clause should not come back"
+        (is (= [[3 2] [2 2] [2 2]]
+               (mt/formatted-rows [int int]
+                 (qp/process-query query)))))
+
+      (testing "If `:fields` is not explicit, then return all the expressions"
+        (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 4 2]
+                [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2 3 2]
+                [3 "The Apple Pan"         11 34.0406 -118.428 2 3 2]]
+               (mt/formatted-rows [int str int 4.0 4.0 int int int]
+                 (qp/process-query (m/dissoc-in query [:query :fields]))))))
+
+      (testing "When aggregating, expressions that aren't used shouldn't come back"
+        (is (= [[2 22] [3 59] [4 13]]
+               (mt/formatted-rows [int int]
+                 (mt/run-mbql-query venues
+                   {:expressions {"Price + 1" [:+ $price 1]
+                                  "1 + 1"     [:+ 1 1]}
+                    :aggregation [:count]
+                    :breakout    [[:expression "Price + 1"]]
+                    :order-by    [[:asc [:expression "Price + 1"]]]
+                    :limit       3}))))))))
 
 (deftest expressions-in-order-by-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -6,7 +6,7 @@
   (:require clojure.data
             [clojure.test :refer :all]
             [clojure.tools.macro :as tools.macro]
-            [clojure.walk :as walk]
+            [environ.core :as env]
             [java-time :as t]
             [medley.core :as m]
             [metabase.driver :as driver]
@@ -261,7 +261,10 @@
                       middleware-fn
                       [middleware-fn])))
          context  (merge
-                   {:timeout 500
+                   ;; CI is S U P E R  S L O W so give this a longer timeout.
+                   {:timeout (if (env/env :ci)
+                               5000
+                               500)
                     :runf    (fn [query rff context]
                                (try
                                  (when run (run))


### PR DESCRIPTION
The issue here was that the `qp.pivot` code was merging in *all* `:expressions` into the `:breakouts` list rather than just the expression that returned the pivot group. It was actually a simple fix but it took me a while to figure that out

Fixes #14604