### PR TITLE
Fix confusing "current" breadcrumb UX

### DIFF
--- a/frontend/src/metabase/components/Breadcrumbs.css
+++ b/frontend/src/metabase/components/Breadcrumbs.css
@@ -17,7 +17,7 @@
   font-size: 0.75rem;
   font-weight: bold;
   text-transform: uppercase;
-  cursor: pointer;
+  cursor: default;
 }
 
 :local(.breadcrumbDivider) {


### PR DESCRIPTION
### Status
PENDIND CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes confusing UX regarding the last (the current) breadcrumb that was displaying a `pointer` cursor on hover, making users believe they can click on it.
- Closes #14879.

### How to test this?
- All tests should pass - this shouldn't alter the behavior of "parent" breadcrumbs or obstruct functionality in any way

### Screenshots
Before
![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/4gu1P2r8/110a269e-6ea9-4b91-956c-89ad41590be7.gif?source=viewer&v=f44c7e4ab1bd4816d7821319ba4ef347)

After
![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/qGuXRON6/89efe442-f05a-4722-a486-d855debb5eb4.gif?source=viewer&v=9e7f97092da78f08f8ddd79a909bbd58)
