### PR TITLE
Fix the editor not getting the focus right away after selecting database

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -453,6 +453,10 @@ export default class NativeQueryEditor extends Component {
         .setDatabaseId(databaseId)
         .setDefaultCollection()
         .update(this.props.setDatasetQuery);
+      if (this._editor && !this.props.readOnly) {
+        // HACK: the cursor doesn't blink without this intended small delay
+        setTimeout(() => this._editor.focus(), 50);
+      }
     }
   };
 


### PR DESCRIPTION
This should fix issue #14774.

### Steps to verify

Note: this only works if 2 or more databases are available (vanilla installation with only the sample dataset doesn't demonstrate the issue).

1. Ask a question, Native query
2. Select a database from the dropdown
3. Type a few characters

### Before

The focus is on the editor, e.g. typing a few characters does not insert the characters in the editor.

### After

The editor has the focus.