### PR TITLE
Ignore source metadata for sources queries if missing 0.38.0+ field refs

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -32,7 +32,9 @@
        form))
    x))
 
-(defn- add-names
+(defn add-names
+  "Walk a MBQL snippet `x` and add comment forms with the names of the Fields referenced to any `:field-id` clauses
+  encountered. Helpful for debugging!"
   [x]
   (walk/postwalk
    (fn [form]

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -56,7 +56,8 @@
                      ;; to end up adding it again when the middleware runs at the top level
                      :query    (assoc-in source-query [:middleware :disable-remaps?] true)}))]
         (for [col cols]
-          (select-keys col [:name :id :table_id :display_name :base_type :special_type :unit :fingerprint :settings :source_alias :field_ref])))
+          (select-keys col [:name :id :table_id :display_name :base_type :special_type :unit :fingerprint :settings
+                            :source_alias :field_ref :parent_id])))
       (catch Throwable e
         (log/error e (str (trs "Error determining expected columns for query")))
         nil))))
@@ -69,22 +70,36 @@
     (cond-> inner-query
       (seq metadata) (assoc :source-metadata metadata))))
 
-(defn- can-add-source-metadata?
-  "Can we add `:source-metadata` about the `:source-query` in this map? True if all of the following are true:
+(defn- legacy-source-metadata?
+  "Whether this source metadata is *legacy* source metadata from < 0.38.0. Legacy source metadata did not include
+  `:field_ref` or `:id`, which made it hard to correctly construct queries with. For MBQL queries, we're better off
+  ignoring legacy source metadata and using `qp/query->expected-cols` to infer the source metadata rather than relying
+  on old stuff that can produce incorrect queries. See #14788 for more information."
+  [source-metadata]
+  (and (seq source-metadata)
+       (every? nil? (map :field_ref source-metadata))))
 
-  *  The map (e.g. an 'inner' MBQL query or a Join) has a `:source-query`
-  *  The `:source-query` is an MBQL query, or a native source query with `:source-metadata`"
+(defn- should-add-source-metadata?
+  "Should we add `:source-metadata` about the `:source-query` in this map? True if all of the following are true:
+
+  * The map (e.g. an 'inner' MBQL query or a Join) has a `:source-query`
+
+  * The map does not *already* have `:source-metadata`, or the `:source-metadata` is 'legacy' source metadata from
+    versions < 0.38.0
+
+  * The `:source-query` is an MBQL query, or a native source query with `:source-metadata`"
   [{{native-source-query?              :native
      source-query-has-source-metadata? :source-metadata
      :as                               source-query} :source-query
     :keys                                            [source-metadata]}]
   (and source-query
-       (not source-metadata)
+       (or (not source-metadata)
+           (legacy-source-metadata? source-metadata))
        (or (not native-source-query?)
            source-query-has-source-metadata?)))
 
 (defn- maybe-add-source-metadata [x]
-  (if (and (map? x) (can-add-source-metadata? x))
+  (if (and (map? x) (should-add-source-metadata? x))
     (add-source-metadata x)
     x))
 

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -110,7 +110,7 @@
               ;; rename `:query` to `:native` because source queries have a slightly different shape
               (let [native-query (set/rename-keys native-query {:query :native})]
                 (cond-> native-query
-                  ;; trim trailing slashes from SQL, but not other types of native queries
+                  ;; trim trailing comments from SQL, but not other types of native queries
                   (string? (:native native-query)) (update :native (partial trim-sql-query card-id))
                   (empty? template-tags)           (dissoc :template-tags))))
             (throw (ex-info (tru "Missing source query in Card {0}" card-id)

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.driver :as driver]
+            [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.add-source-metadata :as add-source-metadata]
             [metabase.test :as mt]
             [metabase.util :as u]))
@@ -13,7 +14,9 @@
 
 (defn- results-metadata [query-results]
   (for [col (-> query-results :data :cols)]
-    (select-keys col [:id :table_id :name :display_name :base_type :special_type :unit :fingerprint :settings :field_ref])))
+    (select-keys
+     col
+     [:id :table_id :name :display_name :base_type :special_type :unit :fingerprint :settings :field_ref :parent_id])))
 
 (defn- venues-source-metadata
   ([]
@@ -309,3 +312,45 @@
                           :id           %ean
                           :field_ref    [:joined-field "Products" $ean]})
                        (ean-metadata (add-source-metadata query))))))))))))
