### PR TITLE
Prevent greeting refresh on the homepage

### DIFF
--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -61,24 +61,33 @@ const getParitionedCollections = createSelector(
   },
 );
 
+const getGreeting = createSelector(
+  [getUser],
+  user => Greeting.sayHello(user.first_name),
+);
+
 //class Overworld extends Zelda
 @Search.loadList({
   query: { collection: "root" },
   wrapped: true,
 })
 @connect(
-  (state, props) => ({
-    // split out collections, pinned, and unpinned since bulk actions only apply to unpinned
-    ...getParitionedCollections(state, props),
-    user: getUser(state, props),
-    showHomepageData: getShowHomepageData(state),
-    showHomepageXrays: getShowHomepageXrays(state),
-  }),
+  (state, props) => {
+    return {
+      // split out collections, pinned, and unpinned since bulk actions only apply to unpinned
+      ...getParitionedCollections(state, props),
+      user: getUser(state, props),
+      showHomepageData: getShowHomepageData(state),
+      showHomepageXrays: getShowHomepageXrays(state),
+      greeting: getGreeting(state, props),
+    };
+  },
   { updateSetting },
 )
 class Overworld extends React.Component {
   render() {
     const {
+      greeting,
       user,
       showHomepageData,
       showHomepageXrays,
@@ -91,7 +100,7 @@ class Overworld extends React.Component {
             <MetabotLogo />
           </Tooltip>
           <Box ml={2}>
-            <Subhead>{Greeting.sayHello(user.first_name)}</Subhead>
+            <Subhead>{greeting}</Subhead>
           </Box>
         </Flex>
         <CollectionItemsLoader collectionId="root">

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -72,16 +72,14 @@ const getGreeting = createSelector(
   wrapped: true,
 })
 @connect(
-  (state, props) => {
-    return {
-      // split out collections, pinned, and unpinned since bulk actions only apply to unpinned
-      ...getParitionedCollections(state, props),
-      user: getUser(state, props),
-      showHomepageData: getShowHomepageData(state),
-      showHomepageXrays: getShowHomepageXrays(state),
-      greeting: getGreeting(state, props),
-    };
-  },
+  (state, props) => ({
+    // split out collections, pinned, and unpinned since bulk actions only apply to unpinned
+    ...getParitionedCollections(state, props),
+    user: getUser(state, props),
+    showHomepageData: getShowHomepageData(state),
+    showHomepageXrays: getShowHomepageXrays(state),
+    greeting: getGreeting(state, props),
+  }),
   { updateSetting },
 )
 class Overworld extends React.Component {


### PR DESCRIPTION
Fixes #11952

We had been calling `Greeting.sayHello` in the render method of the homepage itself, meaning every time the props change we'd get a new greeting. This moves that method call to a selector so it should only be run once.