### PR TITLE
Fix bug with download popover on pivot tabes

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -94,7 +94,7 @@ const QueryDownloadWidget = ({
   </PopoverWithTrigger>
 );
 
-const UnsavedQueryButton = ({ type, result: { json_query }, card }) => (
+const UnsavedQueryButton = ({ type, result: { json_query = {} }, card }) => (
   <DownloadButton
     url={`api/dataset/${type}`}
     params={{ query: JSON.stringify(_.omit(json_query, "constraints")) }}
@@ -104,7 +104,7 @@ const UnsavedQueryButton = ({ type, result: { json_query }, card }) => (
   </DownloadButton>
 );
 
-const SavedQueryButton = ({ type, result: { json_query }, card }) => (
+const SavedQueryButton = ({ type, result: { json_query = {} }, card }) => (
   <DownloadButton
     url={`api/card/${card.id}/query/${type}`}
     params={{ parameters: JSON.stringify(json_query.parameters) }}
@@ -114,7 +114,7 @@ const SavedQueryButton = ({ type, result: { json_query }, card }) => (
   </DownloadButton>
 );
 
-const PublicQueryButton = ({ type, uuid, result: { json_query } }) => (
+const PublicQueryButton = ({ type, uuid, result: { json_query = {} } }) => (
   <DownloadButton
     method="GET"
     url={Urls.publicQuestion(uuid, type)}

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -659,6 +659,12 @@ describe("scenarios > visualizations > pivot tables", () => {
       });
     });
   });
+
+  it("should open the download popover (metabase#14750)", () => {
+    createAndVisitTestQuestion();
+    cy.get(".Icon-download").click();
+    popover().within(() => cy.findByText("Download full results"));
+  });
 });
 
 const testQuery = {


### PR DESCRIPTION
Fixes #14750

We weren't guarding against a missing `json_query` since it's always in the response for normal questions. This exception prevented the popover from displaying.