### PR TITLE
Add loading/error state to sample dataset restore

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -18,11 +18,16 @@ import DeleteDatabaseModal from "../components/DeleteDatabaseModal";
 
 import Database from "metabase/entities/databases";
 
-import { getDeletes, getDeletionError } from "../selectors";
+import {
+  getDeletes,
+  getDeletionError,
+  getIsFetchingSampleDataset,
+} from "../selectors";
 import { deleteDatabase, addSampleDataset } from "../database";
 
 const mapStateToProps = (state, props) => ({
   hasSampleDataset: Database.selectors.getHasSampleDataset(state),
+  isFetchingSampleDataset: getIsFetchingSampleDataset(state),
 
   created: props.location.query.created,
   engines: MetabaseSettings.get("engines"),
@@ -62,6 +67,7 @@ export default class DatabaseList extends Component {
     const {
       databases,
       hasSampleDataset,
+      isFetchingSampleDataset,
       created,
       engines,
       deletionError,
@@ -158,10 +164,18 @@ export default class DatabaseList extends Component {
                   "border-top": databases && databases.length > 0,
                 })}
               >
-                <a
-                  className="text-light text-brand-hover no-decoration"
-                  onClick={() => this.props.addSampleDataset()}
-                >{t`Bring the sample dataset back`}</a>
+                {isFetchingSampleDataset ? (
+                  <span className="text-light no-decoration">
+                    {t`Restoring the sample dataset...`}
+                  </span>
+                ) : (
+                  <a
+                    className="text-light text-brand-hover no-decoration"
+                    onClick={() => this.props.addSampleDataset()}
+                  >
+                    {t`Bring the sample dataset back`}
+                  </a>
+                )}
               </span>
             </div>
           ) : null}

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -21,13 +21,15 @@ import Database from "metabase/entities/databases";
 import {
   getDeletes,
   getDeletionError,
-  getIsFetchingSampleDataset,
+  getIsAddingSampleDataset,
+  getAddSampleDatasetError,
 } from "../selectors";
 import { deleteDatabase, addSampleDataset } from "../database";
 
 const mapStateToProps = (state, props) => ({
   hasSampleDataset: Database.selectors.getHasSampleDataset(state),
-  isFetchingSampleDataset: getIsFetchingSampleDataset(state),
+  isAddingSampleDataset: getIsAddingSampleDataset(state),
+  addSampleDatasetError: getAddSampleDatasetError(state),
 
   created: props.location.query.created,
   engines: MetabaseSettings.get("engines"),
@@ -67,11 +69,14 @@ export default class DatabaseList extends Component {
     const {
       databases,
       hasSampleDataset,
-      isFetchingSampleDataset,
+      isAddingSampleDataset,
+      addSampleDatasetError,
       created,
       engines,
       deletionError,
     } = this.props;
+
+    const error = deletionError || addSampleDatasetError;
 
     return (
       <div className="wrapper">
@@ -82,9 +87,9 @@ export default class DatabaseList extends Component {
           >{t`Add database`}</Link>
           <h2 className="PageTitle">{t`Databases`}</h2>
         </section>
-        {deletionError && (
+        {error && (
           <section>
-            <FormMessage formError={deletionError} />
+            <FormMessage formError={error} />
           </section>
         )}
         <section>
@@ -164,7 +169,7 @@ export default class DatabaseList extends Component {
                   "border-top": databases && databases.length > 0,
                 })}
               >
-                {isFetchingSampleDataset ? (
+                {isAddingSampleDataset ? (
                   <span className="text-light no-decoration">
                     {t`Restoring the sample dataset...`}
                   </span>

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -39,6 +39,8 @@ export const FETCH_DATABASES = "metabase/admin/databases/FETCH_DATABASES";
 export const INITIALIZE_DATABASE =
   "metabase/admin/databases/INITIALIZE_DATABASE";
 export const ADD_SAMPLE_DATASET = "metabase/admin/databases/ADD_SAMPLE_DATASET";
+export const ADD_SAMPLE_DATASET_FAILED =
+  "metabase/admin/databases/ADD_SAMPLE_DATASET_FAILED";
 export const ADDING_SAMPLE_DATASET =
   "metabase/admin/databases/ADDING_SAMPLE_DATASET";
 export const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
@@ -135,7 +137,6 @@ export const initializeDatabase = function(databaseId) {
   };
 };
 
-// addSampleDataset
 export const addSampleDataset = createThunkAction(
   ADD_SAMPLE_DATASET,
   function() {
@@ -152,6 +153,7 @@ export const addSampleDataset = createThunkAction(
         return sampleDataset;
       } catch (error) {
         console.error("error adding sample dataset", error);
+        dispatch.action(ADD_SAMPLE_DATASET_FAILED, { error });
         return error;
       }
     };
@@ -353,12 +355,13 @@ const databaseCreationStep = handleActions(
   DB_EDIT_FORM_CONNECTION_TAB,
 );
 
-const fetchingSampleDataset = handleActions(
+const sampleDataset = handleActions(
   {
-    [ADDING_SAMPLE_DATASET]: () => true,
-    [ADD_SAMPLE_DATASET]: () => false,
+    [ADDING_SAMPLE_DATASET]: () => ({ loading: true }),
+    [ADD_SAMPLE_DATASET]: state => ({ ...state, loading: false }),
+    [ADD_SAMPLE_DATASET_FAILED]: (state, { payload: { error } }) => ({ error }),
   },
-  false,
+  { error: undefined, loading: false },
 );
 
 export default combineReducers({
@@ -366,5 +369,5 @@ export default combineReducers({
   deletionError,
   databaseCreationStep,
   deletes,
-  fetchingSampleDataset,
+  sampleDataset,
 });

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -39,6 +39,8 @@ export const FETCH_DATABASES = "metabase/admin/databases/FETCH_DATABASES";
 export const INITIALIZE_DATABASE =
   "metabase/admin/databases/INITIALIZE_DATABASE";
 export const ADD_SAMPLE_DATASET = "metabase/admin/databases/ADD_SAMPLE_DATASET";
+export const ADDING_SAMPLE_DATASET =
+  "metabase/admin/databases/ADDING_SAMPLE_DATASET";
 export const DELETE_DATABASE = "metabase/admin/databases/DELETE_DATABASE";
 export const SYNC_DATABASE_SCHEMA =
   "metabase/admin/databases/SYNC_DATABASE_SCHEMA";
@@ -139,8 +141,13 @@ export const addSampleDataset = createThunkAction(
   function() {
     return async function(dispatch, getState) {
       try {
+        dispatch.action(ADDING_SAMPLE_DATASET);
         const sampleDataset = await MetabaseApi.db_add_sample_dataset();
-        dispatch(Databases.actions.fetchList(undefined, { reload: true }));
+        await dispatch(
+          Databases.actions.fetchList(undefined, {
+            reload: true,
+          }),
+        );
         MetabaseAnalytics.trackEvent("Databases", "Add Sample Data");
         return sampleDataset;
       } catch (error) {
@@ -346,9 +353,18 @@ const databaseCreationStep = handleActions(
   DB_EDIT_FORM_CONNECTION_TAB,
 );
 
+const fetchingSampleDataset = handleActions(
+  {
+    [ADDING_SAMPLE_DATASET]: () => true,
+    [ADD_SAMPLE_DATASET]: () => false,
+  },
+  false,
+);
+
 export default combineReducers({
   editingDatabase,
   deletionError,
   databaseCreationStep,
   deletes,
+  fetchingSampleDataset,
 });

--- a/frontend/src/metabase/admin/databases/selectors.js
+++ b/frontend/src/metabase/admin/databases/selectors.js
@@ -10,5 +10,7 @@ export const getDatabaseCreationStep = state =>
 export const getDeletes = state => state.admin.databases.deletes;
 export const getDeletionError = state => state.admin.databases.deletionError;
 
-export const getIsFetchingSampleDataset = state =>
-  state.admin.databases.fetchingSampleDataset;
+export const getIsAddingSampleDataset = state =>
+  state.admin.databases.sampleDataset.loading;
+export const getAddSampleDatasetError = state =>
+  state.admin.databases.sampleDataset.error;

--- a/frontend/src/metabase/admin/databases/selectors.js
+++ b/frontend/src/metabase/admin/databases/selectors.js
@@ -9,3 +9,6 @@ export const getDatabaseCreationStep = state =>
 // Database List
 export const getDeletes = state => state.admin.databases.deletes;
 export const getDeletionError = state => state.admin.databases.deletionError;
+
+export const getIsFetchingSampleDataset = state =>
+  state.admin.databases.fetchingSampleDataset;


### PR DESCRIPTION
Resolves #10514 

**Description**
Restoring the sample dataset depends on two requests, a POST to `/api/database/sample_dataset` and then a refetch of the list of databases. I've added some additional state for the UI to use in showing loading and error messages.

**Verification**
Delete the Sample Dataset and then click the `a` tag that appears beneath the databases table -- you should see the element replaced with a message til the sample dataset shows back up.

<img width="301" alt="Screen Shot 2021-02-04 at 3 07 25 PM" src="https://user-images.githubusercontent.com/13057258/106969838-82f9c500-6700-11eb-91f7-a6d0437ccdcb.png">

And the error state looks like this... ("Unknown error" because I just threw gibberish on the front-end)

<img width="1027" alt="Screen Shot 2021-02-04 at 3 51 08 PM" src="https://user-images.githubusercontent.com/13057258/106970040-eab01000-6700-11eb-90ba-3338f5d4389b.png">

