### PR TITLE
Minor guard to catch (unlikely) corner cases of logical NOT

### DIFF
--- a/frontend/src/metabase/lib/expressions/compile.js
+++ b/frontend/src/metabase/lib/expressions/compile.js
@@ -56,9 +56,14 @@ class ExpressionMBQLCompilerVisitor extends ExpressionCstVisitor {
   }
   logicalNotExpression(ctx) {
     const expr = this.visit(ctx.operands[0]);
-    const [fn, ...args] = expr;
-    const shorthand = NEGATIVE_FILTER_SHORTHANDS[fn];
-    return shorthand ? [shorthand, ...args] : ["not", expr];
+    if (Array.isArray(expr)) {
+      const [fn, ...args] = expr;
+      const shorthand = NEGATIVE_FILTER_SHORTHANDS[fn];
+      if (shorthand) {
+        return [shorthand, ...args];
+      }
+    }
+    return ["not", expr];
   }
   relationalExpression(ctx) {
     return this._collapseOperators(ctx.operands, ctx.operators);

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -584,7 +584,7 @@ for (const rule of ALL_RULES) {
     // this just visits every child
     for (const type in ctx) {
       for (const child of ctx[type]) {
-        if (!child.tokenType) {
+        if (!child.tokenType && child.name) {
           const match = this.visit(child, currentContext);
           if (match) {
             return match;

--- a/frontend/test/metabase/lib/expressions/compile.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/compile.unit.spec.js
@@ -177,6 +177,7 @@ describe("metabase/lib/expressions/compile", () => {
     it("should compile logical operations", () => {
       expect(filter("NOT A")).toEqual(["not", ["segment", "A"]]);
       expect(filter("NOT 0")).toEqual(["not", 0]);
+      expect(filter("NOT 'Answer'")).toEqual(["not", "Answer"]);
       expect(filter("NOT NOT 0")).toEqual(["not", ["not", 0]]);
       expect(filter("1 OR 2")).toEqual(["or", 1, 2]);
       expect(filter("2 AND 3")).toEqual(["and", 2, 3]);
@@ -190,6 +191,7 @@ describe("metabase/lib/expressions/compile", () => {
     it("should compile segments", () => {
       expect(filter("[Expensive]")).toEqual(["segment", "Expensive"]);
       expect(filter("NOT [Good]")).toEqual(["not", ["segment", "Good"]]);
+      expect(filter("NOT Answer")).toEqual(["not", ["segment", "Answer"]]);
     });
     it("should compile negative filters", () => {
       expect(filter("NOT CONTAINS('X','Y')")).toEqual([


### PR DESCRIPTION
A simple follow-up to PR #14938, due to some oversight on my part.

How to test? Just run the entire custom expression test suite:
```
yarn test-unit frontend/test/metabase/lib/expressions/
```