### PR TITLE
Some CircleCI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ cache-key-frontend-deps: &CacheKeyFrontendDeps
 # Key used for implementation of run-on-change -- this is the cache key that contains the .SUCCESS dummy file
 # By default the key ALWAYS includes the name of the test job itself ($CIRCLE_STAGE) so you don't need to add that yourself.
 cache-key-run-on-change: &CacheKeyRunOnChange
-  key: v1-{{ checksum ".CACHE-PREFIX" }}-run-on-change-{{ .Environment.CIRCLE_STAGE }}-<< parameters.checksum >>
+  key: v2-{{ checksum ".CACHE-PREFIX" }}-run-on-change-{{ .Environment.CIRCLE_STAGE }}-<< parameters.checksum >>
 
 # Key for the local maven installation of metabase-core (used by build-uberjar-drivers)
 cache-key-metabase-core: &CacheKeyMetabaseCore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ cache-key-metabase-core: &CacheKeyMetabaseCore
 
 # Key for the drivers built by build-uberjar-drivers
 cache-key-drivers: &CacheKeyDrivers
-  key: v1-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-{{ checksum ".MODULES-CHECKSUMS" }}-{{ checksum ".BACKEND-CHECKSUMS" }}-<< parameters.edition >>
+  key: v2-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-{{ checksum ".MODULES-CHECKSUMS" }}-{{ checksum ".BACKEND-CHECKSUMS" }}-<< parameters.edition >>
 
 # This is also used by the uberjar-build-drivers step; this is a unique situation because the build-drivers script has
 # logic to determine whether to rebuild drivers or not that is quite a bit more sophisticated that the run-on-change
@@ -241,9 +241,9 @@ cache-key-drivers: &CacheKeyDrivers
 # redshift driver.
 cache-keys-drivers-with-fallback-keys: &CacheKeyDrivers_WithFallbackKeys
   keys:
-    - v1-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-{{ checksum ".MODULES-CHECKSUMS" }}-{{ checksum ".BACKEND-CHECKSUMS" }}
-    - v1-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-{{ checksum ".MODULES-CHECKSUMS" }}
-    - v1-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-
+    - v2-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-{{ checksum ".MODULES-CHECKSUMS" }}-{{ checksum ".BACKEND-CHECKSUMS" }}
+    - v2-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-{{ checksum ".MODULES-CHECKSUMS" }}
+    - v2-{{ checksum ".CACHE-PREFIX" }}-drivers-<< parameters.edition >>-
 
 # Key for frontend client built by uberjar-build-frontend step
 cache-key-frontend: &CacheKeyFrontend
@@ -251,7 +251,7 @@ cache-key-frontend: &CacheKeyFrontend
 
 # Key for uberjar built by build-uberjar
 cache-key-uberjar: &CacheKeyUberjar
-  key: v1-{{ checksum ".CACHE-PREFIX" }}-uberjar-<< parameters.edition >>-{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}
+  key: v2-{{ checksum ".CACHE-PREFIX" }}-uberjar-<< parameters.edition >>-{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}
 
 
 ########################################################################################################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,7 +1303,7 @@ workflows:
           name: fe-tests-cypress-<< matrix.node >>-<< matrix.edition >>
           requires:
             - build-uberjar-<< matrix.edition >>
-          cypress-group: "default"
+          cypress-group: "default-<< matrix.edition >>"
 
       - fe-tests-cypress:
           name: fe-tests-cypress-mongo-4-<< matrix.edition >>

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -98,6 +98,8 @@ const init = async () => {
             "--parallel",
             "--group",
             process.env["CYPRESS_GROUP"],
+            "--ci-build-id",
+            process.env["CIRCLE_WORKFLOW_ID"],
           ]
         : []),
       ...(hasEnterpriseToken ? ["--env", "HAS_ENTERPRISE_TOKEN=true"] : []),

