### PR TITLE
Add "remapped" version of the repro for #14724

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   createNativeQuestion,
   openOrdersTable,
+  remapDisplayValueToFK,
 } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -366,46 +367,54 @@ describe("scenarios > question > nested", () => {
     cy.findAllByText("Awesome Concrete Shoes");
   });
 
-  it("should use question with joins as a base for a new question (metabase#14724)", () => {
-    const QUESTION_NAME = "14724";
+  ["remapped", "default"].forEach(test => {
+    it(`${test.toUpperCase()} version:\n should use question with joins as a base for a new question (metabase#14724)`, () => {
+      const QUESTION_NAME = "14724";
 
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
+      if (test === "remapped") {
+        cy.state("runnable").skip(); // Unskip or remove this line when "remapped" version of the issue is fixed
+        cy.log("**-- Remap Product ID's display value to `title` --**");
+        remapDisplayValueToFK(ORDERS.PRODUCT_ID, PRODUCTS.TITLE);
+      }
 
-    cy.request("POST", "/api/card", {
-      name: QUESTION_NAME,
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          joins: [
-            {
-              fields: "all",
-              "source-table": PRODUCTS_ID,
-              condition: [
-                "=",
-                ["field-id", ORDERS.PRODUCT_ID],
-                ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-              ],
-              alias: "Products",
-            },
-          ],
+      cy.server();
+      cy.route("POST", "/api/dataset").as("dataset");
+
+      cy.request("POST", "/api/card", {
+        name: QUESTION_NAME,
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            joins: [
+              {
+                fields: "all",
+                "source-table": PRODUCTS_ID,
+                condition: [
+                  "=",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+                ],
+                alias: "Products",
+              },
+            ],
+          },
+          database: 1,
         },
-        database: 1,
-      },
-      display: "table",
-      visualization_settings: {},
-    });
+        display: "table",
+        visualization_settings: {},
+      });
 
-    // Start new question from a saved one
-    cy.visit("/question/new");
-    cy.findByText("Simple question").click();
-    cy.findByText("Saved Questions").click();
-    cy.findByText(QUESTION_NAME).click();
+      // Start new question from a saved one
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText(QUESTION_NAME).click();
 
-    cy.wait("@dataset").then(xhr => {
-      expect(xhr.response.body.error).not.to.exist;
+      cy.wait("@dataset").then(xhr => {
+        expect(xhr.response.body.error).not.to.exist;
+      });
+      cy.contains("37.65");
     });
-    cy.contains("37.65");
   });
 });

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -336,11 +336,10 @@ describe("scenarios > question > nested", () => {
     cy.route("POST", "/api/dataset").as("dataset");
 
     cy.log("**-- 1. Remap Product ID's display value to `title` --**");
-    cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
-      field_id: ORDERS.PRODUCT_ID,
+    remapDisplayValueToFK({
+      display_value: ORDERS.PRODUCT_ID,
       name: "Product ID",
-      human_readable_field_id: PRODUCTS.TITLE,
-      type: "external",
+      fk: PRODUCTS.TITLE,
     });
 
     cy.log("**-- 2. Save simple 'Orders' table with remapped values --**");
@@ -374,7 +373,11 @@ describe("scenarios > question > nested", () => {
       if (test === "remapped") {
         cy.state("runnable").skip(); // Unskip or remove this line when "remapped" version of the issue is fixed
         cy.log("**-- Remap Product ID's display value to `title` --**");
-        remapDisplayValueToFK(ORDERS.PRODUCT_ID, PRODUCTS.TITLE);
+        remapDisplayValueToFK({
+          display_value: ORDERS.PRODUCT_ID,
+          name: "Product ID",
+          fk: PRODUCTS.TITLE,
+        });
       }
 
       cy.server();


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Splits repro for #14724 into 2 versions
    - "Remapped": failing (I'm pushing it skipped)
        - This is the reason why #14724 was [reopened](https://github.com/metabase/metabase/issues/14724#issuecomment-776769686)
    - "Default": passing

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/nested.cy.spec.js`
- You can isolate this test by adding.only() to the test
```javascript
it.only(`${test.toUpperCase()} version:\n should use question with joins as a base for a new question (metabase#14724)`, () => {...})
```
- Then comment out or temporarily unskip the `cy.runnable().skip()` part to let the test run for both scenarios
- The "remapped" version of the test should fail until the related issue is fixed (please see the screenshot below)

### Additional notes:
- Once the issue is fixed, please enable both test cases
- Make sure both are passing and
- Merge them together with the fix

### Screenshots:
1. **Local testing only** with both tests enabled
![image](https://user-images.githubusercontent.com/31325167/107538207-ff3e4d80-6bc3-11eb-9ee1-a9002e088a7c.png)


2. "Remapped" version of the test skipped
![image](https://user-images.githubusercontent.com/31325167/107538093-e33aac00-6bc3-11eb-9a3c-0107ae3e5a88.png)

