### PR TITLE
Add default value to report timezone dropdown

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -234,6 +234,7 @@ const SECTIONS = updateSectionsWithPlugins({
         note: t`Not all databases support timezones, in which case this setting won't take effect.`,
         allowValueCollection: true,
         searchProp: "name",
+        defaultValue: "",
       },
       {
         key: "start-of-week",


### PR DESCRIPTION
Fixes #14682 

**Description**
We aren't setting a `defaultValue` for this dropdown. Setting it to `""` correctly sets the default value.

**Verification**
\~Before\~
![Screen Shot 2021-02-05 at 11 07 36 AM](https://user-images.githubusercontent.com/13057258/107081538-b5123200-67a7-11eb-8526-8a510536b0e7.png)

\~After\~
![Screen Shot 2021-02-05 at 11 46 22 AM](https://user-images.githubusercontent.com/13057258/107081595-cb1ff280-67a7-11eb-93cd-90c399f4573b.png)

