### PR TITLE
Make access logging happen again

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -25,7 +25,7 @@
     <Logger name="metabase" level="INFO"/>
     <Logger name="metabase-enterprise" level="INFO"/>
     <Logger name="metabase.plugins" level="DEBUG"/>
-    <Logger name="metabase.middleware" level="DEBUG"/>
+    <Logger name="metabase.server.middleware" level="DEBUG"/>
     <Logger name="metabase.query-processor.async" level="DEBUG"/>
     <Logger name="com.mchange" level="ERROR"/>
 


### PR DESCRIPTION
Changing the namespace name of the logging middleware broke access
logging. Changing this config file to the proper namespace for logging
makes it happen again

See #14773
