### PR TITLE
#14178 Repro: "Saved Questions" dialog doesn't respect nested collections structure

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -529,6 +529,28 @@ describe("scenarios > collection_defaults", () => {
         .find(".Icon-chevronright")
         .should("not.exist");
     });
+
+    it.skip("'Saved Questions' prompt should respect nested collections structure (metabase#14178)", () => {
+      cy.request("GET", "/api/collection").then(({ body }) => {
+        // Get "Second collection's" id dynamically instead of hard-coding it
+        const SECOND_COLLECTION = body.filter(collection => {
+          return collection.slug === "second_collection";
+        });
+        const [{ id }] = SECOND_COLLECTION;
+
+        // Move first question in a DB snapshot ("Orders") inside "Second collection"
+        cy.request("PUT", "/api/card/1", {
+          collection_id: id,
+        });
+      });
+
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("Everything Else");
+      cy.findByText("Second Collection").should("not.exist");
+      cy.findByText("First Collection");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14178

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/108556524-6dd38780-72f7-11eb-82cb-ffa494a6cf61.png)

