### PR TITLE
Use ReactDOM.createPortal in BodyComponent

### DIFF
--- a/frontend/src/metabase/components/BodyComponent.jsx
+++ b/frontend/src/metabase/components/BodyComponent.jsx
@@ -8,36 +8,26 @@ export default ComposedComponent =>
       (ComposedComponent.displayName || ComposedComponent.name) +
       "]";
 
-    componentWillMount() {
+    constructor(props) {
+      super(props);
+
       this._element = document.createElement("div");
+      this._element.className = props.className || "";
       document.body.appendChild(this._element);
     }
 
-    componentDidMount() {
-      this._render();
-    }
-
     componentDidUpdate() {
-      this._render();
+      this._element.className = this.props.className || "";
     }
 
     componentWillUnmount() {
-      ReactDOM.unmountComponentAtNode(this._element);
-      if (this._element.parentNode) {
-        this._element.parentNode.removeChild(this._element);
-      }
-    }
-
-    _render() {
-      this._element.className = this.props.className || "";
-      ReactDOM.unstable_renderSubtreeIntoContainer(
-        this,
-        <ComposedComponent {...this.props} className={undefined} />,
-        this._element,
-      );
+      document.body.removeChild(this._element);
     }
 
     render() {
-      return null;
+      return ReactDOM.createPortal(
+        <ComposedComponent {...this.props} className={undefined} />,
+        this._element,
+      );
     }
   };


### PR DESCRIPTION
**Description**
Removing usage of `unstable_renderSubtreeIntoContainer` as part of our upgrade to React v16. This is probably the easiest one to swap out so a good one to start on.

**Verification**
`BodyComponent` is used as a decorator to attach a component to the body, outside of the component tree. We use it to wrap the `UndoListing` component. Rendering and using the `UndoListing` component seems to work fine.

<img width="338" alt="Screen Shot 2021-02-11 at 5 27 55 PM" src="https://user-images.githubusercontent.com/13057258/107720194-b30c0f80-6c8e-11eb-961d-c3cb17942532.png">
