### PR TITLE
Switch native query execution to use Statement instead of PreparedStatement

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -119,7 +119,7 @@
         (letfn [(thunk []
                   (with-open [conn (sql-jdbc.execute/connection-with-timezone driver (mt/db) (qp.timezone/report-timezone-id-if-supported))
                               stmt (sql-jdbc.execute/prepared-statement driver conn sql params)
-                              rs   (sql-jdbc.execute/execute-query! driver stmt)]
+                              rs   (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
                     (let [rsmeta (.getMetaData rs)]
                       {:cols (sql-jdbc.execute/column-metadata driver rsmeta)
                        :rows (reduce conj [] (sql-jdbc.execute/reducible-rows driver rs rsmeta canceled-chan))})))]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/common.clj
@@ -103,7 +103,7 @@
       (try
         (with-open [conn (jdbc/get-connection (db/connection))
                     stmt (sql-jdbc.execute/prepared-statement driver conn sql params)
-                    rs   (sql-jdbc.execute/execute-query! driver stmt)]
+                    rs   (sql-jdbc.execute/execute-prepared-statement! driver stmt)]
           (let [rsmeta   (.getMetaData rs)
                 cols     (sql-jdbc.execute/column-metadata driver rsmeta)
                 metadata {:cols cols}

--- a/modules/drivers/oracle/project.clj
+++ b/modules/drivers/oracle/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/oracle-driver "1.0.0"
+(defproject metabase/oracle-driver "1.1.0"
   :min-lein-version "2.5.0"
 
   :include-drivers-dependencies [#"^ojdbc\d+\.jar$"]

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -360,6 +360,22 @@
         (.close stmt)
         (throw e)))))
 
+;; similar rationale to prepared-statement above
+(defmethod sql-jdbc.execute/statement :oracle
+   [_ ^Connection conn]
+   (let [stmt (.createStatement conn
+                                ResultSet/TYPE_FORWARD_ONLY
+                                ResultSet/CONCUR_READ_ONLY)]
+        (try
+          (try
+            (.setFetchDirection stmt ResultSet/FETCH_FORWARD)
+            (catch Throwable e
+              (log/debug e (trs "Error setting result set fetch direction to FETCH_FORWARD"))))
+          stmt
+          (catch Throwable e
+            (.close stmt)
+            (throw e)))))
+
 ;; instead of returning a CLOB object, return the String. (#9026)
 (defmethod sql-jdbc.execute/read-column-thunk [:oracle Types/CLOB]
   [_ ^ResultSet rs _ ^Integer i]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -34,6 +34,9 @@
   (let [native-query (atom nil)]
     (with-redefs [execute/prepared-statement (fn [_ _ sql _]
                                                (reset! native-query sql)
+                                               (throw (Exception. "done")))
+                  execute/execute-select!    (fn [_ _ sql]
+                                               (reset! native-query sql)
                                                (throw (Exception. "done")))]
       (u/ignore-exceptions
         (qp/process-query query))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -35,7 +35,7 @@
     (with-redefs [execute/prepared-statement (fn [_ _ sql _]
                                                (reset! native-query sql)
                                                (throw (Exception. "done")))
-                  execute/execute-select!    (fn [_ _ sql]
+                  execute/execute-statement! (fn [_ _ sql]
                                                (reset! native-query sql)
                                                (throw (Exception. "done")))]
       (u/ignore-exceptions

--- a/modules/drivers/sparksql/project.clj
+++ b/modules/drivers/sparksql/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/sparksql-driver "1.0.0-SNAPSHOT-1.2.2"
+(defproject metabase/sparksql-driver "1.1.0-SNAPSHOT-1.2.2"
   :min-lein-version "2.5.0"
 
   :dependencies

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -164,6 +164,9 @@
         (.close stmt)
         (throw e)))))
 
+;; the current HiveConnection doesn't support .createStatement
+(defmethod sql-jdbc.execute/statement-supported? :sparksql [_] false)
+
 (doseq [feature [:basic-aggregations
                  :binning
                  :expression-aggregations

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -167,7 +167,7 @@
                                              :from   [:temp]}
                                  :quoting :ansi, :allow-dashed-names? true)]
             (with-open [stmt (sql-jdbc.execute/prepared-statement :sqlserver conn sql params)
-                        rs   (sql-jdbc.execute/execute-query! :sqlserver stmt)]
+                        rs   (sql-jdbc.execute/execute-prepared-statement! :sqlserver stmt)]
               (let [row-thunk (sql-jdbc.execute/row-thunk :sqlserver rs (.getMetaData rs))]
                 (is (= [#t "2019-02-01"]
                        (row-thunk))))))
@@ -197,7 +197,7 @@
             (let [sql (format "SELECT %s AS t;" (unprepare/unprepare-value :sqlserver t))]
               (with-open [conn (sql-jdbc.execute/connection-with-timezone :sqlserver (mt/db) nil)
                           stmt (sql-jdbc.execute/prepared-statement :sqlserver conn sql nil)
-                          rs   (sql-jdbc.execute/execute-query! :sqlserver stmt)]
+                          rs   (sql-jdbc.execute/execute-prepared-statement! :sqlserver stmt)]
                 (let [row-thunk (sql-jdbc.execute/row-thunk :sqlserver rs (.getMetaData rs))]
                   (is (= [expected]
                          (row-thunk))

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -308,9 +308,6 @@
     (statement* driver conn canceled-chan)
     (prepared-statement* driver conn sql params canceled-chan)))
 
-(defn- max-rows* [^Statement stmt max-rows]
-  (doto stmt (.setMaxRows max-rows)))
-
 (defmethod ^ResultSet execute-query! :sql-jdbc
   [_ ^PreparedStatement stmt]
   (.executeQuery stmt))
@@ -322,7 +319,7 @@
     (throw (ex-info (str (tru "Select statement did not produce a ResultSet for native query"))
                     {:sql sql :driver driver}))))
 
-(defn ^ResultSet execute-statement-or-prepared-statement [driver ^Statement stmt max-rows params sql]
+(defn- ^ResultSet execute-statement-or-prepared-statement [driver ^Statement stmt max-rows params sql]
   (let [st (doto stmt (.setMaxRows max-rows))]
     (if (empty? params)
       (execute-select! driver st sql)
@@ -438,7 +435,7 @@
 
 (defn execute-reducible-query
   "Default impl of `execute-reducible-query` for sql-jdbc drivers."
-  {:added "0.35.0", :arglists '([driver query context respond] [driver sql native? params max-rows context respond])}
+  {:added "0.35.0", :arglists '([driver query context respond] [driver sql params max-rows context respond])}
   ([driver {{sql :query, params :params} :native, :as outer-query} context respond]
    {:pre [(string? sql) (seq sql)]}
    (let [remark   (qputil/query->remark driver outer-query)

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -71,11 +71,19 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
+(defmulti ^Statement statement-supported?
+  "Indicates whether the given driver supports creating a java.sql.Statement, via the Connection. By default, this is
+  true for all :sql-jdbc drivers.  If the underlying driver does not support Statement creation, override this as
+  false."
+  {:added "0.39.0", :arglists '([driver])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
 (defmulti ^Statement statement
-  "Create a Statement object using the given connection. This is to be used to execute native queries, which implies
-  there are no parameters.  As with prepared-statement, you shouldn't need to override the default implementation for
-  this method; if you do, take care to set options to maximize result set read performance
-  (e.g. `ResultSet/TYPE_FORWARD_ONLY`); refer to the default implementation."
+  "Create a Statement object using the given connection. Only called if statement-supported? above returns true. This
+  is to be used to execute native queries, which implies there are no parameters. As with prepared-statement, you
+  shouldn't need to override the default implementation for this method; if you do, take care to set options to maximize
+  result set read performance (e.g. `ResultSet/TYPE_FORWARD_ONLY`); refer to the default implementation."
   {:added "0.39.0", :arglists '(^java.sql.Statement [driver ^java.sql.Connection connection])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
@@ -265,6 +273,11 @@
         (.close stmt)
         (throw e)))))
 
+;; by default, drivers support .createStatement
+(defmethod statement-supported? :sql-jdbc
+  [_]
+  true)
+
 (defmethod statement :sql-jdbc
   [_ ^Connection conn]
   (let [stmt (.createStatement conn
@@ -292,6 +305,9 @@
           (.cancel stmt))))
     stmt))
 
+(defn- use-statement? [driver params]
+  (and (statement-supported? driver) (empty? params)))
+
 (defn- statement*
   ^Statement [driver conn canceled-chan]
   ;; if canceled-chan gets a message, cancel the Statement
@@ -304,7 +320,7 @@
     stmt))
 
 (defn- ^Statement statement-or-prepared-statement [driver conn sql params canceled-chan]
-  (if (empty? params)
+  (if (use-statement? driver params)
     (statement* driver conn canceled-chan)
     (prepared-statement* driver conn sql params canceled-chan)))
 
@@ -321,7 +337,7 @@
 
 (defn- ^ResultSet execute-statement-or-prepared-statement [driver ^Statement stmt max-rows params sql]
   (let [st (doto stmt (.setMaxRows max-rows))]
-    (if (empty? params)
+    (if (use-statement? driver params)
       (execute-select! driver st sql)
       (execute-query! driver st))))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -455,13 +455,13 @@
         (mt/with-temp Collection [collection]
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
           (mt/with-model-cleanup [Card]
-            ;; Rebind the `prepared-statement` function so that we can capture the generated SQL and inspect it
-            (let [orig       (var-get #'sql-jdbc.execute/prepared-statement)
+            ;; Rebind the `execute-select!` function so that we can capture the generated SQL and inspect it
+            (let [orig       (var-get #'sql-jdbc.execute/execute-select!)
                   sql-result (atom nil)]
-              (with-redefs [sql-jdbc.execute/prepared-statement
-                            (fn [driver conn sql params]
+              (with-redefs [sql-jdbc.execute/execute-select!
+                            (fn [driver stmt sql]
                               (reset! sql-result sql)
-                              (orig driver conn sql params))]
+                              (orig driver stmt sql))]
                 ;; create a card with the metadata
                 (mt/user-http-request :rasta :post 202 "card"
                                       (assoc (card-with-name-and-query card-name)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -455,10 +455,10 @@
         (mt/with-temp Collection [collection]
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
           (mt/with-model-cleanup [Card]
-            ;; Rebind the `execute-select!` function so that we can capture the generated SQL and inspect it
-            (let [orig       (var-get #'sql-jdbc.execute/execute-select!)
+            ;; Rebind the `execute-statement!` function so that we can capture the generated SQL and inspect it
+            (let [orig       (var-get #'sql-jdbc.execute/execute-statement!)
                   sql-result (atom nil)]
-              (with-redefs [sql-jdbc.execute/execute-select!
+              (with-redefs [sql-jdbc.execute/execute-statement!
                             (fn [driver stmt sql]
                               (reset! sql-result sql)
                               (orig driver stmt sql))]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -342,7 +342,7 @@
       (testing "It should be possible to return money column results (#3754)"
         (with-open [conn (sql-jdbc.execute/connection-with-timezone :postgres (mt/db) nil)
                     stmt (sql-jdbc.execute/prepared-statement :postgres conn "SELECT 1000::money AS \"money\";" nil)
-                    rs   (sql-jdbc.execute/execute-query! :postgres stmt)]
+                    rs   (sql-jdbc.execute/execute-prepared-statement! :postgres stmt)]
           (let [row-thunk (sql-jdbc.execute/row-thunk :postgres rs (.getMetaData rs))]
             (is (= [1000.00M]
                    (row-thunk))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -570,3 +570,26 @@
           (sync/sync-database! database)
           (is (= #{"table_with_perms"}
                  (db/select-field :name Table :db_id (:id database)))))))))
+
+(deftest json-operator-?-works
+  (testing "Make sure the Postgres ? operators (for JSON types) work in native queries"
+    (mt/test-driver :postgres
+      (drop-if-exists-and-create-db! "json-test")
+      (let [details (mt/dbdef->connection-details :postgres :db {:database-name "json-test"})
+            spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
+        (doseq [statement ["DROP TABLE IF EXISTS PUBLIC.json_table;"
+                           "CREATE TABLE PUBLIC.json_table (json_val JSON NOT NULL);"
+                           "INSERT INTO PUBLIC.json_table (json_val) VALUES ('{\"a\": 1, \"b\": 2}');"]]
+          (jdbc/execute! spec [statement])))
+      (let [json-db-details (mt/dbdef->connection-details :postgres :db {:database-name "json-test"})
+            query           (str "SELECT json_val::jsonb ? 'a',"
+                                 "json_val::jsonb ?| array['c', 'd'],"
+                                 "json_val::jsonb ?& array['a', 'b']"
+                                 "FROM \"json_table\";")]
+        (mt/with-temp Database [database {:engine :postgres, :details json-db-details}]
+          (mt/with-db database (sync/sync-database! database)
+                               (is (= [[true false true]]
+                                      (-> {:query query}
+                                          (mt/native-query)
+                                          (qp/process-query)
+                                          (mt/rows))))))))))


### PR DESCRIPTION
Switch native query execution to use Statement instead of PreparedStatement

Add new multimethod to create a Statement, rather than PreparedStatement, which works similarly, called statement

Add new multimethod to run a SQL query against a Statement, similar to execute-query!, called execute-select!

Change execute-reducible-query to capture whether the query is native, and if not, use the new multimethods instead
