### PR TITLE
hide change password tab when user is auth'd via google

### DIFF
--- a/frontend/src/metabase/plugins/builtin/auth/google.js
+++ b/frontend/src/metabase/plugins/builtin/auth/google.js
@@ -4,6 +4,7 @@ import { updateIn } from "icepick";
 import {
   PLUGIN_AUTH_PROVIDERS,
   PLUGIN_ADMIN_SETTINGS_UPDATES,
+  PLUGIN_SHOW_CHANGE_PASSWORD_CONDITIONS,
 } from "metabase/plugins";
 
 import MetabaseSettings from "metabase/lib/settings";
@@ -48,3 +49,5 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
     ],
   },
 }));
+
+PLUGIN_SHOW_CHANGE_PASSWORD_CONDITIONS.push(user => !user.google_auth);

--- a/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
@@ -65,18 +65,43 @@ describe("user > settings", () => {
     cy.findByText("Password").should("exist");
   });
 
-  it("should hide change password tab when user is auth'd via ldap", () => {
-    cy.server();
-    cy.route(
-      "GET",
-      "/api/user/current",
-      Object.assign({}, CURRENT_USER, {
-        ldap_auth: true,
-      }),
-    ).as("getUser");
+  describe("when user is authenticated via ldap", () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route(
+        "GET",
+        "/api/user/current",
+        Object.assign({}, CURRENT_USER, {
+          ldap_auth: true,
+        }),
+      ).as("getUser");
 
-    cy.visit("/user/edit_current");
-    cy.wait("@getUser");
-    cy.findByText("Password").should("not.exist");
+      cy.visit("/user/edit_current");
+      cy.wait("@getUser");
+    });
+
+    it("should hide change password tab", () => {
+      cy.findByText("Password").should("not.exist");
+    });
+  });
+
+  describe("when user is authenticated via google", () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route(
+        "GET",
+        "/api/user/current",
+        Object.assign({}, CURRENT_USER, {
+          google_auth: true,
+        }),
+      ).as("getUser");
+
+      cy.visit("/user/edit_current");
+      cy.wait("@getUser");
+    });
+
+    it("should hide change password tab", () => {
+      cy.findByText("Password").should("not.exist");
+    });
   });
 });


### PR DESCRIPTION
Resolves #14732 

**Description**
Same change as https://github.com/metabase/metabase/pull/14714 but using the `user.google_auth` boolean instead of the `user.ldap_auth` boolean.

**Verification**
What the `/user/edit_current` page looks like with this change -- no change password tab.
<img width="721" alt="Screen Shot 2021-02-10 at 10 45 15 AM" src="https://user-images.githubusercontent.com/13057258/107556358-2b8aa780-6b8d-11eb-9f3f-a09501cddad4.png">

