### PR TITLE
#14793 Repro: X-rays fails on explicit joins, when metric is for the joined table

### DIFF
--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -511,7 +511,12 @@ describe("scenarios > question > notebook", () => {
         expect(xhr.response.body.cause).not.to.exist;
         expect(xhr.status).not.to.eq(500);
       });
-      //  TODO: Add positive assertion when this issue gets fixed
+      // Main title
+      cy.contains(/^A closer look at/);
+      // Metric title
+      cy.findByText("How this metric is distributed across different numbers");
+      // Make sure at least one card is rendered
+      cy.get(".DashCard");
     });
   });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -463,6 +463,56 @@ describe("scenarios > question > notebook", () => {
         cy.findByText("49.54");
       });
     });
+
+    it.skip("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
+      cy.server();
+      cy.route("POST", "/api/dataset").as("dataset");
+      cy.route("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
+
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": REVIEWS_ID,
+            joins: [
+              {
+                fields: "all",
+                "source-table": PRODUCTS_ID,
+                condition: [
+                  "=",
+                  ["field-id", REVIEWS.PRODUCT_ID],
+                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+                ],
+                alias: "Products",
+              },
+            ],
+            aggregation: [
+              [
+                "sum",
+                ["joined-field", "Products", ["field-id", PRODUCTS.PRICE]],
+              ],
+            ],
+            breakout: [
+              ["datetime-field", ["field-id", REVIEWS.CREATED_AT], "year"],
+            ],
+          },
+          database: 1,
+        },
+        display: "line",
+      });
+
+      cy.wait("@dataset");
+      cy.get(".dot")
+        .eq(2)
+        .click({ force: true });
+      cy.findByText("X-ray").click();
+
+      cy.wait("@xray").then(xhr => {
+        expect(xhr.response.body.cause).not.to.exist;
+        expect(xhr.status).not.to.eq(500);
+      });
+      //  TODO: Add positive assertion when this issue gets fixed
+    });
   });
 
   describe("nested", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14793 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/notebook.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix


### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/107829709-97862f00-6d8a-11eb-9528-3923a139eef0.png)