+
+(deftest ignore-legacy-source-metadata-test
+  (testing "Should ignore 'legacy' < 0.38.0 source metadata and recalculate it for MBQL queries (#14788)"
+    ;; normally this middleware will use existing source metadata rather than recalculating it, but if we encounter <
+    ;; 0.38.0 source metadata that is missing `:field_ref` and `:id` information we should ignore it.
+    (mt/dataset sample-dataset
+      (let [query             (mt/mbql-query orders
+                                {:source-query {:source-table $$orders
+                                                :joins        [{:source-table $$products
+                                                                :alias         "ℙ"
+                                                                :fields       :all
+                                                                :condition    [:= $product_id &ℙ.products.id]}]
+                                                :order-by     [[:asc $id]]
+                                                :limit        2}})
+            metadata          (qp/query->expected-cols query)
+            ;; the actual metadata this middleware should return. Doesn't have all the columns that come back from
+            ;; `qp/query->expected-cols`
+            expected-metadata (for [col metadata]
+                                (cond-> (dissoc col :description :source :visibility_type)
+                                  ;; for some reason this middleware returns temporal fields with field refs wrapped
+                                  ;; in `:datetime-field` clauses with `:default` unit, whereas `query->expected-cols`
+                                  ;; does not wrap the field refs. It ulimately makes zero difference, so I haven't
+                                  ;; looked into why this is the case yet.
+                                  (isa? (:base_type col) :type/Temporal)
+                                  (update :field_ref (fn [field-ref]
+                                                       [:datetime-field field-ref :default]))))]
+        (letfn [(added-metadata [query]
+                  (get-in (add-source-metadata query) [:query :source-metadata]))]
+          (testing "\nShould add source metadata if there's none already"
+            (is (= expected-metadata
+                   (added-metadata query))))
+          (testing "\nShould use existing metadata if it's already there"
+            ;; since it's using the existing metadata, it should have all the extra keys instead of the subset in
+            ;; `expected-metadata`
+            (is (= metadata
+                   (added-metadata (assoc-in query [:query :source-metadata] metadata)))))
+          (testing "\nShould ignore legacy metadata"
+            ;; pre-0.38.0 metadata didn't have `field_ref` or `id.`
+            (let [legacy-metadata (for [col metadata]
+                                    (dissoc col :field_ref :id))]
+              (is (= expected-metadata
+                     (added-metadata (assoc-in query [:query :source-metadata] legacy-metadata)))))))))))

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -42,10 +42,10 @@
       (is (= (assoc (default-result-with-inner-query
                      {:source-query {:source-table (mt/id :venues)}}
                      (qp/query->expected-cols (mt/mbql-query venues)))
-                    :info {:card-id (u/get-id card)})
+                    :info {:card-id (u/the-id card)})
              (resolve-card-id-source-tables
               (wrap-inner-query
-               {:source-table (str "card__" (u/get-id card))}))))
+               {:source-table (str "card__" (u/the-id card))}))))
 
       (testing "with aggregations/breakouts"
         (is (= (assoc (default-result-with-inner-query
@@ -53,10 +53,10 @@
                         :breakout     [[:field-literal "price" :type/Integer]]
                         :source-query {:source-table (mt/id :venues)}}
                        (qp/query->expected-cols (mt/mbql-query :venues)))
-                      :info {:card-id (u/get-id card)})
+                      :info {:card-id (u/the-id card)})
                (resolve-card-id-source-tables
                 (wrap-inner-query
-                 {:source-table (str "card__" (u/get-id card))
+                 {:source-table (str "card__" (u/the-id card))
                   :aggregation  [[:count]]
                   :breakout     [[:field-literal "price" :type/Integer]]}))))))
 
@@ -66,10 +66,10 @@
                        {:source-query {:source-table (mt/id :checkins)}
                         :filter       [:between [:field-literal "date" :type/Date] "2015-01-01" "2015-02-01"]}
                        (qp/query->expected-cols (mt/mbql-query :checkins)))
-                      :info {:card-id (u/get-id card)})
+                      :info {:card-id (u/the-id card)})
                (resolve-card-id-source-tables
                 (wrap-inner-query
-                 {:source-table (str "card__" (u/get-id card))
+                 {:source-table (str "card__" (u/the-id card))
                   :filter       [:between
                                  [:field-literal "date" :type/Date]
                                  "2015-01-01"
@@ -84,10 +84,10 @@
                       :breakout     [[:field-literal "price" :type/Integer]]
                       :source-query {:native (format "SELECT * FROM %s" (mt/format-name "venues"))}}
                      nil)
-                    :info {:card-id (u/get-id card)})
+                    :info {:card-id (u/the-id card)})
              (resolve-card-id-source-tables
               (wrap-inner-query
-               {:source-table (str "card__" (u/get-id card))
+               {:source-table (str "card__" (u/the-id card))
                 :aggregation  [[:count]]
                 :breakout     [[:field-literal "price" :type/Integer]]})))))))
 
