### PR TITLE
Show context in search results

### DIFF
--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -144,6 +144,16 @@ export default class SearchApp extends React.Component {
   }
 }
 
+function searchContext(item) {
+  if (
+    item.matched_column !== "name" &&
+    item.matched_column !== "display_name"
+  ) {
+    return <p>{item.matched_text}</p>;
+  }
+  return null;
+}
+
 const SearchResultSection = ({ title, items }) => (
   <Card>
     {items.map(item => {
@@ -165,16 +175,19 @@ const SearchResultSection = ({ title, items }) => (
           break;
         default:
           extraInfo = (
-            <div className="inline-block">
-              <Flex align="center" color={color("text-medium")}>
-                <Icon name="folder" size={10} mr="4px" />
-                <span
-                  className="text-small text-bold"
-                  style={{ lineHeight: 1 }}
-                >
-                  {item.collection_name || t`Our Analytics`}
-                </span>
-              </Flex>
+            <div>
+              {searchContext(item)}
+              <div className="inline-block">
+                <Flex align="center" color={color("text-medium")}>
+                  <Icon name="folder" size={10} mr="4px" />
+                  <span
+                    className="text-small text-bold"
+                    style={{ lineHeight: 1 }}
+                  >
+                    {item.collection_name || t`Our Analytics`}
+                  </span>
+                </Flex>
+              </div>
             </div>
           );
           break;
@@ -188,7 +201,7 @@ const SearchResultSection = ({ title, items }) => (
         >
           <EntityItem
             variant="list"
-            name={item.getName()}
+            name={item.getDisplayName()}
             iconName={item.getIcon()}
             iconColor={item.getColor()}
             item={item}

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -548,6 +548,9 @@ export function createEntity(def: EntityDefinition): Entity {
   };
 
   entity.objectSelectors = {
+    getDisplayName(object) {
+      return object.display_name || object.name;
+    },
     getName(object) {
       return object.name;
     },

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -107,7 +107,7 @@ export default class SearchBar extends React.Component {
           <Link to={l.getUrl()}>
             <EntityItem
               iconName={l.getIcon()}
-              name={l.name}
+              name={l.getDisplayName()}
               item={l}
               variant="small"
             />

--- a/frontend/test/metabase/scenarios/auth/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/search.cy.spec.js
@@ -13,21 +13,21 @@ describe("scenarios > auth > search", () => {
       signInAsAdmin();
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
-      cy.findByText("PRODUCTS");
+      cy.findByText("Products");
     });
 
     it("should work for user with permissions (metabase#12332)", () => {
       signInAsNormalUser();
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
-      cy.findByText("PRODUCTS");
+      cy.findByText("Products");
     });
 
     it("should not work for user without permissions", () => {
       signIn("nodata");
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
-      cy.findByText("PRODUCTS").should("not.exist");
+      cy.findByText("Products").should("not.exist");
     });
   });
 });


### PR DESCRIPTION
* Show a native query when it's the search hit (in a generic-enough way to support other custom columns later)
* Show the human-friendly name (display name) for databases in both the search results and the typeahead dropdown

This does mean that matches for the database `name` (not `display_name`) won't have the matching text show up. Like if the `sad-toucan-incidents` table has a display name of `Rasta's Incidents` it will match for a search of `toucan` but the results won't have `sad-toucan-incidents` anywhere. I think this is okay for now?