### PR TITLE
#14749 Repro: Email settings "Save changes" button enabled without any changes

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -5,6 +5,7 @@ import {
   version,
   popover,
   itOpenSourceOnly,
+  setupDummySMTP,
 } from "__support__/cypress";
 
 describe("scenarios > admin > settings", () => {
@@ -327,6 +328,7 @@ describe("scenarios > admin > settings", () => {
       cy.findByText("Send test email").click();
       cy.findByText("Sorry, something went wrong. Please try again.");
     });
+
     it("should be able to clear email settings", () => {
       cy.visit("/admin/settings/email");
       cy.findByText("Clear").click();
@@ -336,6 +338,16 @@ describe("scenarios > admin > settings", () => {
         "have.value",
         "",
       );
+    });
+
+    it.skip("should not offer to save email changes when there aren't any (metabase#14749)", () => {
+      // Make sure some settings are already there
+      setupDummySMTP();
+
+      cy.visit("/admin/settings/email");
+      cy.findByText("Send test email").scrollIntoView();
+      // Needed to scroll the page down first to be able to use findByRole() - it fails otherwise
+      cy.findByRole("button", { name: "Save changes" }).should("be.disabled");
     });
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14749 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/107833865-e5a03000-6d94-11eb-9969-b3939e52c8a2.png)

