### PR TITLE
Custom expression: suggest CASE when editing an expression (Custom column)

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -282,6 +282,17 @@ export function suggest({
           .filter(clause => database.hasFeature(clause.requiresFeature))
           .map(clause => functionSuggestion("functions", clause.name)),
       );
+      if (nextTokenType === Case) {
+        const caseSuggestion = {
+          type: "functions",
+          name: "case",
+          text: "case(",
+          postfixText: ")",
+          prefixTrim: /\w+$/,
+          postfixTrim: /^\w+(\(\)?|$)/,
+        };
+        finalSuggestions.push(caseSuggestion);
+      }
     } else if (nextTokenType === LParen) {
       finalSuggestions.push({
         type: "other",

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -156,6 +156,7 @@ describe("metabase/lib/expression/suggest", () => {
           ...FIELDS_CUSTOM,
           ...FIELDS_CUSTOM_NON_NUMERIC,
           ...[
+            { type: "functions", text: "case(" },
             { type: "functions", text: "coalesce(" },
             ...NUMERIC_FUNCTIONS,
             ...STRING_FUNCTIONS_EXCLUDING_REGEX,
@@ -167,7 +168,9 @@ describe("metabase/lib/expression/suggest", () => {
       it("should suggest numeric fields after an aritmetic", () => {
         expect(suggest({ source: "1 + ", ...expressionOpts })).toEqual([
           ...FIELDS_CUSTOM,
-          ...NUMERIC_FUNCTIONS,
+          ...[{ type: "functions", text: "case(" }, ...NUMERIC_FUNCTIONS].sort(
+            suggestionSort,
+          ),
           OPEN_PAREN,
         ]);
       });
@@ -175,6 +178,7 @@ describe("metabase/lib/expression/suggest", () => {
         expect(suggest({ source: "1 + C", ...expressionOpts })).toEqual([
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
+          { type: "functions", text: "case(" },
           { type: "functions", text: "ceil(" },
         ]);
       });
@@ -241,6 +245,7 @@ describe("metabase/lib/expression/suggest", () => {
           [
             { text: "[Count] ", type: "fields" },
             { text: "[Total] ", type: "fields" },
+            { type: "functions", text: "case(" },
             { text: "coalesce(", type: "functions" },
             ...STRING_FUNCTIONS,
             ...NUMERIC_FUNCTIONS,
@@ -304,15 +309,18 @@ describe("metabase/lib/expression/suggest", () => {
         expect(suggest({ source: "average(c", ...aggregationOpts })).toEqual([
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
-          // { text: "case(", type: "functions" },
+          { text: "case(", type: "functions" },
           // { text: "coalesce(", type: "functions" },
           { text: "ceil(", type: "functions" },
         ]);
       });
       it("should suggest aggregations and metrics after an operator", () => {
         expect(suggest({ source: "1 + ", ...aggregationOpts })).toEqual([
-          ...AGGREGATION_FUNCTIONS,
-          ...NUMERIC_FUNCTIONS,
+          ...[
+            { type: "functions", text: "case(" },
+            ...AGGREGATION_FUNCTIONS,
+            ...NUMERIC_FUNCTIONS,
+          ].sort(suggestionSort),
           ...METRICS_CUSTOM,
           OPEN_PAREN,
         ]);
@@ -323,6 +331,7 @@ describe("metabase/lib/expression/suggest", () => {
           { type: "aggregations", text: "CountIf(" },
           { type: "aggregations", text: "CumulativeCount " },
           { type: "aggregations", text: "CumulativeSum(" },
+          { type: "functions", text: "case(" },
           { type: "functions", text: "ceil(" },
         ]);
       });
@@ -335,8 +344,11 @@ describe("metabase/lib/expression/suggest", () => {
             startRule: "aggregation",
           }),
         ).toEqual([
-          ...AGGREGATION_FUNCTIONS,
-          ...NUMERIC_FUNCTIONS,
+          ...[
+            { type: "functions", text: "case(" },
+            ...AGGREGATION_FUNCTIONS,
+            ...NUMERIC_FUNCTIONS,
+          ].sort(suggestionSort),
           ...METRICS_ORDERS,
           OPEN_PAREN,
         ]);
@@ -369,8 +381,11 @@ describe("metabase/lib/expression/suggest", () => {
           suggest({ source: "", query: ORDERS.query(), startRule: "boolean" }),
         ).toEqual([
           ...FIELDS_ORDERS,
-          ...FILTER_FUNCTIONS,
-          ...UNARY_BOOLEAN_OPERATORS,
+          ...[
+            { type: "functions", text: "case(" },
+            ...FILTER_FUNCTIONS,
+            ...UNARY_BOOLEAN_OPERATORS,
+          ].sort(suggestionSort),
           OPEN_PAREN,
           ...SEGMENTS_ORDERS,
         ]);


### PR DESCRIPTION
This addresses the previously reported issue #12375.

Steps:
1. Ask a question, Custom question
2. Sample Databaset, Products table
3. Custom column

Before:

`case` isn't in the popup list of suggestions.

![image](https://user-images.githubusercontent.com/7288/107394472-c6fa1a80-6ab0-11eb-99a3-b58e9e0b51d0.png)

After:

`case` **is** in the popup list of suggestions.

![image](https://user-images.githubusercontent.com/7288/107394488-cceffb80-6ab0-11eb-97e9-54d4676c5ec9.png)
