### PR TITLE
Split (SQL) repro for EE_520 in two versions

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openOrdersTable,
   openPeopleTable,
   popover,
+  modal,
   restore,
   signInAsAdmin,
   signInAsNormalUser,
@@ -597,107 +598,159 @@ describeWithToken("formatting > sandboxes", () => {
         cy.findByText("McClure-Lockman");
       });
 
-      // Quarantined until further notice
-      // Related issues: #10474, #14629
-      it.skip("advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)", () => {
-        cy.log("**-- 1. Create the first native question with a filter --**");
+      /**
+       * This issue (metabase-enterprise#520) has a peculiar quirk:
+       *  - It works ONLY if SQL question is first run (`result_metadata` builds), and then the question is saved.
+       *  - In a real-world scenario it is quite possible for an admin to save that SQL question without running it first. This fails!
+       *  (more info: https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159)
+       *
+       * That's why this test has 2 versions that reflect both scenarios. We'll call them "normal" and "workaround".
+       * Until the underlying issue is fixed, "normal" scenario will be skipped.
+       *
+       * Related issues: metabase#10474, metabase#14629
+       */
 
-        cy.request("POST", "/api/card", {
-          name: "EE_520_Q1",
-          dataset_query: {
-            database: 1,
-            native: {
-              query:
-                "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL>10",
-              "template-tags": {
-                sandbox: {
-                  "display-name": "Sandbox",
-                  id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
-                  name: "sandbox",
-                  type: "number",
+      ["normal", "workaround"].forEach(test => {
+        it(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {
+          // Remove of comment-out to enable test run for both scenarios
+          test === "normal"
+            ? cy.state("runnable").skip() // https://github.com/cypress-io/cypress-skip-test/blob/master/index.js#L72
+            : null;
+
+          cy.server();
+          cy.route("POST", "/api/card/*/query").as("cardQuery");
+          cy.route("PUT", "/api/card/*").as("questionUpdate");
+
+          cy.log("**-- 1. Create the first native question with a filter --**");
+          cy.request("POST", "/api/card", {
+            name: "EE_520_Q1",
+            dataset_query: {
+              database: 1,
+              native: {
+                query:
+                  "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
+                "template-tags": {
+                  sandbox: {
+                    "display-name": "Sandbox",
+                    id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
+                    name: "sandbox",
+                    type: "number",
+                  },
                 },
               },
+              type: "native",
             },
-            type: "native",
-          },
-          display: "table",
-          visualization_settings: {},
-        }).then(({ body: { id: CARD_ID } }) => {
-          cy.log("**-- 1a. Sandbox `Orders` table based on this question --**");
+            display: "table",
+            visualization_settings: {},
+          }).then(({ body: { id: CARD_ID } }) => {
+            test === "workaround"
+              ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
+              : null;
 
-          cy.request("POST", "/api/mt/gtap", {
-            attribute_remappings: {
-              [ATTR_UID]: ["variable", ["template-tag", "sandbox"]],
-            },
-            card_id: CARD_ID,
-            group_id: COLLECTION_GROUP,
-            table_id: ORDERS_ID,
+            cy.log(
+              "**-- 1a. Sandbox `Orders` table based on this question --**",
+            );
+
+            cy.request("POST", "/api/mt/gtap", {
+              attribute_remappings: {
+                [ATTR_UID]: ["variable", ["template-tag", "sandbox"]],
+              },
+              card_id: CARD_ID,
+              group_id: COLLECTION_GROUP,
+              table_id: ORDERS_ID,
+            });
           });
-        });
-        cy.log("**-- 2. Create the second native question with a filter --**");
-
-        cy.request("POST", "/api/card", {
-          name: "EE_520_Q2",
-          dataset_query: {
-            database: 1,
-            native: {
-              query:
-                "SELECT * FROM PRODUCTS↵WHERE CATEGORY={{sandbox}} AND PRICE>10",
-              "template-tags": {
-                sandbox: {
-                  "display-name": "Sandbox",
-                  id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
-                  name: "sandbox",
-                  type: "text",
-                },
-              },
-            },
-            type: "native",
-          },
-          display: "table",
-          visualization_settings: {},
-        }).then(({ body: { id: CARD_ID } }) => {
           cy.log(
-            "**-- 2a. Sandbox `Products` table based on this question --**",
+            "**-- 2. Create the second native question with a filter --**",
           );
 
-          cy.request("POST", "/api/mt/gtap", {
-            attribute_remappings: {
-              [ATTR_CAT]: ["variable", ["template-tag", "sandbox"]],
+          cy.request("POST", "/api/card", {
+            name: "EE_520_Q2",
+            dataset_query: {
+              database: 1,
+              native: {
+                query:
+                  "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
+                "template-tags": {
+                  sandbox: {
+                    "display-name": "Sandbox",
+                    id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
+                    name: "sandbox",
+                    type: "text",
+                  },
+                },
+              },
+              type: "native",
             },
-            card_id: CARD_ID,
-            group_id: COLLECTION_GROUP,
-            table_id: PRODUCTS_ID,
+            display: "table",
+            visualization_settings: {},
+          }).then(({ body: { id: CARD_ID } }) => {
+            test === "workaround"
+              ? runAndSaveQuestion({
+                  question: CARD_ID,
+                  sandboxValue: "Widget",
+                })
+              : null;
+
+            cy.log(
+              "**-- 2a. Sandbox `Products` table based on this question --**",
+            );
+
+            cy.request("POST", "/api/mt/gtap", {
+              attribute_remappings: {
+                [ATTR_CAT]: ["variable", ["template-tag", "sandbox"]],
+              },
+              card_id: CARD_ID,
+              group_id: COLLECTION_GROUP,
+              table_id: PRODUCTS_ID,
+            });
           });
+
+          updatePermissionsGraph({
+            schema: {
+              [PRODUCTS_ID]: { query: "segmented", read: "all" },
+              [ORDERS_ID]: { query: "segmented", read: "all" },
+            },
+          });
+
+          signOut();
+          signInAsSandboxedUser();
+
+          openOrdersTable();
+
+          cy.log("**-- Reported failing on v1.36.x --**");
+
+          cy.log(
+            "**It should show remapped Display Values instead of Product ID**",
+          );
+          cy.get(".cellData")
+            .contains("Awesome Concrete Shoes")
+            .click();
+          cy.findByText(/View details/i).click();
+
+          cy.log(
+            "**It should show object details instead of filtering by this Product ID**",
+          );
+          // The name of this Vendor is visible in "details" only
+          cy.findByText("McClure-Lockman");
+
+          /**
+           * Helper function related to this test only!
+           */
+          function runAndSaveQuestion({ question, sandboxValue } = {}) {
+            // Run the question
+            cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
+            // Wait for results
+            cy.wait("@cardQuery");
+            // Save the question
+            cy.findByText("Save").click();
+            modal().within(() => {
+              cy.findAllByRole("button", { name: "Save" }).click();
+            });
+            // Wait for an update so the other queries don't accidentally cancel it
+            cy.wait("@questionUpdate");
+          }
         });
-
-        updatePermissionsGraph({
-          schema: {
-            [PRODUCTS_ID]: { query: "segmented", read: "all" },
-            [ORDERS_ID]: { query: "segmented", read: "all" },
-          },
-        });
-
-        signOut();
-        signInAsSandboxedUser();
-
-        openOrdersTable();
-
-        cy.log("**-- Reported failing on v1.36.x --**");
-
-        cy.log(
-          "**It should show remapped Display Values instead of Product ID**",
-        );
-        cy.get(".cellData")
-          .contains("Awesome Concrete Shoes")
-          .click();
-        cy.findByText(/View details/i).click();
-
-        cy.log(
-          "**It should show object details instead of filtering by this Product ID**",
-        );
-        // The name of this Vendor is visible in "details" only
-        cy.findByText("McClure-Lockman");
       });
 
       it.skip("simple sandboxing should work (metabase#14629)", () => {


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces https://github.com/metabase/metabase-enterprise/issues/520 in a more complete way by providing a coverage for potential "real-world" scenario and for a workaround that @flamber found and explained in [this comment](https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159).

### How to test this manually?
- `yarn test-cypress-open --testFiles enterprise/frontend/test/metabase-enterprise`
- `enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js`
- You can isolate this test by adding`.only()` to it
```javascript
it.only(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {...});
```
- Then comment out or temporarily delete this section of the code (or even set the premise to `false`) to enable both test scenarios to run
```javascript
test === "normal"
  ? cy.state("runnable").skip()
  : null;
```
- The "NORMAL" version of the test should fail until the related issue is fixed (please see the screenshot below)

### Additional notes:
- Once the issue is fixed, please enable both test cases
- Make sure both are passing and
- Merge them together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/106959329-cec96000-673a-11eb-8e35-dd7059de0177.png)

