### PR TITLE
Revert "Mb db connection uri parsing (#14716)"

### DIFF
--- a/src/metabase/db/env.clj
+++ b/src/metabase/db/env.clj
@@ -4,10 +4,6 @@
   enviornment variables e.g. `MB_DB_TYPE`, `MB_DB_HOST`, etc. `MB_DB_CONNECTION_URI` is used preferentially if both
   are specified.
 
-  The `MB_DB_CONNECTION_URI` is unparsed and passed to the jdbc driver with once exception: if it includes credentials
-  like `username:password@host:port`. In this case we parse this and log. This functionality will be removed at some
-  point so.
-
   There are two ways we specify JDBC connection information in Metabase code:
 
   1. As a 'connection details' map that is meant to be UI-friendly; this is the actual map we save when creating a
@@ -22,15 +18,11 @@
   Normally you should use the equivalent functions in `metabase.db.connection` which can be overridden rather than
   using this namespace directly."
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [clojure.walk :as walk]
             [metabase.config :as config]
             [metabase.db.spec :as db.spec]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs]]
-            [ring.util.codec :as codec])
-  (:import java.net.URI))
+            [metabase.util.i18n :refer [trs]]))
 
 (defn- get-db-file
   "Takes a filename and converts it to H2-compatible filename."
@@ -58,146 +50,20 @@
      (let [db-file-name (config/config-str :mb-db-file)]
        (get-db-file db-file-name)))))
 
