### PR TITLE
#14705 Repro: Cannot select all items in a collection using checkbox

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -217,6 +217,23 @@ describe("scenarios > collection_defaults", () => {
         // 4. Consequently, "Everything else" should now also be visible
         cy.findByText("Everything else");
       });
+
+      it.skip("should let a user select all items using checkbox (metabase#14705)", () => {
+        cy.visit("/collection/root");
+        cy.findByText("Orders")
+          .closest("a")
+          .within(() => {
+            cy.get(".Icon-table").trigger("mouseover");
+            cy.findByRole("checkbox")
+              .should("be.visible")
+              .click();
+          });
+
+        cy.findByText("1 item selected").should("be.visible");
+        cy.get(".Icon-dash").click();
+        cy.get(".Icon-dash").should("not.exist");
+        cy.findByText("4 items selected");
+      });
     });
 
     // [quarantine]: cannot run tests that rely on email setup in CI (yet)


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14705 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. After clicking the `select-all` icon (dash), it doesn't turn into a checked checkbox (like it did before)
![image](https://user-images.githubusercontent.com/31325167/107715688-1f5b3300-6cd0-11eb-8ed0-388a4d61cb4e.png)

2. Sanity check - even if we skip that assertion (**for local testing purposes only**), only 1 item is still selected:
![image](https://user-images.githubusercontent.com/31325167/107715844-6812ec00-6cd0-11eb-90b7-b5738023bdd6.png)
