### PR TITLE
Merge nested settings between question and dashcard

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { t } from "ttag";
 import visualizations, { getVisualizationRaw } from "metabase/visualizations";
+import { mergeSettings } from "metabase/visualizations/lib/settings";
 import Visualization, {
   ERROR_MESSAGE_GENERIC,
   ERROR_MESSAGE_PERMISSION,
@@ -95,10 +96,10 @@ export default class DashCard extends Component {
 
     const mainCard = {
       ...dashcard.card,
-      visualization_settings: {
-        ...dashcard.card.visualization_settings,
-        ...dashcard.visualization_settings,
-      },
+      visualization_settings: mergeSettings(
+        dashcard.card.visualization_settings,
+        dashcard.visualization_settings,
+      ),
     };
     const cards = [mainCard].concat(dashcard.series || []);
     const dashboardId = dashcard.dashboard_id;

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -268,7 +268,7 @@ export function updateSettings(
 
 // Merge two settings objects together.
 // Settings from the second argument take precedence over the first.
-export function mergeSettings(first: Settings, second: Settings) {
+export function mergeSettings(first: Settings = {}, second: Settings = {}) {
   // Note: This hardcoded list of all nested settings is potentially fragile,
   // but both the list of nested settings and the keys used are very stable.
   const nestedSettings = ["series_settings", "column_settings"];

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -268,8 +268,7 @@ export function updateSettings(
 
 // Merge two settings objects together.
 // Settings from the second argument take precedence over the first.
-// Nested settings are merged by column/series.
-export function mergeSettings(first = {}, second = {}) {
+export function mergeSettings(first: Settings, second: Settings) {
   // Note: This hardcoded list of all nested settings is potentially fragile,
   // but both the list of nested settings and the keys used are very stable.
   const nestedSettings = ["series_settings", "column_settings"];
@@ -279,10 +278,10 @@ export function mergeSettings(first = {}, second = {}) {
     if (first[key] != null || second[key] != null) {
       merged[key] = {};
       for (const nestedKey of Object.keys({ ...first[key], ...second[key] })) {
-        const path = (merged[key][nestedKey] = mergeSettings(
-          getIn(first, [key, nestedKey]),
-          getIn(second, [key, nestedKey]),
-        ));
+        merged[key][nestedKey] = mergeSettings(
+          getIn(first, [key, nestedKey]) || {},
+          getIn(second, [key, nestedKey]) || {},
+        );
       }
     }
   }

--- a/frontend/test/metabase/visualizations/lib/settings.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings.unit.spec.js
@@ -4,6 +4,7 @@ import "metabase/visualizations/index";
 import {
   getComputedSettings,
   getSettingsWidgets,
+  mergeSettings,
 } from "metabase/visualizations/lib/settings";
 
 describe("settings framework", () => {
@@ -170,6 +171,50 @@ describe("settings framework", () => {
       expect(onChangeSettings.mock.calls).toEqual([
         [{ foo: "bar", bar: "bar" }],
       ]);
+    });
+  });
+
+  describe("mergeSettings", () => {
+    it("should merge with second overriding first", () => {
+      expect(
+        mergeSettings({ foo: { a: 1 }, bar: { b: 1 } }, { foo: { c: 1 } }),
+      ).toEqual({ foo: { c: 1 }, bar: { b: 1 } });
+    });
+
+    it("should merge column settings", () => {
+      expect(
+        mergeSettings(
+          { column_settings: { col1: { set1: "val1", set2: "val2" } } },
+          {
+            column_settings: { col1: { set1: "val3" }, col2: { set3: "val4" } },
+          },
+        ),
+      ).toEqual({
+        column_settings: {
+          col1: { set1: "val3", set2: "val2" },
+          col2: { set3: "val4" },
+        },
+      });
+    });
+
+    it("should merge series settings", () => {
+      expect(
+        mergeSettings(
+          { series_settings: { s1: { set1: "val1", set2: "val2" } } },
+          { series_settings: { s1: { set1: "val3" }, s2: { set3: "val4" } } },
+        ),
+      ).toEqual({
+        series_settings: {
+          s1: { set1: "val3", set2: "val2" },
+          s2: { set3: "val4" },
+        },
+      });
+    });
+
+    it("should merge when only one setting has the nested key", () => {
+      expect(
+        mergeSettings({}, { column_settings: { col1: { set1: "val" } } }),
+      ).toEqual({ column_settings: { col1: { set1: "val" } } });
     });
   });
 });

--- a/frontend/test/metabase/visualizations/lib/settings.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings.unit.spec.js
@@ -174,7 +174,7 @@ describe("settings framework", () => {
     });
   });
 
-  describe("mergeSettings", () => {
+  describe("mergeSettings (metabase#14597)", () => {
     it("should merge with second overriding first", () => {
       expect(
         mergeSettings({ foo: { a: 1 }, bar: { b: 1 } }, { foo: { c: 1 } }),


### PR DESCRIPTION
Fixes #14597

A dashcard's visualization settings are determined by merging the question's settings with any settings on the dashcard itself. Previously, we were only merging top level settings keys. This would wipe out any nested settings (column or series settings) if there were any on the dashcard. The issue describes this with adding dashboard click behavior on any table column removing column formatting on all columns. The fix was to create a `mergeSettings` function that's aware of nested settings.