### PR TITLE
Make 'esc' button work with full page modal

### DIFF
--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -56,11 +56,11 @@ export class WindowModal extends Component {
     }
   }
 
-  handleDismissal() {
+  handleDismissal = () => {
     if (this.props.onClose) {
       this.props.onClose();
     }
-  }
+  };
 
   _modalComponent() {
     const className = cx(
@@ -70,7 +70,7 @@ export class WindowModal extends Component {
         .map(type => `Modal--${type}`),
     );
     return (
-      <OnClickOutsideWrapper handleDismissal={this.handleDismissal.bind(this)}>
+      <OnClickOutsideWrapper handleDismissal={this.handleDismissal}>
         <div className={cx(className, "relative bg-white rounded")}>
           {getModalContent({
             ...this.props,

--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -160,6 +160,12 @@ export class FullPageModal extends Component {
     }, 300);
   }
 
+  handleDismissal = () => {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  };
+
   _renderModal(open) {
     ReactDOM.unstable_renderSubtreeIntoContainer(
       this,
@@ -177,7 +183,7 @@ export class FullPageModal extends Component {
               occupies the entire screen. We do this to put this modal on top of
               the OnClickOutsideWrapper popover stack.  Otherwise, clicks within
               this modal might be seen as clicks outside another popover. */}
-            <OnClickOutsideWrapper>
+            <OnClickOutsideWrapper handleDismissal={this.handleDismissal}>
               <div
                 className="full-height relative scroll-y"
                 style={motionStyle}


### PR DESCRIPTION
**Description**
I noticed that pressing the esc key doesn't close full page modals (like the modal that appears when you click the alert icon in the bottom right corner of a question) and it produces an err "this.props.handleDismissal is undefined" because the `OnClickOutsideWrapper` expects it to exist. Copying the impl of `handleDismissal` for the `WindowModal` component seems to do the trick.

**Verification**
Pressing the "esc" now closes a full paged modal. You can't click outside of the modal because it is full screen and clicking the modal still won't close it, as expected.