### PR TITLE
Rename dimensionExpression to identifierExpression

### DIFF
--- a/frontend/src/metabase/lib/expressions/compile.js
+++ b/frontend/src/metabase/lib/expressions/compile.js
@@ -88,8 +88,8 @@ class ExpressionMBQLCompilerVisitor extends ExpressionCstVisitor {
     return mbql;
   }
 
-  dimensionExpression(ctx) {
-    const name = this.visit(ctx.dimensionName);
+  identifierExpression(ctx) {
+    const name = this.visit(ctx.identifierName);
     return this.resolve(ctx.resolveAs, name);
   }
 

--- a/frontend/src/metabase/lib/expressions/parser.js
+++ b/frontend/src/metabase/lib/expressions/parser.js
@@ -294,12 +294,12 @@ export class ExpressionParser extends CstParser {
       $.CONSUME(RParen);
     });
 
-    $.RULE("dimensionExpression", () => {
+    $.RULE("identifierExpression", () => {
       $.OR([
         {
-          ALT: () => $.SUBRULE($.identifierString, { LABEL: "dimensionName" }),
+          ALT: () => $.SUBRULE($.identifierString, { LABEL: "identifierName" }),
         },
-        { ALT: () => $.SUBRULE($.identifier, { LABEL: "dimensionName" }) },
+        { ALT: () => $.SUBRULE($.identifier, { LABEL: "identifierName" }) },
       ]);
     });
 
@@ -358,9 +358,9 @@ export class ExpressionParser extends CstParser {
               }),
           },
           {
-            // dimension (or later recasted into metric or segment)
+            // dimension/metric/segment
             ALT: () =>
-              $.SUBRULE($.dimensionExpression, {
+              $.SUBRULE($.identifierExpression, {
                 ARGS: [returnType],
                 LABEL: "expression",
               }),

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -138,14 +138,14 @@ export function suggest({
       // fields, metrics, segments
       const parentRule = ruleStack.slice(-2, -1)[0];
       const isDimension =
-        parentRule === "dimensionExpression" &&
+        parentRule === "identifierExpression" &&
         (isExpressionType(expectedType, "expression") ||
           isExpressionType(expectedType, "boolean"));
       const isSegment =
-        parentRule === "dimensionExpression" &&
+        parentRule === "identifierExpression" &&
         isExpressionType(expectedType, "boolean");
       const isMetric =
-        parentRule === "dimensionExpression" &&
+        parentRule === "identifierExpression" &&
         isExpressionType(expectedType, "aggregation");
 
       if (isDimension) {
@@ -527,7 +527,7 @@ const ALL_RULES = [
   "multiplicationExpression",
   "functionExpression",
   "caseExpression",
-  "dimensionExpression",
+  "identifierExpression",
   "identifier",
   "identifierString",
   "stringLiteral",

--- a/frontend/src/metabase/lib/expressions/syntax.js
+++ b/frontend/src/metabase/lib/expressions/syntax.js
@@ -166,8 +166,8 @@ export class ExpressionSyntaxVisitor extends ExpressionCstVisitor {
     return this.functionExpression(ctx);
   }
 
-  dimensionExpression(ctx) {
-    return syntaxNode(ctx.resolveAs, this.visit(ctx.dimensionName));
+  identifierExpression(ctx) {
+    return syntaxNode(ctx.resolveAs, this.visit(ctx.identifierName));
   }
 
   identifier(ctx) {

--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -80,7 +80,7 @@ export function typeCheck(cst, rootType) {
       });
     }
 
-    dimensionExpression(ctx) {
+    identifierExpression(ctx) {
       const type = this.typeStack[0];
       if (type === "aggregation") {
         ctx.resolveAs = "metric";
@@ -92,7 +92,7 @@ export function typeCheck(cst, rootType) {
           throw new Error("Incorrect type for dimension");
         }
       }
-      return super.dimensionExpression(ctx);
+      return super.identifierExpression(ctx);
     }
   }
   const checker = new TypeChecker();

--- a/frontend/src/metabase/lib/expressions/visitor.js
+++ b/frontend/src/metabase/lib/expressions/visitor.js
@@ -64,8 +64,8 @@ export class ExpressionVisitor {
     return (ctx.arguments || []).map(argument => this.visit(argument));
   }
 
-  dimensionExpression(ctx) {
-    return this.visit(ctx.dimensionName);
+  identifierExpression(ctx) {
+    return this.visit(ctx.identifierName);
   }
   identifier(ctx) {
     return (ctx.Identifier || []).map(id => id.image);

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -48,8 +48,8 @@ describe("type-checker", () => {
       identifierString(ctx) {
         return parseIdentifierString(ctx.IdentifierString[0].image);
       }
-      dimensionExpression(ctx) {
-        const name = this.visit(ctx.dimensionName);
+      identifierExpression(ctx) {
+        const name = this.visit(ctx.identifierName);
         if (ctx.resolveAs === "metric") {
           this.metrics.push(name);
         } else if (ctx.resolveAs === "segment") {


### PR DESCRIPTION
Since it is used a placeholder for a dimension, a metric, or a segment (resolving to one of them is delegated to the compiler), it makes sense to use a more generic and less confusing name.

This is just the logical next step after PR #14427 (mostly mechanical refactoring).


How to verify? Run the whole expression tests:

```
yarn test-unit frontend/test/metabase/lib/expressions/
```
