### PR TITLE
Remove frontend search sorting

### DIFF
--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -45,22 +45,13 @@ export default class SearchApp extends React.Component {
                 );
               }
 
-              //TODO: this is breaking the ordering; redo this in a follow-up PR
               const resultsByType = _.chain(list)
                 .groupBy("model")
                 .value();
 
               // either use the specified filter type or order the full set according to our preferred order
               // (this should probably just be the default return from the endpoint no?
-              const resultDisplay = resultsByType[location.query.type] || [
-                ...(resultsByType.dashboard || []),
-                ...(resultsByType.metric || []),
-                ...(resultsByType.table || []),
-                ...(resultsByType.segment || []),
-                ...(resultsByType.card || []),
-                ...(resultsByType.collection || []),
-                ...(resultsByType.pulse || []),
-              ];
+              const resultDisplay = resultsByType[location.query.type] || list;
 
               const searchFilters = FILTERS.concat(
                 {


### PR DESCRIPTION
Respect the order provided by the backend. Previously the BE would return things in a ~random order and the FE would group them by type, but we don't want that any more (soon we'll incorporate type into the BE scoring to get at the same problem)

The filtering by type in the sidebar still works as one would expect; that's why we still bother with `resultsByType` at all