### PR TITLE
Use portal in Popover

### DIFF
--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -20,12 +20,13 @@ export default class Popover extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this.handleDismissal = this.handleDismissal.bind(this);
     this.state = {
-      width: null,
-      height: null,
+      maxHeight: 0,
     };
 
-    this.handleDismissal = this.handleDismissal.bind(this);
+    this._popoverElement = this._createPopoverElement();
+    document.body.appendChild(this._popoverElement);
   }
 
   static propTypes = {
@@ -72,44 +73,34 @@ export default class Popover extends Component {
     noOnClickOutsideWrapper: false,
   };
 
-  _getPopoverElement(isOpen) {
-    if (!this._popoverElement && isOpen) {
-      this._popoverElement = document.createElement("span");
-      this._popoverElement.className = "PopoverContainer";
-      document.body.appendChild(this._popoverElement);
-      this._timer = setInterval(() => {
-        const { width, height } = this._popoverElement.getBoundingClientRect();
-        if (this.state.width !== width || this.state.height !== height) {
-          this.setState({ width, height });
-        }
-      }, 100);
-    }
-    return this._popoverElement;
+  _createPopoverElement() {
+    const el = document.createElement("span");
+    el.className = "PopoverContainer";
+    return el;
   }
 
   componentDidMount() {
-    this._renderPopover(this.props.isOpen);
+    this._updateTetherOptions();
+    this._updateMaxHeight();
   }
 
   componentDidUpdate() {
-    this._renderPopover(this.props.isOpen);
+    this._updateTetherOptions();
+    this._updateMaxHeight();
+  }
+
+  _updateMaxHeight() {
+    const maxHeight = this._getMaxHeight();
+    if (this.state.maxHeight !== maxHeight) {
+      this.setState({
+        maxHeight,
+      });
+    }
   }
 
   componentWillUnmount() {
-    if (this._tether) {
-      this._tether.destroy();
-      delete this._tether;
-    }
-    if (this._popoverElement) {
-      this._renderPopover(false);
-      ReactDOM.unmountComponentAtNode(this._popoverElement);
-      if (this._popoverElement.parentNode) {
-        this._popoverElement.parentNode.removeChild(this._popoverElement);
-      }
-      delete this._popoverElement;
-      clearInterval(this._timer);
-      delete this._timer;
-    }
+    document.body.removeChild(this._popoverElement);
+    this._tether && this._tether.destroy();
   }
 
   handleDismissal(...args) {
@@ -118,50 +109,145 @@ export default class Popover extends Component {
     }
   }
 
-  _popoverComponent() {
+  _buildPopover() {
+    const {
+      id,
+      hasBackground,
+      autoWidth,
+      hasArrow,
+      isOpen,
+      className,
+      style,
+      children,
+      noOnClickOutsideWrapper,
+      dismissOnEscape,
+      dismissOnClickOutside,
+    } = this.props;
     const childProps = {
-      maxHeight: this._getMaxHeight(),
+      maxHeight: this.state.maxHeight,
     };
-    const content = (
+    const popoverContent = (
       <div
-        id={this.props.id}
+        id={id}
         className={cx(
           "PopoverBody",
           {
-            "PopoverBody--withBackground": this.props.hasBackground,
-            "PopoverBody--withArrow":
-              this.props.hasArrow && this.props.hasBackground,
-            "PopoverBody--autoWidth": this.props.autoWidth,
+            "PopoverBody--withBackground": hasBackground,
+            "PopoverBody--withArrow": hasArrow && hasBackground,
+            "PopoverBody--autoWidth": autoWidth,
+            "PopoverContainer--open": isOpen,
           },
           // TODO kdoh 10/16/2017 we should eventually remove this
-          this.props.className,
+          className,
         )}
-        style={this.props.style}
+        style={style}
       >
-        {typeof this.props.children === "function"
-          ? this.props.children(childProps)
-          : React.Children.count(this.props.children) === 1 &&
+        {typeof children === "function"
+          ? children(childProps)
+          : React.Children.count(children) === 1 &&
             // NOTE: workaround for https://github.com/facebook/react/issues/12136
-            !Array.isArray(this.props.children)
-          ? React.cloneElement(
-              React.Children.only(this.props.children),
-              childProps,
-            )
-          : this.props.children}
+            !Array.isArray(children)
+          ? React.cloneElement(React.Children.only(children), childProps)
+          : children}
       </div>
     );
-    if (this.props.noOnClickOutsideWrapper) {
-      return content;
+
+    return noOnClickOutsideWrapper ? (
+      popoverContent
+    ) : (
+      <OnClickOutsideWrapper
+        handleDismissal={this.handleDismissal}
+        dismissOnEscape={dismissOnEscape}
+        dismissOnClickOutside={dismissOnClickOutside}
+      >
+        {popoverContent}
+      </OnClickOutsideWrapper>
+    );
+  }
+
+  _updateTetherOptions() {
+    const tetherOptions = {
+      element: this._popoverElement,
+      target: this._getTargetElement(),
+    };
+
+    if (this.props.tetherOptions) {
+      this._setTetherOptions({
+        ...tetherOptions,
+        ...this.props.tetherOptions,
+      });
     } else {
-      return (
-        <OnClickOutsideWrapper
-          handleDismissal={this.handleDismissal}
-          dismissOnEscape={this.props.dismissOnEscape}
-          dismissOnClickOutside={this.props.dismissOnClickOutside}
-        >
-          {content}
-        </OnClickOutsideWrapper>
-      );
+      if (!this._best || !this.props.pinInitialAttachment) {
+        let best = {
+          attachmentX: "center",
+          attachmentY: "top",
+          targetAttachmentX: "center",
+          targetAttachmentY: "bottom",
+          offsetX: 0,
+          offsetY: 0,
+        };
+
+        // horizontal
+        best = this._getBestAttachmentOptions(
+          tetherOptions,
+          best,
+          this.props.horizontalAttachments,
+          ["left", "right"],
+          (best, attachmentX) => ({
+            ...best,
+            attachmentX: attachmentX,
+            targetAttachmentX: this.props.alignHorizontalEdge
+              ? attachmentX
+              : "center",
+            offsetX: {
+              center: 0,
+              left: -this.props.targetOffsetX,
+              right: this.props.targetOffsetX,
+            }[attachmentX],
+          }),
+        );
+
+        // vertical
+        best = this._getBestAttachmentOptions(
+          tetherOptions,
+          best,
+          this.props.verticalAttachments,
+          ["top", "bottom"],
+          (best, attachmentY) => ({
+            ...best,
+            attachmentY: attachmentY,
+            targetAttachmentY: (this.props.alignVerticalEdge
+            ? attachmentY === "bottom"
+            : attachmentY === "top")
+              ? "bottom"
+              : "top",
+            offsetY: {
+              top: this.props.targetOffsetY,
+              bottom: -this.props.targetOffsetY,
+            }[attachmentY],
+          }),
+        );
+
+        this._best = best;
+      }
+
+      // finally set the best options
+      this._setTetherOptions(tetherOptions, this._best);
+    }
+
+    if (this.props.sizeToFit) {
+      const body = tetherOptions.element.querySelector(".PopoverBody");
+      if (this._tether.attachment.top === "top") {
+        if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
+          body.classList.add("scroll-y");
+          body.classList.add("scroll-show");
+        }
+      } else if (this._tether.attachment.top === "bottom") {
+        if (constrainToScreen(body, "top", PAGE_PADDING)) {
+          body.classList.add("scroll-y");
+          body.classList.add("scroll-show");
+        }
+      }
     }
   }
 
@@ -274,115 +360,14 @@ export default class Popover extends Component {
     return target;
   }
 
-  _renderPopover(isOpen) {
-    const popoverElement = this._getPopoverElement(isOpen);
-    if (popoverElement) {
-      if (isOpen) {
-        popoverElement.classList.add("PopoverContainer--open");
-      } else {
-        popoverElement.classList.remove("PopoverContainer--open");
-      }
-    }
-
-    // popover is open, lets do this!
-    if (isOpen) {
-      ReactDOM.unstable_renderSubtreeIntoContainer(
-        this,
-        <span>{isOpen ? this._popoverComponent() : null}</span>,
-        popoverElement,
-      );
-
-      const tetherOptions = {
-        element: popoverElement,
-        target: this._getTargetElement(),
-      };
-
-      if (this.props.tetherOptions) {
-        this._setTetherOptions({
-          ...tetherOptions,
-          ...this.props.tetherOptions,
-        });
-      } else {
-        if (!this._best || !this.props.pinInitialAttachment) {
-          let best = {
-            attachmentX: "center",
-            attachmentY: "top",
-            targetAttachmentX: "center",
-            targetAttachmentY: "bottom",
-            offsetX: 0,
-            offsetY: 0,
-          };
-
-          // horizontal
-          best = this._getBestAttachmentOptions(
-            tetherOptions,
-            best,
-            this.props.horizontalAttachments,
-            ["left", "right"],
-            (best, attachmentX) => ({
-              ...best,
-              attachmentX: attachmentX,
-              targetAttachmentX: this.props.alignHorizontalEdge
-                ? attachmentX
-                : "center",
-              offsetX: {
-                center: 0,
-                left: -this.props.targetOffsetX,
-                right: this.props.targetOffsetX,
-              }[attachmentX],
-            }),
-          );
-
-          // vertical
-          best = this._getBestAttachmentOptions(
-            tetherOptions,
-            best,
-            this.props.verticalAttachments,
-            ["top", "bottom"],
-            (best, attachmentY) => ({
-              ...best,
-              attachmentY: attachmentY,
-              targetAttachmentY: (this.props.alignVerticalEdge
-              ? attachmentY === "bottom"
-              : attachmentY === "top")
-                ? "bottom"
-                : "top",
-              offsetY: {
-                top: this.props.targetOffsetY,
-                bottom: -this.props.targetOffsetY,
-              }[attachmentY],
-            }),
-          );
-
-          this._best = best;
-        }
-
-        // finally set the best options
-        this._setTetherOptions(tetherOptions, this._best);
-      }
-
-      if (this.props.sizeToFit) {
-        const body = tetherOptions.element.querySelector(".PopoverBody");
-        if (this._tether.attachment.top === "top") {
-          if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
-            body.classList.add("scroll-y");
-            body.classList.add("scroll-show");
-          }
-        } else if (this._tether.attachment.top === "bottom") {
-          if (constrainToScreen(body, "top", PAGE_PADDING)) {
-            body.classList.add("scroll-y");
-            body.classList.add("scroll-show");
-          }
-        }
-      }
-    } else {
-      if (this._popoverElement) {
-        ReactDOM.unmountComponentAtNode(this._popoverElement);
-      }
-    }
-  }
-
   render() {
-    return <span className="hide" />;
+    return (
+      <span className="hide">
+        {ReactDOM.createPortal(
+          this.props.isOpen ? this._buildPopover() : null,
+          this._popoverElement,
+        )}
+      </span>
+    );
   }
 }

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
+import SandboxedPortal from "metabase/components/SandboxedPortal";
 
 import OnClickOutsideWrapper from "./OnClickOutsideWrapper";
 import Tether from "tether";
@@ -363,10 +364,11 @@ export default class Popover extends Component {
   render() {
     return (
       <span className="hide">
-        {ReactDOM.createPortal(
-          this.props.isOpen ? this._buildPopover() : null,
-          this._popoverElement,
-        )}
+        {this.props.isOpen ? (
+          <SandboxedPortal container={this._popoverElement}>
+            {this._buildPopover()}
+          </SandboxedPortal>
+        ) : null}
       </span>
     );
   }

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -83,11 +83,13 @@ export default class Popover extends Component {
   componentDidMount() {
     this._updateTetherOptions();
     this._updateMaxHeight();
+    this._updateContainerClass();
   }
 
   componentDidUpdate() {
     this._updateTetherOptions();
     this._updateMaxHeight();
+    this._updateContainerClass();
   }
 
   _updateMaxHeight() {
@@ -96,6 +98,14 @@ export default class Popover extends Component {
       this.setState({
         maxHeight,
       });
+    }
+  }
+
+  _updateContainerClass() {
+    if (this.props.isOpen) {
+      this._popoverElement.classList.add("PopoverContainer--open");
+    } else {
+      this._popoverElement.classList.remove("PopoverContainer--open");
     }
   }
 
@@ -116,7 +126,6 @@ export default class Popover extends Component {
       hasBackground,
       autoWidth,
       hasArrow,
-      isOpen,
       className,
       style,
       children,
@@ -136,7 +145,6 @@ export default class Popover extends Component {
             "PopoverBody--withBackground": hasBackground,
             "PopoverBody--withArrow": hasArrow && hasBackground,
             "PopoverBody--autoWidth": autoWidth,
-            "PopoverContainer--open": isOpen,
           },
           // TODO kdoh 10/16/2017 we should eventually remove this
           className,

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -81,15 +81,21 @@ export default class Popover extends Component {
   }
 
   componentDidMount() {
-    this._updateTetherOptions();
-    this._updateMaxHeight();
     this._updateContainerClass();
+
+    if (this.props.isOpen) {
+      this._updateTetherOptions();
+      this._updateMaxHeight();
+    }
   }
 
   componentDidUpdate() {
-    this._updateTetherOptions();
-    this._updateMaxHeight();
     this._updateContainerClass();
+
+    if (this.props.isOpen) {
+      this._updateTetherOptions();
+      this._updateMaxHeight();
+    }
   }
 
   _updateMaxHeight() {

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -21,7 +21,6 @@ export default class Popover extends Component {
   constructor(props, context) {
     super(props, context);
 
-    this.handleDismissal = this.handleDismissal.bind(this);
     this.state = {
       maxHeight: 0,
     };
@@ -120,11 +119,11 @@ export default class Popover extends Component {
     this._tether && this._tether.destroy();
   }
 
-  handleDismissal(...args) {
+  handleDismissal = (...args) => {
     if (this.props.onClose) {
       this.props.onClose(...args);
     }
-  }
+  };
 
   _buildPopover() {
     const {

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -22,6 +22,7 @@ export default class Popover extends Component {
     super(props, context);
 
     this.state = {
+      // some child components of indeterminate height (see AccordionList) require a maxHeight prop in order to avoid overflowing off of the page
       maxHeight: 0,
     };
 

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -75,7 +75,7 @@ export default class Popover extends Component {
   };
 
   _createPopoverElement() {
-    const el = document.createElement("span");
+    const el = document.createElement("div");
     el.className = "PopoverContainer";
     return el;
   }

--- a/frontend/src/metabase/components/SandboxedPortal.jsx
+++ b/frontend/src/metabase/components/SandboxedPortal.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+function stop(event) {
+  event.stopPropagation();
+}
+
+function SandboxedPortal({ children, container }) {
+  return ReactDOM.createPortal(
+    <div
+      onClick={stop}
+      onContextMenu={stop}
+      onDoubleClick={stop}
+      onDrag={stop}
+      onDragEnd={stop}
+      onDragEnter={stop}
+      onDragExit={stop}
+      onDragLeave={stop}
+      onDragOver={stop}
+      onDragStart={stop}
+      onDrop={stop}
+      onMouseDown={stop}
+      onMouseEnter={stop}
+      onMouseLeave={stop}
+      onMouseMove={stop}
+      onMouseOver={stop}
+      onMouseOut={stop}
+      onMouseUp={stop}
+      onKeyDown={stop}
+      onKeyPress={stop}
+      onKeyUp={stop}
+      onFocus={stop}
+      onBlur={stop}
+      onChange={stop}
+      onInput={stop}
+      onInvalid={stop}
+      onSubmit={stop}
+    >
+      {children}
+    </div>,
+    container,
+  );
+}
+
+export default SandboxedPortal;

--- a/frontend/src/metabase/components/SandboxedPortal.jsx
+++ b/frontend/src/metabase/components/SandboxedPortal.jsx
@@ -5,6 +5,8 @@ function stop(event) {
   event.stopPropagation();
 }
 
+// Prevent DOM events from bubbling through the React component tree
+// See https://reactjs.org/docs/portals.html#event-bubbling-through-portals
 function SandboxedPortal({ children, container }) {
   return ReactDOM.createPortal(
     <div


### PR DESCRIPTION
**Description**
Replacing `ReactDOM.unstable_renderSubtreeIntoContainer` with a portal. I tried to change things minimally while retaining overall behavior. Key changes:
- A call to calculate a `maxHeight` depends on `ReactDOM.findDOMNode`, which you can't use as part of rendering; you're able to get away with this via the old `unstable...` function due to it being called during lifecycle methods.
- React portals bubble events through a portal, so I had to add a new `SandboxedPortal` to mimic the expected behavior of `unstable_renderSubtreeIntoContainer`.

Note -- this still won't fix ALL tests that are broken. Some are broken by wonky custom column editor behavior.

**Verification**
The app has some pretty bizarre scroll behavior pre-this-change, so its effect is very obvious. The tooltip in the below image would flicker pre use of portals.
![Screen Shot 2021-02-16 at 11 24 54 AM](https://user-images.githubusercontent.com/13057258/108111528-a1898580-7049-11eb-83c7-158589f93abb.png)
