### PR TITLE
Custom expression: properly convert negative filters

### DIFF
--- a/frontend/src/metabase/lib/expressions/compile.js
+++ b/frontend/src/metabase/lib/expressions/compile.js
@@ -10,6 +10,11 @@ import {
 
 import { ExpressionCstVisitor, parse } from "./parser";
 
+const NEGATIVE_FILTER_SHORTHANDS = {
+  contains: "does-not-contain",
+  "is-null": "not-null",
+  "is-empty": "not-empty",
+};
 class ExpressionMBQLCompilerVisitor extends ExpressionCstVisitor {
   constructor(options) {
     super();
@@ -50,7 +55,10 @@ class ExpressionMBQLCompilerVisitor extends ExpressionCstVisitor {
     return this.visit(ctx.expression);
   }
   logicalNotExpression(ctx) {
-    return ["not", this.visit(ctx.operands[0])];
+    const expr = this.visit(ctx.operands[0]);
+    const [fn, ...args] = expr;
+    const shorthand = NEGATIVE_FILTER_SHORTHANDS[fn];
+    return shorthand ? [shorthand, ...args] : ["not", expr];
   }
   relationalExpression(ctx) {
     return this._collapseOperators(ctx.operands, ctx.operators);

--- a/frontend/src/metabase/lib/expressions/format.js
+++ b/frontend/src/metabase/lib/expressions/format.js
@@ -50,6 +50,8 @@ export function format(mbql: any, options: FormatterOptions = {}) {
     return formatSegment(mbql, options);
   } else if (isCase(mbql)) {
     return formatCase(mbql, options);
+  } else if (isNegativeFilter(mbql)) {
+    return formatNegativeFilter(mbql, options);
   }
   throw new Error("Unknown MBQL clause " + JSON.stringify(mbql));
 }
@@ -131,4 +133,21 @@ function formatCase([_, clauses, caseOptions = {}], options) {
       ? ", " + format(caseOptions.default, options)
       : "";
   return `${formattedName}(${formattedClauses}${defaultExpression})`;
+}
+
+const NEGATIVE_FILTERS = {
+  "does-not-contain": "contains",
+  "not-empty": "is-empty",
+  "not-null": "is-null",
+};
+
+function isNegativeFilter(expr) {
+  const [fn, ...args] = expr;
+  return typeof NEGATIVE_FILTERS[fn] === "string" && args.length >= 1;
+}
+
+function formatNegativeFilter(mbql, options) {
+  const [fn, ...args] = mbql;
+  const baseFn = NEGATIVE_FILTERS[fn];
+  return "NOT " + format([baseFn, ...args], options);
 }

--- a/frontend/test/metabase/lib/expressions/__support__/shared.js
+++ b/frontend/test/metabase/lib/expressions/__support__/shared.js
@@ -161,6 +161,13 @@ const filter = [
     ["or", ["not", ["between", subtotal, 3, 14]], segment],
     "filter function with OR",
   ],
+  [
+    'NOT contains([User → Name], "John")',
+    ["does-not-contain", userName, "John"],
+    "not contains",
+  ],
+  ["NOT isnull([Tax])", ["not-null", tax], "not null"],
+  ["NOT isempty([Total])", ["not-empty", total], "not empty"],
 ];
 
 export default [

--- a/frontend/test/metabase/lib/expressions/compile.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/compile.unit.spec.js
@@ -191,6 +191,15 @@ describe("metabase/lib/expressions/compile", () => {
       expect(filter("[Expensive]")).toEqual(["segment", "Expensive"]);
       expect(filter("NOT [Good]")).toEqual(["not", ["segment", "Good"]]);
     });
+    it("should compile negative filters", () => {
+      expect(filter("NOT CONTAINS('X','Y')")).toEqual([
+        "does-not-contain",
+        "X",
+        "Y",
+      ]);
+      expect(filter("NOT ISNULL('P')")).toEqual(["not-null", "P"]);
+      expect(filter("NOT ISEMPTY('Q')")).toEqual(["not-empty", "Q"]);
+    });
   });
 
   describe("(for an aggregation)", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -845,7 +845,7 @@ describe("scenarios > question > filter", () => {
     cy.contains("Showing 1,112 rows");
   });
 
-  it.skip("shuld convert negative filter to custom expression (metabase#14880)", () => {
+  it("should convert negative filter to custom expression (metabase#14880)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",
@@ -865,7 +865,8 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Title does not contain Wallet").click();
     cy.get(".Icon-chevronleft").click();
     cy.findByText("Custom Expression").click();
-    // Before we implement this feature, we can only assert that the input field for custom expression doesn't show at all
-    cy.get("[contenteditable='true']");
+    cy.get("[contenteditable='true']").contains(
+      'NOT contains([Title], "Wallet")',
+    );
   });
 });


### PR DESCRIPTION
This should fix issue #14880.

**Steps to verify**:

1. Ask a question, Simple question
2. Sample Dataset, Products
3. Filter, Filter by Title
4. Choose "Does not contain", type `Wallet`, press _Add Filter_
5. Click on the new filter "Title does not contain Wallet"
6. Press the left chevron icon, choose _Custom Expression_

**Before**

Nothing happens, but the JavaScript console shows an error:

```
Unknown MBQL clause ["does-not-contain",["field-id",12],"Wallet",{"case-sensitive":false}]
```

![image](https://user-images.githubusercontent.com/7288/108426336-8016ce00-71f0-11eb-8245-d22030d45e53.png)

**After**

The filter gets converted to something like `NOT contains([Title], "Wallet")`.

![image](https://user-images.githubusercontent.com/7288/108787112-e91c7f80-7529-11eb-9151-6c0c7439010f.png)


**Note**: Another negative filter, such as "Is not empty" should also work the same way.

