### PR TITLE
Fix documentation links for developers

### DIFF
--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -121,8 +121,8 @@ class Settings {
     if (/^v1\.\d+\.\d+$/.test(tag)) {
       // if it's a normal EE version, link to the corresponding CE docs
       tag = tag.replace("v1", "v0");
-    } else if (!tag || /v1/.test(tag)) {
-      // if there's no tag or it's an EE version that might not have a matching CE version, link to latest
+    } else if (!tag || /v1/.test(tag) || /SNAPSHOT$/.test(tag)) {
+      // if there's no tag or it's an EE version that might not have a matching CE version, or it's a local build, link to latest
       tag = "latest";
     }
     if (page) {


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes broken documentation links for developers by redirecting them to the latest version of that doc

### Additional context
- When you build the app locally any link that points to the documentation was leading to the non-existing page. It included `SNAPSHOT` appended to the version so the link could've looked like:
    - `https://www.metabase.com/docs/v0.38.1-SNAPSHOT/enterprise-guide/data-sandboxes.html`
- This PR redirects such links to the `latest` version of the documentation
    - `https://www.metabase.com/docs/latest/enterprise-guide/data-sandboxes.html`

### Questions:
1. Is it ok to simply redirect to the `latest` version instead of the specific version of the document someone has built?
2. This could probably go directly to `master` but I thought to include it in the release branch since we're going to merge IT back to `master` sooner or later. Is that ok?

### Screenshots
Broken link (with wayback prompt in Brave browser)
![image](https://user-images.githubusercontent.com/31325167/108107087-0ddaa800-708f-11eb-866f-0e8cb464b1cc.png)
