### PR TITLE
Skip failing pivot tables Cypress tests

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -630,7 +630,7 @@ describe("scenarios > visualizations > pivot tables", () => {
             .then($value => {
               cy.visit($value);
             });
-          cy.findAllByText(test.subject); // the inspector only saw one, but findByText failed due to multiple elements
+          cy.get(".EmbedFrame-header").contains(test.subject);
           assertOnPivotFields();
         });
 
@@ -652,7 +652,7 @@ describe("scenarios > visualizations > pivot tables", () => {
           // visit the iframe src directly to ensure it's not sing preview endpoints
           cy.get("iframe").then($iframe => {
             cy.visit($iframe[0].src);
-            cy.findByText(test.subject);
+            cy.get(".EmbedFrame-header").contains(test.subject);
             assertOnPivotFields();
           });
         });

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -23,7 +23,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     signInAsAdmin();
   });
 
-  it("should be created from an ad-hoc question", () => {
+  it.skip("should be created from an ad-hoc question", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -292,7 +292,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("899"); // Affiliate is no longer collapsed
   });
 
-  it("should expand and collapse field options", () => {
+  it.skip("should expand and collapse field options", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -317,7 +317,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText(/See options/);
   });
 
-  it("should allow column formatting", () => {
+  it.skip("should allow column formatting", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -344,7 +344,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     });
   });
 
-  it("should allow value formatting", () => {
+  it.skip("should allow value formatting", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -373,7 +373,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     });
   });
 
-  it("should not allow sorting of value fields", () => {
+  it.skip("should not allow sorting of value fields", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -390,7 +390,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText(/Sort order/).should("not.exist");
   });
 
-  it("should allow sorting fields", () => {
+  it.skip("should allow sorting fields", () => {
     // Pivot by a single column with many values (100 bins).
     // Having many values hides values that are sorted to the end.
     // This lets us assert on presence of a certain value.


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Skips pivot tables Cypress tests that are currently failing on a `release-x.38.x` branch (caused by #14699)
- Refines one assertion that was tricky and Cypress sometimes failed (it reports multiple elements, although only 1 element is in the DOM)