### PR TITLE
add copy action to saved question

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -13,6 +13,7 @@ import { generateQueryDescription } from "metabase/lib/query/description";
 import validate from "metabase/lib/validate";
 
 import { t } from "ttag";
+import _ from "underscore";
 
 import "./SaveQuestionModal.css";
 
@@ -25,6 +26,7 @@ export default class SaveQuestionModal extends Component {
     onSave: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     multiStep: PropTypes.bool,
+    clone: PropTypes.bool,
   };
 
   handleSubmit = async details => {
@@ -36,10 +38,10 @@ export default class SaveQuestionModal extends Component {
     //     .setDisplayName(details.name.trim())
     //     .setDescription(details.description ? details.description.trim() : null)
     //     .setCollectionId(details.collection_id)
-    let { card, originalCard, onCreate, onSave } = this.props;
+    let { card, originalCard, onCreate, onSave, clone } = this.props;
 
     card = {
-      ...card,
+      ...(clone ? _.omit(card, "id") : card),
       name:
         details.saveType === "overwrite"
           ? originalCard.name
@@ -90,6 +92,8 @@ export default class SaveQuestionModal extends Component {
 
     const title = this.props.multiStep
       ? t`First, save your question`
+      : this.props.clone
+      ? t`Copy question`
       : t`Save question`;
 
     const showSaveType = !card.id && !!originalCard;

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -13,7 +13,6 @@ import { generateQueryDescription } from "metabase/lib/query/description";
 import validate from "metabase/lib/validate";
 
 import { t } from "ttag";
-import _ from "underscore";
 
 import "./SaveQuestionModal.css";
 
@@ -26,7 +25,6 @@ export default class SaveQuestionModal extends Component {
     onSave: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     multiStep: PropTypes.bool,
-    clone: PropTypes.bool,
   };
 
   handleSubmit = async details => {
@@ -38,10 +36,10 @@ export default class SaveQuestionModal extends Component {
     //     .setDisplayName(details.name.trim())
     //     .setDescription(details.description ? details.description.trim() : null)
     //     .setCollectionId(details.collection_id)
-    let { card, originalCard, onCreate, onSave, clone } = this.props;
+    let { card, originalCard, onCreate, onSave } = this.props;
 
     card = {
-      ...(clone ? _.omit(card, "id") : card),
+      ...card,
       name:
         details.saveType === "overwrite"
           ? originalCard.name
@@ -92,8 +90,6 @@ export default class SaveQuestionModal extends Component {
 
     const title = this.props.multiStep
       ? t`First, save your question`
-      : this.props.clone
-      ? t`Duplicate this question`
       : t`Save question`;
 
     const showSaveType = !card.id && !!originalCard;

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -93,7 +93,7 @@ export default class SaveQuestionModal extends Component {
     const title = this.props.multiStep
       ? t`First, save your question`
       : this.props.clone
-      ? t`Copy question`
+      ? t`Duplicate this question`
       : t`Save question`;
 
     const showSaveType = !card.id && !!originalCard;

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -181,6 +181,19 @@ export default class QueryModals extends React.Component {
       <Modal full onClose={onCloseModal}>
         <QuestionEmbedWidget card={this.props.card} onClose={onCloseModal} />
       </Modal>
+    ) : modal === "clone" ? (
+      <Modal form onClose={onCloseModal}>
+        <SaveQuestionModal
+          card={this.props.card}
+          tableMetadata={this.props.tableMetadata}
+          onCreate={async card => {
+            await this.props.onCreate(card);
+            onOpenModal("saved");
+          }}
+          onClose={onCloseModal}
+          clone
+        />
+      </Modal>
     ) : null;
   }
 }

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -192,7 +192,6 @@ export default class QueryModals extends React.Component {
               ...this.props.card,
               ...formValues,
               description: formValues.description || null,
-              id: undefined,
             });
             return { payload: { object } };
           }}

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -16,6 +16,7 @@ import QuestionEmbedWidget from "metabase/query_builder/containers/QuestionEmbed
 
 import QuestionHistoryModal from "metabase/query_builder/containers/QuestionHistoryModal";
 import { CreateAlertModalContent } from "metabase/query_builder/components/AlertModals";
+import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 
 export default class QueryModals extends React.Component {
   showAlertsAfterQuestionSaved = () => {
@@ -182,16 +183,21 @@ export default class QueryModals extends React.Component {
         <QuestionEmbedWidget card={this.props.card} onClose={onCloseModal} />
       </Modal>
     ) : modal === "clone" ? (
-      <Modal form onClose={onCloseModal}>
-        <SaveQuestionModal
-          card={this.props.card}
-          tableMetadata={this.props.tableMetadata}
-          onCreate={async card => {
-            await this.props.onCreate(card);
-            onOpenModal("saved");
+      <Modal onClose={onCloseModal}>
+        <EntityCopyModal
+          entityType="questions"
+          entityObject={this.props.card}
+          copy={async formValues => {
+            const object = await this.props.onCreate({
+              ...this.props.card,
+              ...formValues,
+              description: formValues.description || null,
+              id: undefined,
+            });
+            return { payload: { object } };
           }}
           onClose={onCloseModal}
-          clone
+          onSaved={() => onOpenModal("saved")}
         />
       </Modal>
     ) : null;

--- a/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
@@ -41,6 +41,11 @@ export default function QuestionEntityMenu({
           title: `Archive`,
           action: () => onOpenModal("archive"),
         },
+        canWrite && {
+          icon: "clone",
+          title: t`Copy this question`,
+          action: () => onOpenModal("clone"),
+        },
       ]}
     />
   );

--- a/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
@@ -43,7 +43,7 @@ export default function QuestionEntityMenu({
         },
         canWrite && {
           icon: "clone",
-          title: t`Copy this question`,
+          title: t`Duplicate this question`,
           action: () => onOpenModal("clone"),
         },
       ]}

--- a/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
@@ -37,14 +37,14 @@ export default function QuestionEntityMenu({
           action: () => onOpenModal("move"),
         },
         canWrite && {
-          icon: "archive",
-          title: `Archive`,
-          action: () => onOpenModal("archive"),
-        },
-        canWrite && {
           icon: "clone",
           title: t`Duplicate this question`,
           action: () => onOpenModal("clone"),
+        },
+        canWrite && {
+          icon: "archive",
+          title: `Archive`,
+          action: () => onOpenModal("archive"),
         },
       ]}
     />

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -86,4 +86,22 @@ describe("scenarios > question > saved", () => {
     cy.findByText("Started from").should("not.exist");
     cy.findByText("Quantity is equal to 100").should("not.exist");
   });
+
+  it("should clone a saved question", () => {
+    cy.server();
+    cy.route("POST", "/api/card").as("cardCreate");
+    cy.route("POST", "/api/card/1/query").as("query");
+
+    cy.visit("/question/1");
+    cy.wait("@query");
+
+    cy.get(".Icon-pencil").click();
+    cy.findByText("Copy this question").click();
+
+    modal().within(() => {
+      cy.findByLabelText("Name").should("have.value", "Orders");
+      cy.findByText("Save").click();
+      cy.wait("@cardCreate");
+    });
+  });
 });

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -87,7 +87,7 @@ describe("scenarios > question > saved", () => {
     cy.findByText("Quantity is equal to 100").should("not.exist");
   });
 
-  it("should clone a saved question", () => {
+  it("should duplicate a saved question", () => {
     cy.server();
     cy.route("POST", "/api/card").as("cardCreate");
     cy.route("POST", "/api/card/1/query").as("query");
@@ -99,8 +99,8 @@ describe("scenarios > question > saved", () => {
     cy.findByText("Duplicate this question").click();
 
     modal().within(() => {
-      cy.findByLabelText("Name").should("have.value", "Orders");
-      cy.findByText("Save").click();
+      cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");
+      cy.findByText("Duplicate").click();
       cy.wait("@cardCreate");
     });
   });

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -96,7 +96,7 @@ describe("scenarios > question > saved", () => {
     cy.wait("@query");
 
     cy.get(".Icon-pencil").click();
-    cy.findByText("Copy this question").click();
+    cy.findByText("Duplicate this question").click();
 
     modal().within(() => {
       cy.findByLabelText("Name").should("have.value", "Orders");


### PR DESCRIPTION
Resolves #4483 

**Description**
Adds a copy action to the "pencil" dropdown on a saved question. Adding a bit of logic to `SaveQuestionModal`. Not sure if I should `omit` any of the `card` properties before I POST it to `/api/card`, but I went ahead and removed `id` from the object.

**Verification**
Current appearance
<img width="280" alt="Screen Shot 2021-02-12 at 4 24 00 PM" src="https://user-images.githubusercontent.com/13057258/107835577-d4cccb80-6d4e-11eb-8580-bd43aad7c971.png">
<img width="684" alt="Screen Shot 2021-02-12 at 4 24 05 PM" src="https://user-images.githubusercontent.com/13057258/107835578-d5fdf880-6d4e-11eb-9288-9a884e28f3c2.png">
