### PR TITLE
Use GitHub Actions to run YAML linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,21 +524,6 @@ jobs:
           paths:
             - metabase/metabase
 
-  yaml-linter:
-    executor: node
-    steps:
-      - attach-workspace
-      - create-checksum-file:
-          filename: .YAML-CHECKSUMS
-          find-args: ". -type f -name '*.yaml' -or -name '*.yml'"
-      - run-on-change:
-          # package.json is included in the cache key in case the yamllint dependency changes
-          checksum: '{{ checksum ".YAML-CHECKSUMS" }}-{{ checksum "package.json" }}'
-          steps:
-            - run-yarn-command:
-                command-name: Lint YAML files
-                command: lint-yaml `find resources -name '*.yaml' -or -name '*.yml'`
-
   verify-i18n-files:
     executor: metabase-ci
     steps:
@@ -990,10 +975,6 @@ workflows:
   build:
     jobs:
       - checkout
-
-      - yaml-linter:
-          requires:
-            - fe-deps
 
       - verify-i18n-files:
           requires:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -1,0 +1,34 @@
+name: YAML
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release**'
+      - 'feature**'
+    tags:
+      - '**'
+    paths:
+    - '**.yml'
+    - '**.yaml'
+    - 'package.json'
+
+jobs:
+
+  yaml-linter:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: yarn run lint-yaml


### PR DESCRIPTION
Same spirit as the previous PRs, #14050 and #14701: leave more available containers for Circle CI to run other priority tasks (e.g. Cypress tests).