### PR TITLE
#14880 Repro: Negative filter can not be converted to custom expression

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -810,4 +810,28 @@ describe("scenarios > question > filter", () => {
     cy.findByText(/Sum of Sum of Total/i);
     cy.findByText("Awesome Bronze Plate");
   });
+
+  it.skip("shuld convert negative filter to custom expression (metabase#14880)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": PRODUCTS_ID,
+          filter: [
+            "does-not-contain",
+            ["field-id", PRODUCTS.TITLE],
+            "Wallet",
+            { "case-sensitive": false },
+          ],
+        },
+        database: 1,
+      },
+      display: "table",
+    });
+    cy.findByText("Title does not contain Wallet").click();
+    cy.get(".Icon-chevronleft").click();
+    cy.findByText("Custom Expression").click();
+    // Before we implement this feature, we can only assert that the input field for custom expression doesn't show at all
+    cy.get("[contenteditable='true']");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14880

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/108438243-27c2e900-724f-11eb-8533-bbd99121b367.png)

