### PR TITLE
Hide bubble formatting for empty table cells

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -144,7 +144,9 @@ export default class TableInteractive extends Component {
       <div className="cellData">{children}</div>
     ),
     renderTableCellWrapper: children => (
-      <div className="cellData">{children}</div>
+      <div className={cx({ cellData: children != null && children !== "" })}>
+        {children}
+      </div>
     ),
   };
 


### PR DESCRIPTION
Fixes #14662 

@flamber mentioned that we still want the action menu for some of these cells. I left it in. I think there are some cases where we'd want to turn it off, but we can figure out those cases when they come up.

### Before
![image](https://user-images.githubusercontent.com/691495/107096625-2ae2c180-67d9-11eb-98e8-ba68802a0e15.png)

### After
![image](https://user-images.githubusercontent.com/691495/107096589-1acae200-67d9-11eb-8be6-019089985cdb.png)
