### PR TITLE
fix(load) aggregated questions can be dumped/loaded

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -14,6 +14,7 @@
             [metabase.models.segment :refer [Segment]]
             [metabase.models.table :refer [Table]]
             [metabase.models.user :refer [User]]
+            [metabase.plugins :as plugins]
             [metabase.util :as u]
             [metabase.util.i18n :refer [deferred-trs trs]]
             [metabase.util.schema :as su]
@@ -37,6 +38,7 @@
 (s/defn load
   "Load serialized metabase instance as created by `dump` command from directory `path`."
   [path context :- Context]
+  (plugins/load-plugins!)               ;
   (mdb/setup-db!)
   (when-not (load/compatible? path)
     (log/warn (trs "Dump was produced using a different version of Metabase. Things may break!")))

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -57,7 +57,7 @@
   [model collections]
   (db/select model {:where [:or [:= :collection_id nil]
                                 (if (not-empty collections)
-                                  [:in :collection_id (map u/get-id collections)]
+                                  [:in :collection_id (map u/the-id collections)]
                                   false)]}))
 
 (defn dump
@@ -73,7 +73,7 @@
                       [])
         collections (db/select Collection
                       {:where [:or [:= :personal_owner_id nil]
-                                   [:= :personal_owner_id (some-> users first u/get-id)]]})]
+                                   [:= :personal_owner_id (some-> users first u/the-id)]]})]
     (dump/dump path
                (Database)
                (Table)

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -54,37 +54,71 @@
         (log/error (trs "Error loading dump: {0}" (.getMessage e)))))))
 
 (defn- select-entities-in-collections
-  [model collections]
-  (db/select model {:where [:or [:= :collection_id nil]
+  ([model collections]
+   (select-entities-in-collections model collections :all))
+  ([model collections state]
+   (let [state-filter (case state
+                        :all nil
+                        :active [:= :archived false])]
+     (db/select model {:where [:and
+                               [:or [:= :collection_id nil]
                                 (if (not-empty collections)
                                   [:in :collection_id (map u/the-id collections)]
-                                  false)]}))
+                                  false)]
+                               state-filter]}))))
+
+(defn- select-segments-in-tables
+  ([tables]
+   (select-segments-in-tables tables :all))
+  ([tables state]
+   (case state
+     :all
+     (mapcat #(db/select Segment :table_id (u/the-id %)) tables)
+     :active
+     (filter
+      #(not (:archived %))
+      (mapcat #(db/select Segment :table_id (u/the-id %)) tables)))))
+
+(defn- select-collections
+  ([users]
+   (select-collections users :active))
+  ([users state]
+   (let [state-filter (case state
+                        :all nil
+                        :active [:= :archived false])]
+     (db/select Collection
+                       {:where [:and
+                                [:or
+                                 [:= :personal_owner_id nil]
+                                 [:= :personal_owner_id (some-> users first u/the-id)]]
+                                state-filter]}))))
 
 (defn dump
   "Serialized metabase instance into directory `path`."
-  [path user]
-  (mdb/setup-db!)
-  (let [users       (if user
-                      (let [user (db/select-one User
-                                   :email        user
-                                   :is_superuser true)]
-                        (assert user (trs "{0} is not a valid user" user))
-                        [user])
-                      [])
-        collections (db/select Collection
-                      {:where [:or [:= :personal_owner_id nil]
-                                   [:= :personal_owner_id (some-> users first u/the-id)]]})]
-    (dump/dump path
-               (Database)
-               (Table)
-               (field/with-values (Field))
-               (Metric)
-               (Segment)
-               collections
-               (select-entities-in-collections Card collections)
-               (select-entities-in-collections Dashboard collections)
-               (select-entities-in-collections Pulse collections)
-               users))
-  (dump/dump-settings path)
-  (dump/dump-dependencies path)
-  (dump/dump-dimensions path))
+  ([path user]
+   (dump path user :active))
+  ([path user state]
+   (mdb/setup-db!)
+   (let [users       (if user
+                       (let [user (db/select-one User
+                                    :email        user
+                                    :is_superuser true)]
+                         (assert user (trs "{0} is not a valid user" user))
+                         [user])
+                       [])
+         tables (Table)
+         collections (Collection)] ;(select-collections users state)]
+     (dump/dump path
+                (Database)
+                tables
+                (field/with-values (Field))
+                (Metric)
+                (select-segments-in-tables tables state)
+                collections
+                (select-entities-in-collections Card collections state)
+                (select-entities-in-collections Dashboard collections state)
+                (select-entities-in-collections Pulse collections state)
+                users))
+   (dump/dump-settings path)
+   (dump/dump-dependencies path)
+   (dump/dump-dimensions path)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -6,7 +6,7 @@
             [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase-enterprise.serialization.names :refer [fully-qualified-name->context]]
-            [metabase-enterprise.serialization.upsert :refer [maybe-upsert-many! maybe-fixup-card-template-ids!]]
+            [metabase-enterprise.serialization.upsert :refer [maybe-fixup-card-template-ids! maybe-upsert-many!]]
             [metabase.config :as config]
             [metabase.mbql.normalize :as mbql.normalize]
             [metabase.mbql.util :as mbql.util]
@@ -246,11 +246,12 @@
     (:source-query query) (update-in query [:source-query] fully-qualified-name->id-rec)
     true query))
 
-
 (defn- source-card
   [fully-qualified-name]
-  (let [{:keys [card]} (fully-qualified-name->context fully-qualified-name)]
-    card))
+  (try
+    (-> (fully-qualified-name->context fully-qualified-name) :card)
+    (catch Throwable e
+      (log/warn e))))
 
 (defn- resolve-native
   [template-tags]

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -326,9 +326,9 @@
           (cond
             (and model dependent-on)
             {:model              (name model)
-             :model_id           (u/get-id model)
+             :model_id           (u/the-id model)
              :dependent_on_model (name dependent-on)
-             :dependent_on_id    (u/get-id dependent-on)
+             :dependent_on_id    (u/the-id dependent-on)
              :created_at         (java.util.Date.)}
 
             (nil? model)

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -257,7 +257,13 @@
                     :dataset_query
                     :type
                     qp.util/normalize-token
-                    (= :query)) (update-in [:dataset_query :query :source-table] source-table)))))
+                    (= :query)) (update-in [:dataset_query :query :source-table] source-table)
+                (-> card
+                    :dataset_query
+                    :query
+                    :source-query
+                    :source-table)
+                (update-in [:dataset_query :query :source-query :source-table] source-table)))))
     ;; Nested cards
     (doseq [path paths]
       (load (str path "/cards") context))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -132,7 +132,9 @@
 
 (def ^:private ^{:arglists '([context model entity-name])} path->context
   "Extract entities from a logical path."
-  (memoize path->context*))
+  ;(memoize path->context*)
+   path->context*
+  )
 
 (defmethod path->context* "databases"
   [context _ db-name]

--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -224,11 +224,11 @@
       (try
         (s/validate (s/maybe Context) context)
         (catch Exception e
-          (ex-info (trs "Can''t resolve {0} in fully qualified name {1}"
-                        (str/join ", " (map name (keys (:value (ex-data e)))))
-                        fully-qualified-name)
-            {:fully-qualified-name fully-qualified-name
-             :context              context}))))))
+          (throw (ex-info (trs "Can''t resolve {0} in fully qualified name {1}"
+                         (str/join ", " (map name (keys (:value (ex-data e)))))
+                         fully-qualified-name)
+                    {:fully-qualified-name fully-qualified-name
+                     :context              context})))))))
 
 (defn name-for-logging
   "Return a string representation of entity suitable for logs"

--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.serialization.names
   "Consistent instance-independent naming scheme that replaces IDs with human-readable paths."
   (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :refer [Collection]]
@@ -226,7 +227,8 @@
       (try
         (s/validate (s/maybe Context) context)
         (catch Exception e
-          (throw (ex-info (trs "Can''t resolve {0} in fully qualified name {1}"
+          (log/warn
+           (ex-info (trs "Can''t resolve {0} in fully qualified name {1}"
                          (str/join ", " (map name (keys (:value (ex-data e)))))
                          fully-qualified-name)
                     {:fully-qualified-name fully-qualified-name

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -114,14 +114,14 @@
 
 (defn- dashboard-cards-for-dashboard
   [dashboard]
-  (let [dashboard-cards (db/select DashboardCard :dashboard_id (u/get-id dashboard))
+  (let [dashboard-cards (db/select DashboardCard :dashboard_id (u/the-id dashboard))
         series          (when (not-empty dashboard-cards)
                           (db/select DashboardCardSeries
-                            :dashboardcard_id [:in (map u/get-id dashboard-cards)]))]
+                            :dashboardcard_id [:in (map u/the-id dashboard-cards)]))]
     (for [dashboard-card dashboard-cards]
       (-> dashboard-card
           (assoc :series (for [series series
-                               :when (= (:dashboardcard_id series) (u/get-id dashboard-card))]
+                               :when (= (:dashboardcard_id series) (u/the-id dashboard-card))]
                            (-> series
                                (update :card_id (partial fully-qualified-name Card))
                                (dissoc :id :dashboardcard_id))))
@@ -140,11 +140,11 @@
 (defmethod serialize-one (type Pulse)
   [pulse]
   (assoc pulse
-    :cards    (for [card (db/select PulseCard :pulse_id (u/get-id pulse))]
+    :cards    (for [card (db/select PulseCard :pulse_id (u/the-id pulse))]
                 (-> card
                     (dissoc :id :pulse_id)
                     (update :card_id (partial fully-qualified-name Card))))
-    :channels (for [channel (db/select PulseChannel :pulse_id (u/get-id pulse))]
+    :channels (for [channel (db/select PulseChannel :pulse_id (u/the-id pulse))]
                 (strip-crud channel))))
 
 (defmethod serialize-one (type User)

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -66,7 +66,8 @@
                                             (if (= db-id mbql.s/saved-questions-virtual-database-id)
                                               "database/__virtual"
                                               (fully-qualified-name Database db-id))))
-      (m/update-existing entity :card-id (partial fully-qualified-name Card))
+      (m/update-existing entity :card_id (partial fully-qualified-name Card)) ; attibutes that refer to db fields use _
+      (m/update-existing entity :card-id (partial fully-qualified-name Card)) ; template-tags use dash
       (m/update-existing entity :source-table (fn [source-table]
                                                 (if (and (string? source-table)
                                                          (str/starts-with? source-table "card__"))

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -66,7 +66,7 @@
                                             (if (= db-id mbql.s/saved-questions-virtual-database-id)
                                               "database/__virtual"
                                               (fully-qualified-name Database db-id))))
-      (m/update-existing entity :card_id (partial fully-qualified-name Card))
+      (m/update-existing entity :card-id (partial fully-qualified-name Card))
       (m/update-existing entity :source-table (fn [source-table]
                                                 (if (and (string? source-table)
                                                          (str/starts-with? source-table "card__"))

--- a/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
@@ -81,7 +81,7 @@
                         (with-error-handling
                           (trs "Error inserting {0}" (name-for-logging model entity))
                           (db/insert! model entity)))]
-      (u/get-id entity))))
+      (u/the-id entity))))
 
 (defn- maybe-insert-many!
   [model on-error entities]
@@ -124,11 +124,11 @@
       (log/info (trs "Updating {0}" (name-for-logging (name model) existing))))
 
     (->> (concat (for [[position _ existing] skip]
-                   [(u/get-id existing) position])
+                   [(u/the-id existing) position])
                  (map vector (maybe-insert-many! model on-error (map second insert))
                       (map first insert))
                  (for [[position entity existing] update]
-                   (let [id (u/get-id existing)]
+                   (let [id (u/the-id existing)]
                      (if (= on-error :abort)
                        (db/update! model id entity)
                        (with-error-handling

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -58,6 +58,7 @@
                          [Card          (Card card-id-root)]
                          [Card          (Card card-id-nested)]
                          [Card          (Card card-id-nested-query)]
+                         [Card          (Card card-id-native-query)]
                          [DashboardCard (DashboardCard dashcard-id)]])]
       (with-world-cleanup
         (load dump-dir {:on-error :abort :mode :skip})

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -54,16 +54,19 @@
                          [Segment       (Segment segment-id)]
                          [Dashboard     (Dashboard dashboard-id)]
                          [Card          (Card card-id)]
+                         [Card          (Card card-arch-id)]
                          [Card          (Card card-id-root)]
                          [Card          (Card card-id-nested)]
                          [Card          (Card card-id-nested-query)]
                          [DashboardCard (DashboardCard dashcard-id)]])]
       (with-world-cleanup
         (load dump-dir {:on-error :abort :mode :skip})
-        (is (every? (fn [[model entity]]
-                   (or (-> entity :name nil?)
-                       (db/select-one model :name (:name entity))))
-                 fingerprint))
+        (doseq [[model entity] fingerprint]
+          (is (or (-> entity :name nil?)
+                  (db/select-one model :name (:name entity))
+                  (and (-> entity :archived) ; archived card hasn't been dump-loaded
+                       (= (:name entity) "My Arch Card")))
+              (str " failed " (pr-str entity))))
         fingerprint))
     (finally
       (delete-directory! dump-dir))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [load])
   (:require [clojure.data :as diff]
             [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
             [expectations :refer [expect]]
             [metabase-enterprise.serialization.cmd :refer [dump load]]
             [metabase-enterprise.serialization.test-util :as ts]
@@ -35,7 +36,8 @@
                     (vector :in)
                     (db/delete! model# :id)))))))
 
-(expect
+
+(deftest dump-load-entities-test
   (try
     ;; in case it already exists
     (u/ignore-exceptions
@@ -54,12 +56,14 @@
                          [Card          (Card card-id)]
                          [Card          (Card card-id-root)]
                          [Card          (Card card-id-nested)]
+                         [Card          (Card card-id-nested-query)]
                          [DashboardCard (DashboardCard dashcard-id)]])]
       (with-world-cleanup
         (load dump-dir {:on-error :abort :mode :skip})
-        (every? (fn [[model entity]]
-                  (or (-> entity :name nil?)
-                      (db/select-one model :name (:name entity))))
-                fingerprint)))
+        (is (every? (fn [[model entity]]
+                   (or (-> entity :name nil?)
+                       (db/select-one model :name (:name entity))))
+                 fingerprint))
+        fingerprint))
     (finally
       (delete-directory! dump-dir))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -83,6 +83,21 @@
                                   {:source-query
                                    {:source-table ~'table-id
                                     }}}}}]
+                   Card       [{~'card-id-native-query :id}
+                               {:query_type :native
+                                :name "My Native Nested Query Card"
+                                :collection_id ~'collection-id
+                                :dataset_query
+                                {:type :native
+                                 :database ~'db-id
+                                 :native
+                                 {:query "{{#1}}"
+                                  :template-tags
+                                  {"#1"{:id "72461b3b-3877-4538-a5a3-7a3041924517"
+                                        :name "#1"
+                                        :display-name "#1"
+                                        :type "card"
+                                        :card-id ~'card-id}}}}}]
                    DashboardCard       [{~'dashcard-id :id}
                                         {:dashboard_id ~'dashboard-id
                                          :card_id ~'card-id}]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -3,7 +3,8 @@
             [metabase.models :refer [Card Collection Dashboard DashboardCard DashboardCardSeries Database Field Metric
                                      Segment Table]]
             [metabase.test.data :as data]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt]
+            [metabase-enterprise.serialization.names :refer [fully-qualified-name]]))
 
 (defmacro with-world
   "Run test in the context of a minimal Metabase instance connected to our test database."
@@ -11,10 +12,10 @@
   `(tt/with-temp* [Database   [{~'db-id :id} (into {} (-> (data/id)
                                                           Database
                                                           (dissoc :id :features :name)))]
-                   Table      [{~'table-id :id} (-> (data/id :venues)
-                                                    Table
-                                                    (dissoc :id)
-                                                    (assoc :db_id ~'db-id))]
+                   Table      [{~'table-id :id :as ~'table} (-> (data/id :venues)
+                                                              Table
+                                                              (dissoc :id)
+                                                              (assoc :db_id ~'db-id))]
                    Field      [{~'numeric-field-id :id} (-> (data/id :venues :price)
                                                             Field
                                                             (dissoc :id)
@@ -60,6 +61,18 @@
                                 :dataset_query {:type :query
                                                 :database ~'db-id
                                                 :query {:source-table (str "card__" ~'card-id)}}}]
+                   Card       [{~'card-id-nested-query :id}
+                               {:table_id ~'table-id
+                                :name "My Nested Query Card"
+                                :collection_id ~'collection-id
+                                :dataset_query
+                                {:type :query
+                                 :database ~'db-id
+                                 :query
+                                 {:source-query
+                                  {:source-query
+                                   {:source-table ~'table-id
+                                    }}}}}]
                    DashboardCard       [{~'dashcard-id :id}
                                         {:dashboard_id ~'dashboard-id
                                          :card_id ~'card-id}]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -47,6 +47,16 @@
                                                 :query {:source-table ~'table-id
                                                         :aggregation [:sum [:field-id ~'numeric-field-id]]
                                                         :breakout [[:field-id ~'category-field-id]]}}}]
+                   Card       [{~'card-arch-id :id}
+                               {;:archived true
+                                :table_id ~'table-id
+                                :name "My Arch Card"
+                                :collection_id ~'collection-id
+                                :dataset_query {:type :query
+                                                :database ~'db-id
+                                                :query {:source-table ~'table-id
+                                                        :aggregation [:sum [:field-id ~'numeric-field-id]]
+                                                        :breakout [[:field-id ~'category-field-id]]}}}]
                    Card       [{~'card-id-root :id}
                                {:table_id ~'table-id
                                 ;; https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -141,8 +141,9 @@
 (defn ^:command load
   "Load serialized metabase instance as created by `dump` command from directory `path`.
 
-   `mode` can be one of `:update` (default) or `:skip`."
-  ([path] (load path :update))
+   `mode` can be one of `:update` or `:skip` (default)."
+  ([path] (load path {"--mode" :skip
+                      "--on-error" :continue}))
 
   ([path & args]
    (let [cmd (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/load)]

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -152,11 +152,13 @@
                     (m/map-vals mbql.u/normalize-token))))))
 
 (defn ^:command dump
-  "Serialized metabase instance into directory `path`."
-  [path & args]
-  (let [cmd (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/dump)
-        {:keys [user]} (cmd-args->map args)]
-    (cmd path user)))
+  "Serialized metabase instance into directory `path`. `args` options may contain --state option with one of
+  `active` (default), `all`. With `active` option, do not dump archived entities."
+  ([path] (dump path {"--state" :active}))
+  ([path & args]
+   (let [cmd (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/dump)
+         {:keys [user]} (cmd-args->map args)]
+     (cmd path user))))
 
 (defn ^:command rotate-encryption-key
   "Rotate the encryption key of a metabase database. The MB_ENCRYPTION_SECRET_KEY environment variable has to be set to


### PR DESCRIPTION
Fixes #15048
Fixes #15047
Fixes #14911
Fixes #13614

Allow nested custom queries to be dump/loaded by drilling down on the source-query attribute and resolving the ids inside.  

Added one test case for each one of the cases that where failing before.