### PR TITLE
remove unstable_renderSubtreeIntoContainer from Tooltip

### DIFF
--- a/frontend/src/metabase/components/Tooltip.jsx
+++ b/frontend/src/metabase/components/Tooltip.jsx
@@ -76,30 +76,6 @@ export default class Tooltip extends Component {
         `Tooltip::componentDidMount: no DOM node for tooltip ${this.props.tooltip}`,
       );
     }
-
-    this._element = document.createElement("div");
-    this.componentDidUpdate();
-  }
-
-  componentDidUpdate() {
-    const { isEnabled, tooltip } = this.props;
-    const isOpen =
-      this.props.isOpen != null ? this.props.isOpen : this.state.isOpen;
-    if (tooltip && isEnabled && isOpen) {
-      ReactDOM.unstable_renderSubtreeIntoContainer(
-        this,
-        <TooltipPopover
-          isOpen={true}
-          target={this}
-          hasArrow
-          {...this.props}
-          children={this.props.tooltip}
-        />,
-        this._element,
-      );
-    } else {
-      ReactDOM.unmountComponentAtNode(this._element);
-    }
   }
 
   componentWillUnmount() {
@@ -114,9 +90,6 @@ export default class Tooltip extends Component {
       console.warn(
         `Tooltip::componentWillUnmount: no DOM node for tooltip ${this.props.tooltip}`,
       );
-    }
-    if (this._element) {
-      ReactDOM.unmountComponentAtNode(this._element);
     }
     clearTimeout(this.timer);
   }
@@ -144,6 +117,22 @@ export default class Tooltip extends Component {
   };
 
   render() {
-    return React.Children.only(this.props.children);
+    const { isEnabled, tooltip } = this.props;
+    const isOpen =
+      this.props.isOpen != null ? this.props.isOpen : this.state.isOpen;
+    return (
+      <React.Fragment>
+        {React.Children.only(this.props.children)}
+        {tooltip && isEnabled && isOpen && (
+          <TooltipPopover
+            isOpen={true}
+            target={this}
+            hasArrow
+            {...this.props}
+            children={this.props.tooltip}
+          />
+        )}
+      </React.Fragment>
+    );
   }
 }


### PR DESCRIPTION
**Description**
Removing `unstable_renderSubtreeIntoContainer` from `Tooltip.jsx`. You'll notice that the `this._element` div we use as the container is never actually appended to the body. `TooltipPopover` is created and its child component is `Popover` and it does the appending of an entirely separate element -- so all of this logic is totally unnecessary. We can put `TooltipPopover` in the `render` function and it behaves they same exact way.

**Verification**
![tooltip](https://user-images.githubusercontent.com/13057258/109232350-11e88300-777d-11eb-8236-ec43ca00ea80.gif)