-(def ^:private jdbc-connection-regex
-  "Regex to be used only when `:mb-db-connection-uri` includes credentials like `username:password@host:port`."
-  #"^(jdbc:)?([^:/@]+)://(?:([^:/@]+)(?::([^:@]+))?@)?([^:@]+)(?::(\d+))?/([^/?]+)(?:\?(.*))?$")
-
-(declare connection-details->jdbc-spec)
-
-(defn- suspicious-postgres-details?
-  "If postgres connection seems iffy. #8908
-  https://github.com/metabase/metabase/issues/8908"
-  [details]
-  (and (= (:ssl details) "true")
-       (not (:sslmode details))))
-
-(defn- parse-connection-string
-  "Parse a DB connection URI like
-  `postgres://cam@localhost.com:5432/cams_cool_db?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory` and
-  return a broken-out map. This should not be used unless the connection string uses the old style where the
-  credentials are included in the like `username:password@host:port`."
-  [uri]
-  (when-let [[_ _ protocol user pass host port db query] (re-matches jdbc-connection-regex uri)]
-    (let [protocol (case (keyword protocol)
-                     :postgres   :postgres
-                     :postgresql :postgres
-                     :mysql      :mysql
-                     :h2         :h2)
-          details
-          (connection-details->jdbc-spec
-           protocol
-           (merge {:type protocol}
-
-                  (case (keyword protocol)
-                    :h2 {:db db}
-                    {:user     user
-                     :password pass
-                     :host     host
-                     :port     port
-                     :dbname   db})
-                  (some-> query
-                          codec/form-decode
-                          walk/keywordize-keys)))]
-      ;; If someone is using Postgres and specifies `ssl=true` they might need to specify `sslmode=require`. Let's let
-      ;; them know about that to make their lives a little easier. See
-      ;; https://github.com/metabase/metabase/issues/8908 for more details.
-      {:connection details
-       :diags (cond-> #{:env.warning/inline-credentials}
-                (and (= protocol :postgres) (suspicious-postgres-details? details))
-                (conj :env.warning/postgres-ssl))})))
-
-(defn- fixup-connection-string
-  "When we allow a raw connection string as our connection, we still perform a few fixups:
-  - ensure it begins with jdbc:
-  - we allow `postgres:` and must change that to `postgresql:`
-  - warn if postgres ssl settings might cause issues
-
-  Return is a map of {:connection string|spec :diags #{info or warnings}}"
+(defn- format-connection-uri
+  "Prepends \"jdbc:\" to the connection-uri string if needed."
   [connection-uri]
-  (when connection-uri
-    (reduce (fn [{:keys [connection] :as m} {:keys [pred diag fix]}]
-              (if (pred connection)
-                (-> m (update :connection fix) (update :diags conj diag))
-                m))
-            {:connection connection-uri
-             :diags #{}}
-            [{:pred #(not (.startsWith ^String % "jdbc:"))
-              :diag :env.info/prepend-jdbc
-              :fix  #(str "jdbc:" %)}
-             {:pred #(re-find #"postgres:" %)
-              :diag :env.info/change-to-postgresql
-              :fix #(str/replace % "postgres:" "postgresql:")}
-             {:pred (fn parse-query-for-postgres
-                      [^String conn]
-                      (when (re-find #"postgres(?:ql)?:" conn)
-                        ;; jdbc:postgresql: is an opaque URI not subject to further parsing. Strip that off and we can
-                        ;; use the structural .getQuery from the URI rather than parsing ourselves
-                        (when-let [details (some-> (.getQuery (URI. (str/replace conn #"^jdbc:" "")))
-                                                   codec/form-decode
-                                                   walk/keywordize-keys)]
-                          (suspicious-postgres-details? details))))
-              :fix identity
-              :diag :env.warning/postgres-ssl}])))
+  (if-let [uri connection-uri]
+    (if (re-find #"^jdbc:" uri)
+      uri
+      (str "jdbc:" uri))))
 
-(defn old-credential-style?
-  "Parse a jdbc connection uri to check for older style credential passing like:
-  mysql://foo:password@172.17.0.2:3306/metabase"
-  [connection-uri]
-  (when connection-uri
-    ;; strip the jdbc prefix off so its a parseable and not opaque URI
-    (let [uri (URI. (str/replace connection-uri #"^jdbc:" ""))]
-      ;; this is how clojure.java.jdbc does it
-      (some? (.getUserInfo uri)))))
+(def ^:private connection-string
+  (delay (format-connection-uri (config/config-str :mb-db-connection-uri))))
 
-(defn- connection-from-jdbc-string
-  "If connection string uses the form `username:password@host:port`, use our custom parsing to return a jdbc spec and
-  warn about this deprecated behavior. If not, return the jdbc string as is since our parsing does not offer all of
-  the options of using a raw jdbc string.
-  Return is a map of {:connection string|spec :diags #{info or warnings}}"
-  [conn-string]
-  (when conn-string
-    (if (old-credential-style? conn-string)
-        ;; prefer not parsing as we don't handle all features of connection strings
-        (parse-connection-string conn-string)
-        (fixup-connection-string conn-string))))
-
-(defn- log-inline-credentials! []
-  (log/warn
-   (u/format-color 'red
-       (str
-        (trs "Warning: using credentials provided inline is deprecated. ")
-        (trs "Change to using the credentials as a query parameter: `?password=your-password&user=user`.")))))
-
-(defn- log-postgres-ssl []
-  (log/warn (trs "Warning: Postgres connection string with `ssl=true` detected.")
-            (trs "You may need to add `?sslmode=require` to your application DB connection string.")
-            (trs "If Metabase fails to launch, please add it and try again.")
-            (trs "See https://github.com/metabase/metabase/issues/8908 for more details.")))
-
-(defn- emit-diags! [diagnostic]
-  (case diagnostic
-    :env.info/change-to-postgresql  (log/info (trs "Replaced 'postgres:' with 'postgresql:' in connection string"))
-    :env.info/prepend-jdbc          (log/info (trs "Prepended 'jdbc:' onto connection string"))
-    :env.warning/inline-credentials (log-inline-credentials!)
-    :env.warning/postgres-ssl       (log-postgres-ssl)
-    (log/warn (trs "Unknown diagnostic in db connection: {0}" diagnostic))))
-
-(def ^:private connection-string-or-spec
-  "Uses `:mb-db-connection-uri` and is either:
-  - the jdbc connection string if it does not use inline credentials, or
-  - a db-spec parsed by this code if it does use inline credentials, or
-  - nil when this value is not set."
-  (delay (when-let [conn-uri (config/config-str :mb-db-connection-uri)]
-           (let [{:keys [connection diags]} (connection-from-jdbc-string conn-uri)]
-             (run! emit-diags! diags)
-             connection))))
-
-(defn- connection-string-or-spec->db-type [x]
-  (cond
-    (map? x) (:type x)
-
-    (string? x)
-    (let [[_ subprotocol] (re-find #"^(?:jdbc:)?([^:]+):" x)]
+(defn- connection-string->db-type [s]
+  (when s
+    (let [[_ subprotocol] (re-find #"^(?:jdbc:)?([^:]+):" s)]
       (try
         (case (keyword subprotocol)
           :postgres   :postgres
@@ -212,7 +78,7 @@
                           {:subprotocol subprotocol})))))))
 
 (def ^:private connection-string-db-type
-  (delay (connection-string-or-spec->db-type @connection-string-or-spec)))
+  (delay (connection-string->db-type @connection-string)))
 
 (def db-type
   "Keyword type name of the application DB details specified by environment variables. Matches corresponding driver
@@ -260,5 +126,5 @@
 (def jdbc-spec
   "`clojure.java.jdbc` spec map for the application DB, using the details map derived from environment variables."
   (delay
-    (or @connection-string-or-spec
+    (or @connection-string
         (connection-details->jdbc-spec @db-type @db-connection-details))))

--- a/test/metabase/db/env_test.clj
+++ b/test/metabase/db/env_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase.db.env :as mdb.env]))
 
-(deftest connection-string-or-spec->db-type-test
+(deftest connection-string->db-type-test
   (doseq [[subprotocol expected] {"postgres"   :postgres
                                   "postgresql" :postgres
                                   "mysql"      :mysql
@@ -12,97 +12,19 @@
                                   (str protocol ":abc")
                                   (str protocol ":cam@localhost/my_db?password=123456")
                                   (str protocol "://localhost/my_db")]]
-    (testing (pr-str (list 'connection-string-or-spec->db-type url))
+    (testing (pr-str (list 'connection-string->db-type url))
       (is (= expected
-             (#'mdb.env/connection-string-or-spec->db-type url)))))
+             (#'mdb.env/connection-string->db-type url)))))
   (testing "Should throw an Exception for an unsupported subprotocol"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Unsupported application database type: \"sqlserver\""
-         (#'mdb.env/connection-string-or-spec->db-type "jdbc:sqlserver://bad"))))
-  (testing "Finds type from jdbc-spec"
-    (let [spec {:password "password",
-                :characterSetResults "UTF8",
-                :characterEncoding "UTF8",
-                :type :mysql,
-                :classname "org.mariadb.jdbc.Driver",
-                :subprotocol "mysql",
-                :useSSL false,
-                :zeroDateTimeBehavior "convertToNull",
-                :user "foo",
-                :subname "//172.17.0.2:3306/metabase",
-                :useCompression true,
-                :useUnicode true}]
-      (is (= :mysql (#'mdb.env/connection-string-or-spec->db-type spec))))))
+         (#'mdb.env/connection-string->db-type "jdbc:sqlserver://bad")))))
 
-(deftest fixup-connection-string-test
-  (let [correct-uri "jdbc:postgresql://localhost:metabase?username=johndoe"]
-    (doseq [[input expected-diags expected]
-            [["postgres://localhost:metabase?username=johndoe"
-              #{:env.info/prepend-jdbc :env.info/change-to-postgresql}
-              correct-uri]
-             ["jdbc:postgres://localhost:metabase?username=johndoe"
-              #{:env.info/change-to-postgresql}
-              correct-uri]
-             [correct-uri #{} correct-uri]
-             [nil nil nil]]]
-      (let [{:keys [connection diags]} (#'mdb.env/fixup-connection-string input)]
-        (is (= expected connection) input)
-        (is (= expected-diags diags) input)))))
-
-(deftest old-credential-style?-test
-  (are [old? conn-uri] (is (= old? (#'mdb.env/old-credential-style? conn-uri)) conn-uri)
-    false "jdbc:mysql://172.17.0.2:3306/metabase?password=password&user=user"
-    false "mysql://172.17.0.2:3306/metabase?password=password&user=user"
-    ;; prefixed with jdbc makes an "opaque" URI which doesn't parse
-    true  "jdbc:mysql://foo@172.17.0.2:3306/metabase?password=password"
-    true  "mysql://foo@172.17.0.2:3306/metabase?password=password"
-    true  "mysql://foo:password@172.17.0.2:3306/metabase"))
-
-(deftest connection-from-jdbc-string-test
-  (let [parsed {:classname   "org.mariadb.jdbc.Driver"
-                :subprotocol "mysql"
-                :subname     "//172.17.0.2:3306/metabase"
-                :type        :mysql
-                :user        "foo"
-                :password    "password"
-                :dbname      "metabase"}]
-    (testing "handles mixed (just password in query params) old style just fine"
-      (let [conn-uri "mysql://foo@172.17.0.2:3306/metabase?password=password"]
-        (is (= {:connection parsed
-                :diags #{:env.warning/inline-credentials}}
-               (#'mdb.env/connection-from-jdbc-string conn-uri)))))
-    (testing "When using old-style passwords parses and returns jdbc specs"
-      (let [conn-uri "mysql://foo:password@172.17.0.2:3306/metabase"]
-        (is (= {:connection parsed
-                :diags #{:env.warning/inline-credentials}}
-               (#'mdb.env/connection-from-jdbc-string conn-uri))))))
-  (testing "handles credentials in query params"
-    (let [conn-uri "mysql://172.17.0.2:3306/metabase?user=user&password=password"]
-      (is (= {:connection (str "jdbc:" conn-uri)
-              :diags #{:env.info/prepend-jdbc}}
-             (#'mdb.env/connection-from-jdbc-string conn-uri)))))
-  (testing "warns about postgres ssl issue #8908"
-    (testing "when it parses due to inline credentials"
-      (let [conn-uri "postgresql://mb@172.17.0.2:5432/metabase?ssl=true"]
-        (is (= {:connection
-                {:ssl "true",
-                 :OpenSourceSubProtocolOverride true,
-                 :password nil,
-                 :type :postgres,
-                 :classname "org.postgresql.Driver",
-                 :subprotocol "postgresql",
-                 :dbname "metabase",
-                 :user "mb",
-                 :subname "//172.17.0.2:5432/metabase"},
-                :diags #{:env.warning/postgres-ssl :env.warning/inline-credentials}}
-               (#'mdb.env/connection-from-jdbc-string conn-uri)))))
-    (testing "when it doesn't parse as well"
-      (doseq [conn-uri ["jdbc:postgresql://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true"
-                        "postgresql://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true"
-                        "postgres://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true"]]
-        (let [{:keys [connection diags]} (#'mdb.env/connection-from-jdbc-string conn-uri)]
-          (is (= "jdbc:postgresql://172.17.0.2:5432/metabase?user=mb&password=pw&ssl=true" connection))
-          (is (contains? diags :env.warning/postgres-ssl))))))
-  (testing "handles nil"
-    (is (nil? (#'mdb.env/connection-from-jdbc-string nil)))))
+(deftest format-connection-uri-test
+  (let [conn-uri "postgresql://localhost:metabase?username=johndoe"
+        jdbc-conn-uri (str "jdbc:" conn-uri)]
+    (doseq [[input expected] [[conn-uri jdbc-conn-uri]
+                              [jdbc-conn-uri jdbc-conn-uri]
+                              [nil nil]]]
+      (is (= expected (#'mdb.env/format-connection-uri input))))))

--- a/test/metabase/db/env_test.clj
+++ b/test/metabase/db/env_test.clj
@@ -2,29 +2,45 @@
   (:require [clojure.test :refer :all]
             [metabase.db.env :as mdb.env]))
 
-(deftest connection-string->db-type-test
-  (doseq [[subprotocol expected] {"postgres"   :postgres
-                                  "postgresql" :postgres
-                                  "mysql"      :mysql
-                                  "h2"         :h2}
-          protocol               [subprotocol (str "jdbc:" subprotocol)]
-          url                    [(str protocol "://abc")
-                                  (str protocol ":abc")
-                                  (str protocol ":cam@localhost/my_db?password=123456")
-                                  (str protocol "://localhost/my_db")]]
-    (testing (pr-str (list 'connection-string->db-type url))
-      (is (= expected
-             (#'mdb.env/connection-string->db-type url)))))
-  (testing "Should throw an Exception for an unsupported subprotocol"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Unsupported application database type: \"sqlserver\""
-         (#'mdb.env/connection-string->db-type "jdbc:sqlserver://bad")))))
+(deftest parse-connection-string-test
+  (testing "can parse with/without jdbc, uri-encoded passwords, passwords in host, etc"
+    (are [conn expected] (= expected (#'mdb.env/parse-connection-string conn))
+      ;; password in host
+      "postgres://dan:password@localhost:5432/metabase"
+      {:type :postgres, :user "dan", :password "password",
+       :host "localhost", :port "5432", :dbname "metabase"}
 
-(deftest format-connection-uri-test
-  (let [conn-uri "postgresql://localhost:metabase?username=johndoe"
-        jdbc-conn-uri (str "jdbc:" conn-uri)]
-    (doseq [[input expected] [[conn-uri jdbc-conn-uri]
-                              [jdbc-conn-uri jdbc-conn-uri]
-                              [nil nil]]]
-      (is (= expected (#'mdb.env/format-connection-uri input))))))
+      ;; password in params
+      "postgresql://localhost:5432/metabase?user=dan&password=password"
+      {:type :postgres, :user "dan", :password "password",
+       :host "localhost", :port "5432", :dbname "metabase"}
+
+      ;; includes uri encoded password
+      "mysql://localhost/metabase?user=newuser&password=metabase%21%40%2540%26amp%3B-%2F%3A"
+      {:type :mysql, :user "newuser", :password "metabase!@%40&amp;-/:",
+       :host "localhost", :port nil, :dbname "metabase"}
+
+      ;; extra options ssl=true
+      "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true"
+      {:type :postgres, :user "fred", :password "secret",
+       :host "localhost", :port nil, :dbname "test", :ssl "true"}
+
+      ;; copied from previous tests
+      "postgres://localhost/toms_cool_db"
+      {:type :postgres, :user nil, :password nil, :host "localhost", :port nil, :dbname "toms_cool_db" }
+
+      "postgresql://localhost/toms_cool_db"
+      {:type :postgres, :user nil, :password nil, :host "localhost", :port nil, :dbname "toms_cool_db"}
+
+      (str "postgres://tom:1234@localhost:5432/toms_cool_db"
+           "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory")
+      {:type :postgres, :user "tom", :password "1234", :host "localhost", :port "5432", :dbname "toms_cool_db",
+       :ssl "true", :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
+
+      (str "jdbc:postgres://tom:1234@localhost:5432/toms_cool_db"
+           "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory")
+      {:type :postgres, :user "tom", :password "1234", :host "localhost", :port "5432", :dbname "toms_cool_db",
+       :ssl "true", :sslfactory "org.postgresql.ssl.NonValidatingFactory"}))
+  (testing "throws if unsupported db type"
+    (let [invalid-conn "oracle://dan:password@localhost:5432/metabase"]
+      (is (thrown? Throwable (#'mdb.env/parse-connection-string invalid-conn))))))


### PR DESCRIPTION
reverting connection string parsing.

original issue: https://github.com/metabase/metabase/issues/14678
PR: https://github.com/metabase/metabase/pull/14716

Issues with it:
assumed just calling `(jdbc/query ...)` on a connection string did not do any parsing. This was incorrect, it parsed it poorly, not just passing it through, and it didn't url-decode when it created the map. If you used passwords in the url parameters these were incorrectly parsed into the db-spec. Found out that could get it through to the driver manager if you passed it like `(jdbc/query {:connection-uri conn-str} ...)` but now we're hitting driver issues relating to charsets on maria.

So gonna give up on this for the time being. Big props to @robdaemon and @flamber for finding these edges.