### PR TITLE
Turn off Cypress recording/parallel runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1298,7 +1298,7 @@ workflows:
       - fe-tests-cypress:
           matrix:
             parameters:
-              node: ["1", "2", "3", "4"]
+              node: ["1"]
               edition: ["ee", "oss"]
           name: fe-tests-cypress-<< matrix.node >>-<< matrix.edition >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,7 +1303,7 @@ workflows:
           name: fe-tests-cypress-<< matrix.node >>-<< matrix.edition >>
           requires:
             - build-uberjar-<< matrix.edition >>
-          cypress-group: "default"
+          cypress-group: "default-<< matrix.edition >>"
 
       - fe-tests-cypress:
           name: fe-tests-cypress-mongo-4-<< matrix.edition >>

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -94,7 +94,6 @@ const init = async () => {
             "junit",
             "--reporter-options",
             "mochaFile=cypress/results/results-[hash].xml",
-            "--record",
             "--parallel",
             "--group",
             process.env["CYPRESS_GROUP"],

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -94,9 +94,6 @@ const init = async () => {
             "junit",
             "--reporter-options",
             "mochaFile=cypress/results/results-[hash].xml",
-            "--parallel",
-            "--group",
-            process.env["CYPRESS_GROUP"],
           ]
         : []),
       ...(hasEnterpriseToken ? ["--env", "HAS_ENTERPRISE_TOKEN=true"] : []),

--- a/frontend/test/cypress.json
+++ b/frontend/test/cypress.json
@@ -1,5 +1,4 @@
 {
-  "projectId": "a394u1",
   "testFiles": "**/*.cy.spec.js",
   "pluginsFile": "frontend/test/cypress-plugins.js",
   "integrationFolder": ".",

--- a/modules/drivers/oracle/project.clj
+++ b/modules/drivers/oracle/project.clj
@@ -13,7 +13,10 @@
 
    :ee
    {:dependencies
-    [[com.oracle.ojdbc/ojdbc8 "19.3.0.0"]]}
+    [[com.oracle.ojdbc/ojdbc8 "19.3.0.0"]]
+
+    :resource-paths
+    ^:replace ["resources-ee"]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
+++ b/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
@@ -1,0 +1,28 @@
+info:
+  name: Metabase Oracle Driver
+  version: 1.0.0-SNAPSHOT
+  description: Allows Metabase to connect to Oracle databases.
+driver:
+  name: oracle
+  display-name: Oracle
+  lazy-load: true
+  parent: sql-jdbc
+  connection-properties:
+    - host
+    - merge:
+        - port
+        - default: 1521
+    - name: sid
+      display-name: Oracle system ID (SID)
+      placehoder: Usually something like ORCL or XE. Optional if using service name
+    - name: service-name
+      display-name: Oracle service name
+      placeholder: Optional TNS alias
+    - user
+    - password
+  connection-properties-include-tunnel-config: true
+init:
+  - step: load-namespace
+    namespace: metabase.driver.oracle
+  - step: register-jdbc-driver
+    class: oracle.jdbc.OracleDriver

--- a/modules/drivers/vertica/project.clj
+++ b/modules/drivers/vertica/project.clj
@@ -11,7 +11,11 @@
      [com.vertica.jdbc/vertica-jdbc "10.0.1-0"]]}
 
    :ee
-   {:dependencies [[com.vertica.jdbc/vertica-jdbc "10.0.1-0"]]}
+   {:dependencies
+    [[com.vertica.jdbc/vertica-jdbc "10.0.1-0"]]
+
+    :resource-paths
+    ^:replace ["resources-ee"]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/vertica/resources-ee/metabase-plugin.yaml
+++ b/modules/drivers/vertica/resources-ee/metabase-plugin.yaml
@@ -1,0 +1,26 @@
+info:
+  name: Metabase Vertica Driver
+  version: 1.0.0-SNAPSHOT
+  description: Allows Metabase to connect to Vertica databases.
+driver:
+  name: vertica
+  display-name: Vertica
+  lazy-load: true
+  parent: sql-jdbc
+  connection-properties:
+    - host
+    - merge:
+        - port
+        - default: 5433
+    - dbname
+    - user
+    - password
+    - merge:
+        - additional-options
+        - placeholder: 'ConnectionLoadBalance=1'
+  connection-properties-include-tunnel-config: true
+init:
+  - step: load-namespace
+    namespace: metabase.driver.vertica
+  - step: register-jdbc-driver
+    class: com.vertica.jdbc.Driver

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -6,6 +6,7 @@
             [clojure.test :as t]
             [clojure.walk :as walk]
             [clojure.tools.logging :as log]
+            [environ.core :as env]
             [java-time :as java-time]
             [metabase.config :as config]
             [metabase.server.middleware.session :as mw.session]
@@ -224,7 +225,11 @@
      :url-param-kwargs url-param-kwargs
      :request-options  request-options}))
 
-(def ^:private response-timeout-ms (u/seconds->ms 15))
+(def ^:private response-timeout-ms
+  ;; CircleCI is crazy slow and likes to randomly pause, so use a much larger timeout when running on CI
+  (u/seconds->ms (if (env/env :ci)
+                   45
+                   15)))
 
 (defn client-full-response
   "Identical to `client` except returns the full HTTP response map, not just the body of the response"


### PR DESCRIPTION
This is just a stopgap so we can trust CI again. It looks like Cypress will take about 25 minutes to run after this.

Once this is merged, we should merge `release-x.38.x` to `master`.

Also:

- Fixes for test failures now that we have separate EE/OSS versions of Oracle and Vertica drivers. These were likely legitimate failures, but we didn't notice them because Cypress tests weren't running
- Bump backend test HTTP client timeout on CircleCI to fix random test failures