### PR TITLE
Watch out for errant DS_Store files in modules/drivers

### DIFF
--- a/bin/build-drivers/src/build_drivers.clj
+++ b/bin/build-drivers/src/build_drivers.clj
@@ -5,7 +5,9 @@
             [metabuild-common.core :as u]))
 
 (defn- all-drivers []
-  (map keyword (.list (io/file (u/filename u/project-root-directory "modules" "drivers")))))
+  (->> (.listFiles (io/file (u/filename u/project-root-directory "modules" "drivers")))
+       (filter #(.isDirectory %)) ;; watch for errant DS_Store files on os_x
+       (map (comp keyword #(.getName %)))))
 
 (defn build-drivers! [edition]
   (let [edition (or edition :oss)]


### PR DESCRIPTION
https://github.com/metabase/metabase/issues/14850

filter modules/drivers to directories rather than all files. possible in the future could filter to directories which contain a resources/metabase-plugin.yaml but not necessary for now i guess. probably better to get the error message later than just not process it.