### PR TITLE
Add hover effect to pivot table cells

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -6,7 +6,7 @@ import { getIn, updateIn } from "icepick";
 import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 
 import { color, lighten } from "metabase/lib/colors";
-import { styles } from "metabase/visualizations/components/TableInteractive.css";
+import "metabase/visualizations/components/TableInteractive.css";
 import { getScrollBarSize } from "metabase/lib/dom";
 
 import Ellipsified from "metabase/components/Ellipsified";

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -6,6 +6,7 @@ import { getIn, updateIn } from "icepick";
 import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 
 import { color, lighten } from "metabase/lib/colors";
+import { styles } from "metabase/visualizations/components/TableInteractive.css";
 import { getScrollBarSize } from "metabase/lib/dom";
 
 import Ellipsified from "metabase/components/Ellipsified";
@@ -597,7 +598,7 @@ function Cell({
         ...(isSubtotal ? { backgroundColor: PIVOT_BG_DARK } : {}),
       }}
       className={cx(
-        "shrink-below-content-size flex-full flex-basis-none",
+        "shrink-below-content-size flex-full flex-basis-none TableInteractive-cellWrapper",
         className,
         {
           "text-bold": isSubtotal,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { getIn, updateIn } from "icepick";
 import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 
-import { color, alpha } from "metabase/lib/colors";
+import { color, lighten } from "metabase/lib/colors";
 import { getScrollBarSize } from "metabase/lib/dom";
 
 import Ellipsified from "metabase/components/Ellipsified";
@@ -25,8 +25,8 @@ import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 import { findDOMNode } from "react-dom";
 
-const PIVOT_BG_LIGHT = alpha(color("brand"), 0.03);
-const PIVOT_BG_DARK = alpha(color("brand"), 0.1);
+const PIVOT_BG_LIGHT = lighten(color("brand"), 0.65);
+const PIVOT_BG_DARK = lighten(color("brand"), 0.6);
 
 const partitions = [
   {
@@ -559,7 +559,7 @@ function RowToggleIcon({
   return (
     <div
       className={cx(
-        "flex align-center cursor-pointer bg-brand-hover text-light text-white-hover",
+        "flex align-center cursor-pointer text-brand-hover text-light",
       )}
       style={{
         padding: "4px",


### PR DESCRIPTION
Fixes #14751

This applies the same cell wrapper class to pivot tables as we use on interactive tables, but there's probably a classier (cough cough) way of implementing this than I have.

This also changes how PIVOT_BG_LIGHT and PIVOT_BG_DARK are computed, using lighten() instead of alpha(), to make the expand/collapse buttons look right.

![hover-effect](https://user-images.githubusercontent.com/2223916/107594070-e46cd880-6bc5-11eb-940e-299aabd500fd.gif)

