### PR TITLE
Saved question selection UX 

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -16,80 +16,17 @@ class CollectionsList extends React.Component {
       currentCollection,
       filter = () => true,
       openCollections,
+      // hack to support using nested collections in the data selector, we should
+      // move to a more elegant so
+      // this is a function that accepts a collection item and returns what we want to have happen based on that
+      useTriggerComponent,
     } = this.props;
     const collections = this.props.collections.filter(filter);
 
     return (
       <Box>
         {collections.map(c => {
-          const isOpen = openCollections.indexOf(c.id) >= 0;
-          const action = isOpen ? this.props.onClose : this.props.onOpen;
-          return (
-            <Box key={c.id}>
-              <CollectionDropTarget collection={c}>
-                {({ highlighted, hovered }) => {
-                  return (
-                    <CollectionLink
-                      to={Urls.collection(c.id)}
-                      // TODO - need to make sure the types match here
-                      selected={String(c.id) === currentCollection}
-                      depth={this.props.depth}
-                      // when we click on a link, if there are children, expand to show sub collections
-                      onClick={() => c.children && action(c.id)}
-                      hovered={hovered}
-                      highlighted={highlighted}
-                    >
-                      <Flex
-                        className="relative"
-                        align={
-                          // if a colleciton name is somewhat long, align things at flex-start ("top") for a slightly better
-                          // visual
-                          c.name.length > 25 ? "flex-start" : "center"
-                        }
-                      >
-                        {c.children && (
-                          <Flex
-                            className="absolute text-brand cursor-pointer"
-                            align="center"
-                            justifyContent="center"
-                            style={{ left: -20 }}
-                          >
-                            <Icon
-                              name={isOpen ? "chevrondown" : "chevronright"}
-                              onClick={ev => {
-                                ev.preventDefault();
-                                action(c.id);
-                              }}
-                              size={12}
-                            />
-                          </Flex>
-                        )}
-                        <Icon
-                          name={initialIcon}
-                          mr={"6px"}
-                          style={{ opacity: 0.4 }}
-                        />
-                        {c.name}
-                      </Flex>
-                    </CollectionLink>
-                  );
-                }}
-              </CollectionDropTarget>
-              {c.children && isOpen && (
-                <Box ml={-SIDEBAR_SPACER} pl={SIDEBAR_SPACER + 10}>
-                  <CollectionsList
-                    openCollections={openCollections}
-                    onOpen={this.props.onOpen}
-                    onClose={this.props.onClose}
-                    collections={c.children}
-                    filter={filter}
-                    currentCollection={currentCollection}
-                    depth={this.props.depth + 1}
-                  />
-                </Box>
-              )}
-            </Box>
-          );
+          return useTriggerComponent(c, this.props);
         })}
       </Box>
     );
