### PR TITLE
#14726 Repro: Custom filter expression does not show original editor on subsequent click

### DIFF
--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openProductsTable,
   popover,
   modal,
+  visitQuestionAdhoc,
 } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -68,6 +69,27 @@ describe("scenarios > question > notebook", () => {
     cy.contains("Visualize").click();
     cy.contains("2372"); // user's id in the table
     cy.contains("Showing 1 row"); // ensure only one user was returned
+  });
+
+  it.skip("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
+    cy.server();
+    cy.route("POST", "/api/dataset").as("dataset");
+
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          filter: ["between", ["field-id", ORDERS.ID], 96, 97],
+        },
+        type: "query",
+      },
+      display: "table",
+    });
+
+    cy.wait("@dataset");
+    cy.findByText("ID 96 97").click();
+    cy.get("[contenteditable='true']").contains("between([ID], 96, 97)");
   });
 
   describe("joins", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14726 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/notebook.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/107424490-fdba4a00-6b1d-11eb-9f35-5f068f9c0415.png)

