### PR TITLE
#14766 Repro: Cannot summarize columns from joined table based on a Saved Question

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -1010,6 +1010,30 @@ describeWithToken("formatting > sandboxes", () => {
       cy.get(".Modal").scrollTo("bottom");
       cy.findByText(ERROR_MESSAGE);
     });
+
+    it.skip("should be able to use summarize columns from joined table based on a saved question (metabase#14766)", () => {
+      cy.server();
+      cy.route("POST", "/api/dataset").as("dataset");
+
+      createJoinedQuestion("14766_joined");
+
+      cy.visit("/question/new");
+      cy.findByText("Custom question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("14766_joined").click();
+      cy.findByText("Pick the metric you want to see").click();
+      cy.findByText("Count of rows").click();
+      cy.findByText("Pick a column to group by").click();
+      cy.findByText(/Products? → ID/).click();
+      cy.findByText("Visualize").click();
+
+      cy.wait("@dataset").then(xhr => {
+        expect(xhr.response.body.error).not.to.exist;
+      });
+
+      // Number of products with ID = 1 (and ID = 19)
+      cy.findAllByText("93");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14766 

### How to test this manually?
- `yarn test-cypress-open --testFiles enterprise/frontend/test/metabase-enterprise`
- `enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Cypress test runner
![image](https://user-images.githubusercontent.com/31325167/107685390-3edc6680-6ca4-11eb-8e00-093da835b700.png)

2. Sanity check (The same thing was possible on 0.37.5)
![image](https://user-images.githubusercontent.com/31325167/107685066-d8efdf00-6ca3-11eb-95c5-13a7279d5757.png)
