### PR TITLE
Add Cypress custom command for creating the dashboard

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -39,9 +39,7 @@ function generateQuestions(user) {
 }
 
 function generateDashboards(user) {
-  cy.request("POST", "/api/dashboard", {
-    name: `${user} dashboard`,
-  });
+  cy.createDashboard(`${user} dashboard`);
 }
 
 describeWithToken("audit > auditing", () => {

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -2,6 +2,11 @@ Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });
 
+Cypress.Commands.add("createDashboard", name => {
+  cy.log(`Create a dashboard: ${name}`);
+  cy.request("POST", "/api/dashboard", { name });
+});
+
 /**
  * PERMISSIONS
  *

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -262,7 +262,7 @@ describe("scenarios > collection_defaults", () => {
     describe("a new dashboard", () => {
       it("should be in the root collection", () => {
         // Make new dashboard and check collection name
-        cy.request("POST", "/api/dashboard", { name: dashboard_name });
+        cy.createDashboard(dashboard_name);
 
         cy.visit("/collection/root");
         cy.findByText(dashboard_name);
@@ -297,7 +297,7 @@ describe("scenarios > collection_defaults", () => {
     describe("a new dashboard", () => {
       it("should be in the root collection", () => {
         // Make new dashboard and check collection name
-        cy.request("POST", "/api/dashboard", { name: dashboard_name });
+        cy.createDashboard(dashboard_name);
 
         cy.visit("/collection/root");
         cy.findByText(dashboard_name);

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -60,9 +60,7 @@ function createQuestion(options, callback) {
 // Once created, add the provided questionId to the dashboard and then
 // map the city/state filters to the template-tags in the native query.
 function createDashboard({ dashboardName, questionId }, callback) {
-  cy.request("POST", "/api/dashboard", {
-    name: dashboardName,
-  }).then(({ body: { id: dashboardId } }) => {
+  cy.createDashboard(dashboardName).then(({ body: { id: dashboardId } }) => {
     cy.request("PUT", `/api/dashboard/${dashboardId}`, {
       parameters: [
         {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -62,11 +62,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       "13927",
       `SELECT PEOPLE.STATE, PEOPLE.CITY from PEOPLE;`,
     ).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("Create a dashboard");
-
-      cy.request("POST", "/api/dashboard", {
-        name: "13927D",
-      }).then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard("13927D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add question to the dashboard");
 
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
@@ -271,10 +267,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: questionId } }) => {
-      // 3. create a dashboard
-      cy.request("POST", "/api/dashboard", {
-        name: "13062D",
-      }).then(({ body: { id: dashboardId } }) => {
+      cy.createDashboard("13062D").then(({ body: { id: dashboardId } }) => {
         // add filter to the dashboard
         cy.request("PUT", `/api/dashboard/${dashboardId}`, {
           parameters: [
@@ -419,11 +412,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       display: "bar",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("Create a dashboard");
-
-      cy.request("POST", "/api/dashboard", {
-        name: "13785D",
-      }).then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard("13785D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add filter to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
@@ -554,10 +543,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      // Create a dashboard
-      cy.request("POST", "/api/dashboard", {
-        name: "14919D",
-      }).then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard("14919D").then(({ body: { id: DASHBOARD_ID } }) => {
         // Add previously added question to the dashboard
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
@@ -638,9 +624,7 @@ function createDashboard(
   { dashboardName = "dashboard", questionId, visualization_settings },
   callback,
 ) {
-  cy.request("POST", "/api/dashboard", {
-    name: dashboardName,
-  }).then(({ body: { id: dashboardId } }) => {
+  cy.createDashboard(dashboardName).then(({ body: { id: dashboardId } }) => {
     cy.request("PUT", `/api/dashboard/${dashboardId}`, {
       parameters: [
         {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -149,10 +149,7 @@ describe("scenarios > dashboard", () => {
       visualization_settings: {},
     });
 
-    // create a dashboard
-    cy.request("POST", "/api/dashboard", {
-      name: "dash:11007",
-    });
+    cy.createDashboard("dash:11007");
 
     cy.visit("/collection/root");
     // enter newly created dashboard
@@ -209,10 +206,7 @@ describe("scenarios > dashboard", () => {
       display: "map",
       visualization_settings: {},
     }).then(({ body: { id: questionId } }) => {
-      // 2. create a dashboard
-      cy.request("POST", "/api/dashboard", {
-        name: "13597D",
-      }).then(({ body: { id: dashboardId } }) => {
+      cy.createDashboard("13597D").then(({ body: { id: dashboardId } }) => {
         // add filter (ID) to the dashboard
         cy.request("PUT", `/api/dashboard/${dashboardId}`, {
           parameters: [
@@ -288,11 +282,7 @@ describe("scenarios > dashboard", () => {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("Create a dashboard");
-
-      cy.request("POST", "/api/dashboard", {
-        name: "14473D",
-      }).then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard("14473D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add 4 filters to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
@@ -526,11 +516,7 @@ describe("scenarios > dashboard", () => {
       display: "table",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("Create a dashboard");
-
-      cy.request("POST", "/api/dashboard", {
-        name: "13150D",
-      }).then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard("13150D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add 3 filters to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -48,7 +48,7 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should search across multiple fields", () => {
-    cy.request("POST", "/api/dashboard", { name: "my dash" });
+    cy.createDashboard("my dash");
 
     cy.visit("/collection/root");
     cy.findByText("my dash").click();

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -73,40 +73,38 @@ describe("scenarios > dashboard > permissions", () => {
       }).then(({ body: { id } }) => (secondQuestionId = id));
     });
 
-    cy.request("POST", "/api/dashboard", { name: "dashboard" }).then(
-      ({ body: { id: dashId } }) => {
+    cy.createDashboard("dashboard").then(({ body: { id: dashId } }) => {
+      cy.request("POST", `/api/dashboard/${dashId}/cards`, {
+        cardId: firstQuestionId,
+      }).then(({ body: { id: dashCardIdA } }) => {
         cy.request("POST", `/api/dashboard/${dashId}/cards`, {
-          cardId: firstQuestionId,
-        }).then(({ body: { id: dashCardIdA } }) => {
-          cy.request("POST", `/api/dashboard/${dashId}/cards`, {
-            cardId: secondQuestionId,
-          }).then(({ body: { id: dashCardIdB } }) => {
-            cy.request("PUT", `/api/dashboard/${dashId}/cards`, {
-              cards: [
-                {
-                  id: dashCardIdA,
-                  card_id: firstQuestionId,
-                  row: 0,
-                  col: 0,
-                  sizeX: 6,
-                  sizeY: 6,
-                },
-                {
-                  id: dashCardIdB,
-                  card_id: secondQuestionId,
-                  row: 0,
-                  col: 6,
-                  sizeX: 6,
-                  sizeY: 6,
-                },
-              ],
-            });
+          cardId: secondQuestionId,
+        }).then(({ body: { id: dashCardIdB } }) => {
+          cy.request("PUT", `/api/dashboard/${dashId}/cards`, {
+            cards: [
+              {
+                id: dashCardIdA,
+                card_id: firstQuestionId,
+                row: 0,
+                col: 0,
+                sizeX: 6,
+                sizeY: 6,
+              },
+              {
+                id: dashCardIdB,
+                card_id: secondQuestionId,
+                row: 0,
+                col: 6,
+                sizeX: 6,
+                sizeY: 6,
+              },
+            ],
           });
         });
-        dashboardId = dashId;
-        cy.visit(`/dashboard/${dashId}`);
-      },
-    );
+      });
+      dashboardId = dashId;
+      cy.visit(`/dashboard/${dashId}`);
+    });
   });
 
   it("should let admins view all cards in a dashboard", () => {

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -13,12 +13,11 @@ describe("scenarios > dashboard > subscriptions", () => {
   });
 
   it("should not allow creation if there are no dashboard cards", () => {
-    cy.log("Create fresh new dashboard");
-    cy.request("POST", "/api/dashboard", {
-      name: "Empty Dashboard",
-    }).then(({ body: { id: DASHBOARD_ID } }) => {
-      cy.visit(`/dashboard/${DASHBOARD_ID}`);
-    });
+    cy.createDashboard("Empty Dashboard").then(
+      ({ body: { id: DASHBOARD_ID } }) => {
+        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+      },
+    );
     // It would be great if we can use either aria-attributes or better class naming to suggest when icons are disabled
     cy.icon("share")
       .closest("a")

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -45,11 +45,8 @@ describe("scenarios > dashboard > text-box", () => {
 
   describe("when text-box is the only element on the dashboard", () => {
     beforeEach(() => {
-      // Create dashboard
       cy.server();
-      cy.request("POST", "/api/dashboard", {
-        name: "Test Dashboard",
-      });
+      cy.createDashboard("Test Dashboard");
     });
 
     // fixed in metabase#11358

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -52,70 +52,71 @@ describe("scenarios > question > filter", () => {
           display: "table",
           visualization_settings: {},
         }).then(({ body: { id: Q2_ID } }) => {
-          cy.log("Create a dashboard");
+          cy.createDashboard("12985D").then(
+            ({ body: { id: DASHBOARD_ID } }) => {
+              cy.log("Add 2 filters to the dashboard");
 
-          cy.request("POST", "/api/dashboard", {
-            name: "12985D",
-          }).then(({ body: { id: DASHBOARD_ID } }) => {
-            cy.log("Add 2 filters to the dashboard");
-
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-              parameters: [
-                {
-                  name: "Date Filter",
-                  slug: "date_filter",
-                  id: "78d4ba0b",
-                  type: "date/all-options",
-                },
-                {
-                  name: "Category",
-                  slug: "category",
-                  id: "20976cce",
-                  type: "category",
-                },
-              ],
-            });
-
-            cy.log("Add nested card to the dashboard");
-
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: Q2_ID,
-            }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log("Connect dashboard filters to the nested card");
-
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+                parameters: [
                   {
-                    id: DASH_CARD_ID,
-                    card_id: Q2_ID,
-                    row: 0,
-                    col: 0,
-                    sizeX: 10,
-                    sizeY: 8,
-                    series: [],
-                    visualization_settings: {},
-                    // Connect both filters and to the card
-                    parameter_mappings: [
-                      {
-                        parameter_id: "78d4ba0b",
-                        card_id: Q2_ID,
-                        target: [
-                          "dimension",
-                          ["field-id", PRODUCTS.CREATED_AT],
-                        ],
-                      },
-                      {
-                        parameter_id: "20976cce",
-                        card_id: Q2_ID,
-                        target: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
-                      },
-                    ],
+                    name: "Date Filter",
+                    slug: "date_filter",
+                    id: "78d4ba0b",
+                    type: "date/all-options",
+                  },
+                  {
+                    name: "Category",
+                    slug: "category",
+                    id: "20976cce",
+                    type: "category",
                   },
                 ],
               });
-            });
-            cy.visit(`/dashboard/${DASHBOARD_ID}`);
-          });
+
+              cy.log("Add nested card to the dashboard");
+
+              cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cardId: Q2_ID,
+              }).then(({ body: { id: DASH_CARD_ID } }) => {
+                cy.log("Connect dashboard filters to the nested card");
+
+                cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                  cards: [
+                    {
+                      id: DASH_CARD_ID,
+                      card_id: Q2_ID,
+                      row: 0,
+                      col: 0,
+                      sizeX: 10,
+                      sizeY: 8,
+                      series: [],
+                      visualization_settings: {},
+                      // Connect both filters and to the card
+                      parameter_mappings: [
+                        {
+                          parameter_id: "78d4ba0b",
+                          card_id: Q2_ID,
+                          target: [
+                            "dimension",
+                            ["field-id", PRODUCTS.CREATED_AT],
+                          ],
+                        },
+                        {
+                          parameter_id: "20976cce",
+                          card_id: Q2_ID,
+                          target: [
+                            "dimension",
+                            ["field-id", PRODUCTS.CATEGORY],
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                });
+              });
+              cy.visit(`/dashboard/${DASHBOARD_ID}`);
+            },
+          );
         });
       });
 
@@ -153,59 +154,57 @@ describe("scenarios > question > filter", () => {
         display: "table",
         visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.log("Create a dashboard");
+        cy.createDashboard("12985-v2D").then(
+          ({ body: { id: DASHBOARD_ID } }) => {
+            cy.log("Add a category filter to the dashboard");
 
-        cy.request("POST", "/api/dashboard", {
-          name: "12985-v2D",
-        }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("Add a category filter to the dashboard");
-
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-            parameters: [
-              {
-                name: "Category",
-                slug: "category",
-                id: "7c4htcv8",
-                type: "category",
-              },
-            ],
-          });
-
-          cy.log("Add previously created question to the dashboard");
-
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: QUESTION_ID,
-          }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log("Connect dashboard filter to the aggregated card");
-
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+              parameters: [
                 {
-                  id: DASH_CARD_ID,
-                  card_id: QUESTION_ID,
-                  row: 0,
-                  col: 0,
-                  sizeX: 8,
-                  sizeY: 6,
-                  series: [],
-                  visualization_settings: {},
-                  // Connect filter to the card
-                  parameter_mappings: [
-                    {
-                      parameter_id: "7c4htcv8",
-                      card_id: QUESTION_ID,
-                      target: [
-                        "dimension",
-                        ["field-literal", "CATEGORY", "type/Text"],
-                      ],
-                    },
-                  ],
+                  name: "Category",
+                  slug: "category",
+                  id: "7c4htcv8",
+                  type: "category",
                 },
               ],
             });
-          });
-          cy.visit(`/dashboard/${DASHBOARD_ID}`);
-        });
+
+            cy.log("Add previously created question to the dashboard");
+
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: QUESTION_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log("Connect dashboard filter to the aggregated card");
+
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: QUESTION_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 8,
+                    sizeY: 6,
+                    series: [],
+                    visualization_settings: {},
+                    // Connect filter to the card
+                    parameter_mappings: [
+                      {
+                        parameter_id: "7c4htcv8",
+                        card_id: QUESTION_ID,
+                        target: [
+                          "dimension",
+                          ["field-literal", "CATEGORY", "type/Text"],
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              });
+            });
+            cy.visit(`/dashboard/${DASHBOARD_ID}`);
+          },
+        );
       });
 
       cy.findByPlaceholderText("Category").click();
@@ -380,11 +379,7 @@ describe("scenarios > question > filter", () => {
       display: "pie",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.log("Create a dashboard");
-
-      cy.request("POST", "/api/dashboard", {
-        name: "13960D",
-      }).then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard("13960D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log(
           "Add filters to the dashboard and set the default value to the first one",
         );

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -229,11 +229,7 @@ describe("scenarios > question > nested", () => {
       },
     );
 
-    cy.log("Create a brand new dashboard");
-
-    cy.request("POST", "/api/dashboard", {
-      name: "13186D",
-    }).then(({ body: { id: DASBOARD_ID } }) => {
+    cy.createDashboard("13186D").then(({ body: { id: DASBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASBOARD_ID}`);
     });
 

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -70,10 +70,7 @@ describe("scenarios > question > null", () => {
       display: "pie",
       visualization_settings: {},
     }).then(({ body: { id: questionId } }) => {
-      // 2. create a dashboard
-      cy.request("POST", "/api/dashboard", {
-        name: "13626D",
-      }).then(({ body: { id: dashboardId } }) => {
+      cy.createDashboard("13626D").then(({ body: { id: dashboardId } }) => {
         // add filter (ID) to the dashboard
         cy.request("PUT", `/api/dashboard/${dashboardId}`, {
           parameters: [
@@ -154,11 +151,7 @@ describe("scenarios > question > null", () => {
         display: "scalar",
         visualization_settings: {},
       }).then(({ body: { id: Q2_ID } }) => {
-        cy.log("Create Dashboard");
-
-        cy.request("POST", "/api/dashboard", {
-          name: "13801D",
-        }).then(({ body: { id: DASHBOARD_ID } }) => {
+        cy.createDashboard("13801D").then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add both previously created questions to the dashboard");
 
           [Q1_ID, Q2_ID].forEach((questionId, index) => {

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -106,9 +106,7 @@ describe("scenarios > question > view", () => {
       cy.findByText("Yes").click();
 
       // Native query saved in dasbhoard
-      cy.request("POST", "/api/dashboard", {
-        name: "Dashboard",
-      });
+      cy.createDashboard("Dashboard");
 
       cy.request("POST", "/api/card", {
         name: "Question",

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -116,11 +116,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         display: "line",
         visualization_settings: {},
       }).then(({ body: { id: Q2_ID } }) => {
-        cy.log("Create a dashboard");
-
-        cy.request("POST", "/api/dashboard", {
-          name: "13457D",
-        }).then(({ body: { id: DASHBOARD_ID } }) => {
+        cy.createDashboard("13457D").then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add the first question to the dashboard");
 
           cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -525,31 +525,30 @@ describe("scenarios > visualizations > pivot tables", () => {
         display: "pivot",
         visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.log("Create new dashboard");
-        cy.request("POST", "/api/dashboard", {
-          name: DASHBOARD_NAME,
-        }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("Add previously created question to that dashboard");
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: QUESTION_ID,
-          }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log("Resize the dashboard card");
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
-                {
-                  id: DASH_CARD_ID,
-                  card_id: QUESTION_ID,
-                  row: 0,
-                  col: 0,
-                  sizeX: 12,
-                  sizeY: 8,
-                },
-              ],
+        cy.createDashboard(DASHBOARD_NAME).then(
+          ({ body: { id: DASHBOARD_ID } }) => {
+            cy.log("Add previously created question to that dashboard");
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: QUESTION_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log("Resize the dashboard card");
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: QUESTION_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 12,
+                    sizeY: 8,
+                  },
+                ],
+              });
+              cy.log("Open the dashboard");
+              cy.visit(`/dashboard/${DASHBOARD_ID}`);
             });
-            cy.log("Open the dashboard");
-            cy.visit(`/dashboard/${DASHBOARD_ID}`);
-          });
-        });
+          },
+        );
       });
     });
 
@@ -586,37 +585,36 @@ describe("scenarios > visualizations > pivot tables", () => {
           enable_embedding: true,
         });
 
-        cy.log("Create new dashboard");
-        cy.request("POST", "/api/dashboard", {
-          name: DASHBOARD_NAME,
-        }).then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("Add previously created question to that dashboard");
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: QUESTION_ID,
-          }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log("Resize the dashboard card");
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
-                {
-                  id: DASH_CARD_ID,
-                  card_id: QUESTION_ID,
-                  row: 0,
-                  col: 0,
-                  sizeX: 12,
-                  sizeY: 8,
-                },
-              ],
+        cy.createDashboard(DASHBOARD_NAME).then(
+          ({ body: { id: DASHBOARD_ID } }) => {
+            cy.log("Add previously created question to that dashboard");
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: QUESTION_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log("Resize the dashboard card");
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: QUESTION_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 12,
+                    sizeY: 8,
+                  },
+                ],
+              });
             });
-          });
 
-          cy.log("Enable sharing");
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/public_link`);
+            cy.log("Enable sharing");
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/public_link`);
 
-          cy.log("Enable embedding");
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-            enable_embedding: true,
-          });
-        });
+            cy.log("Enable embedding");
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+              enable_embedding: true,
+            });
+          },
+        );
         cy.visit(`/question/${QUESTION_ID}`);
       });
     });

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -171,7 +171,7 @@ describe("snapshots", () => {
     });
 
     // dashboard 1: Orders in a dashboard
-    cy.request("POST", "/api/dashboard", { name: "Orders in a dashboard" });
+    cy.createDashboard("Orders in a dashboard");
     cy.request("POST", `/api/dashboard/1/cards`, { cardId: 1 }).then(
       ({ body: { id: dashCardId } }) => {
         cy.request("PUT", `/api/dashboard/1/cards`, {


### PR DESCRIPTION
### Status:
READY

### What does this PR accomplish?
- Adds Cypress custom command for creating dashboards
- Updates all related occurrences of dashboard creation via API in all test files

### How to test this works?
- All tests should pass

### Additional notes:
- Log is now tucked inside a custom function so there is no need anymore to leave logs inside test itself
- Custom command is "chainable" with Cypress' `then`

```javascript
cy.createDashboard("foo").then(({ body }) => {
  cy.log(body.id)
});
```