### PR TITLE
#14873 Repro: `regexextract` breaks query on a sandboxed table

### DIFF
--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -1,0 +1,171 @@
+import {
+  signInAsAdmin,
+  signOut,
+  restore,
+  addPostgresDatabase,
+  withDatabase,
+  USER_GROUPS,
+  describeWithToken,
+} from "__support__/cypress";
+
+const PG_DB_NAME = "QA Postgres12";
+const PG_DB_ID = 2;
+
+const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
+
+const sandboxed_user = {
+  first_name: "User",
+  last_name: "1",
+  email: "u1@metabase.test",
+  password: "12341234",
+  login_attributes: {
+    user_id: "1",
+    user_cat: "Widget",
+  },
+  // Because of the specific restrictions and the way testing dataset was set up,
+  // this user needs to also have access to "collections" (group_id: 4) in order to see saved questions
+  group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
+};
+
+function createUser(user) {
+  return cy.request("POST", "/api/user", user);
+}
+
+describeWithToken("postgres > user > query", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+    addPostgresDatabase(PG_DB_NAME);
+    createUser(sandboxed_user).then(({ body: { id: USER_ID } }) => {
+      cy.log("**-- Dismiss `it's ok to play around` modal for new users --**");
+      cy.request("PUT", `/api/user/${USER_ID}/qbnewb`, {});
+    });
+    // Update basic permissions (the same starting "state" as we have for the "Sample Dataset")
+    cy.request("GET", "/api/permissions/graph", {}).then(
+      ({ body: { groups, revision } }) => {
+        cy.request("PUT", "/api/permissions/graph", {
+          revision,
+          groups: {
+            [ALL_USERS_GROUP]: {
+              [PG_DB_ID]: { schemas: "none", native: "none" },
+            },
+            [DATA_GROUP]: { [PG_DB_ID]: { schemas: "all", native: "write" } },
+            [COLLECTION_GROUP]: {
+              [PG_DB_ID]: { schemas: "none", native: "none" },
+            },
+          },
+        });
+      },
+    );
+  });
+
+  it.skip("should handle the use of `regexextract` in a sandboxed table (metabase#14873)", () => {
+    const CC_NAME = "Firstname";
+    // We need ultra-wide screen to avoid scrolling (custom column is rendered at the last position)
+    cy.viewport(2200, 1200);
+
+    cy.server();
+    cy.route("POST", "/api/dataset/pivot").as("pivotDataset");
+
+    withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) => {
+      cy.log("**-- 1. Create question with custom column --**");
+      cy.request("POST", "/api/card", {
+        name: "14873",
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": PEOPLE_ID,
+            expressions: {
+              [CC_NAME]: [
+                "regex-match-first",
+                ["field-id", PEOPLE.NAME],
+                "^[A-Za-z]+",
+              ],
+            },
+          },
+          database: PG_DB_ID,
+        },
+        display: "table",
+        visualization_settings: {},
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.server();
+        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+
+        cy.log("**-- 2. Sandbox `People` table --**");
+        cy.request("POST", "/api/mt/gtap", {
+          attribute_remappings: {
+            user_id: ["dimension", ["field-id", PEOPLE.ID]],
+          },
+          card_id: null,
+          table_id: PEOPLE_ID,
+          group_id: COLLECTION_GROUP,
+        });
+
+        updatePermissionsGraph({
+          schema: {
+            [PEOPLE_ID]: { query: "segmented", read: "all" },
+          },
+        });
+
+        signOut();
+        signInAsSandboxedUser();
+        cy.visit(`/question/${QUESTION_ID}`);
+
+        cy.wait("@cardQuery").then(xhr => {
+          expect(xhr.response.body.error).not.to.exist;
+        });
+
+        cy.findByText(CC_NAME);
+        cy.findByText(/^Hudson$/);
+      });
+    });
+  });
+});
+
+function signInAsSandboxedUser() {
+  cy.log("**-- Logging in as sandboxed user --**");
+  cy.request("POST", "/api/session", {
+    username: sandboxed_user.email,
+    password: sandboxed_user.password,
+  });
+}
+
+/**
+ * As per definition for `PUT /graph` from `permissions.clj`:
+ *
+ * This should return the same graph, in the same format,
+ * that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary.
+ * This modified graph must correspond to the `PermissionsGraph` schema.
+ *
+ * That's why we must chain GET and PUT requests one after the other.
+ */
+
+function updatePermissionsGraph({
+  schema = {},
+  user_group = COLLECTION_GROUP,
+  database_id = PG_DB_ID,
+} = {}) {
+  if (typeof schema !== "object") {
+    throw new Error("`schema` must be an object!");
+  }
+
+  cy.log("**-- Fetch permissions graph --**");
+  cy.request("GET", "/api/permissions/graph", {}).then(
+    ({ body: { groups, revision } }) => {
+      // This mutates the original `groups` object => we'll pass it next to the `PUT` request
+      groups[user_group] = {
+        [database_id]: {
+          schemas: {
+            public: schema,
+          },
+        },
+      };
+
+      cy.log("**-- Update/save permissions --**");
+      cy.request("PUT", "/api/permissions/graph", {
+        groups,
+        revision,
+      });
+    },
+  );
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14873

### How to test this manually?
- `yarn test-cypress-open --testFiles frontend/test/metabase-db/`
- `frontend/test/metabase-db/postgres/sandboxes.cy.spec.js`
- All tests should pass

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/108747505-cac07f00-753d-11eb-8f5e-95f102ee9d01.png)

Sanity check - the same test from admin's perspective (checking that CC is shown in the ultra-wide viewport)
![image](https://user-images.githubusercontent.com/31325167/108747652-f9d6f080-753d-11eb-98f3-ad61d58ea013.png)
