### PR TITLE
#14776 Repro: Autocomplete results not correctly showing summary columns when full word entered

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -698,4 +698,37 @@ describe("scenarios > question > filter", () => {
       cy.findByText("Showing 1 row");
     });
   });
+
+  it.skip("should provide accurate auto-complete custom-expression suggestions based on the aggregated column name (metabase#14776)", () => {
+    cy.viewport(1400, 1000); // We need a bit taller window for this repro to see all custom filter options in the popover
+    cy.request("POST", "/api/card", {
+      name: "14776",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ],
+        },
+        type: "query",
+      },
+      display: "table",
+      visualization_settings: {},
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.visit(`/question/${QUESTION_ID}/notebook`);
+    });
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+    cy.get("[contenteditable='true']")
+      .as("inputField")
+      .click()
+      .type("su");
+    popover().contains(/Sum of Total/i);
+    cy.get("@inputField")
+      .click()
+      .type("m");
+    popover().contains(/Sum of Total/i);
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14776

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/107987345-1d45ec80-6fce-11eb-890f-92be56c8b710.png)

