### PR TITLE
#14872 Repro: Multi-level aggregations fails when filter is the last section

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -764,4 +764,50 @@ describe("scenarios > question > filter", () => {
     cy.wait("@cardQuery");
     cy.findByText("Rye").should("not.exist");
   });
+
+  it.skip("should handle multi-level aggregations with filter is the last position (metabase#14872)", () => {
+    cy.server();
+    cy.route("POST", "/api/dataset").as("dataset");
+
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-query": {
+            "source-query": {
+              "source-table": ORDERS_ID,
+              filter: ["=", ["field-id", ORDERS.USER_ID], 1],
+              aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
+              breakout: [
+                ["datetime-field", ["field-id", ORDERS.CREATED_AT], "day"],
+                [
+                  "fk->",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["field-id", PRODUCTS.TITLE],
+                ],
+                [
+                  "fk->",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["field-id", PRODUCTS.CATEGORY],
+                ],
+              ],
+            },
+            filter: [">", ["field-literal", "sum", "type/Float"], 100],
+            aggregation: [["sum", ["field-literal", "sum", "type/Float"]]],
+            breakout: [["field-literal", "TITLE", "type/Text"]],
+          },
+          filter: [">", ["field-literal", "sum", "type/Float"], 100],
+        },
+        database: 1,
+      },
+      display: "table",
+    });
+
+    cy.wait("@dataset").then(xhr => {
+      expect(xhr.response.body.error).not.to.exist;
+    });
+
+    cy.findByText(/Sum of Sum of Total/i);
+    cy.findByText("Awesome Bronze Plate");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14872

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/108400919-0d234c80-721c-11eb-9916-da67702511aa.png)


Sanity check - the same question on v0.37.9
![image](https://user-images.githubusercontent.com/31325167/108401001-2a581b00-721c-11eb-8986-416c497cc819.png)

