### PR TITLE
#14515 Repro: Slack-based dashboard subscriptions should have a "Send to Slack now" button

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -141,6 +141,15 @@ describe("scenarios > dashboard > subscriptions", () => {
       cy.findByText("#work").click();
       cy.findAllByRole("button", { name: "Done" }).should("not.be.disabled");
     });
+
+    it.skip("should have 'Send to Slack now' button (metabase#14515)", () => {
+      cy.findAllByRole("button", { name: "Send to Slack now" }).should(
+        "be.disabled",
+      );
+      cy.findByText("Pick a user or channel...").click();
+      cy.findByText("#work").click();
+      cy.findAllByRole("button", { name: "Done" }).should("not.be.disabled");
+    });
   });
 });
 

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -131,11 +131,11 @@ describe("scenarios > dashboard > subscriptions", () => {
         },
       });
       openDashboardSubscriptions();
+      cy.findByText("Send it to Slack").click();
+      cy.findByText("Send this dashboard to Slack");
     });
 
     it("should not enable 'Done' button before channel is selected (metabase#14494)", () => {
-      cy.findByText("Send it to Slack").click();
-      cy.findByText("Send this dashboard to Slack");
       cy.findAllByRole("button", { name: "Done" }).should("be.disabled");
       cy.findByText("Pick a user or channel...").click();
       cy.findByText("#work").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14515 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/109188453-40715880-7793-11eb-9052-02903eab1f77.png)

