### PR TITLE
Use correct filter value for region maps, fix tooltips

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -19,7 +19,10 @@ export default class ChartTooltip extends Component {
     }
     if (Array.isArray(hovered.data)) {
       // Array of key, value, col: { data: [{ key, value, col }], element, event }
-      return hovered.data;
+      return hovered.data.map(d => ({
+        ...d,
+        key: d.key || getFriendlyName(d.col),
+      }));
     } else if (hovered.value !== undefined || hovered.dimensions) {
       // ClickObject: { value, column, dimensions: [{ value, column }], element, event }
       const dimensions = [];

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -231,9 +231,8 @@ export default class ChoroplethMap extends Component {
 
     const rowByFeatureKey = new Map(rows.map(row => [getRowKey(row), row]));
 
-    const getFeatureClickObject = (row, feature) => {
-      console.log({ row, feature });
-      return row == null
+    const getFeatureClickObject = (row, feature) =>
+      row == null
         ? // This branch lets you click on empty regions. We use in dashboard cross-filtering.
           {
             value: null,
@@ -274,7 +273,6 @@ export default class ChoroplethMap extends Component {
             origin: { row, cols },
             settings,
           };
-    };
 
     const isClickable =
       onVisualizationClick &&

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -231,8 +231,9 @@ export default class ChoroplethMap extends Component {
 
     const rowByFeatureKey = new Map(rows.map(row => [getRowKey(row), row]));
 
-    const getFeatureClickObject = (row, feature) =>
-      row == null
+    const getFeatureClickObject = (row, feature) => {
+      console.log({ row, feature });
+      return row == null
         ? // This branch lets you click on empty regions. We use in dashboard cross-filtering.
           {
             value: null,
@@ -254,10 +255,7 @@ export default class ChoroplethMap extends Component {
             column: cols[metricIndex],
             dimensions: [
               {
-                value:
-                  feature != null
-                    ? getFeatureName(feature)
-                    : row[dimensionIndex],
+                value: row[dimensionIndex],
                 column: cols[dimensionIndex],
               },
             ],
@@ -276,6 +274,7 @@ export default class ChoroplethMap extends Component {
             origin: { row, cols },
             settings,
           };
+    };
 
     const isClickable =
       onVisualizationClick &&

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -7,7 +7,6 @@ import {
   popover,
   sidebar,
   USER_GROUPS,
-  visitQuestionAdhoc,
 } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -450,43 +449,6 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       cy.findByText("Gizmo").should("not.exist");
       cy.findByText("Doohickey").should("not.exist");
     });
-  });
-
-  it("should 'View these...' on region map", () => {
-    visitQuestionAdhoc({
-      dataset_query: {
-        database: 1,
-        type: "query",
-        query: {
-          "source-table": PEOPLE_ID,
-          breakout: [["field-id", PEOPLE.STATE]],
-          aggregation: [["count"]],
-        },
-      },
-      display: "map",
-      visualization_settings: {
-        "map.type": "region",
-        "map.region": "us_states",
-      },
-    });
-    cy.get(".Visualization")
-      .find("path")
-      .first()
-      .as("minnesota");
-
-    // hover to see the tooltip
-    cy.get("@minnesota").trigger("mousemove");
-
-    // check tooltip content
-    cy.findByText("State:"); // column name key
-    cy.findByText("Minnesota"); // feature name as value
-
-    // open actions menu and drill within it
-    cy.get("@minnesota").click();
-    cy.findByText("View these People").click();
-    // check that the drill through worked
-    cy.findByText("State is MN");
-    cy.findByText("Showing 96 rows");
   });
 });
 

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -7,6 +7,7 @@ import {
   popover,
   sidebar,
   USER_GROUPS,
+  visitQuestionAdhoc,
 } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -449,6 +450,43 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       cy.findByText("Gizmo").should("not.exist");
       cy.findByText("Doohickey").should("not.exist");
     });
+  });
+
+  it("should 'View these...' on region map", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: 1,
+        type: "query",
+        query: {
+          "source-table": PEOPLE_ID,
+          breakout: [["field-id", PEOPLE.STATE]],
+          aggregation: [["count"]],
+        },
+      },
+      display: "map",
+      visualization_settings: {
+        "map.type": "region",
+        "map.region": "us_states",
+      },
+    });
+    cy.get(".Visualization")
+      .find("path")
+      .first()
+      .as("minnesota");
+
+    // hover to see the tooltip
+    cy.get("@minnesota").trigger("mousemove");
+
+    // check tooltip content
+    cy.findByText("State:"); // column name key
+    cy.findByText("Minnesota"); // feature name as value
+
+    // open actions menu and drill within it
+    cy.get("@minnesota").click();
+    cy.findByText("View these People").click();
+    // check that the drill through worked
+    cy.findByText("State is MN");
+    cy.findByText("Showing 96 rows");
   });
 });
 


### PR DESCRIPTION
Fixes #14650

This PR fixes two small bugs in region maps:
1. Don't use the feature name for the dimension value. (#14650)
2. Display the column name in the tooltip. (I didn't see an issue for this)

~I added a Cypress test that covers both.~ I unskipped the repro and added an assertion for the tooltip.