### PR TITLE
Add new dev QP tool to convert an MBQL query to MBQL shorthand

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -1,6 +1,8 @@
 (ns dev.debug-qp
   (:require [clojure.data :as data]
             [clojure.pprint :as pprint]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
             [clojure.walk :as walk]
             [medley.core :as m]
             [metabase.mbql.schema :as mbql.s]
@@ -8,6 +10,7 @@
             [metabase.models :refer [Field Table]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.reducible :as qp.reducible]
+            [metabase.test :as mt]
             [metabase.util :as u]
             [toucan.db :as db]))
 
@@ -32,6 +35,10 @@
        form))
    x))
 
+(defn- field-and-table-name [field-id]
+  (let [{field-name :name, table-id :table_id} (db/select-one [Field :name :table_id] :id field-id)]
+    [(db/select-one-field :name Table :id table-id) field-name]))
+
 (defn add-names
   "Walk a MBQL snippet `x` and add comment forms with the names of the Fields referenced to any `:field-id` clauses
   encountered. Helpful for debugging!"
@@ -40,10 +47,8 @@
    (fn [form]
      (mbql.u/replace form
        [:field-id id]
-       [:field-id id (let [{field-name :name, table-id :table_id} (db/select-one [Field :name :table_id] :id id)]
-                       (symbol (format "#_\"%s.%s\""
-                                       (db/select-one-field :name Table :id table-id)
-                                       field-name)))]))
+       [:field-id id (let [[field-name table-name] (field-and-table-name id)]
+                       (symbol (format "#_\"%s.%s\"" field-name table-name)))]))
    x))
 
 (defn- format-output [x]
@@ -200,3 +205,125 @@
       (if context
         (qp query context)
         (qp query)))))
+
+(defn- strip-$ [coll]
+  (remove (partial = ::$) coll))
+
+(defn- can-symbolize? [form]
+  (mbql.u/match-one form
+    (s :guard string?)
+    (not (re-find #"\s+" s))
+
+    [:field-id id]
+    (every? can-symbolize? (field-and-table-name id))
+
+    [:field-literal field-name _]
+    (can-symbolize? field-name)
+
+    [:fk-> x y]
+    (every? can-symbolize? [x y])
+
+    [:joined-field join-alias clause]
+    (every? can-symbolize? [join-alias clause])))
+
+(defn- expand [query table]
+  (mbql.u/replace query
+    ([:field-id id] :guard can-symbolize?)
+    (let [[table-name field-name] (field-and-table-name id)
+          field-name              (str/lower-case field-name)
+          table-name              (str/lower-case table-name)]
+      (if (= table-name table)
+        [::$ field-name]
+        [::$ table-name field-name]))
+
+    ([:field-literal field-name base-type] :guard can-symbolize?)
+    [::* field-name (name base-type)]
+
+    ([:datetime-field field-clause unit] :guard can-symbolize?)
+    (into [::! (name unit)] (strip-$ (expand field-clause table)))
+
+    [:datetime-field field-clause unit]
+    [:datetime-field (expand field-clause table) unit]
+
+    ([:fk-> x y] :guard can-symbolize?)
+    [::-> (expand x table) (expand y table)]
+
+    [:fk-> x y]
+    [:fk-> (expand x table) (expand y table)]
+
+    ([:joined-field join-alias field-clause] :guard can-symbolize?)
+    (into [::& join-alias] (strip-$ (expand field-clause table)))
+
+    [:joined-field join-alias field-clause]
+    [:joined-field join-alias (expand field-clause table)]
+
+    (m :guard (every-pred map? (comp integer? :source-table)))
+    (-> (update m :source-table (fn [table-id]
+                                  [::$$ (str/lower-case (db/select-one-field :name Table :id table-id))]))
+        (expand table))))
+
+(defn- symbolize [query]
+  (mbql.u/replace query
+    [::-> x y]
+    (symbol (format "%s->%s" (symbolize x) (str/replace (symbolize y) #"^\$" "")))
+
+    [(qualifier :guard #{::$ ::& ::!}) & args]
+    (symbol (str (name qualifier) (str/join \. (strip-$ args))))
+
+    [::* field-name base-type]
+    (symbol (format "*%s/%s" field-name base-type))
+
+    [::$$ table-name]
+    (symbol (format "$$%s" table-name))))
+
+(defn- query-table-name [{:keys [source-table source-query]}]
+  (cond
+    source-table
+    (str/lower-case (db/select-one-field :name Table :id source-table))
+
+    source-query
+    (recur source-query)))
+
+(defn to-mbql-shorthand
+  ([query]
+   (to-mbql-shorthand query (query-table-name (:query query))))
+
+  ([query table-name]
+   (let [symbolized (-> query (expand table-name) symbolize)
+         table-symb (some-> table-name symbol)]
+     (if (:query symbolized)
+       (list 'mt/mbql-query table-symb (-> (:query symbolized)
+                                           (dissoc :source-table)))
+       (list 'mt/$ids table-symb symbolized)))))
+
+(deftest to-mbql-shorthand-test
+  (mt/dataset sample-dataset
+    (is (= '(mt/mbql-query orders
+              {:joins       [{:source-table $$people
+                              :fields       :all
+                              :condition    [:= $user_id [:joined-field "People - User" $people.id]]
+                              :alias        "People - User"}]
+               :aggregation [[:sum $total]
+                             [:sum $products.id]]
+               :breakout    [&P.people.source
+                             $product_id->products.id
+                             [:fk-> $product_id [:field-literal "w o w" :Type/Text]]
+                             $product_id->*wow/Text
+                             *wow/Text]})
+           (to-mbql-shorthand
+            {:database (mt/id)
+             :type     :query
+             :query    {:joins        [{:fields       :all
+                                        :source-table (mt/id :people)
+                                        :condition    [:=
+                                                       [:field-id (mt/id :orders :user_id)]
+                                                       [:joined-field "People - User" [:field-id (mt/id :people :id)]]]
+                                        :alias        "People - User"}]
+                        :aggregation  [[:sum [:field-id (mt/id :orders :total)]]
+                                       [:sum  [:field-id (mt/id :products :id)]]]
+                        :breakout     [[:joined-field "P" [:field-id (mt/id :people :source)]]
+                                       [:fk-> [:field-id (mt/id :orders :product_id)] [:field-id (mt/id :products :id)]]
+                                       [:fk-> [:field-id (mt/id :orders :product_id)] [:field-literal "w o w" :Type/Text]]
+                                       [:fk-> [:field-id (mt/id :orders :product_id)] [:field-literal "wow" :Type/Text]]
+                                       [:field-literal "wow" :Type/Text]]
+                        :source-table (mt/id :orders)}})))))


### PR DESCRIPTION
New dev QP tool to convert an MBQL query to the MBQL shorthand used in backend tests. The MBQL shorthand is a little terse, but it has the benefit of not needing any changes for both < 39 and >= 39 MBQL so using it in more places means we don't have to update as many tests next time we merge `release-x.38.x` -> `master`