### PR TITLE
Use ReactDOMServer to render html in a contenteditable div

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
+import ReactDOMServer from "react-dom/server";
 
 import TokenizedExpression from "./TokenizedExpression";
 
@@ -145,17 +146,12 @@ export default class TokenizedInput extends Component {
     const inputNode = ReactDOM.findDOMNode(this);
     const restore = saveSelection(inputNode);
 
-    ReactDOM.unmountComponentAtNode(inputNode);
-    while (inputNode.firstChild) {
-      inputNode.removeChild(inputNode.firstChild);
-    }
-    ReactDOM.render(
+    inputNode.innerHTML = ReactDOMServer.renderToStaticMarkup(
       <TokenizedExpression
         source={this._getValue()}
         syntaxTree={this.props.syntaxTree}
         parserOptions={this.props.parserOptions}
       />,
-      inputNode,
     );
 
     if (document.activeElement === inputNode) {


### PR DESCRIPTION
**Description**
We can no longer rely on a synchronous `ReactDOM.render` call. Using the third arg callback of `ReactDOM.render` won't work because this is an input field and we are triggering component updates very frequently here. I'm using `ReactDOMServer` in order to avoid manually rewriting the `TokenizedExpression` component as html and to avoid associated XSS vulnerabilities, etc.

Importing `react-dom/server` increases the size of the (dev) bundle by 126kb, which is not ideal, but going a different route would still most likely require importing an XSS-sanitizing library (unless I missed seeing one we already rely on), which would likely increase the bundle size by a similar amount (dompurify is 552kb unpacked, js-xss is 141kb unpacked, according to npm).

We can't use `ReactDOMServer.renderToStaticMarkup` on interactive DOM elements, but fortunately we aren't using any here. We'd need to add the event listeners ourselves, which doesn't seem like it'd cause a problem. I'm guessing `ReactDOM.renderToString` + `ReactDOM.hydrate` is asynchronous so that is probably not a possbility.

**Verification**
gif of me typing and clicking random things -- does this seem right?
![tok_input](https://user-images.githubusercontent.com/13057258/108407963-52725a80-71d9-11eb-85cd-80b07b1332ea.gif)

And a working custom filter:
![Screen Shot 2021-02-18 at 11 32 12 AM](https://user-images.githubusercontent.com/13057258/108411020-fc071b00-71dc-11eb-91c0-cfcd5d578f97.png)
