### PR TITLE
fix crash in InputWithSelectPrefix on null site-url

### DIFF
--- a/frontend/src/metabase/components/InputWithSelectPrefix.jsx
+++ b/frontend/src/metabase/components/InputWithSelectPrefix.jsx
@@ -24,6 +24,10 @@ function splitValue({
   defaultPrefix,
   caseInsensitivePrefix = false,
 }) {
+  if (value == null) {
+    return ["", ""];
+  }
+
   const prefix = prefixes.find(
     caseInsensitivePrefix
       ? p => value.toLowerCase().startsWith(p.toLowerCase())


### PR DESCRIPTION
This bug was happening in hosting since site-url is set via env var. Major props to @flamber for figuring out the cause.