### PR TITLE
Mb db connection uri parsing

### DIFF
--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -132,7 +132,7 @@
                       (when (re-find #"postgres(?:ql)?:" conn)
                         ;; jdbc:postgresql: is an opaque URI not subject to further parsing. Strip that off and we can
                         ;; use the structural .getQuery from the URI rather than parsing ourselves
-                        (when-let [details (some-> (.getQuery (URI. (str/replace conn #"jdbc:" "")))
+                        (when-let [details (some-> (.getQuery (URI. (str/replace conn #"^jdbc:" "")))
                                                    codec/form-decode
                                                    walk/keywordize-keys)]
                           (suspicious-postgres-details? details))))

--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -4,6 +4,10 @@
   enviornment variables e.g. `MB_DB_TYPE`, `MB_DB_HOST`, etc. `MB_DB_CONNECTION_URI` is used preferentially if both
   are specified.
 
+  The `MB_DB_CONNECTION_URI` is unparsed and passed to the jdbc driver with once exception: if it includes the
+  password like `username:password@host:port`. In this case we parse this and log. This functionality will be removed
+  at some point so.
+
   There are two ways we specify JDBC connection information in Metabase code:
 
   1. As a 'connection details' map that is meant to be UI-friendly; this is the actual map we save when creating a
@@ -18,11 +22,15 @@
   Normally you should use the equivalent functions in `metabase.db.connection` which can be overridden rather than
   using this namespace directly."
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [metabase.config :as config]
             [metabase.db.spec :as db.spec]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs]]))
+            [metabase.util.i18n :refer [trs]]
+            [ring.util.codec :as codec])
+  (:import java.net.URI))
 
 (defn- get-db-file
   "Takes a filename and converts it to H2-compatible filename."
@@ -50,20 +58,92 @@
      (let [db-file-name (config/config-str :mb-db-file)]
        (get-db-file db-file-name)))))
 
-(defn- format-connection-uri
+(def ^:private jdbc-connection-regex
+  "Regex to be used only when `:mb-db-connection-uri` includes a password like `username:password@host:port`."
+  #"^(jdbc:)?([^:/@]+)://(?:([^:/@]+)(?::([^:@]+))?@)?([^:@]+)(?::(\d+))?/([^/?]+)(?:\?(.*))?$")
+
+(declare connection-details->jdbc-spec)
+
+(defn- parse-connection-string
+  "Parse a DB connection URI like
+  `postgres://cam@localhost.com:5432/cams_cool_db?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory` and
+  return a broken-out map. This should not be used unless the connection string uses the old style where the password
+  is included in the like `username:password@host:port`."
+  [uri]
+  (when-let [[_ _ protocol user pass host port db query] (re-matches jdbc-connection-regex uri)]
+    (connection-details->jdbc-spec
+     (keyword protocol)
+     (u/prog1 (merge {:type (case (keyword protocol)
+                              :postgres   :postgres
+                              :postgresql :postgres
+                              :mysql      :mysql
+                              :h2         :h2)}
+
+                     (case (keyword protocol)
+                       :h2 {:db db}
+                       {:user     user
+                        :password pass
+                        :host     host
+                        :port     port
+                        :dbname   db})
+                     (some-> query
+                             codec/form-decode
+                             walk/keywordize-keys))
+       ;; If someone is using Postgres and specifies `ssl=true` they might need to specify `sslmode=require`. Let's let
+       ;; them know about that to make their lives a little easier. See https://github.com/metabase/metabase/issues/8908
+       ;; for more details.
+       (when (and (= (:type <>) :postgres)
+                  (= (:ssl <>) "true")
+                  (not (:sslmode <>)))
+         (log/warn (trs "Warning: Postgres connection string with `ssl=true` detected.")
+                   (trs "You may need to add `?sslmode=require` to your application DB connection string.")
+                   (trs "If Metabase fails to launch, please add it and try again.")
+                   (trs "See https://github.com/metabase/metabase/issues/8908 for more details.")))))))
+
+(defn- ensure-jdbc-protocol
   "Prepends \"jdbc:\" to the connection-uri string if needed."
   [connection-uri]
-  (if-let [uri connection-uri]
-    (if (re-find #"^jdbc:" uri)
-      uri
-      (str "jdbc:" uri))))
+  (when connection-uri
+    (if (re-find #"^jdbc:" connection-uri)
+      connection-uri
+      (str "jdbc:" connection-uri))))
 
-(def ^:private connection-string
-  (delay (format-connection-uri (config/config-str :mb-db-connection-uri))))
+(defn old-password-style?
+  "Parse a jdbc connection uri to check for older style password passing like:
+  mysql://foo:password@172.17.0.2:3306/metabase"
+  [connection-uri]
+  (when connection-uri
+    (let [uri (URI. connection-uri)]
+      ;; this is how clojure.java.jdbc does it
+      (= 2 (count (str/split (.getUserInfo uri) #":"))))))
 
-(defn- connection-string->db-type [s]
-  (when s
-    (let [[_ subprotocol] (re-find #"^(?:jdbc:)?([^:]+):" s)]
+(defn- connection-from-jdbc-string
+  "If connection string uses the form `username:password@host:port`, use our custom parsing to return a jdbc spec and
+  warn about this deprecated behavior. If not, return the jdbc string as is since our parsing does not offer all of
+  the options of using a raw jdbc string."
+  [conn-string]
+  (when conn-string
+    (or (when-not (old-password-style? conn-string)
+          ;; prefer not parsing as we don't handle all features of connection strings
+          (ensure-jdbc-protocol conn-string))
+        (do (log/warn (trs "Warning: using password provided inline is deprecated.")
+                      (trs "Change to using the password as a query parameter: `?password=your-password`."))
+            (parse-connection-string conn-string)))))
+
+(def ^:private connection-string-or-spec
+  "Uses `:mb-db-connection-uri` and is either:
+  - the jdbc connection string if it does not use an inline password, or
+  - a db-spec parsed by this code if it does use an inline password, or
+  - nil when this value is not set."
+  (delay (when-let [conn-uri (config/config-str :mb-db-connection-uri)]
+           (connection-from-jdbc-string conn-uri))))
+
+(defn- connection-string-or-spec->db-type [x]
+  (cond
+    (map? x) (:type x)
+
+    (string? x)
+    (let [[_ subprotocol] (re-find #"^(?:jdbc:)?([^:]+):" x)]
       (try
         (case (keyword subprotocol)
           :postgres   :postgres
@@ -78,7 +158,7 @@
                           {:subprotocol subprotocol})))))))
 
 (def ^:private connection-string-db-type
-  (delay (connection-string->db-type @connection-string)))
+  (delay (connection-string-or-spec->db-type @connection-string-or-spec)))
 
 (def db-type
   "Keyword type name of the application DB details specified by environment variables. Matches corresponding driver
@@ -126,5 +206,5 @@
 (def jdbc-spec
   "`clojure.java.jdbc` spec map for the application DB, using the details map derived from environment variables."
   (delay
-    (or @connection-string
+    (or @connection-string-or-spec
         (connection-details->jdbc-spec @db-type @db-connection-details))))

--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -144,7 +144,8 @@
   mysql://foo:password@172.17.0.2:3306/metabase"
   [connection-uri]
   (when connection-uri
-    (let [uri (URI. connection-uri)]
+    ;; strip the jdbc prefix off so its a parseable and not opaque URI
+    (let [uri (URI. (str/replace connection-uri #"^jdbc:" ""))]
       ;; this is how clojure.java.jdbc does it
       (some? (.getUserInfo uri)))))
 

--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -164,7 +164,7 @@
   (log/warn
    (u/format-color 'red
        (str
-        (trs "Warning: using credentials provided inline is deprecated.")
+        (trs "Warning: using credentials provided inline is deprecated. ")
         (trs "Change to using the credentials as a query parameter: `?password=your-password&user=user`.")))))
 
 (defn- log-postgres-ssl []

--- a/test/metabase/db/env_test.clj
+++ b/test/metabase/db/env_test.clj
@@ -35,13 +35,20 @@
                 :useUnicode true}]
       (is (= :mysql (#'mdb.env/connection-string-or-spec->db-type spec))))))
 
-(deftest ensure-jdbc-protocol-test
-  (let [conn-uri "postgresql://localhost:metabase?username=johndoe"
-        jdbc-conn-uri (str "jdbc:" conn-uri)]
-    (doseq [[input expected] [[conn-uri jdbc-conn-uri]
-                              [jdbc-conn-uri jdbc-conn-uri]
-                              [nil nil]]]
-      (is (= expected (#'mdb.env/ensure-jdbc-protocol input))))))
+(deftest fixup-connection-string-test
+  (let [correct-uri     "jdbc:postgresql://localhost:metabase?username=johndoe"]
+    (doseq [[input expected-diags expected]
+            [["postgres://localhost:metabase?username=johndoe"
+              #{:env.info/prepend-jdbc :env.info/change-to-postgresql}
+              correct-uri]
+             ["jdbc:postgres://localhost:metabase?username=johndoe"
+              #{:env.info/change-to-postgresql}
+              correct-uri]
+             [correct-uri #{} correct-uri]
+             [nil nil nil]]]
+      (let [{:keys [connection diags]} (#'mdb.env/fixup-connection-string input)]
+        (is (= expected connection) input)
+        (is (= expected-diags diags) input)))))
 
 (deftest old-credential-style?-test
   (are [old? conn-uri] (is (= old? (#'mdb.env/old-credential-style? conn-uri)) conn-uri)
@@ -60,12 +67,40 @@
                 :dbname      "metabase"}]
     (testing "handles mixed (just password in query params) old style just fine"
       (let [conn-uri "mysql://foo@172.17.0.2:3306/metabase?password=password"]
-        (is (= parsed (#'mdb.env/connection-from-jdbc-string conn-uri)))))
+        (is (= {:connection parsed
+                :diags #{:env.warning/inline-credentials}}
+               (#'mdb.env/connection-from-jdbc-string conn-uri)))))
     (testing "When using old-style passwords parses and returns jdbc specs"
       (let [conn-uri "mysql://foo:password@172.17.0.2:3306/metabase"]
-        (is (= parsed (#'mdb.env/connection-from-jdbc-string conn-uri))))))
+        (is (= {:connection parsed
+                :diags #{:env.warning/inline-credentials}}
+               (#'mdb.env/connection-from-jdbc-string conn-uri))))))
   (testing "handles credentials in query params"
     (let [conn-uri "mysql://172.17.0.2:3306/metabase?user=user&password=password"]
-        (is (= (str "jdbc:" conn-uri) (#'mdb.env/connection-from-jdbc-string conn-uri)))))
+      (is (= {:connection (str "jdbc:" conn-uri)
+              :diags #{:env.info/prepend-jdbc}}
+             (#'mdb.env/connection-from-jdbc-string conn-uri)))))
+  (testing "warns about postgres ssl issue #8908"
+    (testing "when it parses due to inline credentials"
+      (let [conn-uri "postgresql://mb@172.17.0.2:5432/metabase?ssl=true"]
+        (is (= {:connection
+                {:ssl "true",
+                 :OpenSourceSubProtocolOverride true,
+                 :password nil,
+                 :type :postgres,
+                 :classname "org.postgresql.Driver",
+                 :subprotocol "postgresql",
+                 :dbname "metabase",
+                 :user "mb",
+                 :subname "//172.17.0.2:5432/metabase"},
+                :diags #{:env.warning/postgres-ssl :env.warning/inline-credentials}}
+               (#'mdb.env/connection-from-jdbc-string conn-uri)))))
+    (testing "when it doesn't parse as well"
+      (doseq [conn-uri ["jdbc:postgresql://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true"
+                        "postgresql://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true"
+                        "postgres://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true"]]
+        (let [{:keys [connection diags]} (#'mdb.env/connection-from-jdbc-string conn-uri)]
+          (is (= "jdbc:postgresql://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true" connection))
+          (is (contains? diags :env.warning/postgres-ssl))))))
   (testing "handles nil"
     (is (nil? (#'mdb.env/connection-from-jdbc-string nil)))))

--- a/test/metabase/db/env_test.clj
+++ b/test/metabase/db/env_test.clj
@@ -36,7 +36,7 @@
       (is (= :mysql (#'mdb.env/connection-string-or-spec->db-type spec))))))
 
 (deftest fixup-connection-string-test
-  (let [correct-uri     "jdbc:postgresql://localhost:metabase?username=johndoe"]
+  (let [correct-uri "jdbc:postgresql://localhost:metabase?username=johndoe"]
     (doseq [[input expected-diags expected]
             [["postgres://localhost:metabase?username=johndoe"
               #{:env.info/prepend-jdbc :env.info/change-to-postgresql}
@@ -54,6 +54,8 @@
   (are [old? conn-uri] (is (= old? (#'mdb.env/old-credential-style? conn-uri)) conn-uri)
     false "jdbc:mysql://172.17.0.2:3306/metabase?password=password&user=user"
     false "mysql://172.17.0.2:3306/metabase?password=password&user=user"
+    ;; prefixed with jdbc makes an "opaque" URI which doesn't parse
+    true  "jdbc:mysql://foo@172.17.0.2:3306/metabase?password=password"
     true  "mysql://foo@172.17.0.2:3306/metabase?password=password"
     true  "mysql://foo:password@172.17.0.2:3306/metabase"))
 

--- a/test/metabase/db/env_test.clj
+++ b/test/metabase/db/env_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase.db.env :as mdb.env]))
 
-(deftest connection-string->db-type-test
+(deftest connection-string-or-spec->db-type-test
   (doseq [[subprotocol expected] {"postgres"   :postgres
                                   "postgresql" :postgres
                                   "mysql"      :mysql
@@ -12,19 +12,56 @@
                                   (str protocol ":abc")
                                   (str protocol ":cam@localhost/my_db?password=123456")
                                   (str protocol "://localhost/my_db")]]
-    (testing (pr-str (list 'connection-string->db-type url))
+    (testing (pr-str (list 'connection-string-or-spec->db-type url))
       (is (= expected
-             (#'mdb.env/connection-string->db-type url)))))
+             (#'mdb.env/connection-string-or-spec->db-type url)))))
   (testing "Should throw an Exception for an unsupported subprotocol"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Unsupported application database type: \"sqlserver\""
-         (#'mdb.env/connection-string->db-type "jdbc:sqlserver://bad")))))
+         (#'mdb.env/connection-string-or-spec->db-type "jdbc:sqlserver://bad"))))
+  (testing "Finds type from jdbc-spec"
+    (let [spec {:password "password",
+                :characterSetResults "UTF8",
+                :characterEncoding "UTF8",
+                :type :mysql,
+                :classname "org.mariadb.jdbc.Driver",
+                :subprotocol "mysql",
+                :useSSL false,
+                :zeroDateTimeBehavior "convertToNull",
+                :user "foo",
+                :subname "//172.17.0.2:3306/metabase",
+                :useCompression true,
+                :useUnicode true}]
+      (is (= :mysql (#'mdb.env/connection-string-or-spec->db-type spec))))))
 
-(deftest format-connection-uri-test
+(deftest ensure-jdbc-protocol-test
   (let [conn-uri "postgresql://localhost:metabase?username=johndoe"
         jdbc-conn-uri (str "jdbc:" conn-uri)]
     (doseq [[input expected] [[conn-uri jdbc-conn-uri]
                               [jdbc-conn-uri jdbc-conn-uri]
                               [nil nil]]]
-      (is (= expected (#'mdb.env/format-connection-uri input))))))
+      (is (= expected (#'mdb.env/ensure-jdbc-protocol input))))))
+
+(deftest old-password-style?-test
+  (are [old? conn-uri] (is (= old? (#'mdb.env/old-password-style? conn-uri)))
+    false  "mysql://foo@172.17.0.2:3306/metabase?password=password"
+    true "mysql://foo:password@172.17.0.2:3306/metabase"))
+
+(deftest connection-from-jdbc-string-test
+  (testing "handles old style just fine"
+    (let [conn-uri "mysql://foo@172.17.0.2:3306/metabase?password=password"]
+      (is (= (str "jdbc:" conn-uri)
+             (#'mdb.env/connection-from-jdbc-string conn-uri)))))
+  (testing "When using old-style passwords parses and returns jdbc specs"
+    (let [conn-uri "mysql://foo:password@172.17.0.2:3306/metabase"]
+      (is (= {:classname   "org.mariadb.jdbc.Driver"
+              :subprotocol "mysql"
+              :subname     "//172.17.0.2:3306/metabase"
+              :type        :mysql
+              :user        "foo"
+              :password    "password"
+              :dbname      "metabase"}
+             (#'mdb.env/connection-from-jdbc-string conn-uri)))))
+  (testing "handles nil"
+    (is (nil? (#'mdb.env/connection-from-jdbc-string nil)))))


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/14678

Using the raw jdbc string when its of the form
`username:password@host:port` causes problems if passed directly to
jdbc. Clojure.java.jdbc has some special handling for username and
passwords

```clojure
(if-let [user-info (.getUserInfo uri)]
  {:user (first (str/split user-info #":"))
   :password (second (str/split user-info #":"))})
```

Our logic here is:
1. if mb-db-connection-uri is set and not inline credentials,
return that, possibly prepending jdbc: to it
2. if mb-db-connection-uri is set and is using inline credentials, then
we use the old parsing code which doesn't support all of the crazy
stuff individual connection strings may offer and return a db-spec
3. if all the individual parts are supplied (mb-db-host, mb-db-port,
etc) are used to construct a db-spec

