### PR TITLE
Fix render error when removing a dashboard parameter

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -400,7 +400,10 @@ function Sidebars(props) {
       <ParameterSidebar
         parameter={parameter}
         otherParameters={otherParameters}
-        remove={() => removeParameter(editingParameterId)}
+        remove={() => {
+          setEditingParameter(null);
+          removeParameter(editingParameterId);
+        }}
         done={() => setEditingParameter(null)}
         showAddParameterPopover={showAddParameterPopover}
         setParameter={setParameter}


### PR DESCRIPTION
**Description**
When you click "Remove" to remove a dashboard parameter it causes an error in the render function of `DashCardCardParameterWrapper` component because we remove the parameter from state before closing the parameter-editing view code. This causes the app to break in dev but fortunately prod is more forgiving with regards to exceptions thrown during `render` calls. Dispatching an additional action to turn off this state fixes the issue.

**Verification**
This is what happened in dev before the change:
<img width="1267" alt="Screen Shot 2021-02-26 at 4 47 56 PM" src="https://user-images.githubusercontent.com/13057258/109369893-2ac36800-7853-11eb-9597-bcd08857041b.png">
