### PR TITLE
Prevent delay when showing the expression suggestion for the first time

### DIFF
--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -65,6 +65,8 @@ import { push } from "react-router-redux";
 import Collections from "metabase/entities/collections";
 import { MetabaseApi } from "metabase/services";
 
+import { processSource } from "metabase/lib/expressions/process";
+
 function autocompleteResults(card, prefix) {
   const databaseId = card && card.dataset_query && card.dataset_query.database;
   if (!databaseId) {
@@ -177,6 +179,9 @@ export default class QueryBuilder extends Component {
 
   componentWillMount() {
     this.props.initializeQB(this.props.location, this.props.params);
+
+    // Prime the expression parser & autocomplete
+    processSource({ source: "", targetOffset: 0 });
   }
 
   componentDidMount() {


### PR DESCRIPTION
This should fix #14791.

The delay was a minor regression caused by deferring the construction of the expensive parser (see PR #14133) to prevent atrocious embedding performance.  However, that also meant that the parser and everything else (auto-suggest system) wasn't ready when the user wants to use a custom expression.

With this change, we immediately prime the parser whenever a query builder is started, under the assumption that the app isn't being embedded (hence, past the concern address in PR #14133) and from this point onward, the custom expression parser etc will be likely needed.

Unfortunately, there is no sane automated way to verify this for now.

**Manual verification**

1. Start from a fresh instance/window (important)
2. Ask a question, Custom Expression
3. Sample Dataset, Reviews
4. Custom Column

The list of suggestion should appear (rather) instantly.