### PR TITLE
Custom expression: friendlier feedback on CASE arguments

### DIFF
--- a/frontend/src/metabase/lib/expressions/parser.js
+++ b/frontend/src/metabase/lib/expressions/parser.js
@@ -279,17 +279,9 @@ export class ExpressionParser extends CstParser {
       $.CONSUME(Case, { LABEL: "functionName" });
       $.CONSUME(LParen);
       $.SUBRULE($.boolean, { LABEL: "arguments" });
-      $.CONSUME(Comma);
-      $.SUBRULE($.expression, { LABEL: "arguments", ARGS: [returnType] });
       $.MANY(() => {
-        $.CONSUME2(Comma);
-        $.SUBRULE2($.boolean, { LABEL: "arguments" });
-        $.CONSUME3(Comma);
-        $.SUBRULE3($.expression, { LABEL: "arguments", ARGS: [returnType] });
-      });
-      $.OPTION(() => {
-        $.CONSUME4(Comma);
-        $.SUBRULE4($.expression, { LABEL: "arguments", ARGS: [returnType] });
+        $.CONSUME(Comma);
+        $.SUBRULE1($.boolean, { LABEL: "arguments", ARGS: [returnType] });
       });
       $.CONSUME(RParen);
     });

--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -1,4 +1,4 @@
-import { ngettext, msgid } from "ttag";
+import { ngettext, msgid, t } from "ttag";
 import { ExpressionVisitor } from "./visitor";
 import { CLAUSE_TOKENS } from "./lexer";
 
@@ -38,6 +38,10 @@ export function typeCheck(cst, rootType) {
     caseExpression(ctx) {
       const type = this.typeStack[0];
       const args = ctx.arguments || [];
+      if (args.length < 2) {
+        this.errors.push({ message: t`CASE expects 2 arguments or more` });
+        return [];
+      }
       return args.map((arg, index) => {
         // argument 0, 2, 4, ...(even) is always a boolean, ...
         const argType = index & 1 ? type : "boolean";

--- a/frontend/test/metabase/lib/expressions/parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/parser.unit.spec.js
@@ -1,12 +1,35 @@
 import { parse } from "metabase/lib/expressions/parser";
 
 describe("metabase/lib/expressions/parser", () => {
-  describe("in aggregation mode", () => {
-    function parseAggregation(source) {
-      const tokenVector = null;
-      const startRule = "aggregation";
-      return parse({ source, tokenVector, startRule });
+  function parseSource(source, startRule) {
+    let result = null;
+    try {
+      result = parse({ source, tokenVector: null, startRule });
+      if (result.typeErrors.length > 0) {
+        throw new Error(result.typeErrors);
+      }
+    } catch (e) {
+      let err = e;
+      if (err.length && err.length > 0) {
+        err = err[0];
+        if (typeof err.message === "string") {
+          err = err.message;
+        }
+      }
+      throw err;
     }
+    return result.cst;
+  }
+
+  function parseExpression(expr) {
+    return parseSource(expr, "expression");
+  }
+
+  function parseAggregation(aggregation) {
+    return parseSource(aggregation, "aggregation");
+  }
+
+  describe("in aggregation mode", () => {
     it("should handle a simple aggregation", () => {
       expect(() => parseAggregation("Sum([Price])")).not.toThrow();
     });
@@ -21,11 +44,6 @@ describe("metabase/lib/expressions/parser", () => {
   });
 
   describe("in expression mode", () => {
-    function parseExpression(source) {
-      const tokenVector = null;
-      const startRule = "expression";
-      return parse({ source, tokenVector, startRule });
-    }
     it("should handle a conditional using CASE", () => {
       expect(() =>
         parseExpression("Case( [Discount] > 0, 'Sale', 'Normal' )"),
@@ -35,6 +53,15 @@ describe("metabase/lib/expressions/parser", () => {
       expect(() =>
         parseExpression("Case( [Price]-[Discount] > 50, 'Deal', 'Regular' )"),
       ).not.toThrow();
+    });
+    it("should reject CASE with only one argument", () => {
+      expect(() => parseExpression("case([Deal])")).toThrow();
+    });
+    it("should accept CASE with two arguments", () => {
+      expect(() => parseExpression("case([Deal],x)")).not.toThrow();
+    });
+    it("should accept CASE with three arguments", () => {
+      expect(() => parseExpression("case([Deal],x,y)")).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Apparently CASE isn't a function so this additional handling needs to be added (see also PR #14310).

How to verify:

1. Ask a question, Custom question.
2. Pick Sample Dataset, Products table
3. Custom column, type `case([Price]>100)`

Before this PR:

![image](https://user-images.githubusercontent.com/7288/107835274-c6ca7b00-6d4d-11eb-9f72-801c09bc6b69.png)

After this PR:

![image](https://user-images.githubusercontent.com/7288/107835294-d21da680-6d4d-11eb-9c03-581b9cea53fe.png)

The feedback message is more useful, and also it supports i18n.