### PR TITLE
Sandboxing: run source query if metadata missing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -38,12 +38,11 @@
   "Return a mapping of field names to corresponding cols for given table."
   [table-id]
   (classloader/require 'metabase.query-processor)
-  (into {} (for [col (session/with-current-user nil
-                       ((resolve 'metabase.query-processor/query->expected-cols)
-                        {:database (table/table-id->database-id table-id)
-                         :type     :query
-                         :query    {:source-table table-id}}))]
-             [(:name col) col])))
+  (m/index-by :name (session/with-current-user nil
+                      ((resolve 'metabase.query-processor/query->expected-cols)
+                       {:database (table/table-id->database-id table-id)
+                        :type     :query
+                        :query    {:source-table table-id}}))))
 
 (s/defn check-columns-match-table
   "Make sure the result metadata data columns for the Card associated with a GTAP match up with the columns in the Table


### PR DESCRIPTION
Fixes the inconsistent FK behaviour observed in https://github.com/metabase/metabase-enterprise/issues/520

There is another UX issue here, if the workflow is not to save the sandboxing question before hand, you might have an invalid question which we still allow you to use as a sandbox definition leading to somewhat obfuscated errors.

TODO
- [ ] test