### PR TITLE
Fix regex-match-first operator for Postgres to work properly when run against subqueries

### DIFF
--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -59,7 +59,7 @@ describeWithToken("postgres > user > query", () => {
     );
   });
 
-  it.skip("should handle the use of `regexextract` in a sandboxed table (metabase#14873)", () => {
+  it("should handle the use of `regexextract` in a sandboxed table (metabase#14873)", () => {
     const CC_NAME = "Firstname";
     // We need ultra-wide screen to avoid scrolling (custom column is rendered at the last position)
     cy.viewport(2200, 1200);

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -164,10 +164,11 @@
 
 (defmethod sql.qp/->honeysql [:postgres :regex-match-first]
   [driver [_ arg pattern]]
-  (reify
-    hformat/ToSql
-    (to-sql [_]
-      (str "substring(" (hformat/to-sql (sql.qp/->honeysql driver arg)) " FROM " (hformat/to-sql pattern) ")"))))
+  (let [col-name (hformat/to-sql (sql.qp/->honeysql driver arg))]
+    (reify
+      hformat/ToSql
+      (to-sql [_]
+        (str "substring(" col-name " FROM " (hformat/to-sql pattern) ")")))))
 
 (defmethod sql.qp/->honeysql [:postgres Time]
   [_ time-value]


### PR DESCRIPTION
Fix regex-match-first operator for Postgres to work properly when run against subqueries

Capture col-name at beginning of fn for :regex-match-first operator in Postgres driver to work around laziness problem (see PR #14858)

Adding test