@@ -99,6 +36,77 @@ class CollectionsList extends React.Component {
 CollectionsList.defaultProps = {
   initialIcon: "folder",
   depth: 1,
+  useTriggerComponent: (c, props) => {
+    const isOpen = props.openCollections.indexOf(c.id) >= 0;
+    const action = isOpen ? props.onClose : props.onOpen;
+    return (
+      <Box key={c.id}>
+        <CollectionDropTarget collection={c}>
+          {({ highlighted, hovered }) => {
+            return (
+              <CollectionLink
+                to={Urls.collection(c.id)}
+                // TODO - need to make sure the types match here
+                selected={String(c.id) === props.currentCollection}
+                depth={props.depth}
+                // when we click on a link, if there are children, expand to show sub collections
+                onClick={() => c.children && action(c.id)}
+                hovered={hovered}
+                highlighted={highlighted}
+              >
+                <Flex
+                  className="relative"
+                  align={
+                    // if a colleciton name is somewhat long, align things at flex-start ("top") for a slightly better
+                    // visual
+                    c.name.length > 25 ? "flex-start" : "center"
+                  }
+                >
+                  {c.children && (
+                    <Flex
+                      className="absolute text-brand cursor-pointer"
+                      align="center"
+                      justifyContent="center"
+                      style={{ left: -20 }}
+                    >
+                      <Icon
+                        name={isOpen ? "chevrondown" : "chevronright"}
+                        onClick={ev => {
+                          ev.preventDefault();
+                          action(c.id);
+                        }}
+                        size={12}
+                      />
+                    </Flex>
+                  )}
+                  <Icon
+                    name={props.initialIcon}
+                    mr={"6px"}
+                    style={{ opacity: 0.4 }}
+                  />
+                  {c.name}
+                </Flex>
+              </CollectionLink>
+            );
+          }}
+        </CollectionDropTarget>
+        {c.children && isOpen && (
+          <Box ml={-SIDEBAR_SPACER} pl={SIDEBAR_SPACER + 10}>
+            <CollectionsList
+              openCollections={props.openCollections}
+              onOpen={props.onOpen}
+              onClose={props.onClose}
+              collections={c.children}
+              filter={props.filter}
+              currentCollection={props.currentCollection}
+              depth={props.depth + 1}
+              useTriggerComponent={props.useTriggerComponent}
+            />
+          </Box>
+        )}
+      </Box>
+    );
+  },
 };
 
 export default CollectionsList;

--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -12,10 +12,7 @@ import { SIDEBAR_SPACER } from "metabase/collections/constants";
 class CollectionsList extends React.Component {
   render() {
     const {
-      initialIcon,
-      currentCollection,
       filter = () => true,
-      openCollections,
       // hack to support using nested collections in the data selector, we should
       // move to a more elegant so
       // this is a function that accepts a collection item and returns what we want to have happen based on that
@@ -36,7 +33,8 @@ class CollectionsList extends React.Component {
 CollectionsList.defaultProps = {
   initialIcon: "folder",
   depth: 1,
-  useTriggerComponent: (c, props) => {
+  // named function here avoids eslint error
+  useTriggerComponent: function collectionTrigger(c, props) {
     const isOpen = props.openCollections.indexOf(c.id) >= 0;
     const action = isOpen ? props.onClose : props.onOpen;
     return (

--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -12,18 +12,84 @@ import { SIDEBAR_SPACER } from "metabase/collections/constants";
 class CollectionsList extends React.Component {
   render() {
     const {
+      initialIcon,
+      currentCollection,
       filter = () => true,
-      // hack to support using nested collections in the data selector, we should
-      // move to a more elegant so
-      // this is a function that accepts a collection item and returns what we want to have happen based on that
-      useTriggerComponent,
+      openCollections,
     } = this.props;
     const collections = this.props.collections.filter(filter);
 
     return (
       <Box>
         {collections.map(c => {
-          return useTriggerComponent(c, this.props);
+          const isOpen = openCollections.indexOf(c.id) >= 0;
+          const action = isOpen ? this.props.onClose : this.props.onOpen;
+          return (
+            <Box key={c.id}>
+              <CollectionDropTarget collection={c}>
+                {({ highlighted, hovered }) => {
+                  return (
+                    <CollectionLink
+                      to={Urls.collection(c.id)}
+                      // TODO - need to make sure the types match here
+                      selected={String(c.id) === currentCollection}
+                      depth={this.props.depth}
+                      // when we click on a link, if there are children, expand to show sub collections
+                      onClick={() => c.children && action(c.id)}
+                      hovered={hovered}
+                      highlighted={highlighted}
+                    >
+                      <Flex
+                        className="relative"
+                        align={
+                          // if a colleciton name is somewhat long, align things at flex-start ("top") for a slightly better
+                          // visual
+                          c.name.length > 25 ? "flex-start" : "center"
+                        }
+                      >
+                        {c.children && (
+                          <Flex
+                            className="absolute text-brand cursor-pointer"
+                            align="center"
+                            justifyContent="center"
+                            style={{ left: -20 }}
+                          >
+                            <Icon
+                              name={isOpen ? "chevrondown" : "chevronright"}
+                              onClick={ev => {
+                                ev.preventDefault();
+                                action(c.id);
+                              }}
+                              size={12}
+                            />
+                          </Flex>
+                        )}
+                        <Icon
+                          name={initialIcon}
+                          mr={"6px"}
+                          style={{ opacity: 0.4 }}
+                        />
+                        {c.name}
+                      </Flex>
+                    </CollectionLink>
+                  );
+                }}
+              </CollectionDropTarget>
+              {c.children && isOpen && (
+                <Box ml={-SIDEBAR_SPACER} pl={SIDEBAR_SPACER + 10}>
+                  <CollectionsList
+                    openCollections={openCollections}
+                    onOpen={this.props.onOpen}
+                    onClose={this.props.onClose}
+                    collections={c.children}
+                    filter={filter}
+                    currentCollection={currentCollection}
+                    depth={this.props.depth + 1}
+                  />
+                </Box>
+              )}
+            </Box>
+          );
         })}
       </Box>
     );
@@ -33,78 +99,6 @@ class CollectionsList extends React.Component {
 CollectionsList.defaultProps = {
   initialIcon: "folder",
   depth: 1,
-  // named function here avoids eslint error
-  useTriggerComponent: function collectionTrigger(c, props) {
-    const isOpen = props.openCollections.indexOf(c.id) >= 0;
-    const action = isOpen ? props.onClose : props.onOpen;
-    return (
-      <Box key={c.id}>
-        <CollectionDropTarget collection={c}>
-          {({ highlighted, hovered }) => {
-            return (
-              <CollectionLink
-                to={Urls.collection(c.id)}
-                // TODO - need to make sure the types match here
-                selected={String(c.id) === props.currentCollection}
-                depth={props.depth}
-                // when we click on a link, if there are children, expand to show sub collections
-                onClick={() => c.children && action(c.id)}
-                hovered={hovered}
-                highlighted={highlighted}
-              >
-                <Flex
-                  className="relative"
-                  align={
-                    // if a colleciton name is somewhat long, align things at flex-start ("top") for a slightly better
-                    // visual
-                    c.name.length > 25 ? "flex-start" : "center"
-                  }
-                >
-                  {c.children && (
-                    <Flex
-                      className="absolute text-brand cursor-pointer"
-                      align="center"
-                      justifyContent="center"
-                      style={{ left: -20 }}
-                    >
-                      <Icon
-                        name={isOpen ? "chevrondown" : "chevronright"}
-                        onClick={ev => {
-                          ev.preventDefault();
-                          action(c.id);
-                        }}
-                        size={12}
-                      />
-                    </Flex>
-                  )}
-                  <Icon
-                    name={props.initialIcon}
-                    mr={"6px"}
-                    style={{ opacity: 0.4 }}
-                  />
-                  {c.name}
-                </Flex>
-              </CollectionLink>
-            );
-          }}
-        </CollectionDropTarget>
-        {c.children && isOpen && (
-          <Box ml={-SIDEBAR_SPACER} pl={SIDEBAR_SPACER + 10}>
-            <CollectionsList
-              openCollections={props.openCollections}
-              onOpen={props.onOpen}
-              onClose={props.onClose}
-              collections={c.children}
-              filter={props.filter}
-              currentCollection={props.currentCollection}
-              depth={props.depth + 1}
-              useTriggerComponent={props.useTriggerComponent}
-            />
-          </Box>
-        )}
-      </Box>
-    );
-  },
 };
 
 export default CollectionsList;

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -479,6 +479,7 @@ export const initializeQB = (location, params) => {
     let question = card && new Question(card, getMetadata(getState()));
     if (question && question.isSaved()) {
       // loading a saved question prevents auto-viz selection
+      // TODO - curious about this? why do we do this again?
       question = question.lockDisplay();
     }
 

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -831,12 +831,15 @@ const DatabaseSchemaPicker = ({
         alwaysTogglable={true}
         showItemArrows={hasNextStep}
       />
+      {/* TODO - we probably still need a check to make sure that we should show this option */}
       <div
         className="List-section bg-light"
         onClick={() => onSwitchToSavedQuestions()}
       >
-        <Icon name="all" />
-        {t`Saved Questions`}
+        <div className="List-section-header mx2 py2 flex align-center text-brand-hover cursor-pointer">
+          <Icon className="List-section-icon mr1" name="all" size={20} />
+          <h3>{t`Saved Questions`}</h3>
+        </div>
       </div>
     </span>
   );

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -18,6 +18,8 @@ import Tables from "metabase/entities/tables";
 
 import { getMetadata } from "metabase/selectors/metadata";
 
+import SavedQuestionPicker from "metabase/query_builder/containers/SavedQuestionPicker";
+
 import _ from "underscore";
 
 // chooses a database
@@ -153,6 +155,7 @@ export class UnconnectedDataSelector extends Component {
       isError: false,
       ...state,
       ...computedState,
+      showSavedQuestions: false,
     };
   }
 
@@ -556,6 +559,9 @@ export class UnconnectedDataSelector extends Component {
       await this.previousStep();
     }
     await this.nextStep({ selectedDatabaseId: database && database.id });
+    if (database.is_saved_questions) {
+      this.setState({ showSavedQuestions: true });
+    }
   };
 
   onChangeSchema = async schema => {
@@ -623,7 +629,7 @@ export class UnconnectedDataSelector extends Component {
   }
 
   renderActiveStep() {
-    const { combineDatabaseSchemaSteps, onSwitchToSavedQuestions } = this.props;
+    const { combineDatabaseSchemaSteps } = this.props;
     const props = {
       ...this.state,
 
@@ -636,7 +642,6 @@ export class UnconnectedDataSelector extends Component {
       isLoading: this.state.isLoading,
       hasNextStep: !!this.getNextStep(),
       onBack: this.getPreviousStep() ? this.previousStep : null,
-      onSwitchToSavedQuestions,
     };
 
     switch (this.state.activeStep) {
@@ -661,7 +666,20 @@ export class UnconnectedDataSelector extends Component {
     return null;
   }
 
+  renderSavedQuestion() {
+    const { query } = this.props;
+    return (
+      <SavedQuestionPicker
+        query={query}
+        onChangeSchema={this.onChangeSchema}
+        onChangeTable={this.onChangeTable}
+        onBack={() => this.setState({ showSavedQuestions: false })}
+      />
+    );
+  }
+
   render() {
+    const { showSavedQuestions } = this.state;
     return (
       <PopoverWithTrigger
         id="DataPopover"
@@ -675,7 +693,9 @@ export class UnconnectedDataSelector extends Component {
         sizeToFit
         isOpen={this.props.isOpen}
       >
-        {this.renderActiveStep()}
+        {showSavedQuestions
+          ? this.renderSavedQuestion()
+          : this.renderActiveStep()}
       </PopoverWithTrigger>
     );
   }
@@ -758,7 +778,6 @@ const DatabaseSchemaPicker = ({
   onChangeDatabase,
   hasNextStep,
   isLoading,
-  onSwitchToSavedQuestions,
 }) => {
   if (databases.length === 0) {
     return <DataSelectorLoading />;
@@ -798,50 +817,35 @@ const DatabaseSchemaPicker = ({
   }
 
   return (
-    <span>
-      <AccordionList
-        id="DatabaseSchemaPicker"
-        key="databaseSchemaPicker"
-        className="text-brand"
-        sections={sections}
-        onChange={item => {
-          console.log(item);
-          onChangeSchema(item.schema);
-        }}
-        onChangeSection={(section, sectionIndex) => {
-          if (
-            selectedDatabase &&
-            selectedDatabase.id === databases[sectionIndex].id
-          ) {
-            // You can't change to the current database. If you click on that,
-            // still return "true" to let the AccordionList collapse that section.
-            console.log(section);
-            return true;
-          }
-          console.log(section);
-          onChangeDatabase(databases[sectionIndex]);
+    <AccordionList
+      id="DatabaseSchemaPicker"
+      key="databaseSchemaPicker"
+      className="text-brand"
+      sections={sections}
+      onChange={item => {
+        onChangeSchema(item.schema);
+      }}
+      onChangeSection={(section, sectionIndex) => {
+        if (
+          selectedDatabase &&
+          selectedDatabase.id === databases[sectionIndex].id
+        ) {
+          // You can't change to the current database. If you click on that,
+          // still return "true" to let the AccordionList collapse that section.
           return true;
-        }}
-        itemIsSelected={schema => schema === selectedSchema}
-        renderSectionIcon={item => (
-          <Icon className="Icon text-default" name={item.icon} size={18} />
-        )}
-        renderItemIcon={() => <Icon name="folder" size={16} />}
-        initiallyOpenSection={openSection}
-        alwaysTogglable={true}
-        showItemArrows={hasNextStep}
-      />
-      {/* TODO - we probably still need a check to make sure that we should show this option */}
-      <div
-        className="List-section bg-light"
-        onClick={() => onSwitchToSavedQuestions()}
-      >
-        <div className="List-section-header mx2 py2 flex align-center text-brand-hover cursor-pointer">
-          <Icon className="List-section-icon mr1" name="all" size={20} />
-          <h3>{t`Saved Questions`}</h3>
-        </div>
-      </div>
-    </span>
+        }
+        onChangeDatabase(databases[sectionIndex]);
+        return true;
+      }}
+      itemIsSelected={schema => schema === selectedSchema}
+      renderSectionIcon={item => (
+        <Icon className="Icon text-default" name={item.icon} size={18} />
+      )}
+      renderItemIcon={() => <Icon name="folder" size={16} />}
+      initiallyOpenSection={openSection}
+      alwaysTogglable={true}
+      showItemArrows={hasNextStep}
+    />
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -155,7 +155,6 @@ export class UnconnectedDataSelector extends Component {
       isError: false,
       ...state,
       ...computedState,
-      showSavedQuestions: false,
     };
   }
 
@@ -558,9 +557,8 @@ export class UnconnectedDataSelector extends Component {
       // data before advancing to the next step.
       await this.previousStep();
     }
-    await this.nextStep({ selectedDatabaseId: database && database.id });
-    if (database.is_saved_questions) {
-      this.setState({ showSavedQuestions: true });
+    if (database) {
+      await this.nextStep({ selectedDatabaseId: database && database.id });
     }
   };
 
@@ -644,6 +642,21 @@ export class UnconnectedDataSelector extends Component {
       onBack: this.getPreviousStep() ? this.previousStep : null,
     };
 
+    const { activeStep, selectedDatabase } = this.state;
+    if (selectedDatabase && selectedDatabase.is_saved_questions) {
+      if (activeStep === SCHEMA_STEP && combineDatabaseSchemaSteps) {
+        const { query } = this.props;
+        return (
+          <SavedQuestionPicker
+            query={query}
+            onChangeSchema={this.onChangeSchema}
+            onChangeTable={this.onChangeTable}
+            {...props}
+          />
+        );
+      }
+    }
+
     switch (this.state.activeStep) {
       case DATABASE_STEP:
         return combineDatabaseSchemaSteps ? (
@@ -666,20 +679,7 @@ export class UnconnectedDataSelector extends Component {
     return null;
   }
 
-  renderSavedQuestion() {
-    const { query } = this.props;
-    return (
-      <SavedQuestionPicker
-        query={query}
-        onChangeSchema={this.onChangeSchema}
-        onChangeTable={this.onChangeTable}
-        onBack={() => this.setState({ showSavedQuestions: false })}
-      />
-    );
-  }
-
   render() {
-    const { showSavedQuestions } = this.state;
     return (
       <PopoverWithTrigger
         id="DataPopover"
@@ -693,9 +693,7 @@ export class UnconnectedDataSelector extends Component {
         sizeToFit
         isOpen={this.props.isOpen}
       >
-        {showSavedQuestions
-          ? this.renderSavedQuestion()
-          : this.renderActiveStep()}
+        {this.renderActiveStep()}
       </PopoverWithTrigger>
     );
   }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -12,6 +12,7 @@ function DataStep({ color, query, databases, updateQuery }) {
   return (
     <NotebookCell color={color}>
       <DatabaseSchemaAndTableDataSelector
+        query={query}
         databaseQuery={{ saved: true }}
         selectedDatabaseId={query.databaseId()}
         selectedTableId={query.tableId()}

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -2,22 +2,48 @@ import React from "react";
 
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
 
-export default function QuestionDataSelector({ query, triggerElement }) {
-  return (
-    <DatabaseSchemaAndTableDataSelector
-      // Set this to false for now so we use our own trigger and component instead
-      databaseQuery={{ saved: false }}
-      selectedDatabaseId={query.databaseId()}
-      selectedTableId={query.tableId()}
-      setSourceTableFn={tableId =>
-        query
-          .setTableId(tableId)
-          .setDefaultQuery()
-          .update(null, { run: true })
-      }
-      triggerElement={triggerElement}
-      isOpen
-      onSwitchToSavedQuestions={() => alert("clicked saved q")}
-    />
-  );
+import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import Icon from "metabase/components/Icon";
+
+export default class QuestionDataSelector extends React.Component {
+  state = {
+    isShowingSavedQuestions: false,
+  };
+  render() {
+    const { query, triggerElement } = this.props;
+    return this.state.isShowingSavedQuestions ? (
+      <PopoverWithTrigger triggerElement={triggerElement} isOpen>
+        <div style={{ width: 400 }}>
+          <div>
+            <span
+              onClick={() => this.setState({ isShowingSavedQuestions: false })}
+              className="text-brand-hover flex align-center"
+            >
+              <Icon name="chevronleft" />
+              Back
+            </span>
+          </div>
+          Saved questions go here
+        </div>
+      </PopoverWithTrigger>
+    ) : (
+      <DatabaseSchemaAndTableDataSelector
+        // Set this to false for now so we use our own trigger and component instead
+        databaseQuery={{ saved: false }}
+        selectedDatabaseId={query.databaseId()}
+        selectedTableId={query.tableId()}
+        setSourceTableFn={tableId =>
+          query
+            .setTableId(tableId)
+            .setDefaultQuery()
+            .update(null, { run: true })
+        }
+        triggerElement={triggerElement}
+        isOpen
+        onSwitchToSavedQuestions={() =>
+          this.setState({ isShowingSavedQuestions: true })
+        }
+      />
+    );
+  }
 }

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -5,7 +5,8 @@ import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/compo
 export default function QuestionDataSelector({ query, triggerElement }) {
   return (
     <DatabaseSchemaAndTableDataSelector
-      databaseQuery={{ saved: true }}
+      // Set this to false for now so we use our own trigger and component instead
+      databaseQuery={{ saved: false }}
       selectedDatabaseId={query.databaseId()}
       selectedTableId={query.tableId()}
       setSourceTableFn={tableId =>
@@ -16,6 +17,7 @@ export default function QuestionDataSelector({ query, triggerElement }) {
       }
       triggerElement={triggerElement}
       isOpen
+      onSwitchToSavedQuestions={() => alert("clicked saved q")}
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -3,7 +3,8 @@ import React from "react";
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
-import Icon from "metabase/components/Icon";
+
+import SavedQuestionPicker from "metabase/query_builder/containers/SavedQuestionPicker";
 
 export default class QuestionDataSelector extends React.Component {
   state = {
@@ -13,18 +14,10 @@ export default class QuestionDataSelector extends React.Component {
     const { query, triggerElement } = this.props;
     return this.state.isShowingSavedQuestions ? (
       <PopoverWithTrigger triggerElement={triggerElement} isOpen>
-        <div style={{ width: 400 }}>
-          <div>
-            <span
-              onClick={() => this.setState({ isShowingSavedQuestions: false })}
-              className="text-brand-hover flex align-center"
-            >
-              <Icon name="chevronleft" />
-              Back
-            </span>
-          </div>
-          Saved questions go here
-        </div>
+        <SavedQuestionPicker
+          onBack={() => this.setState({ isShowingSavedQuestions: false })}
+          query={query}
+        />
       </PopoverWithTrigger>
     ) : (
       <DatabaseSchemaAndTableDataSelector

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -2,41 +2,21 @@ import React from "react";
 
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
 
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
-
-import SavedQuestionPicker from "metabase/query_builder/containers/SavedQuestionPicker";
-
-export default class QuestionDataSelector extends React.Component {
-  state = {
-    isShowingSavedQuestions: false,
-  };
-  render() {
-    const { query, triggerElement } = this.props;
-    return this.state.isShowingSavedQuestions ? (
-      <PopoverWithTrigger triggerElement={triggerElement} isOpen>
-        <SavedQuestionPicker
-          onBack={() => this.setState({ isShowingSavedQuestions: false })}
-          query={query}
-        />
-      </PopoverWithTrigger>
-    ) : (
-      <DatabaseSchemaAndTableDataSelector
-        // Set this to false for now so we use our own trigger and component instead
-        databaseQuery={{ saved: false }}
-        selectedDatabaseId={query.databaseId()}
-        selectedTableId={query.tableId()}
-        setSourceTableFn={tableId =>
-          query
-            .setTableId(tableId)
-            .setDefaultQuery()
-            .update(null, { run: true })
-        }
-        triggerElement={triggerElement}
-        isOpen
-        onSwitchToSavedQuestions={() =>
-          this.setState({ isShowingSavedQuestions: true })
-        }
-      />
-    );
-  }
+export default function QuestionDataSelector({ query, triggerElement }) {
+  return (
+    <DatabaseSchemaAndTableDataSelector
+      query={query}
+      databaseQuery={{ saved: true }}
+      selectedDatabaseId={query.databaseId()}
+      selectedTableId={query.tableId()}
+      setSourceTableFn={tableId =>
+        query
+          .setTableId(tableId)
+          .setDefaultQuery()
+          .update(null, { run: true })
+      }
+      triggerElement={triggerElement}
+      isOpen
+    />
+  );
 }

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -33,7 +33,7 @@ class SavedQuestionTableList extends React.Component {
               }}
             >
               <Icon name="table2" />
-              {t.display_name})
+              {t.display_name}
             </li>
           ))}
         </ol>

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -11,8 +11,12 @@ import CollectionsList from "metabase/collections/components/CollectionsList";
 import { generateSchemaId } from "metabase/schema";
 import { MetabaseApi } from "metabase/services";
 
+import VirtualizedList from "metabase/components/VirtualizedList";
+
 // TODO - chastise Cam for this :P
 const SAVED_QUESTION_DB_ID = -1337;
+
+const ROW_HEIGHT = 36; // FIXME
 
 @Schemas.load({
   id: (state, props) =>
@@ -23,14 +27,18 @@ class SavedQuestionTableList extends React.Component {
     const { tables = [] } = this.props.schema;
     if (tables.length > 0) {
       return (
-        <ol className="List text-brand px1 pt2 full">
-          {tables.map(t => (
-            <li
+        <VirtualizedList
+          className="List text-brand px1 pt2 full"
+          items={tables}
+          rowHeight={ROW_HEIGHT}
+          useAutoSizerHeight={false}
+          renderItem={({ item, index }) => (
+            <div
               className="List-section"
-              key={t.id}
+              key={item.id}
               onClick={() => {
                 this.props.query
-                  .setTableId(t.id)
+                  .setTableId(item.id)
                   .setDefaultQuery()
                   .update(null, { run: true });
               }}
@@ -38,12 +46,12 @@ class SavedQuestionTableList extends React.Component {
               <div className="List-item flex mx1">
                 <a className="p1 flex-auto flex align-center cursor-pointer">
                   <Icon name="table2" className="mr1" />
-                  <h4 className="List-item-title">{t.display_name}</h4>
+                  <h4 className="List-item-title">{item.display_name}</h4>
                 </a>
               </div>
-            </li>
-          ))}
-        </ol>
+            </div>
+          )}
+        />
       );
     }
   }
@@ -109,7 +117,7 @@ class SavedQuestionPicker extends React.Component {
       };
       return (
         <div style={{ width: 480 }} className="flex">
-          <div className="bg-light border-right" style={{ width: 360 }}>
+          <div className="bg-light border-right" style={{ width: 240 }}>
             <div>
               <div
                 onClick={() => onBack()}
@@ -176,6 +184,7 @@ class SavedQuestionPicker extends React.Component {
             </div>
           </div>
           <SavedQuestionTableList
+            width={240}
             schemaName={this.state.currentSchema}
             query={this.props.query}
           />

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -4,15 +4,8 @@ import { Flex } from "grid-styled";
 
 import Collection from "metabase/entities/collections";
 import CollectionsList from "metabase/collections/components/CollectionsList";
-import CollectionLink from "metabase/collections/components/CollectionLink";
 
 import { MetabaseApi } from "metabase/services";
-
-import {
-  nonPersonalCollection,
-  currentUserPersonalCollections,
-  getParentPath,
-} from "metabase/collections/utils";
 
 // TODO - chastise Cam for this :P
 const SAVED_QUESTION_DB_ID = -1337;
@@ -93,9 +86,12 @@ class SavedQuestionPicker extends React.Component {
     });
   };
   async componentDidMount() {
+    // TODO - remove once we're done testing
+
+    window.query = this.props.query;
     // IMPORTANT
     // set the database to be the saved question database when we mount
-    this.props.query.setDatabase({ id: SAVED_QUESTION_DB_ID });
+    this.props.query.setDatabaseId(SAVED_QUESTION_DB_ID);
     // TODO api response is unfortunate so we'll absolutely need to make this
     // respond better
     const collectionSchemas = await MetabaseApi.db_schemas({
@@ -104,9 +100,9 @@ class SavedQuestionPicker extends React.Component {
 
     this.setState({
       isLoading: false,
-      // set the current schema to the first one, eventually this should be more
+      // set the current schema to the our analytics one, eventually this should be more
       // intelligent based on where you've been working a lot
-      currentSchema: collectionSchemas[0],
+      currentSchema: "Everything else",
       collectionSchemas: collectionSchemas.map(c => {
         // account for the fact that the backend still calls that "Everything else"
         // TODO - this should be removed when the endpoint is updated

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -109,10 +109,11 @@ class SavedQuestionPicker extends React.Component {
 
     // if we're not loading
     if (this.state.collectionSchemas.length > 0) {
+      // create a filter for the collection list that checks to see if any of the collections map to a schema with the same name
+      // THIS SHOULD BE UNNECESSARY AFTER WE CLEAN UP THE ENDPOINT
       const filter = collection => {
         return this.state.collectionSchemas.indexOf(collection.name) >= 0;
       };
-      console.log(this.state.collectionSchemas);
       return (
         <div style={{ width: 400 }} className="flex">
           <div className="border-right">

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Icon from "metabase/components/Icon";
 import { Flex } from "grid-styled";
+import { t } from "ttag";
 
 import Collection from "metabase/entities/collections";
 import Schemas from "metabase/entities/schemas";
@@ -21,9 +22,10 @@ class SavedQuestionTableList extends React.Component {
     const { tables = [] } = this.props.schema;
     if (tables.length > 0) {
       return (
-        <ol className="px3">
+        <ol className="px3 pt2">
           {tables.map(t => (
             <li
+              className="text-brand-hover flex align-top mb1"
               key={t.id}
               onClick={() => {
                 this.props.query
@@ -32,8 +34,8 @@ class SavedQuestionTableList extends React.Component {
                   .update(null, { run: true });
               }}
             >
-              <Icon name="table2" />
-              {t.display_name}
+              <Icon name="table2" className="mr1" />
+              <h3>{t.display_name}</h3>
             </li>
           ))}
         </ol>
@@ -105,15 +107,15 @@ class SavedQuestionPicker extends React.Component {
       };
       return (
         <div style={{ width: 480 }} className="flex">
-          <div className="border-right" style={{ width: 240 }}>
+          <div className="bg-light border-right" style={{ width: 240 }}>
             <div>
-              <span
+              <div
                 onClick={() => onBack()}
-                className="text-brand-hover flex align-center"
+                className="text-brand-hover flex align-center p1 border-bottom"
               >
-                <Icon name="chevronleft" />
-                Back
-              </span>
+                <Icon name="chevronleft" className="mr1" />
+                <h3>{t`Saved questions`}</h3>
+              </div>
             </div>
             <span
               onClick={() =>
@@ -137,6 +139,7 @@ class SavedQuestionPicker extends React.Component {
                 return (
                   <div>
                     <Flex
+                      mx={3}
                       className="relative"
                       align={
                         // if a colleciton name is somewhat long, align things at flex-start ("top") for a slightly better

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -3,6 +3,9 @@ import Icon from "metabase/components/Icon";
 
 import Collection from "metabase/entities/collections";
 import CollectionsList from "metabase/collections/components/CollectionsList";
+import CollectionLink from "metabase/collections/components/CollectionLink";
+
+import { MetabaseApi } from "metabase/services";
 
 import {
   nonPersonalCollection,
@@ -10,26 +13,134 @@ import {
   getParentPath,
 } from "metabase/collections/utils";
 
-function SavedQuestionPicker({ onBack, query, collections }) {
-  console.log(collections);
-  return (
-    <div style={{ width: 400 }}>
-      <div>
-        <span
-          onClick={() => onBack()}
-          className="text-brand-hover flex align-center"
-        >
-          <Icon name="chevronleft" />
-          Back
-        </span>
-      </div>
-      <CollectionsList
-        openCollections={[]}
-        collections={collections}
-        filter={nonPersonalCollection}
-      />
-    </div>
-  );
+// TODO - chastise Cam for this :P
+const SAVED_QUESTION_DB_ID = -1337;
+
+class SavedQuestionTableList extends React.Component {
+  state = {
+    tables: [],
+    loading: true,
+  };
+  async componentDidMount() {
+    await this.fetchTables();
+  }
+
+  async fetchTables() {
+    this.setState({
+      loading: true,
+    });
+    const schemaTables = await MetabaseApi.db_schema_tables({
+      dbId: SAVED_QUESTION_DB_ID,
+      schemaName: this.props.schemaName,
+    });
+    console.log(schemaTables);
+    this.setState({
+      loading: false,
+      tables: schemaTables,
+    });
+  }
+  render() {
+    const { loading, tables } = this.state;
+    if (loading) {
+      return <div>Loading...</div>;
+    }
+    if (tables.length > 0) {
+      return (
+        <ol className="px3">
+          {tables.map(t => (
+            <li key={t.id}>
+              <Icon name="table2" />
+              {t.display_name})
+            </li>
+          ))}
+        </ol>
+      );
+    }
+  }
+}
+
+// TODO - using a class here so we can use lifecycle methods to do some other API fetching,
+class SavedQuestionPicker extends React.Component {
+  state = {
+    isLoading: true,
+    collectionSchemas: [],
+    currentSchema: null,
+    openCollections: [],
+  };
+  onOpen = id => {
+    this.setState({ openCollections: this.state.openCollections.concat(id) });
+  };
+  onClose = id => {
+    this.setState({
+      openCollections: this.state.openCollections.filter(c => {
+        return c !== id;
+      }),
+    });
+  };
+  async componentDidMount() {
+    // TODO api response is unfortunate so we'll absolutely need to make this
+    // respond better
+    const collectionSchemas = await MetabaseApi.db_schemas({
+      dbId: SAVED_QUESTION_DB_ID,
+    });
+
+    this.setState({
+      isLoading: false,
+      // set the current schema to the first one, eventually this should be more
+      // intelligent based on where you've been working a lot
+      currentSchema: collectionSchemas[0],
+      collectionSchemas: collectionSchemas.map(c => {
+        // account for the fact that the backend still calls that "Everything else"
+        // TODO - this should be removed when the endpoint is updated
+        if (c === "Everything else") {
+          return "Our analytics";
+        }
+        return c;
+      }),
+    });
+  }
+
+  render() {
+    const { onBack, query, collections } = this.props;
+    // we assume we're loading so show something
+    if (this.state.isLoading) {
+      return <div>"Loading..."</div>;
+    }
+
+    // if we're not loading
+    if (this.state.collectionSchemas.length > 0) {
+      const filter = collection => {
+        return this.state.collectionSchemas.indexOf(collection.name) >= 0;
+      };
+      console.log(this.state.collectionSchemas);
+      return (
+        <div style={{ width: 400 }} className="flex">
+          <div className="border-right">
+            <div>
+              <span
+                onClick={() => onBack()}
+                className="text-brand-hover flex align-center"
+              >
+                <Icon name="chevronleft" />
+                Back
+              </span>
+            </div>
+            <CollectionsList
+              openCollections={this.state.openCollections}
+              collections={collections}
+              filter={filter}
+              onClose={this.onClose}
+              onOpen={this.onOpen}
+            />
+          </div>
+          <SavedQuestionTableList schemaName={this.state.currentSchema} />
+        </div>
+      );
+    }
+
+    // We shouldn't get here?
+    return <div>Welllp</div>;
+  }
 }
 
 export default Collection.loadList({

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -68,9 +68,6 @@ class SavedQuestionPicker extends React.Component {
     });
   };
   async componentDidMount() {
-    // TODO - remove once we're done testing
-
-    window.query = this.props.query;
     // IMPORTANT
     // set the database to be the saved question database when we mount
     this.props.query.setDatabaseId(SAVED_QUESTION_DB_ID);
@@ -97,7 +94,7 @@ class SavedQuestionPicker extends React.Component {
   }
 
   render() {
-    const { onBack, query, collections } = this.props;
+    const { onBack, collections } = this.props;
     // we assume we're loading so show something
     if (this.state.isLoading) {
       return <div>"Loading..."</div>;

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -22,10 +22,10 @@ class SavedQuestionTableList extends React.Component {
     const { tables = [] } = this.props.schema;
     if (tables.length > 0) {
       return (
-        <ol className="px3 pt2">
+        <ol className="List text-brand px1 pt2 full">
           {tables.map(t => (
             <li
-              className="text-brand-hover flex align-top mb1"
+              className="List-section"
               key={t.id}
               onClick={() => {
                 this.props.query
@@ -34,8 +34,12 @@ class SavedQuestionTableList extends React.Component {
                   .update(null, { run: true });
               }}
             >
-              <Icon name="table2" className="mr1" />
-              <h3>{t.display_name}</h3>
+              <div className="List-item flex mx1">
+                <a className="p1 flex-auto flex align-center cursor-pointer">
+                  <Icon name="table2" className="mr1" />
+                  <h4 className="List-item-title">{t.display_name}</h4>
+                </a>
+              </div>
             </li>
           ))}
         </ol>
@@ -107,7 +111,7 @@ class SavedQuestionPicker extends React.Component {
       };
       return (
         <div style={{ width: 480 }} className="flex">
-          <div className="bg-light border-right" style={{ width: 240 }}>
+          <div className="bg-light border-right" style={{ width: 360 }}>
             <div>
               <div
                 onClick={() => onBack()}

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Icon from "metabase/components/Icon";
+
+export default function SavedQuestionPicker({ onBack, query }) {
+  return (
+    <div style={{ width: 400 }}>
+      <div>
+        <span
+          onClick={() => onBack()}
+          className="text-brand-hover flex align-center"
+        >
+          <Icon name="chevronleft" />
+          Back
+        </span>
+      </div>
+      Saved questions go here
+    </div>
+  );
+}

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -3,47 +3,22 @@ import Icon from "metabase/components/Icon";
 import { Flex } from "grid-styled";
 
 import Collection from "metabase/entities/collections";
+import Schemas from "metabase/entities/schemas";
 import CollectionsList from "metabase/collections/components/CollectionsList";
 
+import { generateSchemaId } from "metabase/schema";
 import { MetabaseApi } from "metabase/services";
 
 // TODO - chastise Cam for this :P
 const SAVED_QUESTION_DB_ID = -1337;
 
+@Schemas.load({
+  id: (state, props) =>
+    generateSchemaId(SAVED_QUESTION_DB_ID, props.schemaName),
+})
 class SavedQuestionTableList extends React.Component {
-  state = {
-    tables: [],
-    loading: true,
-  };
-  async componentDidMount() {
-    await this.fetchTables();
-  }
-
-  async componentDidUpdate(prevProps) {
-    if (prevProps.schemaName !== this.props.schemaName) {
-      await this.fetchTables();
-    }
-  }
-
-  async fetchTables() {
-    this.setState({
-      loading: true,
-    });
-    const schemaTables = await MetabaseApi.db_schema_tables({
-      dbId: SAVED_QUESTION_DB_ID,
-      schemaName: this.props.schemaName,
-    });
-    console.log(schemaTables);
-    this.setState({
-      loading: false,
-      tables: schemaTables,
-    });
-  }
   render() {
-    const { loading, tables } = this.state;
-    if (loading) {
-      return <div>Loading...</div>;
-    }
+    const { tables = [] } = this.props.schema;
     if (tables.length > 0) {
       return (
         <ol className="px3">

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -1,7 +1,17 @@
 import React from "react";
 import Icon from "metabase/components/Icon";
 
-export default function SavedQuestionPicker({ onBack, query }) {
+import Collection from "metabase/entities/collections";
+import CollectionsList from "metabase/collections/components/CollectionsList";
+
+import {
+  nonPersonalCollection,
+  currentUserPersonalCollections,
+  getParentPath,
+} from "metabase/collections/utils";
+
+function SavedQuestionPicker({ onBack, query, collections }) {
+  console.log(collections);
   return (
     <div style={{ width: 400 }}>
       <div>
@@ -13,7 +23,15 @@ export default function SavedQuestionPicker({ onBack, query }) {
           Back
         </span>
       </div>
-      Saved questions go here
+      <CollectionsList
+        openCollections={[]}
+        collections={collections}
+        filter={nonPersonalCollection}
+      />
     </div>
   );
 }
+
+export default Collection.loadList({
+  query: () => ({ tree: true }),
+})(SavedQuestionPicker);

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -11,12 +11,8 @@ import CollectionsList from "metabase/collections/components/CollectionsList";
 import { generateSchemaId } from "metabase/schema";
 import { MetabaseApi } from "metabase/services";
 
-import VirtualizedList from "metabase/components/VirtualizedList";
-
 // TODO - chastise Cam for this :P
 const SAVED_QUESTION_DB_ID = -1337;
-
-const ROW_HEIGHT = 36; // FIXME
 
 @Schemas.load({
   id: (state, props) =>
@@ -27,18 +23,14 @@ class SavedQuestionTableList extends React.Component {
     const { tables = [] } = this.props.schema;
     if (tables.length > 0) {
       return (
-        <VirtualizedList
-          className="List text-brand px1 pt2 full"
-          items={tables}
-          rowHeight={ROW_HEIGHT}
-          useAutoSizerHeight={false}
-          renderItem={({ item, index }) => (
-            <div
+        <ol className="List text-brand px1 pt2 full">
+          {tables.map(t => (
+            <li
               className="List-section"
-              key={item.id}
+              key={t.id}
               onClick={() => {
                 this.props.query
-                  .setTableId(item.id)
+                  .setTableId(t.id)
                   .setDefaultQuery()
                   .update(null, { run: true });
               }}
@@ -46,12 +38,12 @@ class SavedQuestionTableList extends React.Component {
               <div className="List-item flex mx1">
                 <a className="p1 flex-auto flex align-center cursor-pointer">
                   <Icon name="table2" className="mr1" />
-                  <h4 className="List-item-title">{item.display_name}</h4>
+                  <h4 className="List-item-title">{t.display_name}</h4>
                 </a>
               </div>
-            </div>
-          )}
-        />
+            </li>
+          ))}
+        </ol>
       );
     }
   }
@@ -117,7 +109,7 @@ class SavedQuestionPicker extends React.Component {
       };
       return (
         <div style={{ width: 480 }} className="flex">
-          <div className="bg-light border-right" style={{ width: 240 }}>
+          <div className="bg-light border-right" style={{ width: 360 }}>
             <div>
               <div
                 onClick={() => onBack()}
@@ -184,7 +176,6 @@ class SavedQuestionPicker extends React.Component {
             </div>
           </div>
           <SavedQuestionTableList
-            width={240}
             schemaName={this.state.currentSchema}
             query={this.props.query}
           />

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -24,10 +24,6 @@ const SAVED_QUESTION_DB_ID = -1337;
     generateSchemaId(SAVED_QUESTION_DB_ID, props.schemaName),
 })
 class SavedQuestionTableList extends React.Component {
-  async componentDidMount() {
-    const { schema, onChangeSchema } = this.props;
-    onChangeSchema(schema); // FIXME: is this the right moment?
-  }
   render() {
     const { schema, onChangeTable } = this.props;
     const { tables = [] } = schema;
@@ -75,9 +71,6 @@ class SavedQuestionPicker extends React.Component {
     });
   };
   async componentDidMount() {
-    // IMPORTANT
-    // set the database to be the saved question database when we mount
-    this.props.query.setDatabaseId(SAVED_QUESTION_DB_ID);
     // TODO api response is unfortunate so we'll absolutely need to make this
     // respond better
     const collectionSchemas = await MetabaseApi.db_schemas({

--- a/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/containers/SavedQuestionPicker.jsx
@@ -19,8 +19,13 @@ const SAVED_QUESTION_DB_ID = -1337;
     generateSchemaId(SAVED_QUESTION_DB_ID, props.schemaName),
 })
 class SavedQuestionTableList extends React.Component {
+  async componentDidMount() {
+    const { schema, onChangeSchema } = this.props;
+    onChangeSchema(schema); // FIXME: is this the right moment?
+  }
   render() {
-    const { tables = [] } = this.props.schema;
+    const { schema, onChangeTable } = this.props;
+    const { tables = [] } = schema;
     if (tables.length > 0) {
       return (
         <ol className="List text-brand px1 pt2 full">
@@ -29,10 +34,7 @@ class SavedQuestionTableList extends React.Component {
               className="List-section"
               key={t.id}
               onClick={() => {
-                this.props.query
-                  .setTableId(t.id)
-                  .setDefaultQuery()
-                  .update(null, { run: true });
+                onChangeTable(t);
               }}
             >
               <div className="List-item flex mx1">
@@ -178,6 +180,8 @@ class SavedQuestionPicker extends React.Component {
           <SavedQuestionTableList
             schemaName={this.state.currentSchema}
             query={this.props.query}
+            onChangeSchema={this.props.onChangeSchema}
+            onChangeTable={this.props.onChangeTable}
           />
         </div>
       );


### PR DESCRIPTION
Status - Need help from @daltojohnso to help sort out blockers 

## What this does
Updates the picker you use to select a saved question as a starting point for further exploration to properly account for nested collections and provides more space overall to work.

![image](https://user-images.githubusercontent.com/5248953/108872229-f38d5680-75c7-11eb-8419-9d20e407a73e.png)


How to test

1. Go to "Ask a question" and select "Saved questions"  (see bug below if you only have one database locally)
2. You should see any collections containing saved questions that can be used to start a new question on the left.
3. Clicking on any one of those should show saved questions that are valid starting points for new questions 
4. It should work with large numbers of collections and saved questions

--- 
Project planning scratch (still organizing things here)

Remaining work that has to be done before merge
- [ ] The picker only works for simple mode right now. Not sure how best to also make sure it'll show up in the notebook.
- [ ] Both the collection list and the saved question list probably need to be wrapped in a virtualized list wrapper.
- [ ] Need to test independent scrolling of both the sidebar and list with many items
- [ ] Not sure if we're handling the "no saved questions" case here yet.
- [ ] Handle situation where a parent collection might not have a valid saved q but a child does.
- [ ] There's a "Loading..." state for the entire popover that is quite gross if you hit it (intermittent). We'll need to restructure the markup a bit to have the overall layout stay relatively similar to the final product to prevent flashing.
- [ ] Collection item expand arrows aren't spaced properly

Related issues:
- https://github.com/metabase/metabase/issues/11806 - second bullet point
