### PR TITLE
Use GitHub Actions to run back-end linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1025,34 +1025,6 @@ workflows:
           <<: *Matrix
 
       - lein:
-          name: be-linter-eastwood
-          requires:
-            - be-deps
-          lein-command: eastwood
-          skip-when-no-change: true
-
-      - lein:
-          name: be-linter-docstring-checker
-          requires:
-            - be-deps
-          lein-command: docstring-checker
-          skip-when-no-change: true
-
-      - lein:
-          name: be-linter-namespace-decls
-          requires:
-            - be-deps
-          lein-command: check-namespace-decls
-          skip-when-no-change: true
-
-      - lein:
-          name: be-linter-bikeshed
-          requires:
-            - be-deps
-          lein-command: bikeshed
-          skip-when-no-change: true
-
-      - lein:
           name: be-linter-cloverage
           requires:
             - be-deps
@@ -1062,10 +1034,6 @@ workflows:
                 name: Upload code coverage to codecov.io
                 command: bash <(curl -s https://codecov.io/bash)
           skip-when-no-change: true
-
-      - be-linter-reflection-warnings:
-          requires:
-            - be-deps
 
       - test-driver:
           name: be-tests-bigquery-ee

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,16 +7,13 @@ on:
       - master
       - 'release**'
       - 'feature**'
-      - 'fix**'
-      - 'ci**'
     tags:
       - '**'
     paths:
-    - 'src/metabase/**'
-    - 'modules/drivers/**'
-    - 'enterprise/backend/**'
-    - '**/project.clj'
-    - '**/deps.edn'
+    - '**.clj'
+    - '**.edn'
+    - '**.java'
+    - '**/metabase-plugin.yaml'
     - '.github/workflows/**'
 
 jobs:
@@ -34,8 +31,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
-    - run: lein with-profile +ci,+oss bikeshed
+        key: ${{ runner.os }}-bikeshed-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci bikeshed
 
   be-linter-eastwood:
     runs-on: ubuntu-20.04
@@ -50,8 +47,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
-    - run: lein with-profile +ci,+oss eastwood
+        key: ${{ runner.os }}-eastwood-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci eastwood
 
   be-linter-docstring-checker:
     runs-on: ubuntu-20.04
@@ -66,8 +63,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
-    - run: lein with-profile +ci,+oss docstring-checker
+        key: ${{ runner.os }}-docstring-checker-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci docstring-checker
 
   be-linter-namespace-decls:
     runs-on: ubuntu-20.04
@@ -82,8 +79,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
-    - run: lein with-profile +ci,+oss check-namespace-decls
+        key: ${{ runner.os }}-namespace-decls-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci check-namespace-decls
 
   be-linter-reflection-warnings:
     runs-on: ubuntu-20.04
@@ -98,6 +95,6 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
+        key: ${{ runner.os }}-reflection-${{ hashFiles('**/project.clj') }}
     - run: ./bin/reflection-linter
       name: Run reflection warnings checker

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,103 @@
+name: Backend
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release**'
+      - 'feature**'
+      - 'fix**'
+      - 'ci**'
+    tags:
+      - '**'
+    paths:
+    - 'src/metabase/**'
+    - 'modules/drivers/**'
+    - 'enterprise/backend/**'
+    - '**/project.clj'
+    - '**/deps.edn'
+    - '.github/workflows/**'
+
+jobs:
+
+  be-linter-bikeshed:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci,+oss bikeshed
+
+  be-linter-eastwood:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci,+oss eastwood
+
+  be-linter-docstring-checker:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci,+oss docstring-checker
+
+  be-linter-namespace-decls:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
+    - run: lein with-profile +ci,+oss check-namespace-decls
+
+  be-linter-reflection-warnings:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
+    - run: ./bin/reflection-linter
+      name: Run reflection warnings checker

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -95,6 +95,6 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-reflection-${{ hashFiles('**/project.clj') }}
+        key: ${{ runner.os }}-reflection-warnings-${{ hashFiles('**/project.clj') }}
     - run: ./bin/reflection-linter
       name: Run reflection warnings checker


### PR DESCRIPTION
This frees a few Circle CI containers to run other priority tasks (e.g. Cypress tests).

Note that this GitHub Actions variant doesn't (yet) implement a content-based caching to potentially skip the linters if some back-end code hasn't changed. However, the path-based conditional should make it up for most of it. Thus, if the changeset only touch e.g. `docs/` or `frontend/`, this workflow will not even be executed by GitHub Actions.

For the previous related work on front-end linters, see PR #14050.