### PR TITLE
Update Dockerfile for parallel and 20% faster builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,44 @@
 ###################
-# STAGE 1: builder
+# STAGE 1.1: builder frontend
+###################
+
+FROM node:15.8.0-alpine as frontend
+
+WORKDIR /app/source
+
+ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
+
+# frontend dependencies
+COPY yarn.lock package.json .yarnrc ./
+RUN yarn
+
+###################
+# STAGE 1.2: builder backend
+###################
+
+# Build currently doesn't work on > Java 11 (i18n utils are busted) so build on 8 until we fix this
+FROM adoptopenjdk/openjdk8:alpine as backend
+
+WORKDIR /app/source
+
+ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
+
+# bash:    various shell scripts
+# curl:    needed by script that installs Clojure CLI
+
+RUN apk add --no-cache curl bash
+
+# lein:    backend dependencies and building
+RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
+  chmod +x /usr/local/bin/lein && \
+  /usr/local/bin/lein upgrade
+
+# backend dependencies
+COPY project.clj .
+RUN lein deps
+
+###################
+# STAGE 1.3: main builder
 ###################
 
 # Build currently doesn't work on > Java 11 (i18n utils are busted) so build on 8 until we fix this
@@ -28,28 +67,22 @@ RUN curl https://download.clojure.org/install/linux-install-1.10.1.708.sh -o /tm
   chmod +x /tmp/linux-install-1.10.1.708.sh && \
   sh /tmp/linux-install-1.10.1.708.sh
 
-# install dependencies before adding the rest of the source to maximize caching
-
-# backend dependencies
-COPY project.clj .
-RUN lein deps
-
-# frontend dependencies
-COPY yarn.lock package.json .yarnrc ./
-RUN yarn
-
-# add the rest of the source
-COPY . .
-
-# build the app
-RUN INTERACTIVE=false bin/build
-
 # import AWS RDS cert into /etc/ssl/certs/java/cacerts
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o rds-combined-ca-bundle.pem  && \
   /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds \
   -file rds-combined-ca-bundle.pem \
   -keystore /etc/ssl/certs/java/cacerts \
   -keypass changeit -storepass changeit
+
+COPY --from=frontend /app/source/. .
+COPY --from=backend /app/source/. .
+COPY --from=backend /root/. /root/
+
+# add the rest of the source
+COPY . .
+
+# build the app
+RUN INTERACTIVE=false bin/build
 
 # ###################
 # # STAGE 2: runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1.1: builder frontend
 ###################
 
-FROM node:15.8.0-alpine as frontend
+FROM node:12.20.1-alpine as frontend
 
 WORKDIR /app/source
 
@@ -10,7 +10,7 @@ ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # frontend dependencies
 COPY yarn.lock package.json .yarnrc ./
-RUN yarn
+RUN yarn install --frozen-lockfile
 
 ###################
 # STAGE 1.2: builder backend


### PR DESCRIPTION
This new Dockerfile will build in parallel frontend and backend when using Buildkit: 

run with `DOCKER_BUILDKIT=1 docker build .`

On a build test I achieved 20% less build time than serial build. Can be built without buildkit as well