### PR TITLE
Upgrade HoneySQL version to latest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -102,7 +102,7 @@
    [dk.ative/docjure "1.13.0"]                                        ; Excel export
    [environ "1.2.0"]                                                  ; easy environment management
    [hiccup "1.0.5"]                                                   ; HTML templating
-   [honeysql "0.9.5" :exclusions [org.clojure/clojurescript]]         ; Transform Clojure data structures to SQL
+   [honeysql "1.0.461" :exclusions [org.clojure/clojurescript]]       ; Transform Clojure data structures to SQL
    [instaparse "1.4.10"]                                              ; Make your own parser
    [io.forward/yaml "1.0.9"                                           ; Clojure wrapper for YAML library SnakeYAML (which we already use for liquidbase)
     :exclusions [org.clojure/clojure


### PR DESCRIPTION
Upgrade HoneySQL version to latest released version (1.0.461)

Modifying ddl.clj to account for a difference in behavior for honeysql.helpers/columns introduced in honeysql 0.9.7 (see long comment)
