### PR TITLE
#14775 Repro: Custom column not removed when a join is removed

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -420,16 +420,12 @@ describe("scenarios > question > custom columns", () => {
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.server();
-      cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
       cy.route("POST", "/api/dataset").as("dataset");
 
-      cy.visit(`/question/${QUESTION_ID}`);
-
-      cy.wait("@cardQuery");
-      cy.findByText(CE_NAME);
+      cy.visit(`/question/${QUESTION_ID}/notebook`);
     });
 
-    cy.get(".Icon-notebook").click();
+    // Remove join
     cy.findByText("Join data")
       .parent()
       .find(".Icon-close")


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14775 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/107980297-49f30780-6fc0-11eb-916c-8090d65be64e.png)

