### PR TITLE
#14724 Repro ("inception" version): Handle multi-level nesting

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -382,30 +382,7 @@ describe("scenarios > question > nested", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
-      cy.request("POST", "/api/card", {
-        name: QUESTION_NAME,
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": ORDERS_ID,
-            joins: [
-              {
-                fields: "all",
-                "source-table": PRODUCTS_ID,
-                condition: [
-                  "=",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-                ],
-                alias: "Products",
-              },
-            ],
-          },
-          database: 1,
-        },
-        display: "table",
-        visualization_settings: {},
-      });
+      ordersJoinProducts(QUESTION_NAME);
 
       // Start new question from a saved one
       cy.visit("/question/new");
@@ -420,3 +397,30 @@ describe("scenarios > question > nested", () => {
     });
   });
 });
+
+function ordersJoinProducts(name) {
+  return cy.request("POST", "/api/card", {
+    name,
+    dataset_query: {
+      type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        joins: [
+          {
+            fields: "all",
+            "source-table": PRODUCTS_ID,
+            condition: [
+              "=",
+              ["field-id", ORDERS.PRODUCT_ID],
+              ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+            ],
+            alias: "Products",
+          },
+        ],
+      },
+      database: 1,
+    },
+    display: "table",
+    visualization_settings: {},
+  });
+}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces edge case found in #14724 (it cannot handle multi-level nesting when the original question has joins)
- Unifies all 4 test versions of a repro for this issue
- It now reads as:
![image](https://user-images.githubusercontent.com/31325167/107575031-a71d4080-6bef-11eb-999e-24ccd245ee21.png)

_*Note: This PR is based off of 1c5b6ad10453b989faa70ab4cad39268353abd04 where single-level nesting in a remapped scenario still wasn't fixed. It is EXPECTED that it should fail here as well. This PR merges into #14745._

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/nested.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/107567154-ce6f1000-6be5-11eb-88b6-882fb808c4a7.png)

