### PR TITLE
Increase the memoization cache for search scoring by common subseq

### DIFF
--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -45,22 +45,13 @@ export default class SearchApp extends React.Component {
                 );
               }
 
-              //TODO: this is breaking the ordering; redo this in a follow-up PR
               const resultsByType = _.chain(list)
                 .groupBy("model")
                 .value();
 
               // either use the specified filter type or order the full set according to our preferred order
               // (this should probably just be the default return from the endpoint no?
-              const resultDisplay = resultsByType[location.query.type] || [
-                ...(resultsByType.dashboard || []),
-                ...(resultsByType.metric || []),
-                ...(resultsByType.table || []),
-                ...(resultsByType.segment || []),
-                ...(resultsByType.card || []),
-                ...(resultsByType.collection || []),
-                ...(resultsByType.pulse || []),
-              ];
+              const resultDisplay = resultsByType[location.query.type] || list;
 
               const searchFilters = FILTERS.concat(
                 {

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -37,7 +37,7 @@
    ;; least a 31*31 search (or 50*20, etc) which sounds like more than enough. Memory is cheap and the items are
    ;; small, so we may as well skew high.
    ;; As a precaution, the scorer that uses this limits the number of tokens (see the `take` call below)
-   :fifo/threshold 1000))
+   :fifo/threshold 2000))
 
 ;;; Scoring
 

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -133,3 +133,22 @@
              (context
                  ["rasta" "toucan"]
                  ["aviary" "stats"]))))))
+
+(deftest test-largest-common-subseq-length
+  (let [subseq-length (partial #'search/largest-common-subseq-length =)]
+    (testing "greedy choice can't be taken"
+      (is (= 3
+             (subseq-length ["garden" "path" "this" "is" "not" "a" "garden" "path"]
+                            ["a" "garden" "path"]))))
+    (testing "no match"
+      (is (= 0
+             (subseq-length ["can" "not" "be" "found"]
+                            ["The" "toucan" "is" "a" "South" "American" "bird"]))))
+    (testing "long matches"
+      (is (= 28
+             (subseq-length (map str '(this social bird lives in small flocks in lowland rainforests in countries such as costa rica
+                                       it flies short distances between trees toucans rest in holes in trees))
+                            (map str '(here is some filler
+                                       this social bird lives in small flocks in lowland rainforests in countries such as costa rica
+                                       it flies short distances between trees toucans rest in holes in trees
+                                       here is some more filler))))))))


### PR DESCRIPTION
Also limit the size of input it can get

(Hopefully) [Fixes #14852]

-----

Come to find out there are some obscenely long names on stats, so we were blowing the memoization cache. CS school was a long time ago, but if I'm analyzing the algorithm right this should be okay. I'm a little worried that different values of `tally` are blowing up my `k` estimate. But the "long matches" test (input of lengths 28 and 37; 28×37=1036) worked fine on my piddly CPU and certainly didn't blow up the stack.

----

Ignore the FE changes from #14898; I had to branch off branches to avoid pain with merge conflicts