### PR TITLE
Add ->$ids and ->query-shorthand test util macros

### DIFF
--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -63,6 +63,7 @@
 (p/import-vars
  [data
   $ids
+  ->$ids
   dataset
   db
   format-name
@@ -70,6 +71,7 @@
   mbql-query
   native-query
   query
+  ->query-shorthand
   run-mbql-query
   with-db
   with-temp-copy-of-db]


### PR DESCRIPTION
`mt/$ids` and `mt/query` in reverse. Useful for me when in the REPL and writing tests