### PR TITLE
Add styling for "no results found" in the type ahead search box

### DIFF
--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -97,8 +97,8 @@ export default class SearchBar extends React.Component {
       return (
         <li className="flex flex-column align-center justify-center p4 text-medium text-centered">
           <div className="my3">
-            <Icon name="search" mb={1} size={22} />
-            <h4>{t`No results found`}</h4>
+            <Icon name="search" mb={1} size={24} />
+            <h3 className="text-light">{t`No results found`}</h3>
           </div>
         </li>
       );

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -95,9 +95,11 @@ export default class SearchBar extends React.Component {
   renderResults(results) {
     if (results.length === 0) {
       return (
-        <li>
-          <Icon name="alert" />
-          {t`No results`}
+        <li className="flex flex-column align-center justify-center p4 text-medium text-centered">
+          <div className="my3">
+            <Icon name="search" mb={1} size={22} />
+            <h4>{t`No results found`}</h4>
+          </div>
         </li>
       );
     } else {


### PR DESCRIPTION
## What this does
Adds some basic styling to the type ahead search results in cases where there aren't any results.

How to test
- Type something that you know doesn't exist into the search box and behold.

Before:
![image](https://user-images.githubusercontent.com/5248953/109078495-68958480-76cb-11eb-8472-1f9df7f8c56b.png)

After:
![image](https://user-images.githubusercontent.com/5248953/109078451-5a476880-76cb-11eb-94fe-cd6928a72051.png)

