### PR TITLE
Fix check for disabled button in `add.cy.spec.js`

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -43,12 +43,11 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByText("Save")
+    cy.findByRole("button", { name: "Save" })
       .should("not.be.disabled")
       .click();
 
     cy.wait("@createDatabase");
-
     cy.url().should("match", /\/admin\/databases\?created=42$/);
   });
 
@@ -59,11 +58,13 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByText("Save").should("not.be.disabled");
+    cy.findByRole("button", { name: "Save" })
+      .should("not.be.disabled")
+      .click();
 
     toggleFieldWithDisplayName("let me choose when Metabase syncs and scans");
 
-    cy.findByText("Next")
+    cy.findByRole("button", { name: "Next" })
       .should("not.be.disabled")
       .click();
 
@@ -82,17 +83,17 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByText("Save").should("not.be.disabled");
+    cy.findByRole("button", { name: "Save" }).should("not.be.disabled");
 
     toggleFieldWithDisplayName("let me choose when Metabase syncs and scans");
 
-    cy.findByText("Next")
+    cy.findByRole("button", { name: "Next" })
       .should("not.be.disabled")
       .click();
 
     cy.findByText("Never, I'll do this manually if I need to").click();
 
-    cy.findByText("Save").click();
+    cy.findByRole("button", { name: "Save" }).click();
 
     cy.wait("@createDatabase").then(({ request }) => {
       expect(request.body.engine).to.equal("postgres");
@@ -101,8 +102,7 @@ describe("scenarios > admin > databases > add", () => {
     });
 
     cy.url().should("match", /\/admin\/databases\?created=42$/);
-
-    cy.findByText("Your database has been added!").should("exist");
+    cy.findByText("Your database has been added!");
   });
 
   it("should show error correctly on server error", () => {
@@ -120,10 +120,9 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByText("Save").click();
+    cy.findByRole("button", { name: "Save" }).click();
 
     cy.wait("@createDatabase");
-
     cy.findByText("DATABASE CONNECTION ERROR").should("exist");
   });
 
@@ -167,7 +166,7 @@ describe("scenarios > admin > databases > add", () => {
       }).as("createDatabase");
 
       // submit form and check that the file's body is included
-      cy.contains("Save").click();
+      cy.findByRole("button", { name: "Save" }).click();
       cy.wait("@createDatabase").should(xhr => {
         expect(xhr.request.body.details["service-account-json"]).to.equal(
           '{"foo": 123}',
@@ -197,7 +196,6 @@ describe("scenarios > admin > databases > add", () => {
       cy.visit("/admin/databases/123");
 
       cy.contains("Connect to a Service Account instead");
-
       cy.contains("generate a Client ID and Client Secret for your project");
     });
   });


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- It fixes a check that the button is NOT disabled prior to clicking it
    - It was originally giving false positives because the yielded subject was `<div>`, not a `<button>`

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js`
- All tests should pass

### Screenshots

Before
![image](https://user-images.githubusercontent.com/31325167/107994769-926cee00-6fdd-11eb-959c-5286d38e5f79.png)


After
![image](https://user-images.githubusercontent.com/31325167/107994669-66516d00-6fdd-11eb-9f0d-33ebd1986739.png)

