### PR TITLE
Log complete token validation error only to debug log

### DIFF
--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -144,7 +144,7 @@
     (or (some-> (premium-embedding-token) valid-token->features)
         #{})
     (catch Throwable e
-      (log/error (trs "Error validating token") (ex-message e))
+      (log/error (trs "Error validating token") ":" (ex-message e))
       (log/debug e (trs "Error validating token"))
       #{})))
 

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -144,7 +144,8 @@
     (or (some-> (premium-embedding-token) valid-token->features)
         #{})
     (catch Throwable e
-      (log/error e (trs "Error validating token"))
+      (log/error (trs "Error validating token") (ex-message e))
+      (log/debug e (trs "Error validating token"))
       #{})))
 
 (defsetting hide-embed-branding?


### PR DESCRIPTION
Turns out #14514 wasn't really a bug. The TTL-based memoization works as expected; it only performs a token check request every 5 minutes. The biggest issue is that each token-backed feature lookup caused a stack trace of ~125 lines to be logged. With 22 such failures in loading a single embedded dashboard, that adds up quite quickly. The noise in the log obfuscates the core issue: that the token has expired.

This PR logs the stack trace only to the debug log, and only the message at the `error` level. With this change the error output for a single embedded dashboard load is reduced from ~3700 lines, to ~50.

I'm not overly fond of overloading the error message like this, but it's preferable to requiring each l10n team to translate another, related error message.

Closes #14514.