### PR TITLE
Enable running a single spec in Cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -970,7 +970,7 @@ jobs:
                       <<: *CacheKeyUberjar
                   - steps: << parameters.before-steps >>
                 command: |
-                  run test-cypress-no-build <<# parameters.only-single-database >> --testFiles << parameters.test-files-location >> <</ parameters.only-single-database >>
+                  run test-cypress-no-build <<# parameters.only-single-database >> --folder << parameters.test-files-location >> <</ parameters.only-single-database >>
                 after-steps:
                   - store_artifacts:
                       path: /home/circleci/metabase/metabase/cypress

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -9,13 +9,13 @@ const server = BackendResource.get({ dbKey: "" });
 
 // We currently accept three (optional) command line arguments
 // --open - Opens the Cypress test browser
-// --testFiles <path> - Specifies a different path for the integration folder
+// --folder <path> - Specifies a different path for the integration folder
 // --spec <single-spec-path> - Specifies a path to a single test file
 const userArgs = process.argv.slice(2);
 const isOpenMode = userArgs.includes("--open");
-const testFiles = userArgs.includes("--testFiles");
+const sourceFolder = userArgs.includes("--folder");
 const singleFile = userArgs.includes("--spec");
-const testFilesLocation = userArgs[userArgs.indexOf("--testFiles") + 1];
+const sourceFolderLocation = userArgs[userArgs.indexOf("--folder") + 1];
 const singleFileName = userArgs[userArgs.indexOf("--spec") + 1];
 
 function readFile(fileName) {
@@ -38,8 +38,8 @@ const init = async () => {
     );
   }
 
-  if (testFiles) {
-    console.log(chalk.bold(`Running tests in '${testFilesLocation}'`));
+  if (sourceFolder) {
+    console.log(chalk.bold(`Running tests in '${sourceFolderLocation}'`));
   }
 
   if (singleFile) {
@@ -74,8 +74,8 @@ const init = async () => {
 
   console.log(chalk.bold("Starting Cypress"));
   let commandLineConfig = `baseUrl=${server.host}`;
-  if (testFiles) {
-    commandLineConfig = `${commandLineConfig},integrationFolder=${testFilesLocation}`;
+  if (sourceFolder) {
+    commandLineConfig = `${commandLineConfig},integrationFolder=${sourceFolderLocation}`;
   } else if (singleFile) {
     commandLineConfig = `${commandLineConfig},testFiles=${singleFileName}`;
   } else {

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -7,9 +7,10 @@ const BackendResource = require("./backend.js").BackendResource;
 
 const server = BackendResource.get({ dbKey: "" });
 
-// We currently accept two (optional) command line arguments
+// We currently accept three (optional) command line arguments
 // --open - Opens the Cypress test browser
 // --testFiles <path> - Specifies a different path for the integration folder
+// --spec <single-spec-path> - Specifies a path to a single test file
 const userArgs = process.argv.slice(2);
 const isOpenMode = userArgs.includes("--open");
 const testFiles = userArgs.includes("--testFiles");

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -13,7 +13,9 @@ const server = BackendResource.get({ dbKey: "" });
 const userArgs = process.argv.slice(2);
 const isOpenMode = userArgs.includes("--open");
 const testFiles = userArgs.includes("--testFiles");
+const singleFile = userArgs.includes("--spec");
 const testFilesLocation = userArgs[userArgs.indexOf("--testFiles") + 1];
+const singleFileName = userArgs[userArgs.indexOf("--spec") + 1];
 
 function readFile(fileName) {
   return new Promise(function(resolve, reject) {
@@ -37,6 +39,10 @@ const init = async () => {
 
   if (testFiles) {
     console.log(chalk.bold(`Running tests in '${testFilesLocation}'`));
+  }
+
+  if (singleFile) {
+    console.log(chalk.bold(`Running single spec '${singleFileName}'`));
   }
 
   try {
@@ -69,6 +75,8 @@ const init = async () => {
   let commandLineConfig = `baseUrl=${server.host}`;
   if (testFiles) {
     commandLineConfig = `${commandLineConfig},integrationFolder=${testFilesLocation}`;
+  } else if (singleFile) {
+    commandLineConfig = `${commandLineConfig},testFiles=${singleFileName}`;
   } else {
     // if we're not running specific tests, avoid including db and smoketests
     commandLineConfig = `${commandLineConfig},ignoreTestFiles=**/metabase-{smoketest,db}/**`;

--- a/frontend/test/metabase-smoketest/README.md
+++ b/frontend/test/metabase-smoketest/README.md
@@ -11,7 +11,7 @@ From the root of the repository:
 - If you already have built Metabase with `./bin/build`, just run this to run all the tests.
 
 ```shell
-yarn run test-cypress-no-build --testFiles frontend/test/metabase-smoketest
+yarn run test-cypress-no-build --folder frontend/test/metabase-smoketest
 ```
 
 - Active development, add `--open`

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "test-cypress-open": "./bin/build-for-test && yarn test-cypress-no-build --open",
     "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-no-build --open",
     "test-cypress-no-build": "yarn && CONFIG_FILE=frontend/test/cypress.json babel-node ./frontend/test/__runner__/run_cypress_tests.js",
-    "test-cypress-smoketest": "yarn test-cypress-no-build --testFiles frontend/test/metabase-smoketest"
+    "test-cypress-smoketest": "yarn test-cypress-no-build --folder frontend/test/metabase-smoketest"
   },
   "lint-staged": {
     "frontend/**/*.{js,jsx,css}": [


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds an option to the Cypress `config` that enables running a single spec
    - Great for stress-testing and quick checks
- Renames a confusing custom flag that we were using for setting the `integrationFolder` in `config` as CLI argument

### How to test this locally?
- `yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/new.cy.spec.js`
    - You should see snapshot creator running first
    - Then **only** the specified file should run

### Additional notes:
- This functionality is still not enabled in CI at this point
- I updated related [Wiki page](https://github.com/metabase/metabase/wiki/E2E-Tests-with-Cypress)
---

### Explanation for the confusion and the (mis)use of our own custom flag `--testFiles`
For the reference, we need to look at the official Cypress "API" or defined valid keys for the config (we're interested in files and folders section):
https://docs.cypress.io/guides/references/configuration.html#Folders-Files

- We're building up the `--config` CLI argument programatically in `frontend/test/__runner__/run_cypress_tests.js`.
- Unfortunately, we decided to use `--testFiles` for our own flag that basically determines the `integrationFolder` (tells Cypress which folder to use to run tests from)
    - The confusion stems from a fact that `testfiles` is also a valid Cypress config key (it can be "A String or Array of glob patterns of the test files to load")
 
 Instead of doing this:
 ```javascript
const sourceFolder = userArgs.includes("--folder");
const singleFile = userArgs.includes("--spec");

// and then later in `init()` function use it like this
if (sourceFolder) {
  commandLineConfig = `${commandLineConfig},integrationFolder=${sourceFolderLocation}`;
} else if {
  // testFiles in this context is part of the Cypress spec
  commandLineConfig = `${commandLineConfig},testFiles=${singleFileName}`;
} else { ... }
 ```
 
 we _were_ doing this:
  ```javascript
const testFiles = userArgs.includes("--testFiles"); // misleading flag name
const singleFile = userArgs.includes("--spec");

// and then later in `init()` function use it like this
if (testFiles) {
  commandLineConfig = `${commandLineConfig},integrationFolder=${testFilesLocation}`;
} else if {
  // testFiles in this context is part of the Cypress spec
  commandLineConfig = `${commandLineConfig},testFiles=${singleFileName}`;
} else { ... }
 ```