### PR TITLE
Coerce query id for object details prev/next buttons to int

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1295,7 +1295,7 @@ export const viewNextObjectDetail = () => {
     const question = getQuestion(getState());
     const filter = question.query().filters()[0];
 
-    const newFilter = ["=", filter[1], filter[2] + 1];
+    const newFilter = ["=", filter[1], parseInt(filter[2]) + 1];
 
     dispatch.action(VIEW_NEXT_OBJECT_DETAIL);
 
@@ -1324,7 +1324,7 @@ export const viewPreviousObjectDetail = () => {
       return false;
     }
 
-    const newFilter = ["=", filter[1], filter[2] - 1];
+    const newFilter = ["=", filter[1], parseInt(filter[2]) - 1];
 
     dispatch.action(VIEW_PREVIOUS_OBJECT_DETAIL);
 

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -1,7 +1,10 @@
-import { signInAsNormalUser } from "__support__/cypress";
+import { restore, signInAsNormalUser } from "__support__/cypress";
 
 describe("scenarios > visualizations > object detail", () => {
-  beforeEach(signInAsNormalUser);
+  beforeEach(() => {
+    restore();
+    signInAsNormalUser();
+  });
 
   it("should show orders/reviews connected to a product", () => {
     cy.visit("/browse/1");
@@ -15,5 +18,13 @@ describe("scenarios > visualizations > object detail", () => {
     cy.contains("Reviews")
       .parent()
       .contains("8");
+  });
+
+  it("should allow clicking the next arrow", () => {
+    cy.visit("/browse/1");
+    cy.findByText("Products").click();
+    cy.findByText("1").click();
+    cy.get(".Icon-arrow_right").click();
+    cy.findByText("Small Marble Shoes");
   });
 });


### PR DESCRIPTION
Persuant to #13250.

Root cause is the previous string coercion to make big ints displayable. So this would seem to break it for BigInt-sized ints: but BigInt isn't supported by all browsers. This cut to that gordian knot is very easy.