### PR TITLE
#14957 Repro: Saving a question before query has been executed can be slow with UI "hanging"

### DIFF
--- a/frontend/test/metabase-db/postgres/native.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/native.cy.spec.js
@@ -1,0 +1,27 @@
+import {
+  signInAsAdmin,
+  restore,
+  addPostgresDatabase,
+  modal,
+} from "__support__/cypress";
+
+const PG_DB_NAME = "QA Postgres12";
+
+describe("postgres > question > native", () => {
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+    addPostgresDatabase(PG_DB_NAME);
+  });
+
+  it.skip("should save a question before query has been executed (metabase#14957)", () => {
+    cy.visit("/question/new");
+    cy.findByText("Native query").click();
+    cy.findByText(PG_DB_NAME).click();
+    cy.get(".ace_content").type("select pg_sleep(60)");
+    cy.findByText("Save").click();
+    cy.findByLabelText("Name").type("14957");
+    cy.findByRole("button", { name: "Save" }).click();
+    modal().should("not.exist");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14957

### How to test this manually?
- `yarn test-cypress-open --folder frontend/test/metabase-db/`
- `frontend/test/metabase-db/postgres/native.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:

