### PR TITLE
#14753 repro: Collections without sub-collections have an "expand" arrow

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -521,6 +521,14 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText(/foo:bar/i).click();
       cy.findByText("Orders");
     });
+
+    it.skip("collections without sub-collections shouldn't have chevron icon (metabase#14753)", () => {
+      cy.visit("/collection/root");
+      cy.findByText("Your personal collection")
+        .parent()
+        .find(".Icon-chevronright")
+        .should("not.exist");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14753

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/107990863-aca2ce00-6fd5-11eb-9628-7c979d8889fa.png)

