### PR TITLE
Add Cypress custom command for creating the question

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -299,31 +299,23 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      cy.log("Create and save a question");
-
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: QUESTION_NAME,
-        dataset_query: {
-          database: 1,
-          query: {
-            expressions: {
-              [CC_NAME]: [
-                "case",
+        query: {
+          expressions: {
+            [CC_NAME]: [
+              "case",
+              [
                 [
-                  [
-                    [">", ["field-id", ORDERS.DISCOUNT], 0],
-                    ["field-id", ORDERS.DISCOUNT],
-                  ],
+                  [">", ["field-id", ORDERS.DISCOUNT], 0],
+                  ["field-id", ORDERS.DISCOUNT],
                 ],
-                { default: ["field-id", ORDERS.TOTAL] },
               ],
-            },
-            "source-table": ORDERS_ID,
+              { default: ["field-id", ORDERS.TOTAL] },
+            ],
           },
-          type: "query",
+          "source-table": ORDERS_ID,
         },
-        display: "table",
-        visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
         signOut();
         signInAsSandboxedUser();
@@ -380,25 +372,20 @@ describeWithToken("formatting > sandboxes", () => {
         cy.log(
           "Create question based on steps in [#13641](https://github.com/metabase/metabase/issues/13641)",
         );
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: QUESTION_NAME,
-          dataset_query: {
-            database: 1,
-            query: {
-              aggregation: [["count"]],
-              breakout: [
-                [
-                  "fk->",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["field-id", PRODUCTS.CATEGORY],
-                ],
+          query: {
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "fk->",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["field-id", PRODUCTS.CATEGORY],
               ],
-              "source-table": ORDERS_ID,
-            },
-            type: "query",
+            ],
+            "source-table": ORDERS_ID,
           },
           display: "bar",
-          visualization_settings: {},
         });
 
         signOut();
@@ -458,33 +445,28 @@ describeWithToken("formatting > sandboxes", () => {
       cy.log(
         "Create question based on steps in https://github.com/metabase/metabase-enterprise/issues/535",
       );
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: QUESTION_NAME,
-        dataset_query: {
-          database: 1,
-          query: {
-            aggregation: [["count"]],
-            breakout: [
-              ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.CATEGORY]],
-            ],
-            joins: [
-              {
-                alias: PRODUCTS_ALIAS,
-                condition: [
-                  "=",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.ID]],
-                ],
-                fields: "all",
-                "source-table": PRODUCTS_ID,
-              },
-            ],
-            "source-table": ORDERS_ID,
-          },
-          type: "query",
+        query: {
+          aggregation: [["count"]],
+          breakout: [
+            ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.CATEGORY]],
+          ],
+          joins: [
+            {
+              alias: PRODUCTS_ALIAS,
+              condition: [
+                "=",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.ID]],
+              ],
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+            },
+          ],
+          "source-table": ORDERS_ID,
         },
         display: "bar",
-        visualization_settings: {},
       });
 
       signOut();
