### PR TITLE
Fix #9357: Native question filter widget reordering via drag and drop

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -226,7 +226,7 @@ export default class NativeQuery extends AtomicQuery {
       this._originalQuestion,
       updateIn(
         this._datasetQuery,
-        ["native", "template_tags"],
+        ["native", "template-tags"],
         templateTags => {
           const entries = Array.from(Object.entries(templateTags));
           const oldIndex = _.findIndex(entries, entry => entry[1].id === id);

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -367,7 +367,7 @@ describe("scenarios > question > native", () => {
     cy.get("fieldset").contains("Filter");
   });
 
-  it("can reorder template tags by drag and drop", () => {
+  it("should reorder template tags by drag and drop (metabase#9357)", () => {
     cy.visit("/question/new");
     cy.contains("Native query").click();
 
@@ -380,28 +380,25 @@ describe("scenarios > question > native", () => {
       },
     );
 
-    // drag the firstparameter to last position
-    cy.get(".align-end")
-      .children()
+    // Drag the firstparameter to last position
+    cy.get("fieldset .Icon-empty")
       .first()
-      .find(".cursor-grab")
       .trigger("mousedown", 0, 0, { force: true })
-      .trigger("mousemove", 1, 1, { force: true })
-      .trigger("mousemove", 600, 1, { force: true })
-      .trigger("mouseup", 600, 1, { force: true });
+      .trigger("mousemove", 5, 5, { force: true })
+      .trigger("mousemove", 430, 0, { force: true })
+      .trigger("mouseup", 430, 0, { force: true });
 
-    // ensure they're in the right order
-    cy.contains("Variables")
+    // Ensure they're in the right order
+    cy.findAllByText("Variable name")
       .parent()
-      .parent()
-      .find(".text-brand")
-      .as("variableLabels");
+      .as("variableField");
 
-    cy.get("@variableLabels")
+    cy.get("@variableField")
       .first()
-      .should("have.text", "nextparameter");
-    cy.get("@variableLabels")
+      .findByText("nextparameter");
+
+    cy.get("@variableField")
       .last()
-      .should("have.text", "firstparameter");
+      .findByText("firstparameter");
   });
 });

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -366,4 +366,42 @@ describe("scenarios > question > native", () => {
     // Filter dropdown field
     cy.get("fieldset").contains("Filter");
   });
+
+  it("can reorder template tags by drag and drop", () => {
+    cy.visit("/question/new");
+    cy.contains("Native query").click();
+
+    // Write a query with parameter firstparameter,nextparameter,lastparameter.
+    cy.get(".ace_content").type(
+      "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
+      {
+        parseSpecialCharSequences: false,
+        delay: 0,
+      },
+    );
+
+    // drag the firstparameter to last position
+    cy.get(".align-end")
+      .children()
+      .first()
+      .find(".cursor-grab")
+      .trigger("mousedown", 0, 0, { force: true })
+      .trigger("mousemove", 1, 1, { force: true })
+      .trigger("mousemove", 600, 1, { force: true })
+      .trigger("mouseup", 600, 1, { force: true });
+
+    // ensure they're in the right order
+    cy.contains("Variables")
+      .parent()
+      .parent()
+      .find(".text-brand")
+      .as("variableLabels");
+
+    cy.get("@variableLabels")
+      .first()
+      .should("have.text", "nextparameter");
+    cy.get("@variableLabels")
+      .last()
+      .should("have.text", "firstparameter");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes #9357 
- Adds a Cypress repro for #9357 
- This PR rebases #12471 and fixes a Cypress test 

### How to test this manually?
- `yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/native.cy.spec.js`
- All tests should pass

### Additional notes:
- All credits for this fix go to @sunui who originally found a mistake and wrote the initial version of Cypress repro. Thank you!

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/109030012-b8704d80-76c3-11eb-9946-7b92426960bb.png)