--- a/modules/drivers/oracle/project.clj
+++ b/modules/drivers/oracle/project.clj
@@ -13,7 +13,10 @@
 
    :ee
    {:dependencies
-    [[com.oracle.ojdbc/ojdbc8 "19.3.0.0"]]}
+    [[com.oracle.ojdbc/ojdbc8 "19.3.0.0"]]
+
+    :resource-paths
+    ^:replace ["resources-ee"]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
+++ b/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
@@ -1,0 +1,28 @@
+info:
+  name: Metabase Oracle Driver
+  version: 1.0.0-SNAPSHOT
+  description: Allows Metabase to connect to Oracle databases.
+driver:
+  name: oracle
+  display-name: Oracle
+  lazy-load: true
+  parent: sql-jdbc
+  connection-properties:
+    - host
+    - merge:
+        - port
+        - default: 1521
+    - name: sid
+      display-name: Oracle system ID (SID)
+      placehoder: Usually something like ORCL or XE. Optional if using service name
+    - name: service-name
+      display-name: Oracle service name
+      placeholder: Optional TNS alias
+    - user
+    - password
+  connection-properties-include-tunnel-config: true
+init:
+  - step: load-namespace
+    namespace: metabase.driver.oracle
+  - step: register-jdbc-driver
+    class: oracle.jdbc.OracleDriver

--- a/modules/drivers/vertica/project.clj
+++ b/modules/drivers/vertica/project.clj
@@ -11,7 +11,11 @@
      [com.vertica.jdbc/vertica-jdbc "10.0.1-0"]]}
 
    :ee
-   {:dependencies [[com.vertica.jdbc/vertica-jdbc "10.0.1-0"]]}
+   {:dependencies
+    [[com.vertica.jdbc/vertica-jdbc "10.0.1-0"]]
+
+    :resource-paths
+    ^:replace ["resources-ee"]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/vertica/resources-ee/metabase-plugin.yaml
+++ b/modules/drivers/vertica/resources-ee/metabase-plugin.yaml
@@ -1,0 +1,26 @@
+info:
+  name: Metabase Vertica Driver
+  version: 1.0.0-SNAPSHOT
+  description: Allows Metabase to connect to Vertica databases.
+driver:
+  name: vertica
+  display-name: Vertica
+  lazy-load: true
+  parent: sql-jdbc
+  connection-properties:
+    - host
+    - merge:
+        - port
+        - default: 5433
+    - dbname
+    - user
+    - password
+    - merge:
+        - additional-options
+        - placeholder: 'ConnectionLoadBalance=1'
+  connection-properties-include-tunnel-config: true
+init:
+  - step: load-namespace
+    namespace: metabase.driver.vertica
+  - step: register-jdbc-driver
+    class: com.vertica.jdbc.Driver

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -6,6 +6,7 @@
             [clojure.test :as t]
             [clojure.walk :as walk]
             [clojure.tools.logging :as log]
+            [environ.core :as env]
             [java-time :as java-time]
             [metabase.config :as config]
             [metabase.server.middleware.session :as mw.session]
@@ -224,7 +225,11 @@
      :url-param-kwargs url-param-kwargs
      :request-options  request-options}))
 
-(def ^:private response-timeout-ms (u/seconds->ms 15))
+(def ^:private response-timeout-ms
+  ;; CircleCI is crazy slow and likes to randomly pause, so use a much larger timeout when running on CI
+  (u/seconds->ms (if (env/env :ci)
+                   45
+                   15)))
 
 (defn client-full-response
   "Identical to `client` except returns the full HTTP response map, not just the body of the response"


### PR DESCRIPTION
1. ~Rotates some CircleCI cache keys which I think will address failures of `scenarios > admin > databases > add EE should ship with Oracle and Vertica as options should have Oracle as an option`. I think the root cause is that it's trying to use older cached versions that didn't include the Oracle/Vertica drivers~ Fix issue where `scenarios > admin > databases > add EE should ship with Oracle and Vertica as options should have Oracle as an option` was failing by giving EE/OSS versions of drivers separate profiles so it doesn't try to require the Oracle/Vertica JDBC drivers to be present on the classpath before loading.

2. Bump API endpoint timeout from 15 to 45 seconds on CircleCI. This should fix "request timed out after 15.0 seconds" errors we've been seeing lately

3. Use different keys for Cypress EE/OSS runs