### PR TITLE
Add recency score to search

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -115,8 +115,9 @@ function Score({ score }) {
       {`\n\n
       Pinned:    ${score[0]}
       Dashboard: ${score[1]}
-      Text:      ${score[2]}
-      Model:     ${score[3]}
+      Recency:   ${score[2]}
+      Text:      ${score[3]}
+      Model:     ${score[4]}
       Raw:       ${score && score.join(", ")}`}
     </pre>
   );

--- a/project.clj
+++ b/project.clj
@@ -147,7 +147,7 @@
    [ring/ring-jetty-adapter "1.8.1"]                                  ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
    [ring/ring-json "0.5.0"]                                           ; Ring middleware for reading/writing JSON automatically
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
-   [toucan "1.15.1" :exclusions [org.clojure/java.jdbc                ; Model layer, hydration, and DB utilities
+   [toucan "1.15.3" :exclusions [org.clojure/java.jdbc                ; Model layer, hydration, and DB utilities
                                  org.clojure/tools.logging
                                  org.clojure/tools.namespace
                                  honeysql]]
@@ -367,7 +367,7 @@
                            #_:unused-locals]
       :exclude-linters    [    ; Turn this off temporarily until we finish removing self-deprecated functions & macros
                            :deprecations
-                           ;; this has a fit in libs that use Potemin `import-vars` such as `java-time`
+                           ;; this has a fit in libs that use Potemkin `import-vars` such as `java-time`
                            :implicit-dependencies
                            ;; too many false positives for now
                            :unused-ret-vals]}}]

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -72,6 +72,8 @@
    ;; returned for Card and Dashboard
    :collection_position :integer
    :favorite            :boolean
+   ;; returned for everything except Collection
+   :updated_at          :timestamp
    ;; returned for Card only
    :dashboardcard_count :integer
    :dataset_query       :text
@@ -124,8 +126,7 @@
       ;;
       ;; For MySQL, this is not needed.
       :else
-      [(if (= (mdb/db-type) :mysql)
-         nil
+      [(when-not (= (mdb/db-type) :mysql)
          (hx/cast col-type nil))
        search-col])))
 
@@ -267,7 +268,7 @@
             {:select (:select base-query)
              :from   [[(merge
                         base-query
-                        {:select [:id :schema :db_id :name :description :display_name
+                        {:select [:id :schema :db_id :name :description :display_name :updated_at
                                   [(hx/concat (hx/literal "/db/") :db_id
                                               (hx/literal "/schema/") (hsql/call :case
                                                                         [:not= :schema nil] :schema

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -14,6 +14,11 @@
   "Number of results to return in an API response"
   50)
 
+(def ^:const stale-time-in-days
+  "Results older than this number of days are all considered to be equally old. In other words, there is a ranking
+  bonus for results newer than this (scaled to just how recent they are). c.f. `search.scoring/recency-score`"
+  180)
+
 (def searchable-models
   "Models that can be searched. The order of this list also influences the order of the results: items earlier in the
   list will be ranked higher."
@@ -55,7 +60,7 @@
 
 (def ^:private default-columns
   "Columns returned for all models."
-  [:id :name :description :archived])
+  [:id :name :description :archived :updated_at])
 
 (def ^:private favorite-col
   "Case statement to return boolean values of `:favorite` for Card and Dashboard."
@@ -96,7 +101,7 @@
 
 (defmethod columns-for-model (class Collection)
   [_]
-  (conj default-columns [:id :collection_id] [:name :collection_name]))
+  (conj (remove #{:updated_at} default-columns) [:id :collection_id] [:name :collection_name]))
 
 (defmethod columns-for-model (class Segment)
   [_]
@@ -112,6 +117,7 @@
    :name
    :display_name
    :description
+   :updated_at
    [:id :table_id]
    [:db_id :database_id]
    [:schema :table_schema]

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -26,7 +26,8 @@
    :dataset_query       nil
    :table_schema        nil
    :table_name          nil
-   :table_description   nil})
+   :table_description   nil
+   :updated_at          true})
 
 (defn- table-search-results
   "Segments and Metrics come back with information about their Tables as of 0.33.0. The `model-defaults` for Segment and
@@ -52,9 +53,9 @@
 (defn- default-search-results []
   (sorted-results
    [(make-result "dashboard test dashboard", :model "dashboard", :favorite false)
-    (make-result "collection test collection", :model "collection", :collection {:id true, :name true})
+    (make-result "collection test collection", :model "collection", :collection {:id true, :name true}, :updated_at false)
     (make-result "card test card", :model "card", :favorite false, :dataset_query "{}", :dashboardcard_count 0)
-    (make-result "pulse test pulse", :model "pulse", :archived nil)
+    (make-result "pulse test pulse", :model "pulse", :archived nil, :updated_at false)
     (merge
      (make-result "metric test metric", :model "metric", :description "Lookin' for a blueberry")
      (table-search-results))
@@ -128,7 +129,7 @@
           (-> result
               mt/boolean-ids-and-timestamps
               (update-in [:collection :name] #(some-> % string?))
-              ;; `:score` is just used for debugging and would be a pain to match against
+              ;; `:score` is just used for debugging and would be a pain to match against.
               (dissoc :score))))))))
 
 (defn- search-request


### PR DESCRIPTION
The Toucan upgrade is for this: https://github.com/metabase/toucan/pull/78 (see discussion in #engineering-backend). The tl;dr is that `updated_at` was coming back as a `java.sql.Timestamp` when it should've been a `java.time.OffsetDateTime`.