### PR TITLE
#14757 Repro: New collection saved inside "My personal collection" not available in "New collection" modal

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -529,6 +529,32 @@ describe("scenarios > collection_defaults", () => {
         .find(".Icon-chevronright")
         .should("not.exist");
     });
+
+    it.skip("should offer to save in a newly created collection (that's saved inside 'My personal collection') (metabase#14757)", () => {
+      cy.visit("/collection/root");
+      // Create new collection inside "My personal collection"
+      cy.icon("new_folder").click();
+      cy.findByLabelText("Name").type("Foo");
+      cy.get(".AdminSelect")
+        .findByText("Our analytics")
+        .as("rootSelect")
+        .click();
+      popover()
+        .findByText("My personal collection")
+        .click();
+      cy.findByRole("button", { name: "Create" }).click();
+
+      // Create one more collection and try to put it inside the previously created one
+      cy.icon("new_folder").click();
+      cy.findByLabelText("Name").type("Bar");
+      cy.get("@rootSelect").click();
+      popover()
+        .findByText("My personal collection")
+        .parent()
+        .find(".Icon-chevronright")
+        .click();
+      popover().findByText("Foo");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14757

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/108548434-1ed42500-72ec-11eb-8b4c-bf869d989620.png)
