### PR TITLE
Add set of Cypress custom commands related to permissions API

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -144,7 +144,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
       });
 
-      updatePermissionsGraph({
+      cy.updatePermissionsSchema({
         schema: {
           [ORDERS_ID]: { query: "segmented", read: "all" },
           [PEOPLE_ID]: { query: "segmented", read: "all" },
@@ -234,7 +234,7 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: PEOPLE_ID,
       });
 
-      updatePermissionsGraph({
+      cy.updatePermissionsSchema({
         schema: {
           [ORDERS_ID]: "all",
           [PEOPLE_ID]: { query: "segmented", read: "all" },
@@ -291,7 +291,7 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: ORDERS_ID,
       });
 
-      updatePermissionsGraph({
+      cy.updatePermissionsSchema({
         schema: {
           [ORDERS_ID]: { query: "segmented", read: "all" },
         },
@@ -366,7 +366,7 @@ describeWithToken("formatting > sandboxes", () => {
           table_id: ORDERS_ID,
         });
 
-        updatePermissionsGraph({
+        cy.updatePermissionsSchema({
           schema: {
             [PRODUCTS_ID]: "all",
             [ORDERS_ID]: { query: "segmented", read: "all" },
@@ -442,7 +442,7 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: ORDERS_ID,
       });
 
-      updatePermissionsGraph({
+      cy.updatePermissionsSchema({
         schema: {
           [PRODUCTS_ID]: "all",
           [ORDERS_ID]: { query: "segmented", read: "all" },
@@ -583,7 +583,7 @@ describeWithToken("formatting > sandboxes", () => {
           });
         });
 
-        updatePermissionsGraph({
+        cy.updatePermissionsSchema({
           schema: {
             [PRODUCTS_ID]: { query: "segmented", read: "all" },
             [ORDERS_ID]: { query: "segmented", read: "all" },
@@ -713,7 +713,7 @@ describeWithToken("formatting > sandboxes", () => {
             });
           });
 
-          updatePermissionsGraph({
+          cy.updatePermissionsSchema({
             schema: {
               [PRODUCTS_ID]: { query: "segmented", read: "all" },
               [ORDERS_ID]: { query: "segmented", read: "all" },
@@ -777,7 +777,7 @@ describeWithToken("formatting > sandboxes", () => {
           },
         });
 
-        updatePermissionsGraph({
+        cy.updatePermissionsSchema({
           schema: {
             [ORDERS_ID]: { query: "segmented", read: "all" },
             [PRODUCTS_ID]: "all",
@@ -832,7 +832,7 @@ describeWithToken("formatting > sandboxes", () => {
           group_id: COLLECTION_GROUP,
         });
 
-        updatePermissionsGraph({
+        cy.updatePermissionsSchema({
           schema: {
             [PRODUCTS_ID]: { query: "segmented", read: "all" },
             [ORDERS_ID]: { query: "segmented", read: "all" },
@@ -995,7 +995,7 @@ describeWithToken("formatting > sandboxes", () => {
         group_id: COLLECTION_GROUP,
       });
 
-      updatePermissionsGraph({
+      cy.updatePermissionsSchema({
         schema: {
           [PRODUCTS_ID]: { query: "segmented", read: "all" },
           [ORDERS_ID]: { query: "segmented", read: "all" },
@@ -1039,46 +1039,6 @@ function signInAsSandboxedUser() {
     username: sandboxed_user.email,
     password: sandboxed_user.password,
   });
-}
-
-/**
- * As per definition for `PUT /graph` from `permissions.clj`:
- *
- * This should return the same graph, in the same format,
- * that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary.
- * This modified graph must correspond to the `PermissionsGraph` schema.
- *
- * That's why we must chain GET and PUT requests one after the other.
- */
-
-function updatePermissionsGraph({
-  schema = {},
-  user_group = COLLECTION_GROUP,
-  database_id = 1,
-} = {}) {
-  if (typeof schema !== "object") {
-    throw new Error("`schema` must be an object!");
-  }
-
-  cy.log("**-- Fetch permissions graph --**");
-  cy.request("GET", "/api/permissions/graph", {}).then(
-    ({ body: { groups, revision } }) => {
-      // This mutates the original `groups` object => we'll pass it next to the `PUT` request
-      groups[user_group] = {
-        [database_id]: {
-          schemas: {
-            PUBLIC: schema,
-          },
-        },
-      };
-
-      cy.log("**-- Update/save permissions --**");
-      cy.request("PUT", "/api/permissions/graph", {
-        groups,
-        revision,
-      });
-    },
-  );
 }
 
 function createJoinedQuestion(name) {

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -144,10 +144,12 @@ describeWithToken("formatting > sandboxes", () => {
         });
       });
 
-      cy.updatePermissionsSchema({
-        schema: {
-          [ORDERS_ID]: { query: "segmented", read: "all" },
-          [PEOPLE_ID]: { query: "segmented", read: "all" },
+      cy.updatePermissionsSchemas({
+        schemas: {
+          PUBLIC: {
+            [ORDERS_ID]: { query: "segmented", read: "all" },
+            [PEOPLE_ID]: { query: "segmented", read: "all" },
+          },
         },
         user_group: DATA_GROUP,
       });
@@ -234,12 +236,14 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: PEOPLE_ID,
       });
 
-      cy.updatePermissionsSchema({
-        schema: {
-          [ORDERS_ID]: "all",
-          [PEOPLE_ID]: { query: "segmented", read: "all" },
-          [PRODUCTS_ID]: "all",
-          [REVIEWS_ID]: "all",
+      cy.updatePermissionsSchemas({
+        schemas: {
+          PUBLIC: {
+            [ORDERS_ID]: "all",
+            [PEOPLE_ID]: { query: "segmented", read: "all" },
+            [PRODUCTS_ID]: "all",
+            [REVIEWS_ID]: "all",
+          },
         },
       });
 
@@ -291,9 +295,11 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: ORDERS_ID,
       });
 
-      cy.updatePermissionsSchema({
-        schema: {
-          [ORDERS_ID]: { query: "segmented", read: "all" },
+      cy.updatePermissionsSchemas({
+        schemas: {
+          PUBLIC: {
+            [ORDERS_ID]: { query: "segmented", read: "all" },
+          },
         },
       });
 
@@ -366,10 +372,12 @@ describeWithToken("formatting > sandboxes", () => {
           table_id: ORDERS_ID,
         });
 
-        cy.updatePermissionsSchema({
-          schema: {
-            [PRODUCTS_ID]: "all",
-            [ORDERS_ID]: { query: "segmented", read: "all" },
+        cy.updatePermissionsSchemas({
+          schemas: {
+            PUBLIC: {
+              [PRODUCTS_ID]: "all",
+              [ORDERS_ID]: { query: "segmented", read: "all" },
+            },
           },
         });
 
@@ -442,10 +450,12 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: ORDERS_ID,
       });
 
-      cy.updatePermissionsSchema({
-        schema: {
-          [PRODUCTS_ID]: "all",
-          [ORDERS_ID]: { query: "segmented", read: "all" },
+      cy.updatePermissionsSchemas({
+        schemas: {
+          PUBLIC: {
+            [PRODUCTS_ID]: "all",
+            [ORDERS_ID]: { query: "segmented", read: "all" },
+          },
         },
       });
 
@@ -583,10 +593,12 @@ describeWithToken("formatting > sandboxes", () => {
           });
         });
 
-        cy.updatePermissionsSchema({
-          schema: {
-            [PRODUCTS_ID]: { query: "segmented", read: "all" },
-            [ORDERS_ID]: { query: "segmented", read: "all" },
+        cy.updatePermissionsSchemas({
+          schemas: {
+            PUBLIC: {
+              [PRODUCTS_ID]: { query: "segmented", read: "all" },
+              [ORDERS_ID]: { query: "segmented", read: "all" },
+            },
           },
         });
 
@@ -713,10 +725,12 @@ describeWithToken("formatting > sandboxes", () => {
             });
           });
 
-          cy.updatePermissionsSchema({
-            schema: {
-              [PRODUCTS_ID]: { query: "segmented", read: "all" },
-              [ORDERS_ID]: { query: "segmented", read: "all" },
+          cy.updatePermissionsSchemas({
+            schemas: {
+              PUBLIC: {
+                [PRODUCTS_ID]: { query: "segmented", read: "all" },
+                [ORDERS_ID]: { query: "segmented", read: "all" },
+              },
             },
           });
 
@@ -777,10 +791,12 @@ describeWithToken("formatting > sandboxes", () => {
           },
         });
 
-        cy.updatePermissionsSchema({
-          schema: {
-            [ORDERS_ID]: { query: "segmented", read: "all" },
-            [PRODUCTS_ID]: "all",
+        cy.updatePermissionsSchemas({
+          schemas: {
+            PUBLIC: {
+              [ORDERS_ID]: { query: "segmented", read: "all" },
+              [PRODUCTS_ID]: "all",
+            },
           },
         });
 
@@ -832,10 +848,12 @@ describeWithToken("formatting > sandboxes", () => {
           group_id: COLLECTION_GROUP,
         });
 
-        cy.updatePermissionsSchema({
-          schema: {
-            [PRODUCTS_ID]: { query: "segmented", read: "all" },
-            [ORDERS_ID]: { query: "segmented", read: "all" },
+        cy.updatePermissionsSchemas({
+          schemas: {
+            PUBLIC: {
+              [PRODUCTS_ID]: { query: "segmented", read: "all" },
+              [ORDERS_ID]: { query: "segmented", read: "all" },
+            },
           },
         });
 
@@ -995,10 +1013,12 @@ describeWithToken("formatting > sandboxes", () => {
         group_id: COLLECTION_GROUP,
       });
 
-      cy.updatePermissionsSchema({
-        schema: {
-          [PRODUCTS_ID]: { query: "segmented", read: "all" },
-          [ORDERS_ID]: { query: "segmented", read: "all" },
+      cy.updatePermissionsSchemas({
+        schemas: {
+          PUBLIC: {
+            [PRODUCTS_ID]: { query: "segmented", read: "all" },
+            [ORDERS_ID]: { query: "segmented", read: "all" },
+          },
         },
       });
 

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -37,10 +37,10 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "updatePermissionsSchema",
-  ({ schema = {}, user_group = 4, database_id = 1 } = {}) => {
-    if (typeof schema !== "object") {
-      throw new Error("`schema` must be an object!");
+  "updatePermissionsSchemas",
+  ({ schemas = {}, user_group = 4, database_id = 1 } = {}) => {
+    if (typeof schemas !== "object") {
+      throw new Error("`schemas` must be an object!");
     }
 
     cy.log("**-- Fetch permissions graph --**");
@@ -49,9 +49,7 @@ Cypress.Commands.add(
         const UPDATED_GROUPS = Object.assign(groups, {
           [user_group]: {
             [database_id]: {
-              schemas: {
-                public: schema,
-              },
+              schemas,
             },
           },
         });

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -1,3 +1,37 @@
 Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });
+
+/**
+ * PERMISSIONS
+ *
+ * As per definition for `PUT /graph` from `permissions.clj`:
+ *
+ * "This should return the same graph, in the same format,
+ * that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary.
+ * This modified graph must correspond to the `PermissionsGraph` schema."
+ *
+ * That's why we must chain GET and PUT requests one after the other.
+ */
+
+Cypress.Commands.add(
+  "updatePermissionsGraph",
+  (groupsPermissionsObject = {}) => {
+    if (typeof groupsPermissionsObject !== "object") {
+      throw new Error("`groupsPermissionsObject` must be an object!");
+    }
+
+    cy.log("**-- Fetch permissions graph --**");
+    cy.request("GET", "/api/permissions/graph").then(
+      ({ body: { groups, revision } }) => {
+        const UPDATED_GROUPS = Object.assign(groups, groupsPermissionsObject);
+
+        cy.log("**-- Update/save permissions --**");
+        cy.request("PUT", "/api/permissions/graph", {
+          groups: UPDATED_GROUPS,
+          revision,
+        });
+      },
+    );
+  },
+);

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -65,3 +65,22 @@ Cypress.Commands.add(
     );
   },
 );
+
+Cypress.Commands.add("updateCollectionGraph", (groupsCollectionObject = {}) => {
+  if (typeof groupsCollectionObject !== "object") {
+    throw new Error("`groupsCollectionObject` must be an object!");
+  }
+
+  cy.log("**-- Fetch permissions graph --**");
+  cy.request("GET", "/api/collection/graph").then(
+    ({ body: { groups, revision } }) => {
+      const UPDATED_GROUPS = Object.assign(groups, groupsCollectionObject);
+
+      cy.log("**-- Update/save permissions --**");
+      cy.request("PUT", "/api/collection/graph", {
+        groups: UPDATED_GROUPS,
+        revision,
+      });
+    },
+  );
+});

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -35,3 +35,33 @@ Cypress.Commands.add(
     );
   },
 );
+
+Cypress.Commands.add(
+  "updatePermissionsSchema",
+  ({ schema = {}, user_group = 4, database_id = 1 } = {}) => {
+    if (typeof schema !== "object") {
+      throw new Error("`schema` must be an object!");
+    }
+
+    cy.log("**-- Fetch permissions graph --**");
+    cy.request("GET", "/api/permissions/graph").then(
+      ({ body: { groups, revision } }) => {
+        const UPDATED_GROUPS = Object.assign(groups, {
+          [user_group]: {
+            [database_id]: {
+              schemas: {
+                public: schema,
+              },
+            },
+          },
+        });
+
+        cy.log("**-- Update/save permissions --**");
+        cy.request("PUT", "/api/permissions/graph", {
+          groups: UPDATED_GROUPS,
+          revision,
+        });
+      },
+    );
+  },
+);

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -41,22 +41,15 @@ describeWithToken("postgres > user > query", () => {
       cy.request("PUT", `/api/user/${USER_ID}/qbnewb`, {});
     });
     // Update basic permissions (the same starting "state" as we have for the "Sample Dataset")
-    cy.request("GET", "/api/permissions/graph", {}).then(
-      ({ body: { groups, revision } }) => {
-        cy.request("PUT", "/api/permissions/graph", {
-          revision,
-          groups: {
-            [ALL_USERS_GROUP]: {
-              [PG_DB_ID]: { schemas: "none", native: "none" },
-            },
-            [DATA_GROUP]: { [PG_DB_ID]: { schemas: "all", native: "write" } },
-            [COLLECTION_GROUP]: {
-              [PG_DB_ID]: { schemas: "none", native: "none" },
-            },
-          },
-        });
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [PG_DB_ID]: { schemas: "none", native: "none" },
       },
-    );
+      [DATA_GROUP]: { [PG_DB_ID]: { schemas: "all", native: "write" } },
+      [COLLECTION_GROUP]: {
+        [PG_DB_ID]: { schemas: "none", native: "none" },
+      },
+    });
   });
 
   it.skip("should handle the use of `regexextract` in a sandboxed table (metabase#14873)", () => {

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -94,10 +94,12 @@ describeWithToken("postgres > user > query", () => {
           group_id: COLLECTION_GROUP,
         });
 
-        cy.updatePermissionsSchema({
+        cy.updatePermissionsSchemas({
           database_id: PG_DB_ID,
-          schema: {
-            [PEOPLE_ID]: { query: "segmented", read: "all" },
+          schemas: {
+            public: {
+              [PEOPLE_ID]: { query: "segmented", read: "all" },
+            },
           },
         });
 

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -94,7 +94,8 @@ describeWithToken("postgres > user > query", () => {
           group_id: COLLECTION_GROUP,
         });
 
-        updatePermissionsGraph({
+        cy.updatePermissionsSchema({
+          database_id: PG_DB_ID,
           schema: {
             [PEOPLE_ID]: { query: "segmented", read: "all" },
           },
@@ -121,44 +122,4 @@ function signInAsSandboxedUser() {
     username: sandboxed_user.email,
     password: sandboxed_user.password,
   });
-}
-
-/**
- * As per definition for `PUT /graph` from `permissions.clj`:
- *
- * This should return the same graph, in the same format,
- * that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary.
- * This modified graph must correspond to the `PermissionsGraph` schema.
- *
- * That's why we must chain GET and PUT requests one after the other.
- */
-
-function updatePermissionsGraph({
-  schema = {},
-  user_group = COLLECTION_GROUP,
-  database_id = PG_DB_ID,
-} = {}) {
-  if (typeof schema !== "object") {
-    throw new Error("`schema` must be an object!");
-  }
-
-  cy.log("**-- Fetch permissions graph --**");
-  cy.request("GET", "/api/permissions/graph", {}).then(
-    ({ body: { groups, revision } }) => {
-      // This mutates the original `groups` object => we'll pass it next to the `PUT` request
-      groups[user_group] = {
-        [database_id]: {
-          schemas: {
-            public: schema,
-          },
-        },
-      };
-
-      cy.log("**-- Update/save permissions --**");
-      cy.request("PUT", "/api/permissions/graph", {
-        groups,
-        revision,
-      });
-    },
-  );
 }

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -102,13 +102,10 @@ describe("snapshots", () => {
       [COLLECTION_GROUP]: { "1": { schemas: "none", native: "none" } },
     });
 
-    cy.request("PUT", "/api/collection/graph", {
-      revision: 0,
-      groups: {
-        [ALL_USERS_GROUP]: { root: "none" },
-        [DATA_GROUP]: { root: "none" },
-        [COLLECTION_GROUP]: { root: "write" },
-      },
+    cy.updateCollectionGraph({
+      [ALL_USERS_GROUP]: { root: "none" },
+      [DATA_GROUP]: { root: "none" },
+      [COLLECTION_GROUP]: { root: "write" },
     });
   }
 

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -96,15 +96,12 @@ describe("snapshots", () => {
     // Make a call to `/api/user` because some things (personal collections) get created there
     cy.request("GET", "/api/user");
 
-    // permissions
-    cy.request("PUT", "/api/permissions/graph", {
-      revision: 0,
-      groups: {
-        [ALL_USERS_GROUP]: { "1": { schemas: "none", native: "none" } },
-        [DATA_GROUP]: { "1": { schemas: "all", native: "write" } },
-        [COLLECTION_GROUP]: { "1": { schemas: "none", native: "none" } },
-      },
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: { "1": { schemas: "none", native: "none" } },
+      [DATA_GROUP]: { "1": { schemas: "all", native: "write" } },
+      [COLLECTION_GROUP]: { "1": { schemas: "none", native: "none" } },
     });
+
     cy.request("PUT", "/api/collection/graph", {
       revision: 0,
       groups: {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Abstracts API calls related to updating (table and collection) permissions in a form of Cypress custom commands

### Additional notes:
From a `api/defendpoint PUT "/graph"` definition in `src/metabase/api/permissions.clj`:
> Do a batch update of Permissions by passing in a modified graph. This should return the same graph, in the same format, that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary.
> This modified graph must correspond to the `PermissionsGraph` schema.

Response body from calling `GET /api/permissions/graph` gives us `groups` object and `revision` counter:
```javascript
{
  groups: {
    // group_id
    1: {
      // database_id
      1: {
        native: "write",
        schemas: "all"
      }
    },
    // group_id
    2: {
      // database_id
      1: {
        native: "write",
        schemas: "all"
      }
    }
  },
  revision: 3
}
```

We **must** match this schema and must not tamper with the revision counter, otherwise the `PUT` call will immediately fail.
To achieve this, we:
1. Chain `GET` and `PUT` requests
2. Obtain `groups` and `revision` from `GET`
3. Construct updated `groups` object (that we'll pass next to the `PUT` request) using `Object.assign(groups, newGroupsPermissions)`
4. Pass `revision` untouched as we received it from the `GET`

This is the same principle we're using for all three custom commands.

#### Commands:
- `/api/permissions/graph`
    1. `cy.updatePermissionsGraph` 
        - accepts modified `groups` object
    2. `cy.updatePermissionsSchemas` 
        - accepts modified `schemas` object, along with `database_id` and `group_id`
        - finer-grain (table-level) control compared to the previous command
- `/api/collection/graph`
    1. `cy.updateCollection/graph` - update modified `groups` object

#### Examples
```javascript
// Group-level
cy.updatePermissionsGraph({
  [ALL_USERS_GROUP]: { "1": { schemas: "none", native: "none" } },
  [DATA_GROUP]: { "1": { schemas: "all", native: "write" } },
  [COLLECTION_GROUP]: { "1": { schemas: "none", native: "none" } },
});

// Table-level
cy.updatePermissionsSchemas({
  schemas: {
    PUBLIC: { // Depending on the case-sensitivity of a DB, this key could also be lowercase
      [PRODUCTS_ID]: { query: "segmented", read: "all" },
      [ORDERS_ID]: { query: "segmented", read: "all" },
    },
  },
});

// Collections group level
cy.updateCollectionGraph({
  [ALL_USERS_GROUP]: { root: "none" },
  [DATA_GROUP]: { root: "none" },
  [COLLECTION_GROUP]: { root: "write" },
});
```