### PR TITLE
#14959 Repro: Can not convert case-insensitive filter to custom expression

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -862,7 +862,6 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Reviewer contains MULLER").click();
     cy.get(".Icon-chevronleft").click();
     cy.findByText("Custom Expression").click();
-    // Before we implement this feature, we can only assert that the input field for custom expression doesn't show at all
     cy.get("[contenteditable='true']").contains(
       'contains([Reviewer], "MULLER")',
     );


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14959

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/109155823-54f02980-7770-11eb-8b1e-3a01f567c97d.png)

