### PR TITLE
#14907 Repro: Snippet folder is showing as part of collections

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
@@ -159,4 +159,21 @@ describeWithToken("scenarios > question > snippets", () => {
     cy.findByText("my favorite snippets").click();
     cy.findByText("snippet 1");
   });
+
+  it.skip("should not display snippet folder as part of collections (metabase#14907)", () => {
+    cy.server();
+    cy.route("GET", "/api/collection/root").as("collections");
+
+    cy.request("POST", "/api/collection", {
+      name: "Snippet Folder",
+      description: null,
+      color: "#509EE3",
+      parent_id: null,
+      namespace: "snippets",
+    });
+
+    cy.visit("/collection/root");
+    cy.wait("@collections");
+    cy.findByText("Snippet Folder").should("not.exist");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14907 

### How to test this manually?
- `yarn test-cypress-open --testFiles enterprise/frontend/test/metabase-enterprise/`
- `enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/108714758-3db7fe80-751a-11eb-8b54-011b5797ed8b.png)

