### PR TITLE
Refine and upgrade repro for #12985

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -18,7 +18,7 @@ describe("scenarios > question > filter", () => {
   });
 
   describe("dashboard filter dropdown/search (metabase#12985)", () => {
-    it.skip("Repro 1: should work for saved nested questions", () => {
+    it("Repro 1: should work for saved nested questions", () => {
       // Save a Question
       openProductsTable();
       cy.findByText("Save").click();

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -17,70 +17,74 @@ describe("scenarios > question > filter", () => {
     signInAsAdmin();
   });
 
-  it.skip("should load needed data (metabase#12985)", () => {
-    // Save a Question
-    openProductsTable();
-    cy.findByText("Save").click();
-    cy.findByPlaceholderText("What is the name of your card?")
-      .clear()
-      .type("Q1");
-    cy.findAllByText("Save")
-      .last()
-      .click();
-    cy.findByText("Not now").click();
+  describe("dashboard filter dropdown/search (metabase#12985)", () => {
+    it.skip("Repro 1: should work for saved nested questions", () => {
+      // Save a Question
+      openProductsTable();
+      cy.findByText("Save").click();
+      cy.findByPlaceholderText("What is the name of your card?")
+        .clear()
+        .type("Q1");
+      cy.findAllByText("Save")
+        .last()
+        .click();
+      cy.findByText("Not now").click();
 
-    // From Q1, save Q2
-    cy.visit("/question/new");
-    cy.findByText("Simple question").click();
-    cy.findByText("Saved Questions").click();
-    cy.findByText("Q1").click();
-    cy.findByText("Save").click();
-    cy.findByPlaceholderText("What is the name of your card?")
-      .clear()
-      .type("Q2");
-    cy.findAllByText("Save")
-      .last()
-      .click();
+      // From Q1, save Q2
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("Q1").click();
+      cy.findByText("Save").click();
+      cy.findByPlaceholderText("What is the name of your card?")
+        .clear()
+        .type("Q2");
+      cy.findAllByText("Save")
+        .last()
+        .click();
 
-    // Add Q2 to a dashboard
-    cy.findByText("Yes please!").click();
-    cy.findByText("Orders in a dashboard").click();
+      // Add Q2 to a dashboard
+      cy.findByText("Yes please!").click();
+      cy.findByText("Orders in a dashboard").click();
 
-    // Add two dashboard filters
-    cy.get(".Icon-filter").click();
-    cy.findByText("Time").click();
-    cy.findByText("All Options").click();
-    cy.findAllByText("Select…")
-      .last()
-      .click();
-    cy.findByText("Created At").click();
+      // Add two dashboard filters
+      cy.get(".Icon-filter").click();
+      cy.findByText("Time").click();
+      cy.findByText("All Options").click();
+      cy.findAllByText("Select…")
+        .last()
+        .click();
+      cy.findByText("Created At").click();
 
-    cy.get(".Icon-filter").click();
-    cy.findByText("Other Categories").click();
-    cy.findAllByText("Select…")
-      .last()
-      .click();
-    popover().within(() => {
-      cy.findByText("Category").click();
-    });
-
-    // Save dashboard and refresh page
-    cy.findAllByText("Done")
-      .first()
-      .click();
-
-    cy.findByText("Save").click();
-    cy.findByText("You're editing this dashboard.").should("not.exist");
-
-    // Check category search
-    cy.get("fieldset")
-      .last()
-      .within(() => {
+      cy.get(".Icon-filter").click();
+      cy.findByText("Other Categories").click();
+      cy.findAllByText("Select…")
+        .last()
+        .click();
+      popover().within(() => {
         cy.findByText("Category").click();
       });
-    cy.log("**Failing to show dropdown in v0.36.0 through v.0.37.0**");
-    cy.findByText("Gadget").click();
-    cy.findByText("Add filter").click();
+
+      // Save dashboard and refresh page
+      cy.findAllByText("Done")
+        .first()
+        .click();
+
+      cy.findByText("Save").click();
+      cy.findByText("You're editing this dashboard.").should("not.exist");
+
+      // Check category search
+      cy.get("fieldset")
+        .last()
+        .within(() => {
+          cy.findByText("Category").click();
+        });
+      cy.log("**Failing to show dropdown in v0.36.0 through v.0.37.0**");
+      cy.findByText("Gadget").click();
+      cy.findByText("Add filter").click();
+    });
+
+    it("Repro 2: should work for aggregated questions", () => {});
   });
 
   it("should filter a joined table by 'Is not' filter (metabase#13534)", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -19,69 +19,111 @@ describe("scenarios > question > filter", () => {
 
   describe("dashboard filter dropdown/search (metabase#12985)", () => {
     it("Repro 1: should work for saved nested questions", () => {
-      // Save a Question
-      openProductsTable();
-      cy.findByText("Save").click();
-      cy.findByPlaceholderText("What is the name of your card?")
-        .clear()
-        .type("Q1");
-      cy.findAllByText("Save")
-        .last()
-        .click();
-      cy.findByText("Not now").click();
+      cy.log("**-- 1. Create base card --**");
 
-      // From Q1, save Q2
-      cy.visit("/question/new");
-      cy.findByText("Simple question").click();
-      cy.findByText("Saved Questions").click();
-      cy.findByText("Q1").click();
-      cy.findByText("Save").click();
-      cy.findByPlaceholderText("What is the name of your card?")
-        .clear()
-        .type("Q2");
-      cy.findAllByText("Save")
-        .last()
-        .click();
+      cy.request("POST", "/api/card", {
+        name: "Q1",
+        dataset_query: {
+          database: 1,
+          query: { "source-table": PRODUCTS_ID },
+          type: "query",
+        },
+        display: "table",
+        visualization_settings: {},
+      }).then(({ body: { id: Q1_ID } }) => {
+        cy.log("**-- 2. Create nested card based on the first one --**");
 
-      // Add Q2 to a dashboard
-      cy.findByText("Yes please!").click();
-      cy.findByText("Orders in a dashboard").click();
+        cy.request("POST", "/api/card", {
+          name: "Q2",
+          dataset_query: {
+            database: 1,
+            query: { "source-table": `card__${Q1_ID}` },
+            type: "query",
+          },
+          display: "table",
+          visualization_settings: {},
+        }).then(({ body: { id: Q2_ID } }) => {
+          cy.log("**-- 3. Create a dashboard --**");
 
-      // Add two dashboard filters
-      cy.get(".Icon-filter").click();
-      cy.findByText("Time").click();
-      cy.findByText("All Options").click();
-      cy.findAllByText("Select…")
-        .last()
-        .click();
-      cy.findByText("Created At").click();
+          cy.request("POST", "/api/dashboard", {
+            name: "12985D",
+          }).then(({ body: { id: DASHBOARD_ID } }) => {
+            cy.log("**-- 4. Add 2 filters to the dashboard --**");
 
-      cy.get(".Icon-filter").click();
-      cy.findByText("Other Categories").click();
-      cy.findAllByText("Select…")
-        .last()
-        .click();
-      popover().within(() => {
-        cy.findByText("Category").click();
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+              parameters: [
+                {
+                  name: "Date Filter",
+                  slug: "date_filter",
+                  id: "78d4ba0b",
+                  type: "date/all-options",
+                },
+                {
+                  name: "Category",
+                  slug: "category",
+                  id: "20976cce",
+                  type: "category",
+                },
+              ],
+            });
+
+            cy.log("**-- 5. Add nested card to the dashboard --**");
+
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: Q2_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log(
+                "**-- 6. Connect dashboard filters to the nested card --**",
+              );
+
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: Q2_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 10,
+                    sizeY: 8,
+                    series: [],
+                    visualization_settings: {},
+                    // Connect both filters and to the card
+                    parameter_mappings: [
+                      {
+                        parameter_id: "78d4ba0b",
+                        card_id: Q2_ID,
+                        target: [
+                          "dimension",
+                          ["field-id", PRODUCTS.CREATED_AT],
+                        ],
+                      },
+                      {
+                        parameter_id: "20976cce",
+                        card_id: Q2_ID,
+                        target: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
+                      },
+                    ],
+                  },
+                ],
+              });
+            });
+            cy.visit(`/dashboard/${DASHBOARD_ID}`);
+          });
+        });
       });
 
-      // Save dashboard and refresh page
-      cy.findAllByText("Done")
-        .first()
-        .click();
-
-      cy.findByText("Save").click();
-      cy.findByText("You're editing this dashboard.").should("not.exist");
-
-      // Check category search
       cy.get("fieldset")
         .last()
         .within(() => {
           cy.findByText("Category").click();
         });
       cy.log("**Failing to show dropdown in v0.36.0 through v.0.37.0**");
-      cy.findByText("Gadget").click();
+      popover()
+        .contains("Gadget")
+        .click();
       cy.findByText("Add filter").click();
+      cy.url().should("contain", "?category=Gadget");
+      cy.findByText("Ergonomic Silk Coat");
     });
 
     it("Repro 2: should work for aggregated questions", () => {});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Splits repro for #12985 into two reproductions (and groups them inside one `describe` block)
    - **Reproduction 1** was the existing one - it's rewritten to use API instead of UI (fixed in #14804)
    - **Reproduction 2** (Dropdown should work for **aggregated questions**) was added in this PR (still failing)

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- **Reproduction 2** should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix


### Screenshots:
Reproduction 1 works, while reproduction 2 fails:
![image](https://user-images.githubusercontent.com/31325167/107890799-1b6f2100-6f1b-11eb-9557-21e436585e6c.png)

Popover with the filter options (categories) never appears
![image](https://user-images.githubusercontent.com/31325167/107890815-3cd00d00-6f1b-11eb-93eb-e3498bbf13ed.png)