@@ -533,19 +515,12 @@ describeWithToken("formatting > sandboxes", () => {
         cy.route("POST", "/api/dataset").as("dataset");
 
         cy.log("Create 'Orders'-based question using QB");
-
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: "520_Orders",
-          dataset_query: {
-            type: "query",
-            query: {
-              "source-table": ORDERS_ID,
-              filter: [">", ["field-id", ORDERS.TOTAL], 10],
-            },
-            database: 1,
+          query: {
+            "source-table": ORDERS_ID,
+            filter: [">", ["field-id", ORDERS.TOTAL], 10],
           },
-          display: "table",
-          visualization_settings: {},
         }).then(({ body: { id: CARD_ID } }) => {
           cy.log(
             "Sandbox `Orders` table based on this QB question and user attribute",
@@ -562,18 +537,12 @@ describeWithToken("formatting > sandboxes", () => {
         });
 
         cy.log("Create 'Products'-based question using QB");
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: "520_Products",
-          dataset_query: {
-            type: "query",
-            query: {
-              "source-table": PRODUCTS_ID,
-              filter: [">", ["field-id", PRODUCTS.PRICE], 10],
-            },
-            database: 1,
+          query: {
+            "source-table": PRODUCTS_ID,
+            filter: [">", ["field-id", PRODUCTS.PRICE], 10],
           },
-          display: "table",
-          visualization_settings: {},
         }).then(({ body: { id: CARD_ID } }) => {
           cy.log(
             "Sandbox `Products` table based on this QB question and user attribute",
@@ -847,37 +816,28 @@ describeWithToken("formatting > sandboxes", () => {
 
         cy.log("Create question with joins");
 
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: QUESTION_NAME,
-          dataset_query: {
-            database: 1,
-            query: {
-              aggregation: [["count"]],
-              breakout: [
-                [
-                  "joined-field",
-                  PRODUCTS_ALIAS,
-                  ["field-id", PRODUCTS.CATEGORY],
+          query: {
+            aggregation: [["count"]],
+            breakout: [
+              ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.CATEGORY]],
+            ],
+            joins: [
+              {
+                fields: "all",
+                "source-table": PRODUCTS_ID,
+                condition: [
+                  "=",
+                  ["field-id", ORDERS.PRODUCT_ID],
+                  ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.ID]],
                 ],
-              ],
-              joins: [
-                {
-                  fields: "all",
-                  "source-table": PRODUCTS_ID,
-                  condition: [
-                    "=",
-                    ["field-id", ORDERS.PRODUCT_ID],
-                    ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.ID]],
-                  ],
-                  alias: PRODUCTS_ALIAS,
-                },
-              ],
-              "source-table": ORDERS_ID,
-            },
-            type: "query",
+                alias: PRODUCTS_ALIAS,
+              },
+            ],
+            "source-table": ORDERS_ID,
           },
           display: "bar",
-          visualization_settings: {},
         });
 
         signOut();
@@ -1143,28 +1103,23 @@ function signInAsSandboxedUser() {
 }
 
 function createJoinedQuestion(name) {
-  return cy.request("POST", "/api/card", {
+  return cy.createQuestion({
     name,
-    dataset_query: {
-      type: "query",
-      query: {
-        "source-table": ORDERS_ID,
-        joins: [
-          {
-            fields: "all",
-            "source-table": PRODUCTS_ID,
-            condition: [
-              "=",
-              ["field-id", ORDERS.PRODUCT_ID],
-              ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-            ],
-            alias: "Products",
-          },
-        ],
-      },
-      database: 1,
+
+    query: {
+      "source-table": ORDERS_ID,
+      joins: [
+        {
+          fields: "all",
+          "source-table": PRODUCTS_ID,
+          condition: [
+            "=",
+            ["field-id", ORDERS.PRODUCT_ID],
+            ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+          ],
+          alias: "Products",
+        },
+      ],
     },
-    display: "table",
-    visualization_settings: {},
   });
 }

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -7,6 +7,29 @@ Cypress.Commands.add("createDashboard", name => {
   cy.request("POST", "/api/dashboard", { name });
 });
 
+Cypress.Commands.add(
+  "createQuestion",
+  ({
+    name = "card",
+    query = {},
+    display = "table",
+    database = 1,
+    visualization_settings = {},
+  } = {}) => {
+    cy.log(`Create a question: ${name}`);
+    cy.request("POST", "/api/card", {
+      name,
+      dataset_query: {
+        type: "query",
+        query,
+        database,
+      },
+      display,
+      visualization_settings,
+    });
+  },
+);
+
 /**
  * PERMISSIONS
  *

--- a/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
@@ -21,26 +21,21 @@ describe.skip("mysql > user > question > custom column", () => {
 
     withDatabase(2, ({ PEOPLE, PEOPLE_ID }) => {
       cy.log("Create a question with `Source` column and abbreviated CC");
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "12445",
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": PEOPLE_ID,
-            breakout: [["expression", CC_NAME]],
-            expressions: {
-              [CC_NAME]: [
-                "substring",
-                ["field-id", PEOPLE.SOURCE],
-                0,
-                4, // we want 4 letter abbreviation
-              ],
-            },
+        query: {
+          "source-table": PEOPLE_ID,
+          breakout: [["expression", CC_NAME]],
+          expressions: {
+            [CC_NAME]: [
+              "substring",
+              ["field-id", PEOPLE.SOURCE],
+              0,
+              4, // we want 4 letter abbreviation
+            ],
           },
-          database: 2,
         },
-        display: "table",
-        visualization_settings: {},
+        database: 2,
       }).then(({ body: { id: QUESTION_ID } }) => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -61,25 +61,20 @@ describeWithToken("postgres > user > query", () => {
     cy.route("POST", "/api/dataset/pivot").as("pivotDataset");
 
     withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) => {
-      cy.log("Create question with custom column");
-      cy.request("POST", "/api/card", {
+      // Question with a custom column created with `regextract`
+      cy.createQuestion({
         name: "14873",
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": PEOPLE_ID,
-            expressions: {
-              [CC_NAME]: [
-                "regex-match-first",
-                ["field-id", PEOPLE.NAME],
-                "^[A-Za-z]+",
-              ],
-            },
+        query: {
+          "source-table": PEOPLE_ID,
+          expressions: {
+            [CC_NAME]: [
+              "regex-match-first",
+              ["field-id", PEOPLE.NAME],
+              "^[A-Za-z]+",
+            ],
           },
-          database: PG_DB_ID,
         },
-        display: "table",
-        visualization_settings: {},
+        database: PG_DB_ID,
       }).then(({ body: { id: QUESTION_ID } }) => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -86,21 +86,15 @@ describe("scenarios > admin > datamodel > metadata", () => {
       special_type: null,
     });
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "14124",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "hour-of-day"],
-          ],
-        },
-        type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          ["datetime-field", ["field-id", ORDERS.CREATED_AT], "hour-of-day"],
+        ],
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
 

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -15,22 +15,15 @@ describe("scenarios > admin > permissions", () => {
     // filter: created before June 1st, 2016
     // summarize: Count by CreatedAt: Week
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "Orders created before June 1st 2016",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"],
-          ],
-          filter: ["<", ["field-id", ORDERS.CREATED_AT], "2016-06-01"],
-        },
-        type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"]],
+        filter: ["<", ["field-id", ORDERS.CREATED_AT], "2016-06-01"],
       },
       display: "line",
-      visualization_settings: {},
     });
 
     // find and open that question
@@ -44,24 +37,20 @@ describe("scenarios > admin > permissions", () => {
   });
 
   it("should display days on X-axis correctly when grouped by 'Day of the Week' (metabase#13604)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13604",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "day-of-week"],
-          ],
-          filter: [
-            "between",
-            ["field-id", ORDERS.CREATED_AT],
-            "2020-03-02", // Monday
-            "2020-03-03", // Tuesday
-          ],
-        },
-        type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          ["datetime-field", ["field-id", ORDERS.CREATED_AT], "day-of-week"],
+        ],
+        filter: [
+          "between",
+          ["field-id", ORDERS.CREATED_AT],
+          "2020-03-02", // Monday
+          "2020-03-03", // Tuesday
+        ],
       },
       display: "bar",
       visualization_settings: {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -396,21 +396,16 @@ describe("scenarios > dashboard > dashboard drill", () => {
   it.skip("should apply correct date range on a graph drill-through (metabase#13785)", () => {
     cy.log("Create a question");
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13785",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": REVIEWS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["datetime-field", ["field-id", REVIEWS.CREATED_AT], "month"],
-          ],
-        },
-        type: "query",
+      query: {
+        "source-table": REVIEWS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          ["datetime-field", ["field-id", REVIEWS.CREATED_AT], "month"],
+        ],
       },
       display: "bar",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard("13785D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add filter to the dashboard");
@@ -532,16 +527,9 @@ describe("scenarios > dashboard > dashboard drill", () => {
   it.skip("should not remove click behavior on 'reset to defaults' (metabase#14919)", () => {
     const LINK_NAME = "Home";
 
-    // Create question
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "14919",
-      dataset_query: {
-        database: 1,
-        query: { "source-table": PRODUCTS_ID },
-        type: "query",
-      },
-      display: "table",
-      visualization_settings: {},
+      query: { "source-table": PRODUCTS_ID },
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard("14919D").then(({ body: { id: DASHBOARD_ID } }) => {
         // Add previously added question to the dashboard

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -192,19 +192,13 @@ describe("scenarios > dashboard", () => {
   });
 
   it.skip("should update a dashboard filter by clicking on a map pin (metabase#13597)", () => {
-    // 1. create a question based on repro steps in #13597
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13597",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": PEOPLE_ID,
-          limit: 2,
-        },
-        type: "query",
+      query: {
+        "source-table": PEOPLE_ID,
+        limit: 2,
       },
       display: "map",
-      visualization_settings: {},
     }).then(({ body: { id: questionId } }) => {
       cy.createDashboard("13597D").then(({ body: { id: dashboardId } }) => {
         // add filter (ID) to the dashboard
@@ -504,17 +498,9 @@ describe("scenarios > dashboard", () => {
   });
 
   it.skip("should not send additional card queries for all filters (metabase#13150)", () => {
-    cy.log("Create a question");
-
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13150 (Products)",
-      dataset_query: {
-        database: 1,
-        query: { "source-table": PRODUCTS_ID },
-        type: "query",
-      },
-      display: "table",
-      visualization_settings: {},
+      query: { "source-table": PRODUCTS_ID },
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard("13150D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add 3 filters to the dashboard");

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -31,34 +31,29 @@ describe("scenarios > x-rays", () => {
   it.skip("should work on questions with explicit joins (metabase#13112)", () => {
     const PRODUCTS_ALIAS = "Products";
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13112",
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          joins: [
-            {
-              fields: "all",
-              "source-table": PRODUCTS_ID,
-              condition: [
-                "=",
-                ["field-id", ORDERS.PRODUCT_ID],
-                ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.ID]],
-              ],
-              alias: PRODUCTS_ALIAS,
-            },
-          ],
-          aggregation: [["count"]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-            ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.CATEGORY]],
-          ],
-        },
-        database: 1,
+      query: {
+        "source-table": ORDERS_ID,
+        joins: [
+          {
+            fields: "all",
+            "source-table": PRODUCTS_ID,
+            condition: [
+              "=",
+              ["field-id", ORDERS.PRODUCT_ID],
+              ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.ID]],
+            ],
+            alias: PRODUCTS_ALIAS,
+          },
+        ],
+        aggregation: [["count"]],
+        breakout: [
+          ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ["joined-field", PRODUCTS_ALIAS, ["field-id", PRODUCTS.CATEGORY]],
+        ],
       },
       display: "line",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.server();
       cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -205,28 +205,22 @@ describe("scenarios > question > custom columns", () => {
 
     signInAsAdmin();
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13857",
-      dataset_query: {
-        database: 1,
-        query: {
-          expressions: {
-            [CC_NAME]: ["*", ["field-literal", CE_NAME, "type/Float"], 1234],
-          },
-          "source-query": {
-            aggregation: [
-              ["aggregation-options", ["*", 1, 1], { "display-name": CE_NAME }],
-            ],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-            ],
-            "source-table": ORDERS_ID,
-          },
+      query: {
+        expressions: {
+          [CC_NAME]: ["*", ["field-literal", CE_NAME, "type/Float"], 1234],
         },
-        type: "query",
+        "source-query": {
+          aggregation: [
+            ["aggregation-options", ["*", 1, 1], { "display-name": CE_NAME }],
+          ],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ],
+          "source-table": ORDERS_ID,
+        },
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.server();
       cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
@@ -246,32 +240,25 @@ describe("scenarios > question > custom columns", () => {
     const CC_NAME = "OneisOne";
     signInAsAdmin();
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "14080",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          expressions: { [CC_NAME]: ["*", 1, 1] },
-          aggregation: [
+      query: {
+        "source-table": ORDERS_ID,
+        expressions: { [CC_NAME]: ["*", 1, 1] },
+        aggregation: [
+          [
+            "distinct",
             [
-              "distinct",
-              [
-                "fk->",
-                ["field-id", ORDERS.PRODUCT_ID],
-                ["field-id", PRODUCTS.ID],
-              ],
+              "fk->",
+              ["field-id", ORDERS.PRODUCT_ID],
+              ["field-id", PRODUCTS.ID],
             ],
-            ["sum", ["expression", CC_NAME]],
           ],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-          ],
-        },
-        type: "query",
+          ["sum", ["expression", CC_NAME]],
+        ],
+        breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"]],
       },
       display: "line",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.server();
       cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
@@ -289,24 +276,18 @@ describe("scenarios > question > custom columns", () => {
   });
 
   it.skip("should create custom column after aggregation with 'cum-sum/count' (metabase#13634)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13634",
-      dataset_query: {
-        database: 1,
-        query: {
-          expressions: { "Foo Bar": ["+", 57910, 1] },
-          "source-query": {
-            aggregation: [["cum-count"]],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-            ],
-            "source-table": ORDERS_ID,
-          },
+      query: {
+        expressions: { "Foo Bar": ["+", 57910, 1] },
+        "source-query": {
+          aggregation: [["cum-count"]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ],
+          "source-table": ORDERS_ID,
         },
-        type: "query",
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: questionId } }) => {
       cy.visit(`/question/${questionId}`);
       cy.findByText("13634");
@@ -320,27 +301,21 @@ describe("scenarios > question > custom columns", () => {
   it.skip("should not be dropped if filter is changed after aggregation (metaabase#14193)", () => {
     const CC_NAME = "Double the fun";
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "14193",
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-query": {
-            "source-table": ORDERS_ID,
-            filter: [">", ["field-id", ORDERS.SUBTOTAL], 0],
-            aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-            ],
-          },
-          expressions: {
-            [CC_NAME]: ["*", ["field-literal", "sum", "type/Float"], 2],
-          },
+      query: {
+        "source-query": {
+          "source-table": ORDERS_ID,
+          filter: [">", ["field-id", ORDERS.SUBTOTAL], 0],
+          aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+          ],
         },
-        database: 1,
+        expressions: {
+          [CC_NAME]: ["*", ["field-literal", "sum", "type/Float"], 2],
+        },
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
 
@@ -363,22 +338,16 @@ describe("scenarios > question > custom columns", () => {
     // Uppercase is important for this reproduction on H2
     const CC_NAME = "CATEGORY";
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "14255",
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": PRODUCTS_ID,
-          expressions: {
-            [CC_NAME]: ["concat", ["field-id", PRODUCTS.CATEGORY], "2"],
-          },
-          aggregation: [["count"]],
-          breakout: [["expression", CC_NAME]],
+      query: {
+        "source-table": PRODUCTS_ID,
+        expressions: {
+          [CC_NAME]: ["concat", ["field-id", PRODUCTS.CATEGORY], "2"],
         },
-        database: 1,
+        aggregation: [["count"]],
+        breakout: [["expression", CC_NAME]],
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
 
@@ -390,35 +359,29 @@ describe("scenarios > question > custom columns", () => {
   it.skip("should drop custom column (based on a joined field) when a join is removed (metabase#14775)", () => {
     const CE_NAME = "Rounded price";
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "14775",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          joins: [
-            {
-              fields: "all",
-              "source-table": PRODUCTS_ID,
-              condition: [
-                "=",
-                ["field-id", ORDERS.PRODUCT_ID],
-                ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-              ],
-              alias: "Products",
-            },
-          ],
-          expressions: {
-            [CE_NAME]: [
-              "ceil",
-              ["joined-field", "Products", ["field-id", PRODUCTS.PRICE]],
+      query: {
+        "source-table": ORDERS_ID,
+        joins: [
+          {
+            fields: "all",
+            "source-table": PRODUCTS_ID,
+            condition: [
+              "=",
+              ["field-id", ORDERS.PRODUCT_ID],
+              ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
             ],
+            alias: "Products",
           },
+        ],
+        expressions: {
+          [CE_NAME]: [
+            "ceil",
+            ["joined-field", "Products", ["field-id", PRODUCTS.PRICE]],
+          ],
         },
-        type: "query",
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -17,21 +17,14 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     signInAsAdmin();
 
     // Create a simple question of orders by week
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "GH_12568: Simple",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"],
-          ],
-        },
-        type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "week"]],
       },
       display: "line",
-      visualization_settings: {},
     });
 
     // Create a native question of orders by day
@@ -151,33 +144,27 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should handle duplicate column names in nested queries (metabase#10511)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "10511",
-      dataset_query: {
-        database: 1,
-        query: {
-          filter: [">", ["field-literal", "count", "type/Integer"], 5],
-          "source-query": {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+      query: {
+        filter: [">", ["field-literal", "count", "type/Integer"], 5],
+        "source-query": {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+            [
+              "datetime-field",
               [
-                "datetime-field",
-                [
-                  "fk->",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["field-id", PRODUCTS.CREATED_AT],
-                ],
-                "month",
+                "fk->",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["field-id", PRODUCTS.CREATED_AT],
               ],
+              "month",
             ],
-          },
+          ],
         },
-        type: "query",
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: questionId } }) => {
       cy.visit(`/question/${questionId}`);
       cy.findByText("10511");
@@ -213,18 +200,11 @@ describe("scenarios > question > nested", () => {
     createNativeQuestion("13816_Q1", "SELECT * FROM PRODUCTS").then(
       ({ body: { id: Q1_ID } }) => {
         cy.log("Convert it to `query` and save as Q2");
-
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: "13816_Q2",
-          dataset_query: {
-            database: 1,
-            query: {
-              "source-table": `card__${Q1_ID}`,
-            },
-            type: "query",
+          query: {
+            "source-table": `card__${Q1_ID}`,
           },
-          display: "table",
-          visualization_settings: {},
         });
       },
     );
@@ -276,15 +256,10 @@ describe("scenarios > question > nested", () => {
         "source-table": ORDERS_ID,
       };
 
-      cy.log("Create new question which uses previously defined metric");
-
-      cy.request("POST", "/api/card", {
+      // Create new question which uses previously defined metric
+      cy.createQuestion({
         name: "Orders with discount applied",
-        dataset_query: {
-          database: 1,
-          query: ORIGINAL_QUERY,
-          type: "query",
-        },
+        query: ORIGINAL_QUERY,
         display: "bar",
         visualization_settings: {
           "graph.dimension": ["TOTAL"],
@@ -324,6 +299,9 @@ describe("scenarios > question > nested", () => {
       "Related issue [#14629](https://github.com/metabase/metabase/issues/14629)",
     );
 
+    cy.log("**single** quotes");
+    cy.log("**double** quotes");
+
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
@@ -335,15 +313,9 @@ describe("scenarios > question > nested", () => {
     });
 
     cy.log("Save simple 'Orders' table with remapped values");
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "Orders (remapped)",
-      dataset_query: {
-        database: 1,
-        query: { "source-table": ORDERS_ID },
-        type: "query",
-      },
-      display: "table",
-      visualization_settings: {},
+      query: { "source-table": ORDERS_ID },
     });
 
     // Try to use saved question as a base for a new / nested question
@@ -396,15 +368,9 @@ describe("scenarios > question > nested", () => {
         // Use the original question qith joins, then save it again
         ordersJoinProducts(QUESTION_NAME).then(
           ({ body: { id: ORIGINAL_QUESTION_ID } }) => {
-            cy.request("POST", "/api/card", {
+            cy.createQuestion({
               name: SECOND_QUESTION_NAME,
-              dataset_query: {
-                database: 1,
-                query: { "source-table": `card__${ORIGINAL_QUESTION_ID}` },
-                type: "query",
-              },
-              display: "table",
-              visualization_settings: {},
+              query: { "source-table": `card__${ORIGINAL_QUESTION_ID}` },
             });
           },
         );
@@ -473,28 +439,22 @@ describe("scenarios > question > nested", () => {
 });
 
 function ordersJoinProducts(name) {
-  return cy.request("POST", "/api/card", {
+  return cy.createQuestion({
     name,
-    dataset_query: {
-      type: "query",
-      query: {
-        "source-table": ORDERS_ID,
-        joins: [
-          {
-            fields: "all",
-            "source-table": PRODUCTS_ID,
-            condition: [
-              "=",
-              ["field-id", ORDERS.PRODUCT_ID],
-              ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-            ],
-            alias: "Products",
-          },
-        ],
-      },
-      database: 1,
+    query: {
+      "source-table": ORDERS_ID,
+      joins: [
+        {
+          fields: "all",
+          "source-table": PRODUCTS_ID,
+          condition: [
+            "=",
+            ["field-id", ORDERS.PRODUCT_ID],
+            ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+          ],
+          alias: "Products",
+        },
+      ],
     },
-    display: "table",
-    visualization_settings: {},
   });
 }

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -299,9 +299,6 @@ describe("scenarios > question > nested", () => {
       "Related issue [#14629](https://github.com/metabase/metabase/issues/14629)",
     );
 
-    cy.log("**single** quotes");
-    cy.log("**double** quotes");
-
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
@@ -312,7 +309,6 @@ describe("scenarios > question > nested", () => {
       fk: PRODUCTS.TITLE,
     });
 
-    cy.log("Save simple 'Orders' table with remapped values");
     cy.createQuestion({
       name: "Orders (remapped)",
       query: { "source-table": ORDERS_ID },

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -40,26 +40,20 @@ describe("scenarios > question > new", () => {
     });
 
     it.skip("should handle (removing) multiple metrics when one is sorted (metabase#13990)", () => {
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "12625",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [
-              ["count"],
-              ["sum", ["field-id", ORDERS.SUBTOTAL]],
-              ["sum", ["field-id", ORDERS.TOTAL]],
-            ],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-            ],
-            "order-by": [["desc", ["aggregation", 1]]],
-          },
-          type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [
+            ["count"],
+            ["sum", ["field-id", ORDERS.SUBTOTAL]],
+            ["sum", ["field-id", ORDERS.TOTAL]],
+          ],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+          ],
+          "order-by": [["desc", ["aggregation", 1]]],
         },
-        display: "table",
-        visualization_settings: {},
       }).then(({ body: { id: QESTION_ID } }) => {
         cy.server();
         cy.route("POST", `/api/card/${QESTION_ID}/query`).as("cardQuery");
@@ -143,17 +137,11 @@ describe("scenarios > question > new", () => {
 
     it("should display date granularity on Summarize when opened from saved question (metabase#11439)", () => {
       // save "Orders" as question
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "11439",
-        dataset_query: {
-          database: 1,
-          query: { "source-table": ORDERS_ID },
-          type: "query",
-        },
-        type: "query",
-        display: "table",
-        visualization_settings: {},
+        query: { "source-table": ORDERS_ID },
       });
+
       // it is essential for this repro to find question following these exact steps
       // (for example, visiting `/collection/root` would yield different result)
       cy.visit("/");
@@ -179,21 +167,16 @@ describe("scenarios > question > new", () => {
     });
 
     it.skip("should display timeseries filter and granularity widgets at the bottom of the screen (metabase#11183)", () => {
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "11183",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["sum", ["field-id", ORDERS.SUBTOTAL]]],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-            ],
-          },
-          type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["sum", ["field-id", ORDERS.SUBTOTAL]]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ],
         },
         display: "line",
-        visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
@@ -299,22 +282,16 @@ describe("scenarios > question > new", () => {
 
     it.skip("trend visualization should work regardless of column order (metabase#13710)", () => {
       cy.server();
-
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "13710",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": ORDERS_ID,
-            breakout: [
-              ["field-id", ORDERS.QUANTITY],
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-            ],
-          },
-          type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          breakout: [
+            ["field-id", ORDERS.QUANTITY],
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+          ],
         },
         display: "smartscalar",
-        visualization_settings: {},
       }).then(({ body: { id: questionId } }) => {
         cy.route("POST", `/api/card/${questionId}/query`).as("cardQuery");
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -257,74 +257,62 @@ describe("scenarios > question > notebook", () => {
 
     it.skip("should join saved questions that themselves contain joins (metabase#12928)", () => {
       // Save Question 1
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "12928_Q1",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["joined-field", "Products", ["field-id", PRODUCTS.CATEGORY]],
-              ["joined-field", "People - User", ["field-id", PEOPLE.SOURCE]],
-            ],
-            joins: [
-              {
-                alias: "Products",
-                condition: [
-                  "=",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-                ],
-                fields: "all",
-                "source-table": PRODUCTS_ID,
-              },
-              {
-                alias: "People - User",
-                condition: [
-                  "=",
-                  ["field-id", ORDERS.USER_ID],
-                  ["joined-field", "People - User", ["field-id", PEOPLE.ID]],
-                ],
-                fields: "all",
-                "source-table": PEOPLE_ID,
-              },
-            ],
-          },
-          type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["joined-field", "Products", ["field-id", PRODUCTS.CATEGORY]],
+            ["joined-field", "People - User", ["field-id", PEOPLE.SOURCE]],
+          ],
+          joins: [
+            {
+              alias: "Products",
+              condition: [
+                "=",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+              ],
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+            },
+            {
+              alias: "People - User",
+              condition: [
+                "=",
+                ["field-id", ORDERS.USER_ID],
+                ["joined-field", "People - User", ["field-id", PEOPLE.ID]],
+              ],
+              fields: "all",
+              "source-table": PEOPLE_ID,
+            },
+          ],
         },
-        display: "table",
-        visualization_settings: {},
       });
 
       // Save Question 2
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "12928_Q2",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": REVIEWS_ID,
-            aggregation: [["avg", ["field-id", REVIEWS.RATING]]],
-            breakout: [
-              ["joined-field", "Products", ["field-id", PRODUCTS.CATEGORY]],
-            ],
-            joins: [
-              {
-                alias: "Products",
-                condition: [
-                  "=",
-                  ["field-id", REVIEWS.PRODUCT_ID],
-                  ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
-                ],
-                fields: "all",
-                "source-table": PRODUCTS_ID,
-              },
-            ],
-          },
-          type: "query",
+        query: {
+          "source-table": REVIEWS_ID,
+          aggregation: [["avg", ["field-id", REVIEWS.RATING]]],
+          breakout: [
+            ["joined-field", "Products", ["field-id", PRODUCTS.CATEGORY]],
+          ],
+          joins: [
+            {
+              alias: "Products",
+              condition: [
+                "=",
+                ["field-id", REVIEWS.PRODUCT_ID],
+                ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+              ],
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+            },
+          ],
         },
-        display: "table",
-        visualization_settings: {},
       });
 
       cy.server();
@@ -359,52 +347,39 @@ describe("scenarios > question > notebook", () => {
     it.skip("should join saved question with sorted metric (metabase#13744)", () => {
       cy.server();
       // create first question based on repro steps in #13744
-
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "13744",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": PRODUCTS_ID,
-            aggregation: [["count"]],
-            breakout: [["field-id", PRODUCTS.CATEGORY]],
-            "order-by": [["asc", ["aggregation", 0]]],
-          },
-          type: "query",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          breakout: [["field-id", PRODUCTS.CATEGORY]],
+          "order-by": [["asc", ["aggregation", 0]]],
         },
-        display: "table",
-        visualization_settings: {},
       }).then(({ body: { id: questionId } }) => {
         const ALIAS = `Question ${questionId}`;
 
         // create new question and join it with a previous one
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: "13744_joined",
-          dataset_query: {
-            database: 1,
-            query: {
-              joins: [
-                {
-                  alias: ALIAS,
-                  fields: "all",
-                  condition: [
-                    "=",
-                    ["field-id", PRODUCTS.CATEGORY],
-                    [
-                      "joined-field",
-                      ALIAS,
-                      ["field-literal", "CATEGORY", "type/Text"],
-                    ],
+          query: {
+            joins: [
+              {
+                alias: ALIAS,
+                fields: "all",
+                condition: [
+                  "=",
+                  ["field-id", PRODUCTS.CATEGORY],
+                  [
+                    "joined-field",
+                    ALIAS,
+                    ["field-literal", "CATEGORY", "type/Text"],
                   ],
-                  "source-table": `card__${questionId}`,
-                },
-              ],
-              "source-table": PRODUCTS_ID,
-            },
-            type: "query",
+                ],
+                "source-table": `card__${questionId}`,
+              },
+            ],
+            "source-table": PRODUCTS_ID,
           },
-          display: "table",
-          visualization_settings: {},
         }).then(({ body: { id: joinedQuestionId } }) => {
           // listen on the final card query which means the data for this question loaded
           cy.route("POST", `/api/card/${joinedQuestionId}/query`).as(
@@ -427,30 +402,25 @@ describe("scenarios > question > notebook", () => {
     });
 
     it.skip("should be able to do subsequent aggregation on a custom expression (metabase#14649)", () => {
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "14649_min",
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-query": {
-              "source-table": ORDERS_ID,
-              aggregation: [
-                [
-                  "aggregation-options",
-                  ["sum", ["field-id", ORDERS.SUBTOTAL]],
-                  { "display-name": "Revenue" },
-                ],
+        query: {
+          "source-query": {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              [
+                "aggregation-options",
+                ["sum", ["field-id", ORDERS.SUBTOTAL]],
+                { "display-name": "Revenue" },
               ],
-              breakout: [
-                ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-              ],
-            },
-            aggregation: [["min", ["field-literal", "Revenue", "type/Float"]]],
+            ],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+            ],
           },
-          database: 1,
+          aggregation: [["min", ["field-literal", "Revenue", "type/Float"]]],
         },
         display: "scalar",
-        visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
@@ -631,64 +601,44 @@ describe("scenarios > question > notebook", () => {
 function joinTwoSavedQuestions(ALIAS = "Joined Question") {
   cy.server();
 
-  cy.log("Prepare Question 1");
-  cy.request("POST", "/api/card", {
+  cy.createQuestion({
     name: "Q1",
-    dataset_query: {
-      database: 1,
-      query: {
-        aggregation: ["sum", ["field-id", ORDERS.TOTAL]],
-        breakout: [["field-id", ORDERS.PRODUCT_ID]],
-        "source-table": ORDERS_ID,
-      },
-      type: "query",
+    query: {
+      aggregation: ["sum", ["field-id", ORDERS.TOTAL]],
+      breakout: [["field-id", ORDERS.PRODUCT_ID]],
+      "source-table": ORDERS_ID,
     },
-    display: "table",
-    visualization_settings: {},
   }).then(({ body: { id: Q1_ID } }) => {
-    cy.log("Prepare Question 2");
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "Q2",
-      dataset_query: {
-        database: 1,
-        query: {
-          aggregation: ["sum", ["field-id", PRODUCTS.RATING]],
-          breakout: [["field-id", PRODUCTS.ID]],
-          "source-table": PRODUCTS_ID,
-        },
-        type: "query",
+      query: {
+        aggregation: ["sum", ["field-id", PRODUCTS.RATING]],
+        breakout: [["field-id", PRODUCTS.ID]],
+        "source-table": PRODUCTS_ID,
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: Q2_ID } }) => {
       cy.log("Create Question 3 based on 2 previously saved questions");
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "Q3",
-        dataset_query: {
-          database: 1,
-          query: {
-            joins: [
-              {
-                alias: ALIAS,
-                condition: [
-                  "=",
-                  ["field-literal", "PRODUCT_ID", "type/Integer"],
-                  [
-                    "joined-field",
-                    ALIAS,
-                    ["field-literal", "ID", "type/BigInteger"],
-                  ],
+        query: {
+          joins: [
+            {
+              alias: ALIAS,
+              condition: [
+                "=",
+                ["field-literal", "PRODUCT_ID", "type/Integer"],
+                [
+                  "joined-field",
+                  ALIAS,
+                  ["field-literal", "ID", "type/BigInteger"],
                 ],
-                fields: "all",
-                "source-table": `card__${Q2_ID}`,
-              },
-            ],
-            "source-table": `card__${Q1_ID}`,
-          },
-          type: "query",
+              ],
+              fields: "all",
+              "source-table": `card__${Q2_ID}`,
+            },
+          ],
+          "source-table": `card__${Q1_ID}`,
         },
-        display: "table",
-        visualization_settings: {},
       }).then(({ body: { id: Q3_ID } }) => {
         cy.route("POST", `/api/card/${Q3_ID}/query`).as("cardQuery");
         cy.visit(`/question/${Q3_ID}`);

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -16,19 +16,13 @@ describe("scenarios > question > null", () => {
   });
 
   it("should display rows whose value is `null` (metabase#13571)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13571",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          fields: [["field-id", ORDERS.DISCOUNT]],
-          filter: ["=", ["field-id", ORDERS.ID], 1],
-        },
-        type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        fields: [["field-id", ORDERS.DISCOUNT]],
+        filter: ["=", ["field-id", ORDERS.ID], 1],
       },
-      display: "table",
-      visualization_settings: {},
     });
 
     // find and open previously created question
@@ -47,28 +41,22 @@ describe("scenarios > question > null", () => {
   it.skip("pie chart should handle `0`/`null` values (metabase#13626)", () => {
     // Preparation for the test: "Arrange and Act phase" - see repro steps in #13626
 
-    // 1. create a question
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13626",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["sum", ["expression", "NewDiscount"]]],
-          breakout: [["field-id", ORDERS.ID]],
-          expressions: {
-            NewDiscount: [
-              "case",
-              [[["=", ["field-id", ORDERS.ID], 2], 0]],
-              { default: ["field-id", ORDERS.DISCOUNT] },
-            ],
-          },
-          filter: ["=", ["field-id", ORDERS.ID], 1, 2, 3],
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["sum", ["expression", "NewDiscount"]]],
+        breakout: [["field-id", ORDERS.ID]],
+        expressions: {
+          NewDiscount: [
+            "case",
+            [[["=", ["field-id", ORDERS.ID], 2], 0]],
+            { default: ["field-id", ORDERS.DISCOUNT] },
+          ],
         },
-        type: "query",
+        filter: ["=", ["field-id", ORDERS.ID], 1, 2, 3],
       },
       display: "pie",
-      visualization_settings: {},
     }).then(({ body: { id: questionId } }) => {
       cy.createDashboard("13626D").then(({ body: { id: dashboardId } }) => {
         // add filter (ID) to the dashboard

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -21,34 +21,29 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it("should allow brush date filter", () => {
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "Orders by Product → Created At (month) and Product → Category",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            [
-              "datetime-field",
-              [
-                "fk->",
-                ["field-id", ORDERS.PRODUCT_ID],
-                ["field-id", PRODUCTS.CREATED_AT],
-              ],
-              "month",
-            ],
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          [
+            "datetime-field",
             [
               "fk->",
               ["field-id", ORDERS.PRODUCT_ID],
-              ["field-id", PRODUCTS.CATEGORY],
+              ["field-id", PRODUCTS.CREATED_AT],
             ],
+            "month",
           ],
-        },
-        type: "query",
+          [
+            "fk->",
+            ["field-id", ORDERS.PRODUCT_ID],
+            ["field-id", PRODUCTS.CATEGORY],
+          ],
+        ],
       },
       display: "line",
-      visualization_settings: {},
     }).then(response => {
       cy.visit(`/question/${response.body.id}`);
 
@@ -77,44 +72,28 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it.skip("should allow drill-through on combined cards with different amount of series (metabase#13457)", () => {
-    cy.log("Create the first question");
-
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "13457_Q1",
-      dataset_query: {
-        database: 1,
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"]],
+      },
+      display: "line",
+    }).then(({ body: { id: Q1_ID } }) => {
+      cy.createQuestion({
+        name: "13457_Q2",
         query: {
           "source-table": ORDERS_ID,
-          aggregation: [["count"]],
+          aggregation: [
+            ["avg", ["field-id", ORDERS.DISCOUNT]],
+            ["avg", ["field-id", ORDERS.QUANTITY]],
+          ],
           breakout: [
             ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
           ],
         },
-        type: "query",
-      },
-      display: "line",
-      visualization_settings: {},
-    }).then(({ body: { id: Q1_ID } }) => {
-      cy.log("Create the second question");
-
-      cy.request("POST", "/api/card", {
-        name: "13457_Q2",
-        dataset_query: {
-          database: 1,
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [
-              ["avg", ["field-id", ORDERS.DISCOUNT]],
-              ["avg", ["field-id", ORDERS.QUANTITY]],
-            ],
-            breakout: [
-              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-            ],
-          },
-          type: "query",
-        },
         display: "line",
-        visualization_settings: {},
       }).then(({ body: { id: Q2_ID } }) => {
         cy.createDashboard("13457D").then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add the first question to the dashboard");
@@ -182,19 +161,12 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
-    // save a question of people in CA
-    cy.request("POST", "/api/card", {
+    // People in CA
+    cy.createQuestion({
       name: "CA People",
-      display: "table",
-      visualization_settings: {},
-      dataset_query: {
-        database: 1,
-        query: { "source-table": PEOPLE_ID, limit: 5 },
-        type: "query",
-      },
+      query: { "source-table": PEOPLE_ID, limit: 5 },
     });
-
-    // build a new question off that grouping by City
+    // Build a new question off that grouping by City
     cy.visit("/question/new");
     cy.contains("Simple question").click();
     cy.contains("Saved Questions").click();
@@ -222,20 +194,14 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it.skip("should drill through a with date filter (metabase#12496)", () => {
-    // save a question of orders by week
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "Orders by Created At: Week",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [["datetime-field", ORDERS.CREATED_AT, "week"]],
-        },
-        type: "query",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["datetime-field", ORDERS.CREATED_AT, "week"]],
       },
       display: "line",
-      visualization_settings: {},
     });
 
     // Load the question up
@@ -362,37 +328,32 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       const ALIAS = `Question ${SQL_ID}`;
 
       // Create a QB question and join it with the previously created native question
-      cy.request("POST", "/api/card", {
+      cy.createQuestion({
         name: "14495",
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": PEOPLE_ID,
-            joins: [
-              {
-                fields: "all",
-                "source-table": `card__${SQL_ID}`,
-                condition: [
-                  "=",
-                  ["field-id", PEOPLE.ID],
-                  [
-                    "joined-field",
-                    ALIAS,
-                    ["field-literal", "ID", "type/BigInteger"],
-                  ],
+        query: {
+          "source-table": PEOPLE_ID,
+          joins: [
+            {
+              fields: "all",
+              "source-table": `card__${SQL_ID}`,
+              condition: [
+                "=",
+                ["field-id", PEOPLE.ID],
+                [
+                  "joined-field",
+                  ALIAS,
+                  ["field-literal", "ID", "type/BigInteger"],
                 ],
-                alias: ALIAS,
-              },
-            ],
-            aggregation: [["count"]],
-            breakout: [
-              ["datetime-field", ["field-id", PEOPLE.CREATED_AT], "month"],
-            ],
-          },
-          database: 1,
+              ],
+              alias: ALIAS,
+            },
+          ],
+          aggregation: [["count"]],
+          breakout: [
+            ["datetime-field", ["field-id", PEOPLE.CREATED_AT], "month"],
+          ],
         },
         display: "bar",
-        visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
         // Prepare to wait for certain imporatnt queries
         cy.server();

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -75,22 +75,17 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
 
       beforeEach(() => {
         // Create muliscalar card
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: CARD_NAME,
-          dataset_query: {
-            database: 1,
-            query: {
-              "source-table": PEOPLE_ID,
-              aggregation: [["count"]],
-              breakout: [
-                ["field-id", PEOPLE.SOURCE],
-                ["datetime-field", ["field-id", PEOPLE.CREATED_AT], "month"],
-              ],
-            },
-            type: "query",
+          query: {
+            "source-table": PEOPLE_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field-id", PEOPLE.SOURCE],
+              ["datetime-field", ["field-id", PEOPLE.CREATED_AT], "month"],
+            ],
           },
           display: "line",
-          visualization_settings: {},
         }).then(({ body: { id: CARD_ID } }) => {
           cy.createDashboard(DASHBOARD_NAME).then(
             ({ body: { id: DASHBOARD_ID } }) => {
@@ -128,29 +123,19 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       it("should respect visualization type when entering a question from a dashboard (metabase#13415)", () => {
         const QUESTION_NAME = "13415";
 
-        cy.log("Create a question");
-        cy.request("POST", "/api/card", {
+        cy.createQuestion({
           name: QUESTION_NAME,
-          dataset_query: {
-            database: 1,
-            query: {
-              "source-table": ORDERS_ID,
-              aggregation: [["count"]],
-              breakout: [
-                [
-                  "fk->",
-                  ["field-id", ORDERS.PRODUCT_ID],
-                  ["field-id", PRODUCTS.CATEGORY],
-                ],
-                ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              [
+                "fk->",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["field-id", PRODUCTS.CATEGORY],
               ],
-            },
-            type: "query",
-          },
-          display: "table",
-          visualization_settings: {
-            "table.pivot_column": "CATEGORY",
-            "table.cell_column": "count",
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+            ],
           },
         }).then(({ body: { id: QUESTION_ID } }) => {
           cy.createDashboard("13415D").then(

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -130,44 +130,22 @@ describe("snapshots", () => {
 
   function createQuestionAndDashboard({ ORDERS, ORDERS_ID }) {
     // question 1: Orders
-    cy.request("POST", "/api/card", {
-      name: "Orders",
-      display: "table",
-      visualization_settings: {},
-      dataset_query: {
-        database: 1,
-        query: { "source-table": ORDERS_ID },
-        type: "query",
-      },
-    });
+    cy.createQuestion({ name: "Orders", query: { "source-table": ORDERS_ID } });
 
     // question 2: Orders, Count
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "Orders, Count",
-      display: "table",
-      visualization_settings: {},
-      dataset_query: {
-        database: 1,
-        query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
-        type: "query",
-      },
+      query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
     });
 
-    cy.request("POST", "/api/card", {
+    cy.createQuestion({
       name: "Orders, Count, Grouped by Created At (year)",
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-          ],
-        },
-        database: 1,
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"]],
       },
       display: "line",
-      visualization_settings: {},
     });
 
     // dashboard 1: Orders in a dashboard


### PR DESCRIPTION
### Status:
READY

### What does this PR accomplish?
- Adds Cypress custom command for creating (query) questions
- Updates all related occurrences of question creation via API in all test files

### How to test this works?
- All tests should pass

### Additional notes:
- Log is now tucked inside a custom function so there is no need anymore to leave logs inside test itself
- It accepts 5 arguments:
    - `name` (string), default value = `card`: question's name
    - `query` (object), default value = `{}`: MBQL query
    - `display` (string), default value = `table`: chosen visualization for the question
    - `database` (number | string), default value = `1` (sample dataset): database id
    - `visualization_settings` (object), default value = `{}`: as the name suggests, specific visualization settings; rarely explicitly set
- It makes test easier to read 

```javascript
// before
cy.log("Save simple 'Orders' table with remapped values");
cy.request("POST", "/api/card", {
  name: "Orders (remapped)",
  dataset_query: {
    database: 1,
    query: { "source-table": ORDERS_ID },
    type: "query",
  },
  display: "table",
  visualization_settings: {},
});

// after
cy.createQuestion({
  name: "Orders (remapped)",
  query: { "source-table": ORDERS_ID },
})
```

- Custom command is "chainable" with Cypress' `then`

```javascript
cy.createQuestion({...}).then(({ body: { id: QUESTION_ID } }) => {
  cy.visit(`/question/${QUESTION_ID}`);
});
```