### PR TITLE
Put Waterfall and Pivot chart options in a better spot in viz selector

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -11,9 +11,9 @@ import { color, lighten } from "metabase/lib/colors";
 import visualizations from "metabase/visualizations";
 
 const FIXED_LAYOUT = [
-  ["line", "bar", "combo", "area", "waterfall", "row"],
+  ["line", "bar", "combo", "area", "row", "waterfall"],
   ["scatter", "pie", "funnel", "smartscalar", "progress", "gauge"],
-  ["scalar", "table", "map"],
+  ["scalar", "table", "pivot", "map"],
 ];
 const FIXED_TYPES = new Set(_.flatten(FIXED_LAYOUT));
 


### PR DESCRIPTION
Closes #14762. I've just switched the position of Row vs. Waterfall, and moved Pivot up next to Table

![image](https://user-images.githubusercontent.com/2223916/107986355-bbab6100-6f80-11eb-8ead-34d7dace6182.png)


