### PR TITLE
Sort GeoJSON maps

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -237,10 +237,15 @@ export default class Map extends Component {
         return null;
       },
       getProps: () => ({
-        options: Object.entries(MetabaseSettings.get("custom-geojson", {})).map(
-          // $FlowFixMe:
-          ([key, value]) => ({ name: value.name, value: key }),
-        ),
+        options: _.chain(
+          Object.entries(MetabaseSettings.get("custom-geojson", {})),
+        )
+          .map(
+            // $FlowFixMe:
+            ([key, value]) => ({ name: value.name, value: key }),
+          )
+          .sortBy(x => x.name.toLowerCase())
+          .value(),
       }),
       getHidden: (series, vizSettings) => vizSettings["map.type"] !== "region",
     },

--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -240,10 +240,7 @@ export default class Map extends Component {
         options: _.chain(
           Object.entries(MetabaseSettings.get("custom-geojson", {})),
         )
-          .map(
-            // $FlowFixMe:
-            ([key, value]) => ({ name: value.name, value: key }),
-          )
+          .map(([key, value]) => ({ name: value.name, value: key }))
           .sortBy(x => x.name.toLowerCase())
           .value(),
       }),

--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -237,10 +237,9 @@ export default class Map extends Component {
         return null;
       },
       getProps: () => ({
-        options: _.chain(
-          Object.entries(MetabaseSettings.get("custom-geojson", {})),
-        )
-          .map(([key, value]) => ({ name: value.name, value: key }))
+        options: _.chain(MetabaseSettings.get("custom-geojson", {}))
+          .pairs()
+          .map(([key, value]) => ({ name: value.name || "", value: key }))
           .sortBy(x => x.name.toLowerCase())
           .value(),
       }),


### PR DESCRIPTION
https://github.com/metabase/metabase/issues/14696

Sort GeoJSON files on maps visualization

## Before
![image](https://user-images.githubusercontent.com/6377293/107126607-8747ee80-6876-11eb-8d3a-aefcb23eff3e.png)

## After
<img width="1355" alt="image" src="https://user-images.githubusercontent.com/6377293/107126618-9a5abe80-6876-11eb-82eb-367538207a11.png">

## Questions

Simple implementation, just chaining with underscore. One question is how to elegantly handle null names. Figure @paulrosenzweig might have 1-liner trick for that. Also its possible that `name` is required? Not sure if that's actually validated or just by convention always true.