### PR TITLE
Don't show reset settings button for text cards

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -244,7 +244,13 @@ class ChartSettings extends Component {
       />
     ));
 
-    const onReset = !_.isEqual(settings, {}) ? this.handleResetSettings : null;
+    const onReset =
+      !_.isEqual(settings, {}) &&
+      // resetting virtual cards wipes the text and broke the UI (metabase#14644)
+      !settings.virtual_card
+        ? this.handleResetSettings
+        : null;
+    console.log({ settings, onReset });
 
     // custom render prop layout:
     if (children) {

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -245,9 +245,7 @@ class ChartSettings extends Component {
     ));
 
     const onReset =
-      !_.isEqual(settings, {}) &&
-      // resetting virtual cards wipes the text and broke the UI (metabase#14644)
-      !settings.virtual_card
+      !_.isEqual(settings, {}) && !settings.virtual_card // resetting virtual cards wipes the text and broke the UI (metabase#14644)
         ? this.handleResetSettings
         : null;
 

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -250,7 +250,6 @@ class ChartSettings extends Component {
       !settings.virtual_card
         ? this.handleResetSettings
         : null;
-    console.log({ settings, onReset });
 
     // custom render prop layout:
     if (children) {


### PR DESCRIPTION
Fixes #14644

As usual, text cards are breaking assumptions we make around the codebase. Resetting most dashcards by setting the visualization settings to `{}` is the right move. For text cards, that breaks them.

To fix, I took away the button to reset the settings on text cards. The available settings are so minimal that I don't think we need a reset button. 

I don't think this behavior really needs a test, but if people feel differently I can add one.