### PR TITLE
Make SSH heartbeat interval configurable

### DIFF
--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -1005,6 +1005,13 @@ Default: `X-Forwarded-For`
 
 Identify the source of HTTP requests by this header's value, instead of its remote address. Related to [MB_DISABLE_SESSION_THROTTLE](#mb_disable_session_throttle).
 
+#### `MB_SSH_HEARTBEAT_INTERVAL_SEC`
+
+Type: integer<br>
+Default: `180`
+
+Controls how often the heartbeats are sent when an SSH tunnel is established (in seconds).
+
 #### `MB_SSL_CERTIFICATE_PUBLIC_KEY`
 
 Type: string<br>

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -389,3 +389,9 @@
   :visibility :public
   :type       :keyword
   :default    "sunday")
+
+(defsetting ssh-heartbeat-interval-sec
+  (deferred-tru "Controls how often the heartbeats are sent when an SSH tunnel is established (in seconds).")
+  :visibility :public
+  :type       :integer
+  :default    180)


### PR DESCRIPTION
Adding entry in public_settings.clj for ssh heartbeat interval, and referencing that from ssh.clj

Putting new setting under General tab in settings UI

Adding the heartbeat interval to the existing log message when tunnel is established
