### PR TITLE
Upgrade `react-sortable-hoc` library to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-resizable": "^1.9.0",
     "react-router": "3",
     "react-router-redux": "^4.0.8",
-    "react-sortable-hoc": "^0.6.8",
+    "react-sortable-hoc": "^1.11.0",
     "react-textarea-autosize": "^5.2.1",
     "react-transition-group": "1",
     "react-virtualized": "^9.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,6 +836,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.2.0":
+  version "7.13.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.7.tgz#d494e39d198ee9ca04f4dcb76d25d9d7a1dc961a"
+  integrity sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.4.5":
   version "7.12.3"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.3.tgz#65f37d670ebb4083e74fd9b5178044ccc64d4f83"
@@ -2660,7 +2667,7 @@ babel-register@^6.26.0, babel-register@^6.9.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -8537,7 +8544,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.11.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.5.1:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.5.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -11152,14 +11159,13 @@ react-router@3:
     react-is "^16.13.0"
     warning "^3.0.0"
 
-react-sortable-hoc@^0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz#b08562f570d7c41f6e393fca52879d2ebb9118e9"
-  integrity sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==
+react-sortable-hoc@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz#fe4022362bbafc4b836f5104b9676608a40a278f"
+  integrity sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==
   dependencies:
-    babel-runtime "^6.11.6"
-    invariant "^2.2.1"
-    lodash "^4.12.0"
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.4"
     prop-types "^15.5.7"
 
 react-test-renderer@15:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Upgrades `react-sortable-hoc` library to the latest version

### How to verify this still works?
- App should build normally
- All tests should pass

#### Manually:
We use this library in 4 components, so there are some places in UI where you can check if drag and drop functionality still works:
- Native filter widgets
- ![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/4gu1eryA/9b0709a0-79d2-40a6-b95f-67f6bfcaed18.gif?source=viewer&v=795f01d675dd7add63203777c0b5d325)

- Column settings 
![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/llu9d0zG/6ac3cc31-8a56-413c-9be8-edaa2255d0b2.gif?v=68b3c82e7dcfef20fb29bb2a189a1820)

- Column reordering (visualization settings)
![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/kpu7W87P/71a78d64-8166-41e5-be0e-3b95d6e0ee58.gif?source=viewer&v=dc9d4abc7929120bfe42bc399e48d5ee)

- Conditional formatting rules reordering
![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/jkueWXmZ/f28436d2-4280-4867-81bd-b00ccc5e3844.gif?source=viewer&v=7ba350a50312aa0f272aabae8168ff1e)