### PR TITLE
Ensure connection string goes through jdbc without changes

### DIFF
--- a/src/metabase/db/connection_pool_setup.clj
+++ b/src/metabase/db/connection_pool_setup.clj
@@ -25,9 +25,9 @@
      {"maxPoolSize" max-pool-size})))
 
 (s/defn ^:private connection-pool-spec :- {:datasource javax.sql.DataSource, s/Keyword s/Any}
-  [jdbc-spec :- (s/cond-pre s/Str su/Map)]
-  (if (string? jdbc-spec)
-    {:datasource (connection-pool/pooled-data-source-from-url jdbc-spec application-db-connection-pool-props)}
+  [jdbc-spec :- su/Map]
+  (if-let [conn-uri (:connection-uri jdbc-spec)]
+    {:datasource (connection-pool/pooled-data-source-from-url conn-uri application-db-connection-pool-props)}
     (connection-pool/connection-pool-spec jdbc-spec application-db-connection-pool-props)))
 
 (defn create-connection-pool!

--- a/test/metabase/db/connection_pool_setup_test.clj
+++ b/test/metabase/db/connection_pool_setup_test.clj
@@ -20,5 +20,5 @@
         (test* {:subprotocol "h2"
                 :subname     (format "mem:%s;DB_CLOSE_DELAY=10" (mt/random-name))
                 :classname   "org.h2.Driver"}))
-      (testing "from a connection URL"
-        (test* (format "jdbc:h2:mem:%s;DB_CLOSE_DELAY=10" (mt/random-name)))))))
+      (testing "from a connection URL spec"
+        (test* {:connection-uri (format "jdbc:h2:mem:%s;DB_CLOSE_DELAY=10" (mt/random-name))})))))

--- a/test/metabase/db/env_test.clj
+++ b/test/metabase/db/env_test.clj
@@ -108,3 +108,4 @@
           (is (contains? diags :env.warning/postgres-ssl))))))
   (testing "handles nil"
     (is (nil? (#'mdb.env/connection-from-jdbc-string nil)))))
+;; there's a postgres test ensuring that connection strings with uri-encoded params can succeed


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/14836


Now `metabase.db.env/jdbc-spec` no longer is that weird dance of either a string or a db-spec. Now its always a map, with either a single `{:connection-uri "your thing"}` (which goes right through clojure.java.jdbc to the driver manager) or its the db-spec.