### PR TITLE
Add Cypress custom log command

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/ad-hoc.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/ad-hoc.cy.spec.js
@@ -10,7 +10,7 @@ describeWithToken("audit > ad-hoc", () => {
     beforeEach(() => {
       restore();
 
-      cy.log("**Run ad hoc native query as normal user**");
+      cy.log("Run ad hoc native query as normal user");
       signInAsNormalUser();
       cy.visit("/question/new");
       cy.findByText("Native query").click();
@@ -35,7 +35,7 @@ describeWithToken("audit > ad-hoc", () => {
           cy.findByText("Ad-hoc").click();
         });
 
-      cy.log("**Assert that the query page is not blank**");
+      cy.log("Assert that the query page is not blank");
       cy.url().should("include", "/admin/audit/query/");
 
       cy.get(".PageTitle").contains("Query");

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -59,24 +59,24 @@ describeWithToken("audit > auditing", () => {
       generateDashboards(user);
     });
 
-    cy.log("**Download a question**");
+    cy.log("Download a question");
     cy.visit("/question/3");
     cy.icon("download").click();
     cy.request("POST", "/api/card/1/query/json");
 
     signIn("nodata");
 
-    cy.log(`**View ${normal}'s dashboard**`);
+    cy.log(`View ${normal}'s dashboard`);
     cy.visit("/collection/root?type=dashboard");
     cy.findByText(NORMAL_DASHBOARD).click();
     cy.findByText("This dashboard is looking empty.");
     cy.findByText("My personal collection").should("not.exist");
 
-    cy.log("**View old existing question**");
+    cy.log("View old existing question");
     cy.visit("/question/2");
     cy.findByText("18,760");
 
-    cy.log(`**View newly created ${admin}'s question**`);
+    cy.log(`View newly created ${admin}'s question`);
     cy.visit("/collection/root?type");
     cy.findByText(ADMIN_QUESTION).click();
     cy.findByPlaceholderText(/ID/i);

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -54,10 +54,10 @@ describeWithToken("formatting > whitelabel", () => {
     it("should be able to set colors using color-picker dialog", () => {
       cy.visit("/admin/settings/whitelabel");
 
-      cy.log("**--1. Select color with squares--**");
+      cy.log("Select color with squares");
       changeThemeColor(1, colors.primary.hex);
 
-      cy.log("**--2. Select color by entering rgb value--**");
+      cy.log("Select color by entering rgb value");
       cy.get("td")
         .eq(5)
         .click();
@@ -78,7 +78,7 @@ describeWithToken("formatting > whitelabel", () => {
         .type(colors.nav.rgb[2]);
       cy.findByText("Done").click();
 
-      cy.log("**--3. Select color by typing hex code--**");
+      cy.log("Select color by typing hex code");
       cy.get("td")
         .eq(29)
         .click();
@@ -95,7 +95,7 @@ describeWithToken("formatting > whitelabel", () => {
     const COMPANY_NAME = "Test Co";
 
     beforeEach(() => {
-      cy.log("**Change company name**");
+      cy.log("Change company name");
       cy.visit("/admin/settings/whitelabel");
       cy.findByPlaceholderText("Metabase")
         .clear()
@@ -108,17 +108,17 @@ describeWithToken("formatting > whitelabel", () => {
     });
 
     it("changes should reflect in different parts of UI", () => {
-      cy.log("**--1. New company should show up on activity page--**");
+      cy.log("New company should show up on activity page");
       cy.visit("/activity");
       cy.findByText(`${COMPANY_NAME} is up and running.`);
       cy.findByText("Metabase is up and running.").should("not.exist");
 
-      cy.log("**--2. New company should show up when logged out--**");
+      cy.log("New company should show up when logged out");
       signOut();
       cy.visit("/");
       cy.findByText(`Sign in to ${COMPANY_NAME}`);
 
-      cy.log("**--3. New company should show up for a normal user--**");
+      cy.log("New company should show up for a normal user");
       signInAsNormalUser();
       cy.visit("/activity");
       cy.findByText(`${COMPANY_NAME} is up and running.`);
@@ -208,7 +208,7 @@ describeWithToken("formatting > whitelabel", () => {
 
   describe("company logo", () => {
     beforeEach(() => {
-      cy.log("**Add a logo**");
+      cy.log("Add a logo");
       cy.readFile(
         "enterprise/frontend/test/metabase-enterprise/_support_/logo.jpeg",
         "base64",
@@ -241,7 +241,7 @@ describeWithToken("formatting > whitelabel", () => {
     beforeEach(() => {
       cy.visit("/admin/settings/whitelabel");
 
-      cy.log("**Add favicon**");
+      cy.log("Add favicon");
       cy.findByPlaceholderText("frontend_client/favicon.ico").type(
         "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
       );

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -431,7 +431,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
     });
 
-    it.only("should allow drill-through for sandboxed user (metabase-enterprise#535)", () => {
+    it("should allow drill-through for sandboxed user (metabase-enterprise#535)", () => {
       const PRODUCTS_ALIAS = "Products";
       const QUESTION_NAME = "EE_535";
 

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -110,7 +110,7 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      cy.log("**--Create parametrized SQL question--**");
+      cy.log("Create parametrized SQL question");
       cy.request("POST", "/api/card", {
         name: "sql param",
         dataset_query: {
@@ -168,17 +168,17 @@ describeWithToken("formatting > sandboxes", () => {
 
     describe("question with joins", () => {
       it("should be sandboxed even after applying a filter to the question", () => {
-        cy.log("**--0. Open saved question with joins--**");
+        cy.log("Open saved question with joins");
         cy.visit("/collection/root");
         cy.findByText(QUESTION_NAME).click();
 
-        cy.log("**--1. Make sure user is initially sandboxed--**");
+        cy.log("Make sure user is initially sandboxed");
         cy.get(".TableInteractive-cellWrapper--firstColumn").should(
           "have.length",
           11,
         );
 
-        cy.log("**--2. Add filter to a question--**");
+        cy.log("Add filter to a question");
         cy.icon("notebook").click();
         cy.findByText("Filter").click();
         popover().within(() => {
@@ -190,7 +190,7 @@ describeWithToken("formatting > sandboxes", () => {
         cy.findByText("Add filter").click();
         cy.findByText("Visualize").click();
 
-        cy.log("**--3. Make sure user is still sandboxed--**");
+        cy.log("Make sure user is still sandboxed");
         cy.get(".TableInteractive-cellWrapper--firstColumn").should(
           "have.length",
           7,
@@ -215,17 +215,13 @@ describeWithToken("formatting > sandboxes", () => {
       restore();
       signInAsAdmin();
       createUser(sandboxed_user).then(({ body: { id: USER_ID } }) => {
-        cy.log(
-          "**-- Dismiss `it's ok to play around` modal for new users --**",
-        );
+        cy.log("Dismiss `it's ok to play around` modal for new users");
         cy.request("PUT", `/api/user/${USER_ID}/qbnewb`, {});
       });
     });
 
     it("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {
-      cy.log(
-        "**-- 1. Sandbox `People` table on `user_id` attribute for `data` group --**",
-      );
+      cy.log("Sandbox `People` table on `user_id` attribute for `data` group");
 
       cy.request("POST", "/api/mt/gtap", {
         attribute_remappings: {
@@ -256,7 +252,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("Pick a column to group by").click();
 
       cy.log(
-        "**-- Original issue reported failure to find 'User' group / foreign key--**",
+        "Original issue reported failure to find 'User' group / foreign key",
       );
 
       popover().within(() => {
@@ -284,7 +280,7 @@ describeWithToken("formatting > sandboxes", () => {
       const QUESTION_NAME = "EE_548";
       const CC_NAME = "CC_548"; // Custom column
 
-      cy.log("**-- 1. Sandbox `Orders` table on `user_id` attribute --**");
+      cy.log("Sandbox `Orders` table on `user_id` attribute");
 
       cy.request("POST", "/api/mt/gtap", {
         attribute_remappings: {
@@ -303,7 +299,7 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      cy.log("**-- 2. Create and save a question --**");
+      cy.log("Create and save a question");
 
       cy.request("POST", "/api/card", {
         name: QUESTION_NAME,
@@ -339,7 +335,7 @@ describeWithToken("formatting > sandboxes", () => {
         cy.visit(`/question/${QUESTION_ID}`);
         cy.findByText(QUESTION_NAME);
 
-        cy.log("**Reported failing since v1.36.4**");
+        cy.log("Reported failing since v1.36.4");
         cy.wait("@cardQuery").then(xhr => {
           expect(xhr.response.body.error).not.to.exist;
         });
@@ -353,7 +349,7 @@ describeWithToken("formatting > sandboxes", () => {
         const QUESTION_NAME = "13641";
 
         if (test === "remapped") {
-          cy.log("**-- Remap Product ID's display value to `title` --**");
+          cy.log("Remap Product ID's display value to `title`");
           remapDisplayValueToFK({
             display_value: ORDERS.PRODUCT_ID,
             name: "Product ID",
@@ -361,7 +357,7 @@ describeWithToken("formatting > sandboxes", () => {
           });
         }
 
-        cy.log("**-- 1. Sandbox `Orders` table on `user_id` attribute --**");
+        cy.log("Sandbox `Orders` table on `user_id` attribute");
 
         cy.request("POST", "/api/mt/gtap", {
           attribute_remappings: {
@@ -382,7 +378,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
 
         cy.log(
-          "**-- 2. Create question based on steps in [#13641](https://github.com/metabase/metabase/issues/13641)--**",
+          "Create question based on steps in [#13641](https://github.com/metabase/metabase/issues/13641)",
         );
         cy.request("POST", "/api/card", {
           name: QUESTION_NAME,
@@ -426,7 +422,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
         cy.findByText("View these Orders").click();
 
-        cy.log("**Reported failing on v1.37.0.2**");
+        cy.log("Reported failing on v1.37.0.2");
         cy.wait("@dataset").then(xhr => {
           expect(xhr.response.body.error).not.to.exist;
         });
@@ -435,11 +431,11 @@ describeWithToken("formatting > sandboxes", () => {
       });
     });
 
-    it("should allow drill-through for sandboxed user (metabase-enterprise#535)", () => {
+    it.only("should allow drill-through for sandboxed user (metabase-enterprise#535)", () => {
       const PRODUCTS_ALIAS = "Products";
       const QUESTION_NAME = "EE_535";
 
-      cy.log("**-- 1. Sandbox `Orders` table on `user_id` attribute --**");
+      cy.log("Sandbox `Orders` table on `user_id` attribute");
 
       cy.request("POST", "/api/mt/gtap", {
         attribute_remappings: {
@@ -460,7 +456,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
 
       cy.log(
-        "**-- 2. Create question based on steps in [#535](https://github.com/metabase/metabase-enterprise/issues/535)--**",
+        "Create question based on steps in https://github.com/metabase/metabase-enterprise/issues/535",
       );
       cy.request("POST", "/api/card", {
         name: QUESTION_NAME,
@@ -513,14 +509,14 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("View these Orders").click();
 
       cy.wait("@dataset");
-      cy.log("**Reported failing on v1.36.4**");
+      cy.log("Reported failing on v1.36.4");
       cy.findByText("Category is Doohickey");
       cy.findByText("97.44"); // Subtotal for order #10
     });
 
     describe("with display values remapped to use a foreign key", () => {
       beforeEach(() => {
-        cy.log("**-- Remap Product ID's display value to `title` --**");
+        cy.log("Remap Product ID's display value to `title`");
         remapDisplayValueToFK({
           display_value: ORDERS.PRODUCT_ID,
           name: "Product ID",
@@ -536,7 +532,7 @@ describeWithToken("formatting > sandboxes", () => {
         cy.server();
         cy.route("POST", "/api/dataset").as("dataset");
 
-        cy.log("**-- 1. Create 'Orders'-based question using QB --**");
+        cy.log("Create 'Orders'-based question using QB");
 
         cy.request("POST", "/api/card", {
           name: "520_Orders",
@@ -552,7 +548,7 @@ describeWithToken("formatting > sandboxes", () => {
           visualization_settings: {},
         }).then(({ body: { id: CARD_ID } }) => {
           cy.log(
-            "**-- 1a. Sandbox `Orders` table based on this QB question and user attribute --**",
+            "Sandbox `Orders` table based on this QB question and user attribute",
           );
 
           cy.request("POST", "/api/mt/gtap", {
@@ -565,7 +561,7 @@ describeWithToken("formatting > sandboxes", () => {
           });
         });
 
-        cy.log("**-- 2. Create 'Products'-based question using QB --**");
+        cy.log("Create 'Products'-based question using QB");
         cy.request("POST", "/api/card", {
           name: "520_Products",
           dataset_query: {
@@ -580,7 +576,7 @@ describeWithToken("formatting > sandboxes", () => {
           visualization_settings: {},
         }).then(({ body: { id: CARD_ID } }) => {
           cy.log(
-            "**-- 2a. Sandbox `Products` table based on this QB question and user attribute --**",
+            "Sandbox `Products` table based on this QB question and user attribute",
           );
 
           cy.request("POST", "/api/mt/gtap", {
@@ -617,7 +613,7 @@ describeWithToken("formatting > sandboxes", () => {
         cy.findByText(/View details/i).click();
 
         cy.log(
-          "**It should show object details instead of filtering by this Product ID**",
+          "It should show object details instead of filtering by this Product ID",
         );
         cy.findByText("McClure-Lockman");
       });
@@ -640,7 +636,7 @@ describeWithToken("formatting > sandboxes", () => {
           cy.route("POST", "/api/card/*/query").as("cardQuery");
           cy.route("PUT", "/api/card/*").as("questionUpdate");
 
-          cy.log("**-- 1. Create the first native question with a filter --**");
+          cy.log("Create the first native question with a filter");
           cy.request("POST", "/api/card", {
             name: "EE_520_Q1",
             dataset_query: {
@@ -666,9 +662,7 @@ describeWithToken("formatting > sandboxes", () => {
               ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
               : null;
 
-            cy.log(
-              "**-- 1a. Sandbox `Orders` table based on this question --**",
-            );
+            cy.log("Sandbox `Orders` table based on this question");
 
             cy.request("POST", "/api/mt/gtap", {
               attribute_remappings: {
@@ -679,9 +673,7 @@ describeWithToken("formatting > sandboxes", () => {
               table_id: ORDERS_ID,
             });
           });
-          cy.log(
-            "**-- 2. Create the second native question with a filter --**",
-          );
+          cy.log("Create the second native question with a filter");
 
           cy.request("POST", "/api/card", {
             name: "EE_520_Q2",
@@ -711,9 +703,7 @@ describeWithToken("formatting > sandboxes", () => {
                 })
               : null;
 
-            cy.log(
-              "**-- 2a. Sandbox `Products` table based on this question --**",
-            );
+            cy.log("Sandbox `Products` table based on this question");
 
             cy.request("POST", "/api/mt/gtap", {
               attribute_remappings: {
@@ -739,10 +729,10 @@ describeWithToken("formatting > sandboxes", () => {
 
           openOrdersTable();
 
-          cy.log("**-- Reported failing on v1.36.x --**");
+          cy.log("Reported failing on v1.36.x");
 
           cy.log(
-            "**It should show remapped Display Values instead of Product ID**",
+            "It should show remapped Display Values instead of Product ID",
           );
           cy.get(".cellData")
             .contains("Awesome Concrete Shoes")
@@ -750,7 +740,7 @@ describeWithToken("formatting > sandboxes", () => {
           cy.findByText(/View details/i).click();
 
           cy.log(
-            "**It should show object details instead of filtering by this Product ID**",
+            "It should show object details instead of filtering by this Product ID",
           );
           // The name of this Vendor is visible in "details" only
           cy.findByText("McClure-Lockman");
@@ -778,9 +768,7 @@ describeWithToken("formatting > sandboxes", () => {
         cy.server();
         cy.route("POST", "/api/dataset").as("dataset");
 
-        cy.log(
-          "**-- 1. Sandbox `Orders` table based on user attribute `attr_uid` --**",
-        );
+        cy.log("Sandbox `Orders` table based on user attribute `attr_uid`");
 
         cy.request("POST", "/api/mt/gtap", {
           table_id: ORDERS_ID,
@@ -818,7 +806,7 @@ describeWithToken("formatting > sandboxes", () => {
         const PRODUCTS_ALIAS = "Products";
 
         if (test === "remapped") {
-          cy.log("**-- Remap Product ID's display value to `title` --**");
+          cy.log("Remap Product ID's display value to `title`");
           remapDisplayValueToFK({
             display_value: ORDERS.PRODUCT_ID,
             name: "Product ID",
@@ -826,7 +814,7 @@ describeWithToken("formatting > sandboxes", () => {
           });
         }
 
-        cy.log("**-- 1. Sandbox `Orders` table --**");
+        cy.log("Sandbox `Orders` table");
 
         cy.request("POST", "/api/mt/gtap", {
           attribute_remappings: {
@@ -837,7 +825,7 @@ describeWithToken("formatting > sandboxes", () => {
           group_id: COLLECTION_GROUP,
         });
 
-        cy.log("**-- 2. Sandbox `Products` table --**");
+        cy.log("Sandbox `Products` table");
 
         cy.request("POST", "/api/mt/gtap", {
           attribute_remappings: {
@@ -857,7 +845,7 @@ describeWithToken("formatting > sandboxes", () => {
           },
         });
 
-        cy.log("**-- 3. Create question with joins --**");
+        cy.log("Create question with joins");
 
         cy.request("POST", "/api/card", {
           name: QUESTION_NAME,
@@ -928,7 +916,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.route("POST", "/api/mt/gtap").as("sandboxTable");
 
       cy.log(
-        "**-- 1. Create question that will have differently-typed columns than the sandboxed table --**",
+        "Create question that will have differently-typed columns than the sandboxed table",
       );
 
       cy.request("POST", "/api/card", {
@@ -993,7 +981,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
-      cy.log("**-- 1. Sandbox `Orders` table --**");
+      cy.log("Sandbox `Orders` table");
       cy.request("POST", "/api/mt/gtap", {
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
@@ -1003,7 +991,7 @@ describeWithToken("formatting > sandboxes", () => {
         group_id: COLLECTION_GROUP,
       });
 
-      cy.log("**-- 2. Sandbox `Products` table --**");
+      cy.log("Sandbox `Products` table");
       cy.request("POST", "/api/mt/gtap", {
         attribute_remappings: {
           [ATTR_CAT]: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
@@ -1148,7 +1136,7 @@ describeWithToken("formatting > sandboxes", () => {
 });
 
 function signInAsSandboxedUser() {
-  cy.log("**-- Logging in as sandboxed user --**");
+  cy.log("Logging in as sandboxed user");
   cy.request("POST", "/api/session", {
     username: sandboxed_user.email,
     password: sandboxed_user.password,

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -21,12 +21,12 @@ Cypress.Commands.add(
       throw new Error("`groupsPermissionsObject` must be an object!");
     }
 
-    cy.log("**-- Fetch permissions graph --**");
+    cy.log("Fetch permissions graph");
     cy.request("GET", "/api/permissions/graph").then(
       ({ body: { groups, revision } }) => {
         const UPDATED_GROUPS = Object.assign(groups, groupsPermissionsObject);
 
-        cy.log("**-- Update/save permissions --**");
+        cy.log("Update/save permissions");
         cy.request("PUT", "/api/permissions/graph", {
           groups: UPDATED_GROUPS,
           revision,
@@ -43,7 +43,7 @@ Cypress.Commands.add(
       throw new Error("`schemas` must be an object!");
     }
 
-    cy.log("**-- Fetch permissions graph --**");
+    cy.log("Fetch permissions graph");
     cy.request("GET", "/api/permissions/graph").then(
       ({ body: { groups, revision } }) => {
         const UPDATED_GROUPS = Object.assign(groups, {
@@ -54,7 +54,7 @@ Cypress.Commands.add(
           },
         });
 
-        cy.log("**-- Update/save permissions --**");
+        cy.log("Update/save permissions");
         cy.request("PUT", "/api/permissions/graph", {
           groups: UPDATED_GROUPS,
           revision,
@@ -69,12 +69,12 @@ Cypress.Commands.add("updateCollectionGraph", (groupsCollectionObject = {}) => {
     throw new Error("`groupsCollectionObject` must be an object!");
   }
 
-  cy.log("**-- Fetch permissions graph --**");
+  cy.log("Fetch permissions graph");
   cy.request("GET", "/api/collection/graph").then(
     ({ body: { groups, revision } }) => {
       const UPDATED_GROUPS = Object.assign(groups, groupsCollectionObject);
 
-      cy.log("**-- Update/save permissions --**");
+      cy.log("Update/save permissions");
       cy.request("PUT", "/api/collection/graph", {
         groups: UPDATED_GROUPS,
         revision,

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -83,9 +83,11 @@ Cypress.Commands.add("updateCollectionGraph", (groupsCollectionObject = {}) => {
   );
 });
 
-Cypress.Commands.overwrite("log", (originalFn, message) => {
-  window.logCalls = window.logCalls || 1;
+/**
+ * OVERWRITES
+ */
 
+Cypress.Commands.overwrite("log", (originalFn, message) => {
   Cypress.log({
     displayName: `--- ${window.logCalls}. ${message} ---`,
     name: `--- ${window.logCalls}. ${message} ---`,
@@ -93,4 +95,9 @@ Cypress.Commands.overwrite("log", (originalFn, message) => {
   });
 
   window.logCalls++;
+});
+
+// We want to reset the log counter for every new test (do not remove from this file)
+beforeEach(() => {
+  window.logCalls = 1;
 });

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -82,3 +82,15 @@ Cypress.Commands.add("updateCollectionGraph", (groupsCollectionObject = {}) => {
     },
   );
 });
+
+Cypress.Commands.overwrite("log", (originalFn, message) => {
+  window.logCalls = window.logCalls || 1;
+
+  Cypress.log({
+    displayName: `--- ${window.logCalls}. ${message} ---`,
+    name: `--- ${window.logCalls}. ${message} ---`,
+    message: "",
+  });
+
+  window.logCalls++;
+});

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -44,12 +44,12 @@ export const USER_GROUPS = {
 };
 
 export function signIn(user = "admin") {
-  cy.log(`**--- Logging in as ${user} ---**`);
+  cy.log(`Logging in as ${user}`);
   cy.request("POST", "/api/session", USERS[user]);
 }
 
 export function signOut() {
-  cy.log(`**--- Signing out ---**`);
+  cy.log("Signing out");
   cy.clearCookie("metabase.SESSION");
 }
 
@@ -66,7 +66,7 @@ export function snapshot(name) {
 }
 
 export function restore(name = "default") {
-  cy.log(`**--- Restore Data Set ---**`);
+  cy.log("Restore Data Set");
   cy.request("POST", `/api/testing/restore/${name}`);
 }
 
@@ -247,7 +247,7 @@ export function createBasicAlert({ firstAlert, includeNormal } = {}) {
 }
 
 export function setupDummySMTP() {
-  cy.log("**Set up dummy SMTP server**");
+  cy.log("Set up dummy SMTP server");
   cy.request("PUT", "/api/setting", {
     "email-smtp-host": "smtp.foo.test",
     "email-smtp-port": "587",

--- a/frontend/test/metabase-db/mongo/query.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/query.cy.spec.js
@@ -76,7 +76,7 @@ describe("mongodb > user > query", () => {
       cy.findByText("Visualize").click();
       cy.wait("@dataset");
 
-      cy.log("**Reported failing on stats ~v0.36.3**");
+      cy.log("Reported failing on stats ~v0.36.3");
       cy.findAllByText("1,966").should("have.length", 1); // City
       cy.findByText("49"); // State
     });

--- a/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
@@ -20,9 +20,7 @@ describe.skip("mysql > user > question > custom column", () => {
     const CC_NAME = "Abbr";
 
     withDatabase(2, ({ PEOPLE, PEOPLE_ID }) => {
-      cy.log(
-        "**--1. Create a question with `Source` column and abbreviated CC--**",
-      );
+      cy.log("Create a question with `Source` column and abbreviated CC");
       cy.request("POST", "/api/card", {
         name: "12445",
         dataset_query: {

--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -22,7 +22,7 @@ describe("postgres > question > custom columns", () => {
     cy.findByText(PG_DB_NAME).click();
     cy.findByText("People").click();
 
-    cy.log("**-- 1. Create custom column using `regexextract()` --**");
+    cy.log("Create custom column using `regexextract()`");
 
     cy.icon("add_data").click();
     popover().within(() => {
@@ -36,7 +36,7 @@ describe("postgres > question > custom columns", () => {
         .click();
     });
 
-    cy.log("**-- 2. Add filter based on custom column--**");
+    cy.log("Add filter based on custom column");
 
     cy.findByText("Add filters to narrow your answer").click();
     popover().within(() => {
@@ -67,7 +67,7 @@ describe("postgres > question > custom columns", () => {
     cy.findByText(PG_DB_NAME).click();
     cy.findByText("People").click();
 
-    cy.log("**-- 1. Create custom column using `regexextract()` --**");
+    cy.log("Create custom column using `regexextract()`");
 
     cy.icon("add_data").click();
     popover().within(() => {
@@ -76,7 +76,7 @@ describe("postgres > question > custom columns", () => {
         .blur();
 
       // It removes escaped characters already on blur
-      cy.log("**Reported failing on v0.36.4**");
+      cy.log("Reported failing on v0.36.4");
       cy.contains(ESCAPED_REGEX);
     });
   });

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -33,7 +33,7 @@ describe("postgres > user > query", () => {
     cy.get(".LoadingSpinner").should("not.exist");
 
     // Assertions
-    cy.log("**Fails in v0.36.6**");
+    cy.log("Fails in v0.36.6");
     // This could be omitted because real test is searching for "37.65" on the page
     cy.findByText("There was a problem with your question").should("not.exist");
     cy.contains("37.65");
@@ -62,7 +62,7 @@ describe("postgres > user > query", () => {
     );
 
     cy.log(
-      "**Reported failing on v0.38.0-rc1 querying Postgres, Redshift and BigQuery. It works on MySQL and H2.**",
+      "Reported failing on v0.38.0-rc1 querying Postgres, Redshift and BigQuery. It works on MySQL and H2.",
     );
     cy.wait("@pivotDataset").then(xhr => {
       expect(xhr.response.body.cause || "").not.to.contain("ERROR");

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -37,7 +37,7 @@ describeWithToken("postgres > user > query", () => {
     signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);
     createUser(sandboxed_user).then(({ body: { id: USER_ID } }) => {
-      cy.log("**-- Dismiss `it's ok to play around` modal for new users --**");
+      cy.log("Dismiss `it's ok to play around` modal for new users");
       cy.request("PUT", `/api/user/${USER_ID}/qbnewb`, {});
     });
     // Update basic permissions (the same starting "state" as we have for the "Sample Dataset")
@@ -61,7 +61,7 @@ describeWithToken("postgres > user > query", () => {
     cy.route("POST", "/api/dataset/pivot").as("pivotDataset");
 
     withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) => {
-      cy.log("**-- 1. Create question with custom column --**");
+      cy.log("Create question with custom column");
       cy.request("POST", "/api/card", {
         name: "14873",
         dataset_query: {
@@ -84,7 +84,7 @@ describeWithToken("postgres > user > query", () => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
 
-        cy.log("**-- 2. Sandbox `People` table --**");
+        cy.log("Sandbox `People` table");
         cy.request("POST", "/api/mt/gtap", {
           attribute_remappings: {
             user_id: ["dimension", ["field-id", PEOPLE.ID]],
@@ -119,7 +119,7 @@ describeWithToken("postgres > user > query", () => {
 });
 
 function signInAsSandboxedUser() {
-  cy.log("**-- Logging in as sandboxed user --**");
+  cy.log("Logging in as sandboxed user");
   cy.request("POST", "/api/session", {
     username: sandboxed_user.email,
     password: sandboxed_user.password,

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -49,14 +49,14 @@ describe("scenarios > admin > databases > edit", () => {
     });
 
     it("should respect the settings for automatic query running (metabase#13187)", () => {
-      cy.log("**--Turn off `auto run queries`--**");
+      cy.log("Turn off `auto run queries`");
       cy.request("PUT", "/api/database/1", {
         auto_run_queries: false,
       });
 
       cy.visit("/admin/databases/1");
 
-      cy.log("**Reported failing on v0.36.4**");
+      cy.log("Reported failing on v0.36.4");
       cy.findByLabelText(
         "Automatically run queries when doing simple filtering and summarizing",
       ).should("have.attr", "aria-checked", "false");

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
       "You might want to update the field name to make sure it still makes sense based on your remapping choices.",
     );
 
-    cy.log("**Name of the product should be displayed instead of its ID**");
+    cy.log("Name of the product should be displayed instead of its ID");
     openOrdersTable();
     cy.findAllByText("Awesome Concrete Shoes");
   });
@@ -74,7 +74,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     });
     cy.findByText("Save").click();
 
-    cy.log("**Numeric ratings should be remapped to custom strings**");
+    cy.log("Numeric ratings should be remapped to custom strings");
     openReviewsTable();
     Object.values(customMap).forEach(rating => {
       cy.findAllByText(rating);
@@ -106,7 +106,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
       cy.findByText("Created At: Hour of day");
 
-      cy.log("**Reported failing in v0.37.2**");
+      cy.log("Reported failing in v0.37.2");
       cy.findByText(/^3:00 AM$/);
     });
   });

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -27,7 +27,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       });
       cy.findByText("Add filters to narrow your answer").click();
 
-      cy.log("**Fails in v0.36.0 and v0.36.3. It exists in v0.35.4**");
+      cy.log("Fails in v0.36.0 and v0.36.3. It exists in v0.35.4");
       popover().within(() => {
         cy.findByText("Custom Expression");
       });

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -36,7 +36,7 @@ describe("scenarios > admin > datamodel > segments", () => {
       });
       cy.findByText("Add filters to narrow your answer").click();
 
-      cy.log("**Fails in v0.36.0 and v0.36.3. It exists in v0.35.4**");
+      cy.log("Fails in v0.36.0 and v0.36.3. It exists in v0.35.4");
       popover().within(() => {
         cy.findByText("Custom Expression");
       });

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -30,7 +30,7 @@ describe("scenarios > admin > people", () => {
     it("should render (metabase-enterprise#210)", () => {
       cy.visit("/admin/people");
 
-      cy.log("**Assert it loads People by default**");
+      cy.log("Assert it loads People by default");
       cy.get(".PageTitle").contains("People");
 
       cy.get(".ContentTable tbody tr")
@@ -44,7 +44,7 @@ describe("scenarios > admin > people", () => {
         cy.findByText("Groups").click();
       });
 
-      cy.log("**Switch to 'Groups' and make sure it renders properly**");
+      cy.log("Switch to 'Groups' and make sure it renders properly");
       cy.get(".PageTitle").contains("Groups");
 
       // Administrators, All Users, collection, data
@@ -131,7 +131,7 @@ describe("scenarios > admin > people", () => {
         clickButton("Deactivate");
         cy.findByText(FULL_NAME).should("not.exist");
 
-        cy.log("**-- It should load inactive users --**");
+        cy.log("It should load inactive users");
         cy.findByText("Deactivated").click();
         cy.findByText(FULL_NAME);
         cy.icon("refresh").click();

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -37,7 +37,7 @@ describe("scenarios > admin > permissions", () => {
     cy.visit("/collection/root");
     cy.findByText("Orders created before June 1st 2016").click();
 
-    cy.log("**Assert the dates on the X axis**");
+    cy.log("Assert the dates on the X axis");
     // it's hard and tricky to invoke hover in Cypress, especially in our graphs
     // that's why we have to assert on the x-axis, instead of a popover that shows on a dot hover
     cy.get(".axis.x").contains("April 25, 2016");
@@ -74,7 +74,7 @@ describe("scenarios > admin > permissions", () => {
     cy.visit("/collection/root");
     cy.findByText("13604").click();
 
-    cy.log("**Reported failing on v0.37.0.2 and labeled as `.Regression`**");
+    cy.log("Reported failing on v0.37.0.2 and labeled as `.Regression`");
     cy.get(".axis.x")
       .contains(/sunday/i)
       .should("not.exist");

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -51,7 +51,7 @@ describe("scenarios > admin > settings", () => {
 
     // NOTE: This test is not concerned with HOW we style the error message - only that there is one.
     //       If we update UI in the future (for example: we show an error within a popup/modal), the test in current form could fail.
-    cy.log("**Making sure we display an error message in UI**");
+    cy.log("Making sure we display an error message in UI");
     // Same reasoning for regex as above
     cy.get(".SaveStatus").contains(/^Error: Invalid site URL/);
   });

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -44,7 +44,7 @@ describe("scenarios > collection_defaults", () => {
 
     describe("new collections", () => {
       beforeEach(() => {
-        cy.log("**--Create new collection--**");
+        cy.log("Create new collection");
         cy.request("POST", "/api/collection", {
           name: collection.name,
           color: "#ff9a9a",
@@ -71,7 +71,7 @@ describe("scenarios > collection_defaults", () => {
       describe("a new sub-collection", () => {
         beforeEach(() => {
           cy.log(
-            "**--Create a sub collection within previously created collection--**",
+            "Create a sub collection within previously created collection",
           );
           cy.request("POST", "/api/collection", {
             name: sub_collection.name,
@@ -147,7 +147,7 @@ describe("scenarios > collection_defaults", () => {
               "Third collection",
             );
 
-            cy.log("**-- Create two more nested collections --**");
+            cy.log("Create two more nested collections");
             [
               "Fourth collection",
               "Fifth collection with a very long name",
@@ -370,7 +370,7 @@ describe("scenarios > collection_defaults", () => {
           cy.findByText(/Our analytics/i);
           cy.findByText(/My personal collection/i);
           cy.findByText("Parent").should("not.exist");
-          cy.log("**Reported failing from v0.34.3**");
+          cy.log("Reported failing from v0.34.3");
           cy.findByText("Child");
         });
       });
@@ -465,7 +465,7 @@ describe("scenarios > collection_defaults", () => {
 
     it("should update UI when nested child collection is moved to the root collection (metabase#14482)", () => {
       cy.visit("/collection/root");
-      cy.log("**Move 'Second collection' to the root");
+      cy.log("Move 'Second collection' to the root");
       openDropdownFor("First collection");
       cy.findByText("Second collection").click();
       cy.icon("pencil").click();

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -56,23 +56,23 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it.skip("should insert values from hidden column on custom destination URL click through (metabase#13927)", () => {
-    cy.log("**-- 1. Create a question --**");
+    cy.log("Create a question");
 
     createNativeQuestion(
       "13927",
       `SELECT PEOPLE.STATE, PEOPLE.CITY from PEOPLE;`,
     ).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("**-- 2. Create a dashboard --**");
+      cy.log("Create a dashboard");
 
       cy.request("POST", "/api/dashboard", {
         name: "13927D",
       }).then(({ body: { id: DASHBOARD_ID } }) => {
-        cy.log("**-- 3. Add question to the dashboard --**");
+        cy.log("Add question to the dashboard");
 
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
         }).then(({ body: { id: DASH_CARD_ID } }) => {
-          cy.log("**-- 4. Set card parameters --**");
+          cy.log("Set card parameters");
 
           cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cards: [
@@ -123,7 +123,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           "Click to find out which state does Rye belong to.",
         ).click();
 
-        cy.log("**Reported failing on v0.37.2**");
+        cy.log("Reported failing on v0.37.2");
         cy.location("pathname").should("eq", "/test/CO");
       });
     });
@@ -314,9 +314,9 @@ describe("scenarios > dashboard > dashboard drill", () => {
         });
 
         // NOTE: The actual "Assertion" phase begins here
-        cy.log("**Reported failing on Metabase 1.34.3 and 0.36.2**");
+        cy.log("Reported failing on Metabase 1.34.3 and 0.36.2");
 
-        cy.log("**The first case**");
+        cy.log("The first case");
         // set filter values (ratings 5 and 4) directly through the URL
         cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
 
@@ -328,7 +328,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.findByText("Rating is equal to 2 selections");
         cy.contains("Reprehenderit non error"); // xavier's review
 
-        cy.log("**The second case**");
+        cy.log("The second case");
         // go back to the dashboard
         cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
         cy.findByText("2 selections");
@@ -344,9 +344,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     // In this test we're using already present dashboard ("Orders in a dashboard")
     const FILTER_ID = "7c9ege62";
 
-    cy.log(
-      "**-- 1. Add filter (with the default Category) to the dashboard --**",
-    );
+    cy.log("Add filter (with the default Category) to the dashboard");
     cy.request("PUT", "/api/dashboard/1", {
       parameters: [
         {
@@ -359,7 +357,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       ],
     });
 
-    cy.log("**-- 2. Connect filter to the existing card --**");
+    cy.log("Connect filter to the existing card");
     cy.request("PUT", "/api/dashboard/1/cards", {
       cards: [
         {
@@ -403,7 +401,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it.skip("should apply correct date range on a graph drill-through (metabase#13785)", () => {
-    cy.log("**-- 1. Create a question --**");
+    cy.log("Create a question");
 
     cy.request("POST", "/api/card", {
       name: "13785",
@@ -421,12 +419,12 @@ describe("scenarios > dashboard > dashboard drill", () => {
       display: "bar",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("**-- 2. Create a dashboard --**");
+      cy.log("Create a dashboard");
 
       cy.request("POST", "/api/dashboard", {
         name: "13785D",
       }).then(({ body: { id: DASHBOARD_ID } }) => {
-        cy.log("**-- 3. Add filter to the dashboard --**");
+        cy.log("Add filter to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
           parameters: [
@@ -438,12 +436,12 @@ describe("scenarios > dashboard > dashboard drill", () => {
             },
           ],
         });
-        cy.log("**-- 4. Add question to the dashboard --**");
+        cy.log("Add question to the dashboard");
 
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
         }).then(({ body: { id: DASH_CARD_ID } }) => {
-          cy.log("**-- 5. Connect dashboard filter to the question --**");
+          cy.log("Connect dashboard filter to the question");
 
           cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cards: [

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -86,7 +86,7 @@ describe("scenarios > dashboard", () => {
 
     saveDashboard();
 
-    cy.log("**Assert that the selected filter is present in the dashboard**");
+    cy.log("Assert that the selected filter is present in the dashboard");
     cy.icon("location");
     cy.findByText("State");
   });
@@ -276,7 +276,7 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should display column options for cross-filter (metabase#14473)", () => {
-    cy.log("**-- 1. Create a question --**");
+    cy.log("Create a question");
 
     cy.request("POST", "/api/card", {
       name: "14473",
@@ -288,12 +288,12 @@ describe("scenarios > dashboard", () => {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("**-- 2. Create a dashboard --**");
+      cy.log("Create a dashboard");
 
       cy.request("POST", "/api/dashboard", {
         name: "14473D",
       }).then(({ body: { id: DASHBOARD_ID } }) => {
-        cy.log("**-- 3. Add 4 filters to the dashboard --**");
+        cy.log("Add 4 filters to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
           parameters: [
@@ -314,7 +314,7 @@ describe("scenarios > dashboard", () => {
           ],
         });
 
-        cy.log("**-- 4. Add previously created question to the dashboard --**");
+        cy.log("Add previously created question to the dashboard");
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
         });
@@ -336,7 +336,7 @@ describe("scenarios > dashboard", () => {
   it.skip("should show QB question on a dashboard with filter connected to card without data-permission (metabase#12720)", () => {
     // In this test we're using already present question ("Orders") and the dashboard with that question ("Orders in a dashboard")
     cy.log(
-      "**-- 1. Add filter to the dashboard with the default value (after January 1st, 2020) --**",
+      "Add filter to the dashboard with the default value (after January 1st, 2020)",
     );
     cy.request("PUT", "/api/dashboard/1", {
       parameters: [
@@ -350,7 +350,7 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    cy.log("**-- 2. Create SQL question with a filter --**");
+    cy.log("Create SQL question with a filter");
 
     cy.request("POST", "/api/card", {
       name: "12720_SQL",
@@ -375,13 +375,13 @@ describe("scenarios > dashboard", () => {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: SQL_ID } }) => {
-      cy.log("**-- 3. Add SQL question to the dashboard --**");
+      cy.log("Add SQL question to the dashboard");
 
       cy.request("POST", "/api/dashboard/1/cards", {
         cardId: SQL_ID,
       }).then(({ body: { id: SQL_DASH_CARD_ID } }) => {
         cy.log(
-          "**-- 4. Edit both cards (adjust their size and connect them to the filter) --**",
+          "Edit both cards (adjust their size and connect them to the filter)",
         );
 
         cy.request("PUT", "/api/dashboard/1/cards", {
@@ -447,7 +447,7 @@ describe("scenarios > dashboard", () => {
     // In this test we're using already present dashboard ("Orders in a dashboard")
     const FILTER_ID = "d7988e02";
 
-    cy.log("**-- 1. Add filter to the dashboard --**");
+    cy.log("Add filter to the dashboard");
     cy.request("PUT", "/api/dashboard/1", {
       parameters: [
         {
@@ -459,7 +459,7 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    cy.log("**-- 2. Connect filter to the existing card --**");
+    cy.log("Connect filter to the existing card");
     cy.request("PUT", "/api/dashboard/1/cards", {
       cards: [
         {
@@ -507,14 +507,14 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Orders in a dashboard").click();
 
     cy.log(
-      "**-- Clicking on the filter again should NOT send another query to the source DB again! Results should have been cached by now. --**",
+      "Clicking on the filter again should NOT send another query to the source DB again! Results should have been cached by now.",
     );
     cy.get("@filterWidget").click();
     expectedRouteCalls({ route_alias: "fetchFromDB", calls: 1 });
   });
 
   it.skip("should not send additional card queries for all filters (metabase#13150)", () => {
-    cy.log("**-- 1. Create a question --**");
+    cy.log("Create a question");
 
     cy.request("POST", "/api/card", {
       name: "13150 (Products)",
@@ -526,12 +526,12 @@ describe("scenarios > dashboard", () => {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("**-- 2. Create a dashboard --**");
+      cy.log("Create a dashboard");
 
       cy.request("POST", "/api/dashboard", {
         name: "13150D",
       }).then(({ body: { id: DASHBOARD_ID } }) => {
-        cy.log("**-- 3. Add 3 filters to the dashboard --**");
+        cy.log("Add 3 filters to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
           parameters: [
@@ -546,12 +546,12 @@ describe("scenarios > dashboard", () => {
           ],
         });
 
-        cy.log("**-- 4. Add previously created qeustion to the dashboard --**");
+        cy.log("Add previously created qeustion to the dashboard");
 
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
         }).then(({ body: { id: DASH_CARD_ID } }) => {
-          cy.log("**-- 5. Connect all filters to the card --**");
+          cy.log("Connect all filters to the card");
 
           cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cards: [

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -137,10 +137,10 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Save").click();
     cy.findByText("You're editing this dashboard.").should("not.exist");
 
-    cy.log("**Filter name should be 'unnamed' and the value cleared**");
+    cy.log("Filter name should be 'unnamed' and the value cleared");
     cy.findByPlaceholderText(/unnamed/i);
 
-    cy.log("**URL should reset**");
+    cy.log("URL should reset");
     cy.location("pathname").should("eq", "/dashboard/1");
   });
 
@@ -219,7 +219,7 @@ describe("scenarios > dashboard > parameters", () => {
     });
     cy.findByText("New question").should("not.exist");
 
-    cy.log("**Bug was breaking the dashboard at this point**");
+    cy.log("Bug was breaking the dashboard at this point");
     cy.visit("/dashboard/1");
     // error was always ending in "is undefined" when dashboard broke in the past
     cy.contains(/is undefined$/).should("not.exist");

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > dashboard > subscriptions", () => {
   });
 
   it("should not allow creation if there are no dashboard cards", () => {
-    cy.log("**Create fresh new dashboard**");
+    cy.log("Create fresh new dashboard");
     cy.request("POST", "/api/dashboard", {
       name: "Empty Dashboard",
     }).then(({ body: { id: DASHBOARD_ID } }) => {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -190,7 +190,7 @@ describe("scenarios > question > custom columns", () => {
     cy.log(
       "**Fails in 0.35.0, 0.35.1, 0.35.2, 0.35.4 and the latest master (2020-10-21)**",
     );
-    cy.log("**Works in 0.35.3**");
+    cy.log("Works in 0.35.3");
     // ID should be "1" but it is picking the product ID and is showing "14"
     cy.get(".TableInteractive-cellWrapper--firstColumn")
       .eq(1) // the second cell from the top in the first column (the first one is a header cell)
@@ -233,7 +233,7 @@ describe("scenarios > question > custom columns", () => {
 
       cy.visit(`/question/${QUESTION_ID}`);
 
-      cy.log("**Reported failing v0.34.3 through v0.37.2**");
+      cy.log("Reported failing v0.34.3 through v0.37.2");
       cy.wait("@cardQuery").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
       });
@@ -278,7 +278,7 @@ describe("scenarios > question > custom columns", () => {
 
       cy.visit(`/question/${QUESTION_ID}`);
 
-      cy.log("**Regression since v0.37.1 - it works on v0.37.0**");
+      cy.log("Regression since v0.37.1 - it works on v0.37.0");
       cy.wait("@cardQuery").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
       });
@@ -311,7 +311,7 @@ describe("scenarios > question > custom columns", () => {
       cy.visit(`/question/${questionId}`);
       cy.findByText("13634");
 
-      cy.log("**Reported failing in v0.34.3, v0.35.4, v0.36.8.2, v0.37.0.2**");
+      cy.log("Reported failing in v0.34.3, v0.35.4, v0.36.8.2, v0.37.0.2");
       cy.findByText("Foo Bar");
       cy.findAllByText("57911");
     });
@@ -433,7 +433,7 @@ describe("scenarios > question > custom columns", () => {
       .click({ force: true }); // x is hidden and hover doesn't work so we have to force it
     cy.findByText("Join data").should("not.exist");
 
-    cy.log("**Reported failing on 0.38.1-SNAPSHOT (6d77f099)**");
+    cy.log("Reported failing on 0.38.1-SNAPSHOT (6d77f099)");
     cy.get("[class*=NotebookCellItem]")
       .contains(CE_NAME)
       .should("not.exist");

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -28,7 +28,7 @@ describe("scenarios > question > filter", () => {
 
   describe("dashboard filter dropdown/search (metabase#12985)", () => {
     it("Repro 1: should work for saved nested questions", () => {
-      cy.log("**-- 1. Create base card --**");
+      cy.log("Create base card");
 
       cy.request("POST", "/api/card", {
         name: "Q1",
@@ -40,7 +40,7 @@ describe("scenarios > question > filter", () => {
         display: "table",
         visualization_settings: {},
       }).then(({ body: { id: Q1_ID } }) => {
-        cy.log("**-- 2. Create nested card based on the first one --**");
+        cy.log("Create nested card based on the first one");
 
         cy.request("POST", "/api/card", {
           name: "Q2",
@@ -52,12 +52,12 @@ describe("scenarios > question > filter", () => {
           display: "table",
           visualization_settings: {},
         }).then(({ body: { id: Q2_ID } }) => {
-          cy.log("**-- 3. Create a dashboard --**");
+          cy.log("Create a dashboard");
 
           cy.request("POST", "/api/dashboard", {
             name: "12985D",
           }).then(({ body: { id: DASHBOARD_ID } }) => {
-            cy.log("**-- 4. Add 2 filters to the dashboard --**");
+            cy.log("Add 2 filters to the dashboard");
 
             cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
               parameters: [
@@ -76,14 +76,12 @@ describe("scenarios > question > filter", () => {
               ],
             });
 
-            cy.log("**-- 5. Add nested card to the dashboard --**");
+            cy.log("Add nested card to the dashboard");
 
             cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
               cardId: Q2_ID,
             }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log(
-                "**-- 6. Connect dashboard filters to the nested card --**",
-              );
+              cy.log("Connect dashboard filters to the nested card");
 
               cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
                 cards: [
@@ -126,7 +124,7 @@ describe("scenarios > question > filter", () => {
         .within(() => {
           cy.findByText("Category").click();
         });
-      cy.log("**Failing to show dropdown in v0.36.0 through v.0.37.0**");
+      cy.log("Failing to show dropdown in v0.36.0 through v.0.37.0");
       popover()
         .contains("Gadget")
         .click();
@@ -136,7 +134,7 @@ describe("scenarios > question > filter", () => {
     });
 
     it.skip("Repro 2: should work for aggregated questions", () => {
-      cy.log("**-- 1. Create question with aggregation --**");
+      cy.log("Create question with aggregation");
 
       cy.request("POST", "/api/card", {
         name: "12985-v2",
@@ -155,12 +153,12 @@ describe("scenarios > question > filter", () => {
         display: "table",
         visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.log("**-- 2. Create a dashboard --**");
+        cy.log("Create a dashboard");
 
         cy.request("POST", "/api/dashboard", {
           name: "12985-v2D",
         }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("**-- 3. Add a category filter to the dashboard --**");
+          cy.log("Add a category filter to the dashboard");
 
           cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
             parameters: [
@@ -173,16 +171,12 @@ describe("scenarios > question > filter", () => {
             ],
           });
 
-          cy.log(
-            "**-- 4. Add previously created question to the dashboard --**",
-          );
+          cy.log("Add previously created question to the dashboard");
 
           cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cardId: QUESTION_ID,
           }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log(
-              "**-- 5. Connect dashboard filter to the aggregated card --**",
-            );
+            cy.log("Connect dashboard filter to the aggregated card");
 
             cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
               cards: [
@@ -251,7 +245,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Visualize").click();
     // wait for results to load
     cy.get(".LoadingSpinner").should("not.exist");
-    cy.log("**The point of failure in 0.37.0-rc3**");
+    cy.log("The point of failure in 0.37.0-rc3");
     cy.contains("37.65");
     cy.findByText("There was a problem with your question").should("not.exist");
     // this is not the point of this repro, but additionally make sure the filter is working as intended on "Gizmo"
@@ -301,7 +295,7 @@ describe("scenarios > question > filter", () => {
     }).then(({ body: { id: questionId } }) => {
       cy.visit(`/question/${questionId}`);
       cy.findByText("12872");
-      cy.log("**At the moment of unfixed issue, it's showing '0'**");
+      cy.log("At the moment of unfixed issue, it's showing '0'");
       cy.get(".ScalarValue").contains("1");
     });
   });
@@ -329,7 +323,7 @@ describe("scenarios > question > filter", () => {
       .click();
     cy.findByText("Add filter").click();
 
-    cy.log("**Reported failing on v0.36.4 and v0.36.5.1**");
+    cy.log("Reported failing on v0.36.4 and v0.36.5.1");
     cy.get(".LoadingSpinner").should("not.exist");
     cy.findAllByText("148.23"); // one of the subtotals for this product
     cy.findAllByText("Fantastic Wool Shirt").should("not.exist");
@@ -363,14 +357,14 @@ describe("scenarios > question > filter", () => {
       cy.visit(`/question/${questionId}`);
       cy.wait("@cardQuery");
 
-      cy.log("**Reported failing on v0.35.4**");
+      cy.log("Reported failing on v0.35.4");
       cy.log(`Error message: **Column 'source.${CE_NAME}' not found;**`);
       cy.findAllByText("Gizmo");
     });
   });
 
   it.skip("should not preserve cleared filter with the default value on refresh (metabase#13960)", () => {
-    cy.log("**--1. Create a question--**");
+    cy.log("Create a question");
 
     cy.request("POST", "/api/card", {
       name: "13960",
@@ -386,13 +380,13 @@ describe("scenarios > question > filter", () => {
       display: "pie",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("**--2. Create a dashboard--**");
+      cy.log("Create a dashboard");
 
       cy.request("POST", "/api/dashboard", {
         name: "13960D",
       }).then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log(
-          "**--3. Add filters to the dashboard and set the default value to the first one--**",
+          "Add filters to the dashboard and set the default value to the first one",
         );
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
@@ -409,12 +403,12 @@ describe("scenarios > question > filter", () => {
           ],
         });
 
-        cy.log("**--4. Add question to the dashboard--**");
+        cy.log("Add question to the dashboard");
 
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
         }).then(({ body: { id: DASH_CARD_ID } }) => {
-          cy.log("**--5. Connect the filters to the card--**");
+          cy.log("Connect the filters to the card");
 
           cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cards: [
@@ -539,8 +533,8 @@ describe("scenarios > question > filter", () => {
 
       cy.get("@rerunQuestion").click();
 
-      cy.log("**--Reported tested and failing on v0.34.3 through v0.37.3--**");
-      cy.log("**URL is correct at this point, but there are no results**");
+      cy.log("Reported tested and failing on v0.34.3 through v0.37.3");
+      cy.log("URL is correct at this point, but there are no results");
       cy.location("search").should("eq", `?${ID_FILTER.name}=1`);
       cy.findByText("Rustic Paper Wallet"); // Product ID 1, Gizmo
     });
@@ -597,13 +591,13 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Custom Expression").click();
 
     // This issue has two problematic parts. We're testing for both:
-    cy.log("**--1. Popover should display all custom expression options--**");
+    cy.log("Popover should display all custom expression options");
     // Popover shows up even without explicitly clicking the contenteditable field
     popover().within(() => {
       cy.findAllByRole("listitem").contains(/functions/i);
     });
 
-    cy.log("**--2. Should not display error prematurely--**");
+    cy.log("Should not display error prematurely");
     cy.get("[contenteditable='true']")
       .click()
       .type("contains(");

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -248,7 +248,7 @@ describe("scenarios > question > native", () => {
       // We can ask variations of that question "on the fly"
       cy.findByText(QUESTION).click();
 
-      cy.log("**Apply a filter**");
+      cy.log("Apply a filter");
       cy.findAllByText("Filter")
         .first()
         .click();
@@ -306,7 +306,7 @@ describe("scenarios > question > native", () => {
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
       cy.findByText("14302");
-      cy.log("**Reported on v0.37.5 - Regression since v0.37.0**");
+      cy.log("Reported on v0.37.5 - Regression since v0.37.0");
       cy.findByText("Save").should("not.exist");
     });
   });
@@ -361,7 +361,7 @@ describe("scenarios > question > native", () => {
     cy.findByText(/Revert/i).click(); // Revert to the first revision
     cy.findByText(/Open Editor/i).click();
 
-    cy.log("**Reported failing on v0.35.3**");
+    cy.log("Reported failing on v0.35.3");
     cy.findByText(ORIGINAL_QUERY);
     // Filter dropdown field
     cy.get("fieldset").contains("Filter");

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -200,7 +200,7 @@ describe("scenarios > question > nested", () => {
       .click();
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
-    cy.log("**Reported failing on v0.34.3 - v0.37.0.2**");
+    cy.log("Reported failing on v0.34.3 - v0.37.0.2");
     popover()
       .contains("Average of Total")
       .closest(".List-item")
@@ -208,11 +208,11 @@ describe("scenarios > question > nested", () => {
   });
 
   it.skip("should show all filter options for a nested question (metabase#13186)", () => {
-    cy.log("**-- 1. Create and save native question Q1 --**");
+    cy.log("Create and save native question Q1");
 
     createNativeQuestion("13816_Q1", "SELECT * FROM PRODUCTS").then(
       ({ body: { id: Q1_ID } }) => {
-        cy.log("**-- 2. Convert it to `query` and save as Q2 --**");
+        cy.log("Convert it to `query` and save as Q2");
 
         cy.request("POST", "/api/card", {
           name: "13816_Q2",
@@ -229,7 +229,7 @@ describe("scenarios > question > nested", () => {
       },
     );
 
-    cy.log("**-- 3. Create a brand new dashboard --**");
+    cy.log("Create a brand new dashboard");
 
     cy.request("POST", "/api/dashboard", {
       name: "13186D",
@@ -250,7 +250,7 @@ describe("scenarios > question > nested", () => {
     // ...and try to connect it to the question
     cy.findByText("Select…").click();
 
-    cy.log("**Reported failing in v0.36.4 (`Category` is missing)**");
+    cy.log("Reported failing in v0.36.4 (`Category` is missing)");
     popover().within(() => {
       cy.findByText(/Category/i);
       cy.findByText(/Title/i);
@@ -261,7 +261,7 @@ describe("scenarios > question > nested", () => {
   it.skip("should apply metrics including filter to the nested question (metabase#12507)", () => {
     const METRIC_NAME = "Discount Applied";
 
-    cy.log("**-- 1. Create a metric with a filter --**");
+    cy.log("Create a metric with a filter");
 
     cy.request("POST", "/api/metric", {
       name: METRIC_NAME,
@@ -280,9 +280,7 @@ describe("scenarios > question > nested", () => {
         "source-table": ORDERS_ID,
       };
 
-      cy.log(
-        "**-- 2. Create new question which uses previously defined metric --**",
-      );
+      cy.log("Create new question which uses previously defined metric");
 
       cy.request("POST", "/api/card", {
         name: "Orders with discount applied",
@@ -300,9 +298,7 @@ describe("scenarios > question > nested", () => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
 
-        cy.log(
-          "**-- 3. Create a nested question based on the previous one --**",
-        );
+        cy.log("Create a nested question based on the previous one");
 
         // we're adding filter and saving/overwriting the original question, keeping the same ID
         cy.request("PUT", `/api/card/${QUESTION_ID}`, {
@@ -316,7 +312,7 @@ describe("scenarios > question > nested", () => {
           },
         });
 
-        cy.log("**Reported failing since v0.35.2**");
+        cy.log("Reported failing since v0.35.2");
         cy.visit(`/question/${QUESTION_ID}`);
         cy.wait("@cardQuery").then(xhr => {
           expect(xhr.response.body.error).not.to.exist;
@@ -335,14 +331,14 @@ describe("scenarios > question > nested", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
-    cy.log("**-- 1. Remap Product ID's display value to `title` --**");
+    cy.log("Remap Product ID's display value to `title`");
     remapDisplayValueToFK({
       display_value: ORDERS.PRODUCT_ID,
       name: "Product ID",
       fk: PRODUCTS.TITLE,
     });
 
-    cy.log("**-- 2. Save simple 'Orders' table with remapped values --**");
+    cy.log("Save simple 'Orders' table with remapped values");
     cy.request("POST", "/api/card", {
       name: "Orders (remapped)",
       dataset_query: {
@@ -373,7 +369,7 @@ describe("scenarios > question > nested", () => {
 
       beforeEach(() => {
         if (test === "remapped") {
-          cy.log("**-- Remap Product ID's display value to `title` --**");
+          cy.log("Remap Product ID's display value to `title`");
           remapDisplayValueToFK({
             display_value: ORDERS.PRODUCT_ID,
             name: "Product ID",
@@ -449,7 +445,7 @@ describe("scenarios > question > nested", () => {
     cy.findByText("Group by")
       .parent()
       .within(() => {
-        cy.log("**Regression that worked on 0.37.9**");
+        cy.log("Regression that worked on 0.37.9");
         isSelected("Products → Category");
       });
 

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -165,7 +165,7 @@ describe("scenarios > question > new", () => {
       cy.findByText("Group by")
         .parent()
         .within(() => {
-          cy.log("**Reported failing since v0.33.5.1**");
+          cy.log("Reported failing since v0.33.5.1");
           cy.log(
             "**Marked as regression of [#10441](https://github.com/metabase/metabase/issues/10441)**",
           );
@@ -202,7 +202,7 @@ describe("scenarios > question > new", () => {
       });
 
       cy.wait("@cardQuery");
-      cy.log("**Reported missing in v0.33.1**");
+      cy.log("Reported missing in v0.33.1");
       cy.get(".AdminSelect")
         .as("select")
         .contains(/All Time/i);
@@ -250,7 +250,7 @@ describe("scenarios > question > new", () => {
           .type(FORMULA)
           .blur();
 
-        cy.log("**Fails after blur in v0.36.6**");
+        cy.log("Fails after blur in v0.36.6");
         // Implicit assertion
         cy.get("[contentEditable=true]").contains(FORMULA);
       });
@@ -322,8 +322,8 @@ describe("scenarios > question > new", () => {
         cy.findByText("13710");
 
         cy.wait("@cardQuery");
-        cy.log("**Reported failing on v0.35 - v0.37.0.2**");
-        cy.log("**Bug: showing blank visualization**");
+        cy.log("Reported failing on v0.35 - v0.37.0.2");
+        cy.log("Bug: showing blank visualization");
         cy.get(".ScalarValue").contains("33");
       });
     });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -129,20 +129,20 @@ describe("scenarios > question > notebook", () => {
     });
 
     it("should allow post-join filters (metabase#12221)", () => {
-      cy.log("start a custom question with Orders");
+      cy.log("Start a custom question with Orders");
       cy.visit("/question/new");
       cy.contains("Custom question").click();
       cy.contains("Sample Dataset").click();
       cy.contains("Orders").click();
 
-      cy.log("join to People table using default settings");
+      cy.log("Join to People table using default settings");
       cy.icon("join_left_outer ").click();
       cy.contains("People").click();
       cy.contains("Orders + People");
       cy.contains("Visualize").click();
       cy.contains("Showing first 2,000");
 
-      cy.log("attempt to filter on the joined table");
+      cy.log("Attempt to filter on the joined table");
       cy.contains("Filter").click();
       cy.contains("Email").click();
       cy.contains("People – Email");
@@ -234,7 +234,7 @@ describe("scenarios > question > notebook", () => {
         cy.findByText("Product ID").click();
       });
 
-      cy.log("**It shouldn't use FK for a column title**");
+      cy.log("It shouldn't use FK for a column title");
       cy.findByText("Summarize").click();
       cy.findByText("Pick a column to group by").click();
 
@@ -349,7 +349,7 @@ describe("scenarios > question > notebook", () => {
       cy.findByText("Visualize").click();
 
       cy.findByText("12928_Q1 + 12928_Q2");
-      cy.log("**Reported failing in v1.35.4.1 and `master` on July, 16 2020**");
+      cy.log("Reported failing in v1.35.4.1 and `master` on July, 16 2020");
       // TODO: Add a positive assertion once this issue is fixed
       cy.wait("@dataset").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
@@ -415,8 +415,8 @@ describe("scenarios > question > notebook", () => {
           cy.visit(`/question/${joinedQuestionId}`);
           cy.findByText("13744_joined");
 
-          cy.log("**Reported failing on v0.34.3 - v0.37.0.2**");
-          cy.log("**Reported error log: 'No aggregation at index: 0'**");
+          cy.log("Reported failing on v0.34.3 - v0.37.0.2");
+          cy.log("Reported error log: 'No aggregation at index: 0'");
           // assert directly on XHR instead of relying on UI
           cy.wait("@cardQuery").then(xhr => {
             expect(xhr.response.body.error).not.to.exist;
@@ -467,7 +467,7 @@ describe("scenarios > question > notebook", () => {
     it.skip("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
-      cy.route("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
+      cy.route("GET", "/api/automagic-dashboards/adhoc/").as("xray");
 
       visitQuestionAdhoc({
         dataset_query: {
@@ -631,7 +631,7 @@ describe("scenarios > question > notebook", () => {
 function joinTwoSavedQuestions(ALIAS = "Joined Question") {
   cy.server();
 
-  cy.log("**-- Prepare Question 1 --**");
+  cy.log("Prepare Question 1");
   cy.request("POST", "/api/card", {
     name: "Q1",
     dataset_query: {
@@ -646,7 +646,7 @@ function joinTwoSavedQuestions(ALIAS = "Joined Question") {
     display: "table",
     visualization_settings: {},
   }).then(({ body: { id: Q1_ID } }) => {
-    cy.log("**-- Prepare Question 2 --**");
+    cy.log("Prepare Question 2");
     cy.request("POST", "/api/card", {
       name: "Q2",
       dataset_query: {
@@ -661,9 +661,7 @@ function joinTwoSavedQuestions(ALIAS = "Joined Question") {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: Q2_ID } }) => {
-      cy.log(
-        "**-- Create Question 3 based on 2 previously saved questions --**",
-      );
+      cy.log("Create Question 3 based on 2 previously saved questions");
       cy.request("POST", "/api/card", {
         name: "Q3",
         dataset_query: {
@@ -697,7 +695,7 @@ function joinTwoSavedQuestions(ALIAS = "Joined Question") {
 
         cy.wait("@cardQuery");
 
-        cy.log("**Reported in v0.36.0**");
+        cy.log("Reported in v0.36.0");
         cy.icon("notebook").click();
         cy.url().should("contain", "/notebook");
         cy.findByText("Visualize").should("exist");

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > question > null", () => {
     cy.visit("/collection/root");
     cy.findByText("13571").click();
 
-    cy.log("**'No Results since at least v0.34.3**");
+    cy.log("'No Results since at least v0.34.3");
     cy.findByText("Discount");
     cy.findByText("Empty");
   });
@@ -115,7 +115,7 @@ describe("scenarios > question > null", () => {
         cy.visit(`/dashboard/${dashboardId}?id=1`);
         cy.findByText("13626D");
 
-        cy.log("**Reported failing in v0.37.0.2**");
+        cy.log("Reported failing in v0.37.0.2");
         cy.get(".DashCard").within(() => {
           cy.get(".LoadingSpinner").should("not.exist");
           cy.findByText("13626");
@@ -130,7 +130,7 @@ describe("scenarios > question > null", () => {
   });
 
   it("dashboard should handle cards with null values (metabase#13801)", () => {
-    cy.log("**-- Create Question 1 --**");
+    cy.log("Create Question 1");
 
     cy.request("POST", "/api/card", {
       name: "13801_Q1",
@@ -142,7 +142,7 @@ describe("scenarios > question > null", () => {
       display: "scalar",
       visualization_settings: {},
     }).then(({ body: { id: Q1_ID } }) => {
-      cy.log("**-- Create Question 2 --**");
+      cy.log("Create Question 2");
 
       cy.request("POST", "/api/card", {
         name: "13801_Q2",
@@ -154,14 +154,12 @@ describe("scenarios > question > null", () => {
         display: "scalar",
         visualization_settings: {},
       }).then(({ body: { id: Q2_ID } }) => {
-        cy.log("**-- Create Dashboard --**");
+        cy.log("Create Dashboard");
 
         cy.request("POST", "/api/dashboard", {
           name: "13801D",
         }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log(
-            `**-- Add both previously created questions to the dashboard--**`,
-          );
+          cy.log("Add both previously created questions to the dashboard");
 
           [Q1_ID, Q2_ID].forEach((questionId, index) => {
             cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -77,7 +77,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it.skip("should allow drill-through on combined cards with different amount of series (metabase#13457)", () => {
-    cy.log("**--1. Create the first question--**");
+    cy.log("Create the first question");
 
     cy.request("POST", "/api/card", {
       name: "13457_Q1",
@@ -95,7 +95,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       display: "line",
       visualization_settings: {},
     }).then(({ body: { id: Q1_ID } }) => {
-      cy.log("**--2. Create the second question--**");
+      cy.log("Create the second question");
 
       cy.request("POST", "/api/card", {
         name: "13457_Q2",
@@ -116,18 +116,18 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         display: "line",
         visualization_settings: {},
       }).then(({ body: { id: Q2_ID } }) => {
-        cy.log("**--3. Create a dashboard--**");
+        cy.log("Create a dashboard");
 
         cy.request("POST", "/api/dashboard", {
           name: "13457D",
         }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("**--4. Add the first question to the dashboard--**");
+          cy.log("Add the first question to the dashboard");
 
           cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cardId: Q1_ID,
           }).then(({ body: { id: DASH_CARD_ID } }) => {
             cy.log(
-              "**--5. Add additional series combining it with the second question--**",
+              "Add additional series combining it with the second question",
             );
 
             cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
@@ -154,7 +154,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
           cy.visit(`/dashboard/${DASHBOARD_ID}`);
 
-          cy.log("**The first series line**");
+          cy.log("The first series line");
           cy.get(".sub.enable-dots._0")
             .find(".dot")
             .eq(0)
@@ -166,7 +166,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           cy.findByText("13457D").click();
 
           // Second line from the second question
-          cy.log("**The third series line**");
+          cy.log("The third series line");
           cy.get(".sub.enable-dots._2")
             .find(".dot")
             .eq(0)
@@ -256,7 +256,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // check that filter is applied and rows displayed
     cy.contains("Showing 127 rows");
 
-    cy.log("**Filter should show the range between two dates**");
+    cy.log("Filter should show the range between two dates");
     // Now click on the filter widget to see if the proper parameters got passed in
     cy.contains("Created At between").click();
   });
@@ -285,7 +285,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("Visualization").click();
     cy.icon("line").click();
     cy.findByText("Done").click();
-    cy.log("**Mid-point assertion**");
+    cy.log("Mid-point assertion");
     cy.contains("Count by Created At: Month");
     // at this point, filter is displaying correctly with the name
     cy.contains("Count is greater than 1");
@@ -296,7 +296,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       .click({ force: true });
     cy.findByText("View these Orders").click();
 
-    cy.log("**Reproduced on 0.34.3, 0.35.4, 0.36.7 and 0.37.0-rc2**");
+    cy.log("Reproduced on 0.34.3, 0.35.4, 0.36.7 and 0.37.0-rc2");
     // when the bug is present, filter is missing a name (showing only "is 256")
     cy.contains("Count is equal to 256");
     cy.findByText("There was a problem with your question").should("not.exist");
@@ -335,7 +335,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
   it.skip("should drill-through a custom question that joins a native SQL question (metabase#14495)", () => {
     // Restrict "normal user" (belongs to the DATA_GROUP) from writing native queries
-    cy.log("**-- Fetch permissions graph --**");
+    cy.log("Fetch permissions graph");
     cy.request("GET", "/api/permissions/graph", {}).then(
       ({ body: { groups, revision } }) => {
         // This mutates the original `groups` object => we'll pass it next to the `PUT` request
@@ -344,7 +344,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           1: { schemas: "all", native: "none" },
         };
 
-        cy.log("**-- Update/save permissions --**");
+        cy.log("Update/save permissions");
         cy.request("PUT", "/api/permissions/graph", {
           groups,
           revision,
@@ -441,10 +441,10 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
     // [quarantine] flaky
     it.skip("should result in a correct query result", () => {
-      cy.log("**Assert that the URL is correct**");
+      cy.log("Assert that the URL is correct");
       cy.url().should("include", "/question#");
 
-      cy.log("**Assert on the correct product category: Widget**");
+      cy.log("Assert on the correct product category: Widget");
       cy.findByText("Category is Widget");
       cy.findByText("Gizmo").should("not.exist");
       cy.findByText("Doohickey").should("not.exist");

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -32,7 +32,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       });
 
       it("should result in a correct query result", () => {
-        cy.log("**Assert that the url is correct**");
+        cy.log("Assert that the url is correct");
         cy.location("pathname").should("eq", `/question/${Q2.id}`);
 
         cy.contains("18,760");
@@ -129,7 +129,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       it("should respect visualization type when entering a question from a dashboard (metabase#13415)", () => {
         const QUESTION_NAME = "13415";
 
-        cy.log("**--1. Create a question--**");
+        cy.log("Create a question");
         cy.request("POST", "/api/card", {
           name: QUESTION_NAME,
           dataset_query: {
@@ -154,14 +154,12 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
             "table.cell_column": "count",
           },
         }).then(({ body: { id: QUESTION_ID } }) => {
-          cy.log("**--2. Create a dashboard--**");
+          cy.log("Create a dashboard");
 
           cy.request("POST", "/api/dashboard", {
             name: "13415D",
           }).then(({ body: { id: DASHBOARD_ID } }) => {
-            cy.log(
-              "**--3. Add filter with the default value to the dashboard--**",
-            );
+            cy.log("Add filter with the default value to the dashboard");
 
             cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
               parameters: [
@@ -175,14 +173,12 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
               ],
             });
 
-            cy.log(
-              "**--4. Add previously created question to the dashboard--**",
-            );
+            cy.log("Add previously created question to the dashboard");
 
             cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
               cardId: QUESTION_ID,
             }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log("**--5. Connect filter to that question--**");
+              cy.log("Connect filter to that question");
 
               cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
                 cards: [

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -140,7 +140,7 @@ describe("scenarios > visualizations > maps", () => {
     cy.get("@texas").click();
     cy.findByText(/View these People/i).click();
 
-    cy.log("**Reported as a regression since v0.37.0**");
+    cy.log("Reported as a regression since v0.37.0");
     cy.wait("@dataset").then(xhr => {
       expect(xhr.request.body.query.filter).not.to.contain("Texas");
     });

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -58,7 +58,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.contains(`Started from ${QUESTION_NAME}`);
 
-    cy.log("**-- Assertions on a table itself --**");
+    cy.log("Assertions on a table itself");
     cy.get(".Visualization").within(() => {
       cy.findByText(/Users? → Source/);
       cy.findByText("783"); // Affiliate - Doohickey
@@ -115,7 +115,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     // One field should now be empty
     cy.findByText("Drag fields here");
 
-    cy.log("**-- Implicit assertions on a table itself --**");
+    cy.log("Implicit assertions on a table itself");
     cy.get(".Visualization").within(() => {
       cy.findByText(/Products? → Category/);
       cy.findByText(/Users? → Source/);
@@ -304,12 +304,12 @@ describe("scenarios > visualizations > pivot tables", () => {
       .findByText(/Users? → Source/)
       .click();
 
-    cy.log("**-- Collapse the options panel --**");
+    cy.log("Collapse the options panel");
     cy.icon("chevronup").click();
     cy.findByText(/Formatting/).should("not.exist");
     cy.findByText(/See options/).should("not.exist");
 
-    cy.log("**-- Expand it again --**");
+    cy.log("Expand it again");
     cy.icon("chevrondown")
       .first()
       .click();
@@ -331,10 +331,10 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("Formatting");
     cy.findByText(/See options/).click();
 
-    cy.log("**-- New panel for the column options --**");
+    cy.log("New panel for the column options");
     cy.findByText(/Column title/);
 
-    cy.log("**-- Change the title for this column --**");
+    cy.log("Change the title for this column");
     cy.get("input[id=column_title]")
       .clear()
       .type("ModifiedTITLE");
@@ -359,12 +359,12 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText(/Formatting/);
     cy.findByText(/See options/).click();
 
-    cy.log("**-- New panel for the column options --**");
+    cy.log("New panel for the column options");
     cy.findByText("Column title");
     cy.findByText("Style");
     cy.findByText("Separator style");
 
-    cy.log("**-- Change the value formatting --**");
+    cy.log("Change the value formatting");
     cy.findByText("Normal").click();
     cy.findByText("Percent").click();
     cy.findByText("Done").click();
@@ -508,22 +508,22 @@ describe("scenarios > visualizations > pivot tables", () => {
 
   describe("dashboards", () => {
     beforeEach(() => {
-      cy.log("**--1. Create a question--**");
+      cy.log("Create a question");
       cy.request("POST", "/api/card", {
         name: QUESTION_NAME,
         dataset_query: testQuery,
         display: "pivot",
         visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.log("**--2. Create new dashboard--**");
+        cy.log("Create new dashboard");
         cy.request("POST", "/api/dashboard", {
           name: DASHBOARD_NAME,
         }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("**--Add previously created question to that dashboard--**");
+          cy.log("Add previously created question to that dashboard");
           cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cardId: QUESTION_ID,
           }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log("**--Resize the dashboard card--**");
+            cy.log("Resize the dashboard card");
             cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
               cards: [
                 {
@@ -536,7 +536,7 @@ describe("scenarios > visualizations > pivot tables", () => {
                 },
               ],
             });
-            cy.log("**--Open the dashboard--**");
+            cy.log("Open the dashboard");
             cy.visit(`/dashboard/${DASHBOARD_ID}`);
           });
         });
@@ -561,30 +561,30 @@ describe("scenarios > visualizations > pivot tables", () => {
   describe("sharing (metabase#14447)", () => {
     beforeEach(() => {
       cy.viewport(1400, 800); // Row totals on embed preview was getting cut off at the normal width
-      cy.log("**--1. Create a question--**");
+      cy.log("Create a question");
       cy.request("POST", "/api/card", {
         name: QUESTION_NAME,
         dataset_query: testQuery,
         display: "pivot",
         visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.log("**--1a. Enable sharing--**");
+        cy.log("Enable sharing");
         cy.request("POST", `/api/card/${QUESTION_ID}/public_link`);
 
-        cy.log("**--1b. Enable embedding--**");
+        cy.log("Enable embedding");
         cy.request("PUT", `/api/card/${QUESTION_ID}`, {
           enable_embedding: true,
         });
 
-        cy.log("**--2. Create new dashboard--**");
+        cy.log("Create new dashboard");
         cy.request("POST", "/api/dashboard", {
           name: DASHBOARD_NAME,
         }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("**--Add previously created question to that dashboard--**");
+          cy.log("Add previously created question to that dashboard");
           cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cardId: QUESTION_ID,
           }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log("**--Resize the dashboard card--**");
+            cy.log("Resize the dashboard card");
             cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
               cards: [
                 {
@@ -599,10 +599,10 @@ describe("scenarios > visualizations > pivot tables", () => {
             });
           });
 
-          cy.log("**--2a. Enable sharing--**");
+          cy.log("Enable sharing");
           cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/public_link`);
 
-          cy.log("**--2b. Enable embedding--**");
+          cy.log("Enable embedding");
           cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
             enable_embedding: true,
           });
@@ -699,7 +699,7 @@ function createAndVisitTestQuestion({ display = "pivot" } = {}) {
 function assertOnPivotSettings() {
   cy.get("[draggable=true]").as("fieldOption");
 
-  cy.log("**-- Implicit side-bar assertions --**");
+  cy.log("Implicit side-bar assertions");
   cy.findByText(/Pivot Table options/i);
 
   cy.findAllByText("Fields to use for the table").eq(0);
@@ -717,7 +717,7 @@ function assertOnPivotSettings() {
 }
 
 function assertOnPivotFields() {
-  cy.log("**-- Implicit assertions on a table itself --**");
+  cy.log("Implicit assertions on a table itself");
 
   cy.findByText(/Users? → Source/);
   cy.findByText(/Row totals/i);


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
- Adds a custom Cypress log function
    - Updates all occurrences of hard-coded custom formatting in the cy.logs we had so far

### How to verify this works?
- All tests should still pass
- Every log in the Cypress runner sidebar should behave like a numbered list item

### Additional notes
- Since this overwrites the original `cy.log()`, its usage is still the same (you simply write `cy.log("message")`)
- The only downside of this approach is that now we can't use custom (markdown) formatting that the original `cy.log()` accepted
    - `"**text**"`for **bold**
    - `"_text_"`for _italic_

### Screenshots
![image](https://user-images.githubusercontent.com/31325167/109338824-14bfa280-7867-11eb-9cde-3af91e8e0c2e.png)

