### PR TITLE
Replace ExitOnOutOfMemoryError with CrashOnOutOfMemoryError

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -28,7 +28,7 @@ fi
 JAVA_OPTS="${JAVA_OPTS} -XX:+IgnoreUnrecognizedVMOptions"
 JAVA_OPTS="${JAVA_OPTS} -Dfile.encoding=UTF-8"
 JAVA_OPTS="${JAVA_OPTS} -Dlogfile.path=target/log"
-JAVA_OPTS="${JAVA_OPTS} -XX:+ExitOnOutOfMemoryError"
+JAVA_OPTS="${JAVA_OPTS} -XX:+CrashOnOutOfMemoryError"
 JAVA_OPTS="${JAVA_OPTS} -server"
 
 if [ ! -z "$JAVA_TIMEZONE" ]; then


### PR DESCRIPTION
This will make the JVM output more details as it crashes for running out of memory.

New output:

```text
rroland@tardis:~/src/metabase/target/uberjar$ java -Xmx50m -XX:+CrashOnOutOfMemoryError -jar metabase.jar
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2021-02-25 11:38:31,689 INFO metabase.util :: Maximum memory available to JVM: 50.0 MB
Aborting due to java.lang.OutOfMemoryError: Java heap space
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (debug.cpp:338), pid=40255, tid=40256
#  fatal error: OutOfMemory encountered: Java heap space
#
# JRE version: OpenJDK Runtime Environment (11.0.10+9) (build 11.0.10+9-post-Debian-1)
# Java VM: OpenJDK 64-Bit Server VM (11.0.10+9-post-Debian-1, mixed mode, sharing, tiered, compressed oops, g1 gc, linux-amd64)
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /home/rroland/src/metabase/target/uberjar/hs_err_pid40255.log
#
# If you would like to submit a bug report, please visit:
#   https://bugs.debian.org/openjdk-11
#
Aborted
```

Previous output:

```text
rroland@tardis:~/src/metabase/target/uberjar$ java -Xmx50m -XX:+ExitOnOutOfMemoryError -jar metabase.jar
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2021-02-25 11:38:46,898 INFO metabase.util :: Maximum memory available to JVM: 50.0 MB
Terminating due to java.lang.OutOfMemoryError: Java heap space
```