@@ -98,7 +98,7 @@
                                                    {:limit 100})}]
                     Card [card-2 {:dataset_query {:database mbql.s/saved-questions-virtual-database-id
                                                   :type     :query
-                                                  :query    {:source-table (str "card__" (u/get-id card-1)), :limit 50}}}]]
+                                                  :query    {:source-table (str "card__" (u/the-id card-1)), :limit 50}}}]]
       (is (= (-> (default-result-with-inner-query
                   {:limit        25
                    :source-query {:limit           50
@@ -108,10 +108,10 @@
                   (qp/query->expected-cols (mt/mbql-query :venues)))
                  (assoc-in [:query :source-query :source-metadata]
                            (mt/derecordize (qp/query->expected-cols (mt/mbql-query :venues))))
-                 (assoc :info {:card-id (u/get-id card-2)}))
+                 (assoc :info {:card-id (u/the-id card-2)}))
              (resolve-card-id-source-tables
               (wrap-inner-query
-               {:source-table (str "card__" (u/get-id card-2)), :limit 25})))))))
+               {:source-table (str "card__" (u/the-id card-2)), :limit 25})))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -119,70 +119,67 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest joins-test
-  (mt/with-temp Card [{card-id :id} {:dataset_query   (mt/mbql-query categories {:limit 100})
-                                     :result_metadata [{:name         "name"
-                                                        :display_name "Card Name"
-                                                        :base_type    "type/Text"}]}]
-    (testing "Are `card__id` source tables resolved in `:joins`?"
-      (is (= (mt/mbql-query venues
-               {:joins [{:source-query    {:source-table $$categories, :limit 100}
-                         :alias           "c",
-                         :condition       [:= $category_id [:joined-field "c" $categories.id]]
-                         :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]}]})
-             (resolve-card-id-source-tables
-              (mt/mbql-query venues
-                {:joins [{:source-table (str "card__" card-id)
-                          :alias        "c"
-                          :condition    [:= $category_id [:joined-field "c" $categories.id]]}]})))))
-
-    (testing "Are `card__id` source tables resolved in JOINs against a source query?"
-      (is (= (mt/mbql-query venues
-               {:joins [{:source-query {:source-query    {:source-table $$categories, :limit 100}
-                                        :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]}
-                         :alias        "c",
-                         :condition    [:= $category_id [:joined-field "c" $categories.id]]}]})
-             (resolve-card-id-source-tables
-              (mt/mbql-query venues
-                {:joins [{:source-query {:source-table (str "card__" card-id)}
-                          :alias        "c"
-                          :condition    [:= $category_id [:joined-field "c" $categories.id]]}]})))))
-
-    (testing "Are `card__id` source tables resolved in JOINs inside nested source queries?"
-      (is (= (mt/mbql-query venues
-               {:source-query {:source-table $$venues
-                               :joins        [{:source-query    {:source-table $$categories
-                                                                 :limit        100}
-                                               :alias           "c"
-                                               :condition       [:= $category_id [:joined-field "c" $categories.id]]
-                                               :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]}]}})
-             (resolve-card-id-source-tables
-              (mt/mbql-query venues
-                {:source-query
-                 {:source-table $$venues
-                  :joins        [{:source-table (str "card__" card-id)
-                                  :alias        "c"
-                                  :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}})))))
-
-    (testing "Can we recursively resolve multiple card ID `:source-table`s in Joins?"
-      (mt/with-temp Card [{card-2-id :id} {:dataset_query
-                                           (mt/mbql-query nil
-                                             {:source-table (str "card__" card-id), :limit 200})}]
+  (let [query    (mt/mbql-query categories {:limit 100})
+        metadata (for [col (qp/query->expected-cols query)]
+                   (select-keys col [:name :display_name :id :base_type :field_ref]))]
+    (mt/with-temp Card [{card-id :id} {:dataset_query query, :result_metadata metadata}]
+      (testing "Are `card__id` source tables resolved in `:joins`?"
         (is (= (mt/mbql-query venues
-                 {:joins [{:alias           "c"
-                           :condition       [:= $category_id &c.$categories.id]
-                           :source-query    {:source-query    {:source-table $$categories :limit 100}
-                                             :source-metadata [{:name "name", :display_name "Card Name", :base_type :type/Text}]
-                                             :limit           200}
-                           :source-metadata [{:name         "name"
-                                              :display_name "Card Name"
-                                              :base_type    :type/Text
-                                              :field_ref    [:field-literal "name" :type/Text]
-                                               :source       :fields}]}]})
+                 {:joins [{:source-query    {:source-table $$categories, :limit 100}
+                           :alias           "c",
+                           :condition       [:= $category_id [:joined-field "c" $categories.id]]
+                           :source-metadata metadata}]})
                (resolve-card-id-source-tables
                 (mt/mbql-query venues
-                  {:joins [{:source-table (str "card__" card-2-id)
+                  {:joins [{:source-table (str "card__" card-id)
                             :alias        "c"
-                            :condition    [:= $category_id &c.categories.id]}]}))))))))
+                            :condition    [:= $category_id [:joined-field "c" $categories.id]]}]})))))
+
+      (testing "Are `card__id` source tables resolved in JOINs against a source query?"
+        (is (= (mt/mbql-query venues
+                 {:joins [{:source-query {:source-query    {:source-table $$categories, :limit 100}
+                                          :source-metadata metadata}
+                           :alias        "c",
+                           :condition    [:= $category_id [:joined-field "c" $categories.id]]}]})
+               (resolve-card-id-source-tables
+                (mt/mbql-query venues
+                  {:joins [{:source-query {:source-table (str "card__" card-id)}
+                            :alias        "c"
+                            :condition    [:= $category_id [:joined-field "c" $categories.id]]}]})))))
+
+      (testing "Are `card__id` source tables resolved in JOINs inside nested source queries?"
+        (is (= (mt/mbql-query venues
+                 {:source-query {:source-table $$venues
+                                 :joins        [{:source-query    {:source-table $$categories
+                                                                   :limit        100}
+                                                 :alias           "c"
+                                                 :condition       [:= $category_id [:joined-field "c" $categories.id]]
+                                                 :source-metadata metadata}]}})
+               (resolve-card-id-source-tables
+                (mt/mbql-query venues
+                  {:source-query
+                   {:source-table $$venues
+                    :joins        [{:source-table (str "card__" card-id)
+                                    :alias        "c"
+                                    :condition    [:= $category_id [:joined-field "c" $categories.id]]}]}})))))
+
+      (testing "Can we recursively resolve multiple card ID `:source-table`s in Joins?"
+        (mt/with-temp Card [{card-2-id :id} {:dataset_query
+                                             (mt/mbql-query nil
+                                               {:source-table (str "card__" card-id), :limit 200})
+                                             :result_metadata metadata}]
+          (is (= (mt/mbql-query venues
+                   {:joins [{:alias           "c"
+                             :condition       [:= $category_id &c.$categories.id]
+                             :source-query    {:source-query    {:source-table $$categories :limit 100}
+                                               :source-metadata metadata
+                                               :limit           200}
+                             :source-metadata metadata}]})
+                 (resolve-card-id-source-tables
+                  (mt/mbql-query venues
+                    {:joins [{:source-table (str "card__" card-2-id)
+                              :alias        "c"
+                              :condition    [:= $category_id &c.categories.id]}]})))))))))
 
 (deftest circular-dependency-test
   (testing "Middleware should throw an Exception if we try to resolve a source query for a card whose source query is itself"


### PR DESCRIPTION
Part of the root cause of all of our nested query woes was that the saved source metadata only included the name and type of the Fields in the original query, but not any other information such as the Table that it came from, its original `:id`,  or the preferred way to reference it `:field_ref`). Over the last week I made a number of improvements to allow the QP to handle `:field-id` clauses at any level, even when the actual Field being referred to is a product of a join in a source query... this allows sandbox queries to finally work completely transparently and seamlessly. This works best if we have the original Field Id and `:field_ref`, which now comes back with source metadata in 0.38.0+

In #14788, @flamber noticed that queries using "legacy" < 0.38.0 source metadata stopped working, because I had written the 0.38.0 code to expect the improved 0.38.0+ metadata. This PR detects this situation and ignores the legacy metadata (we can easily recalculate the columns that will be returned for an MBQL query without running the query -- it's just a little less efficient than if we already had it cached.)

Fixes #14788