### PR TITLE
import smaller version of jsrsasign

### DIFF
--- a/frontend/src/metabase/public/lib/embed.js
+++ b/frontend/src/metabase/public/lib/embed.js
@@ -1,7 +1,7 @@
 import querystring from "querystring";
 
 // using jsrsasign because jsonwebtoken doesn't work on the web :-/
-import KJUR from "jsrsasign";
+import { jws } from "jsrsasign/lib/jsrsasign-jwths-min";
 
 export function getSignedToken(
   resourceType,
@@ -19,7 +19,7 @@ export function getSignedToken(
   if (previewEmbeddingParams) {
     unsignedToken._embedding_params = previewEmbeddingParams;
   }
-  return KJUR.jws.JWS.sign(null, { alg: "HS256", typ: "JWT" }, unsignedToken, {
+  return jws.JWS.sign(null, { alg: "HS256", typ: "JWT" }, unsignedToken, {
     utf8: secretKey,
   });
 }


### PR DESCRIPTION
**Description**
From https://github.com/kjur/jsrsasign/wiki/NOTE-jsrsasign-subset-package:
```
This package [https://kjur.github.io/jsrsasign/jsrsasign-jwths-min.js] is to sign and verify JSON Web Signatures(JWS) and JSON Web Token(JWT) with HS* signature algorithm.
```

Which is precisely the only thing we use this dependency for. Saves us ~200kb.

**Verifiction**
todo