### PR TITLE
Fix broken pivot table tests

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -245,7 +245,7 @@ class ChartSettings extends Component {
     ));
 
     const onReset =
-      !_.isEqual(settings, {}) && !settings.virtual_card // resetting virtual cards wipes the text and broke the UI (metabase#14644)
+      !_.isEqual(settings, {}) && (settings || {}).virtual_card == null // resetting virtual cards wipes the text and broke the UI (metabase#14644)
         ? this.handleResetSettings
         : null;
 

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -23,7 +23,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     signInAsAdmin();
   });
 
-  it.skip("should be created from an ad-hoc question", () => {
+  it("should be created from an ad-hoc question", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -292,7 +292,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("899"); // Affiliate is no longer collapsed
   });
 
-  it.skip("should expand and collapse field options", () => {
+  it("should expand and collapse field options", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -317,7 +317,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText(/See options/);
   });
 
-  it.skip("should allow column formatting", () => {
+  it("should allow column formatting", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -344,7 +344,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     });
   });
 
-  it.skip("should allow value formatting", () => {
+  it("should allow value formatting", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -373,7 +373,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     });
   });
 
-  it.skip("should not allow sorting of value fields", () => {
+  it("should not allow sorting of value fields", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
@@ -390,7 +390,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText(/Sort order/).should("not.exist");
   });
 
-  it.skip("should allow sorting fields", () => {
+  it("should allow sorting fields", () => {
     // Pivot by a single column with many values (100 bins).
     // Having many values hides values that are sorted to the end.
     // This lets us assert on presence of a certain value.


### PR DESCRIPTION
Fixes #14699

My change in #14667 broke those tests. I'm not sure if this issue arose in real usage, but in tests we open questions directly without any settings. We could always include settings via the test helper, but it was simple enough to add fallback for this case `|| {}`.