### PR TITLE
Add Cypress custom command for creating native questions

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -13,28 +13,23 @@ const { PRODUCTS } = SAMPLE_DATASET;
 const year = new Date().getFullYear();
 
 function generateQuestions(user) {
-  cy.request("POST", `/api/card`, {
+  cy.createNativeQuestion({
     name: `${user} question`,
-    dataset_query: {
-      type: "native",
-      native: {
-        query: "SELECT * FROM products WHERE {{ID}}",
-        "template-tags": {
-          ID: {
-            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-            name: "ID",
-            display_name: "ID",
-            type: "dimension",
-            dimension: ["field-id", PRODUCTS.ID],
-            "widget-type": "category",
-            default: null,
-          },
+    native: {
+      query: "SELECT * FROM products WHERE {{ID}}",
+      "template-tags": {
+        ID: {
+          id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+          name: "ID",
+          display_name: "ID",
+          type: "dimension",
+          dimension: ["field-id", PRODUCTS.ID],
+          "widget-type": "category",
+          default: null,
         },
       },
-      database: 1,
     },
     display: "scalar",
-    visualization_settings: {},
   });
 }
 

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -110,28 +110,21 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      cy.log("Create parametrized SQL question");
-      cy.request("POST", "/api/card", {
+      cy.createNativeQuestion({
         name: "sql param",
-        dataset_query: {
-          type: "native",
-          native: {
-            query: `select id,name,address,email from people where {{${TTAG_NAME}}}`,
-            "template-tags": {
-              [TTAG_NAME]: {
-                id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
-                name: TTAG_NAME,
-                "display-name": "CID",
-                type: "dimension",
-                dimension: ["field-id", PEOPLE.ID],
-                "widget-type": "id",
-              },
+        native: {
+          query: `select id,name,address,email from people where {{${TTAG_NAME}}}`,
+          "template-tags": {
+            [TTAG_NAME]: {
+              id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
+              name: TTAG_NAME,
+              "display-name": "CID",
+              type: "dimension",
+              dimension: ["field-id", PEOPLE.ID],
+              "widget-type": "id",
             },
           },
-          database: 1,
         },
-        display: "table",
-        visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
         // Sandbox `People` table based on previously created SQL question
         cy.request("POST", "/api/mt/gtap", {
@@ -605,27 +598,20 @@ describeWithToken("formatting > sandboxes", () => {
           cy.route("POST", "/api/card/*/query").as("cardQuery");
           cy.route("PUT", "/api/card/*").as("questionUpdate");
 
-          cy.log("Create the first native question with a filter");
-          cy.request("POST", "/api/card", {
+          cy.createNativeQuestion({
             name: "EE_520_Q1",
-            dataset_query: {
-              database: 1,
-              native: {
-                query:
-                  "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
-                "template-tags": {
-                  sandbox: {
-                    "display-name": "Sandbox",
-                    id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
-                    name: "sandbox",
-                    type: "number",
-                  },
+            native: {
+              query:
+                "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
+              "template-tags": {
+                sandbox: {
+                  "display-name": "Sandbox",
+                  id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
+                  name: "sandbox",
+                  type: "number",
                 },
               },
-              type: "native",
             },
-            display: "table",
-            visualization_settings: {},
           }).then(({ body: { id: CARD_ID } }) => {
             test === "workaround"
               ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
@@ -642,28 +628,21 @@ describeWithToken("formatting > sandboxes", () => {
               table_id: ORDERS_ID,
             });
           });
-          cy.log("Create the second native question with a filter");
 
-          cy.request("POST", "/api/card", {
+          cy.createNativeQuestion({
             name: "EE_520_Q2",
-            dataset_query: {
-              database: 1,
-              native: {
-                query:
-                  "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
-                "template-tags": {
-                  sandbox: {
-                    "display-name": "Sandbox",
-                    id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
-                    name: "sandbox",
-                    type: "text",
-                  },
+            native: {
+              query:
+                "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
+              "template-tags": {
+                sandbox: {
+                  "display-name": "Sandbox",
+                  id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
+                  name: "sandbox",
+                  type: "text",
                 },
               },
-              type: "native",
             },
-            display: "table",
-            visualization_settings: {},
           }).then(({ body: { id: CARD_ID } }) => {
             test === "workaround"
               ? runAndSaveQuestion({
@@ -875,19 +854,10 @@ describeWithToken("formatting > sandboxes", () => {
       cy.server();
       cy.route("POST", "/api/mt/gtap").as("sandboxTable");
 
-      cy.log(
-        "Create question that will have differently-typed columns than the sandboxed table",
-      );
-
-      cy.request("POST", "/api/card", {
+      // Question with differently-typed columns than the sandboxed table
+      cy.createNativeQuestion({
         name: QUESTION_NAME,
-        dataset_query: {
-          database: 1,
-          type: "native",
-          native: { query: "SELECT CAST(ID AS VARCHAR) AS ID FROM ORDERS;" },
-        },
-        display: "table",
-        visualization_settings: {},
+        native: { query: "SELECT CAST(ID AS VARCHAR) AS ID FROM ORDERS;" },
       });
 
       cy.visit("/admin/permissions/databases/1/schemas/PUBLIC/tables");

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -30,6 +30,29 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  "createNativeQuestion",
+  ({
+    name = "native",
+    native = {},
+    display = "table",
+    database = 1,
+    visualization_settings = {},
+  } = {}) => {
+    cy.log(`Create a native question: ${name}`);
+    cy.request("POST", "/api/card", {
+      name,
+      dataset_query: {
+        type: "native",
+        native,
+        database,
+      },
+      display,
+      visualization_settings,
+    });
+  },
+);
+
 /**
  * PERMISSIONS
  *

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -79,30 +79,24 @@ describe("scenarios > admin > permissions", () => {
   // TODO:
   //  - Keep an eye on this test in CI and update the week range as needed.
   it.skip("should respect start of the week in SQL questions with filters (metabase#14294)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "14294",
-      dataset_query: {
-        database: 1,
-        native: {
-          "template-tags": {
-            date_range: {
-              id: "93961154-c3d5-7c93-7b59-f4e494fda499",
-              name: "date_range",
-              "display-name": "Date range",
-              type: "dimension",
-              dimension: ["field-id", ORDERS.CREATED_AT],
-              "widget-type": "date/all-options",
-              default: "past220weeks",
-              required: true,
-            },
+      native: {
+        query:
+          "select ID, CREATED_AT, dayname(CREATED_AT) as CREATED_AT_DAY\nfrom ORDERS \n[[where {{date_range}}]]\norder by CREATED_AT",
+        "template-tags": {
+          date_range: {
+            id: "93961154-c3d5-7c93-7b59-f4e494fda499",
+            name: "date_range",
+            "display-name": "Date range",
+            type: "dimension",
+            dimension: ["field-id", ORDERS.CREATED_AT],
+            "widget-type": "date/all-options",
+            default: "past220weeks",
+            required: true,
           },
-          query:
-            "select ID, CREATED_AT, dayname(CREATED_AT) as CREATED_AT_DAY\nfrom ORDERS \n[[where {{date_range}}]]\norder by CREATED_AT",
         },
-        type: "native",
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
       cy.get(".TableInteractive-header")

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -21,36 +21,31 @@ function createDashboardWithQuestion(
 
 // Create a native SQL question with two parameters for city and state.
 function createQuestion(options, callback) {
-  cy.request("POST", "/api/card", {
+  cy.createNativeQuestion({
     name: "Count of People by State (SQL)",
-    dataset_query: {
-      type: "native",
-      native: {
-        query:
-          'SELECT "PUBLIC"."PEOPLE"."STATE" AS "STATE", count(*) AS "count" FROM "PUBLIC"."PEOPLE" WHERE 1=1 [[ AND {{city}}]] [[ AND {{state}}]] GROUP BY "PUBLIC"."PEOPLE"."STATE" ORDER BY "count" DESC, "PUBLIC"."PEOPLE"."STATE" ASC',
-        "template-tags": {
-          city: {
-            id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
-            name: "city",
-            "display-name": "City",
-            type: "dimension",
-            dimension: ["field-id", PEOPLE.CITY],
-            "widget-type": "category",
-          },
-          state: {
-            id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
-            name: "state",
-            "display-name": "State",
-            type: "dimension",
-            dimension: ["field-id", PEOPLE.STATE],
-            "widget-type": "category",
-          },
+    native: {
+      query:
+        'SELECT "PUBLIC"."PEOPLE"."STATE" AS "STATE", count(*) AS "count" FROM "PUBLIC"."PEOPLE" WHERE 1=1 [[ AND {{city}}]] [[ AND {{state}}]] GROUP BY "PUBLIC"."PEOPLE"."STATE" ORDER BY "count" DESC, "PUBLIC"."PEOPLE"."STATE" ASC',
+      "template-tags": {
+        city: {
+          id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
+          name: "city",
+          "display-name": "City",
+          type: "dimension",
+          dimension: ["field-id", PEOPLE.CITY],
+          "widget-type": "category",
+        },
+        state: {
+          id: "6b8b10ef-0104-1047-1e1b-2492d5954555",
+          name: "state",
+          "display-name": "State",
+          type: "dimension",
+          dimension: ["field-id", PEOPLE.STATE],
+          "widget-type": "category",
         },
       },
-      database: 1,
     },
     display: "bar",
-    visualization_settings: {},
   }).then(({ body: { id: questionId } }) => {
     callback(questionId);
   });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -264,17 +264,9 @@ describe("scenarios > dashboard", () => {
   });
 
   it("should display column options for cross-filter (metabase#14473)", () => {
-    cy.log("Create a question");
-
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "14473",
-      dataset_query: {
-        type: "native",
-        native: { query: "SELECT COUNT(*) FROM PRODUCTS", "template-tags": {} },
-        database: 1,
-      },
-      display: "table",
-      visualization_settings: {},
+      native: { query: "SELECT COUNT(*) FROM PRODUCTS", "template-tags": {} },
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard("14473D").then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add 4 filters to the dashboard");
@@ -334,30 +326,22 @@ describe("scenarios > dashboard", () => {
       ],
     });
 
-    cy.log("Create SQL question with a filter");
-
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "12720_SQL",
-      dataset_query: {
-        type: "native",
-        native: {
-          query: "SELECT * FROM ORDERS WHERE {{filter}}",
-          "template-tags": {
-            filter: {
-              id: "1d006bb7-045f-6c57-e41b-2661a7648276",
-              name: "filter",
-              "display-name": "Filter",
-              type: "dimension",
-              dimension: ["field-id", ORDERS.CREATED_AT],
-              "widget-type": "date/month-year",
-              default: null,
-            },
+      native: {
+        query: "SELECT * FROM ORDERS WHERE {{filter}}",
+        "template-tags": {
+          filter: {
+            id: "1d006bb7-045f-6c57-e41b-2661a7648276",
+            name: "filter",
+            "display-name": "Filter",
+            type: "dimension",
+            dimension: ["field-id", ORDERS.CREATED_AT],
+            "widget-type": "date/month-year",
+            default: null,
           },
         },
-        database: 1,
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: SQL_ID } }) => {
       cy.log("Add SQL question to the dashboard");
 

--- a/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
@@ -9,47 +9,35 @@ describe("scenarios > dashboard > nested cards", () => {
   it("should show fields on nested cards", () => {
     createDashboardWithNestedCard(dashId => {
       cy.visit(`/dashboard/${dashId}`);
-      cy.icon("pencil").click();
-      cy.icon("filter").click();
-      popover()
-        .contains("Time")
-        .click();
-      popover()
-        .contains("All Options")
-        .click();
-      cy.get(".DashCard")
-        .contains("Select")
-        .click();
-      popover().contains("CREATED_AT");
     });
+    cy.icon("pencil").click();
+    cy.icon("filter").click();
+    popover()
+      .contains("Time")
+      .click();
+    popover()
+      .contains("All Options")
+      .click();
+    cy.get(".DashCard")
+      .contains("Select")
+      .click();
+    popover().contains("CREATED_AT");
   });
 });
 
 function createDashboardWithNestedCard(callback) {
-  cy.request("POST", "/api/card", {
+  cy.createNativeQuestion({
     name: "Q1",
-    dataset_query: {
-      type: "native",
-      native: { query: 'SELECT * FROM "ORDERS"', "template-tags": {} },
-      database: 1,
-    },
-    display: "table",
-    visualization_settings: {},
+    native: { query: 'SELECT * FROM "ORDERS"', "template-tags": {} },
   }).then(({ body }) =>
     cy
-      .request("POST", "/api/card", {
+      .createQuestion({
         name: "Q2",
-        display: "table",
-        visualization_settings: {},
-        dataset_query: {
-          database: 1,
-          query: { "source-table": `card__${body.id}` },
-          type: "query",
-        },
+        query: { "source-table": `card__${body.id}` },
       })
       .then(({ body: { id: cardId } }) =>
         cy
-          .request("POST", "/api/dashboard", { name: "Q2 in a dashboard" })
+          .createDashboard("Q2 in a dashboard")
           .then(({ body: { id: dashId } }) => {
             cy.request("POST", `/api/dashboard/${dashId}/cards`, { cardId });
             callback(dashId);

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -52,18 +52,6 @@ describe("scenarios > dashboard > permissions", () => {
         dataset_query: {
           database: 1,
           type: "native",
-          native: { query: "select 'foo'" },
-        },
-        display: "table",
-        visualization_settings: {},
-        name: "First Question",
-        collection_id,
-      }).then(({ body: { id } }) => (firstQuestionId = id));
-
-      cy.request("POST", "/api/card", {
-        dataset_query: {
-          database: 1,
-          type: "native",
           native: { query: "select 'bar'" },
         },
         display: "table",

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -21,13 +21,9 @@ describe("scenarios > dashboard > title drill", () => {
 });
 
 function createDashboard(callback) {
-  cy.request("POST", "/api/card", {
+  cy.createNativeQuestion({
     name: "Q1",
-    dataset_query: {
-      type: "native",
-      native: { query: 'SELECT 1 as "foo", 2 as "bar"', "template-tags": {} },
-      database: 1,
-    },
+    native: { query: 'SELECT 1 as "foo", 2 as "bar"', "template-tags": {} },
     display: "bar",
     visualization_settings: {
       "graph.dimensions": ["foo"],

--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -32,28 +32,23 @@ describe.skip("scenarios > public", () => {
     signInAsAdmin();
 
     // setup parameterized question
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "sql param",
-      dataset_query: {
-        type: "native",
-        native: {
-          query: "select count(*) from products where {{c}}",
-          "template-tags": {
-            c: {
-              id: "e126f242-fbaa-1feb-7331-21ac59f021cc",
-              name: "c",
-              "display-name": "Category",
-              type: "dimension",
-              dimension: ["field-id", PRODUCTS.CATEGORY],
-              default: null,
-              "widget-type": "category",
-            },
+      native: {
+        query: "select count(*) from products where {{c}}",
+        "template-tags": {
+          c: {
+            id: "e126f242-fbaa-1feb-7331-21ac59f021cc",
+            name: "c",
+            "display-name": "Category",
+            type: "dimension",
+            dimension: ["field-id", PRODUCTS.CATEGORY],
+            default: null,
+            "widget-type": "category",
           },
         },
-        database: 1,
       },
       display: "scalar",
-      visualization_settings: {},
     }).then(({ body }) => {
       questionId = body.id;
     });

--- a/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
@@ -78,19 +78,13 @@ describe("scenarios > question > download", () => {
     let questionId;
 
     beforeEach(() => {
-      cy.request("POST", "/api/card", {
+      cy.createNativeQuestion({
         name: "10803",
-        dataset_query: {
-          type: "native",
-          native: {
-            query:
-              "SELECT PARSEDATETIME('2020-06-03', 'yyyy-MM-dd') AS \"birth_date\", PARSEDATETIME('2020-06-03 23:41:23', 'yyyy-MM-dd hh:mm:ss') AS \"created_at\"",
-            "template-tags": {},
-          },
-          database: 1,
+        native: {
+          query:
+            "SELECT PARSEDATETIME('2020-06-03', 'yyyy-MM-dd') AS \"birth_date\", PARSEDATETIME('2020-06-03 23:41:23', 'yyyy-MM-dd hh:mm:ss') AS \"created_at\"",
+          "template-tags": {},
         },
-        display: "table",
-        visualization_settings: {},
       }).then(({ body }) => {
         questionId = body.id;
       });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -434,36 +434,30 @@ describe("scenarios > question > filter", () => {
       { name: "prodid", display_name: "ProdId", type: "number" },
     ];
 
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: QUESTION_NAME,
-      dataset_query: {
-        type: "native",
-        native: {
-          query:
-            "SELECT * FROM PRODUCTS WHERE 1=1 AND {{category}} [[AND ID={{prodid}}]]",
-          "template-tags": {
-            [CATEGORY_FILTER.name]: {
-              id: "00315d5e-4a41-99da-1a41-e5254dacff9d",
-              name: CATEGORY_FILTER.name,
-              "display-name": CATEGORY_FILTER.display_name,
-              type: CATEGORY_FILTER.type,
-              default: "Doohickey",
-              dimension: ["field-id", PRODUCTS.CATEGORY],
-              "widget-type": "category",
-            },
-            [ID_FILTER.name]: {
-              id: "4775bccc-e82a-4069-fc6b-2acc90aadb8b",
-              name: ID_FILTER.name,
-              "display-name": ID_FILTER.display_name,
-              type: ID_FILTER.type,
-              default: null,
-            },
+      native: {
+        query:
+          "SELECT * FROM PRODUCTS WHERE 1=1 AND {{category}} [[AND ID={{prodid}}]]",
+        "template-tags": {
+          [CATEGORY_FILTER.name]: {
+            id: "00315d5e-4a41-99da-1a41-e5254dacff9d",
+            name: CATEGORY_FILTER.name,
+            "display-name": CATEGORY_FILTER.display_name,
+            type: CATEGORY_FILTER.type,
+            default: "Doohickey",
+            dimension: ["field-id", PRODUCTS.CATEGORY],
+            "widget-type": "category",
+          },
+          [ID_FILTER.name]: {
+            id: "4775bccc-e82a-4069-fc6b-2acc90aadb8b",
+            name: ID_FILTER.name,
+            "display-name": ID_FILTER.display_name,
+            type: ID_FILTER.type,
+            default: null,
           },
         },
-        database: 1,
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
 

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -163,31 +163,22 @@ describe("scenarios > question > native", () => {
   });
 
   it("can load a question with a date filter (from issue metabase#12228)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "Test Question",
-      dataset_query: {
-        type: "native",
-        native: {
-          query: "select count(*) from orders where {{created_at}}",
-          "template-tags": {
-            created_at: {
-              id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-              name: "created_at",
-              "display-name": "Created at",
-              type: "dimension",
-              dimension: ["field-id", ORDERS.CREATED_AT],
-              "widget-type": "date/month-year",
-            },
+      native: {
+        query: "select count(*) from orders where {{created_at}}",
+        "template-tags": {
+          created_at: {
+            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+            name: "created_at",
+            "display-name": "Created at",
+            type: "dimension",
+            dimension: ["field-id", ORDERS.CREATED_AT],
+            "widget-type": "date/month-year",
           },
         },
-        database: 1,
       },
       display: "scalar",
-      description: null,
-      visualization_settings: {},
-      collection_id: null,
-      result_metadata: null,
-      metadata_checksum: null,
     }).then(response => {
       cy.visit(`/question/${response.body.id}?created_at=2020-01`);
       cy.contains("580");
@@ -281,28 +272,22 @@ describe("scenarios > question > native", () => {
   });
 
   it.skip("should not make the question dirty when there are no changes (metabase#14302)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "14302",
-      dataset_query: {
-        type: "native",
-        native: {
-          query:
-            'SELECT "CATEGORY", COUNT(*)\nFROM "PRODUCTS"\nWHERE "PRICE" > {{PRICE}}\nGROUP BY "CATEGORY"',
-          "template-tags": {
-            PRICE: {
-              id: "39b51ccd-47a7-9df6-a1c5-371918352c79",
-              name: "PRICE",
-              "display-name": "Price",
-              type: "number",
-              default: "10",
-              required: true,
-            },
+      native: {
+        query:
+          'SELECT "CATEGORY", COUNT(*)\nFROM "PRODUCTS"\nWHERE "PRICE" > {{PRICE}}\nGROUP BY "CATEGORY"',
+        "template-tags": {
+          PRICE: {
+            id: "39b51ccd-47a7-9df6-a1c5-371918352c79",
+            name: "PRICE",
+            "display-name": "Price",
+            type: "number",
+            default: "10",
+            required: true,
           },
         },
-        database: 1,
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
       cy.findByText("14302");
@@ -315,28 +300,22 @@ describe("scenarios > question > native", () => {
     const ORIGINAL_QUERY = "SELECT * FROM ORDERS WHERE {{filter}} LIMIT 2";
 
     // Start with the original version of the question made with API
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "12581",
-      dataset_query: {
-        type: "native",
-        native: {
-          query: ORIGINAL_QUERY,
-          "template-tags": {
-            filter: {
-              id: "a3b95feb-b6d2-33b6-660b-bb656f59b1d7",
-              name: "filter",
-              "display-name": "Filter",
-              type: "dimension",
-              dimension: ["field-id", ORDERS.CREATED_AT],
-              "widget-type": "date/month-year",
-              default: null,
-            },
+      native: {
+        query: ORIGINAL_QUERY,
+        "template-tags": {
+          filter: {
+            id: "a3b95feb-b6d2-33b6-660b-bb656f59b1d7",
+            name: "filter",
+            "display-name": "Filter",
+            type: "dimension",
+            dimension: ["field-id", ORDERS.CREATED_AT],
+            "widget-type": "date/month-year",
+            default: null,
           },
         },
-        database: 1,
       },
-      display: "table",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
     });

--- a/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
@@ -8,50 +8,30 @@ describe("scenarios > question > native subquery", () => {
 
   it("should allow a user with no data access to execute a native subquery", () => {
     // Create the initial SQL question and followup nested question
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "People in WA",
-      dataset_query: {
-        type: "native",
-        native: {
-          query: "select * from PEOPLE where STATE = 'WA'",
-        },
-        database: 1,
+      native: {
+        query: "select * from PEOPLE where STATE = 'WA'",
       },
-      display: "table",
-      description: null,
-      visualization_settings: {},
-      collection_id: null,
-      result_metadata: null,
-      metadata_checksum: null,
     })
       .then(response => {
         cy.wrap(response.body.id).as("nestedQuestionId");
         const tagID = `#${response.body.id}`;
 
-        cy.request("POST", "/api/card", {
+        cy.createNativeQuestion({
           name: "Count of People in WA",
-          dataset_query: {
-            type: "native",
-            native: {
-              query: `select COUNT(*) from {{#${response.body.id}}}`,
-              "template-tags": {
-                [tagID]: {
-                  id: "10422a0f-292d-10a3-fd90-407cc9e3e20e",
-                  name: tagID,
-                  "display-name": tagID,
-                  type: "card",
-                  "card-id": response.body.id,
-                },
+          native: {
+            query: `select COUNT(*) from {{#${response.body.id}}}`,
+            "template-tags": {
+              [tagID]: {
+                id: "10422a0f-292d-10a3-fd90-407cc9e3e20e",
+                name: tagID,
+                "display-name": tagID,
+                type: "card",
+                "card-id": response.body.id,
               },
             },
-            database: 1,
           },
-          display: "table",
-          description: null,
-          visualization_settings: {},
-          collection_id: null,
-          result_metadata: null,
-          metadata_checksum: null,
         });
       })
       .then(response => {

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -28,56 +28,46 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     });
 
     // Create a native question of orders by day
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "GH_12568: SQL",
-      dataset_query: {
-        type: "native",
-        native: {
-          query:
-            "SELECT date_trunc('day', CREATED_AT) as date, COUNT(*) as count FROM ORDERS GROUP BY date_trunc('day', CREATED_AT)",
-        },
-        database: 1,
+      native: {
+        query:
+          "SELECT date_trunc('day', CREATED_AT) as date, COUNT(*) as count FROM ORDERS GROUP BY date_trunc('day', CREATED_AT)",
       },
       display: "scalar",
-      visualization_settings: {},
     });
 
     // Create a complex native question
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "GH_12568: Complex SQL",
-      dataset_query: {
-        type: "native",
-        native: {
-          query: `WITH tmp_user_order_dates as (
-              SELECT
-                o.USER_ID,
-                o.CREATED_AT,
-                o.QUANTITY
-              FROM
-                ORDERS o
-            ),
-
-            tmp_prior_orders_by_date as (
-              select
-                  tbod.USER_ID,
-                  tbod.CREATED_AT,
-                  tbod.QUANTITY,
-                  (select count(*) from tmp_user_order_dates tbod2 where tbod2.USER_ID = tbod.USER_ID and tbod2.CREATED_AT < tbod.CREATED_AT ) as PRIOR_ORDERS
-              from tmp_user_order_dates tbod
-            )
-
+      native: {
+        query: `WITH tmp_user_order_dates as (
+            SELECT
+              o.USER_ID,
+              o.CREATED_AT,
+              o.QUANTITY
+            FROM
+              ORDERS o
+          ),
+  
+          tmp_prior_orders_by_date as (
             select
-              date_trunc('day', tpobd.CREATED_AT) as "Date",
-              case when tpobd.PRIOR_ORDERS > 0 then 'Return' else 'New' end as "Customer Type",
-              sum(QUANTITY) as "Items Sold"
-            from tmp_prior_orders_by_date tpobd
-            group by date_trunc('day', tpobd.CREATED_AT), "Customer Type"
-            order by date_trunc('day', tpobd.CREATED_AT) asc`,
-        },
-        database: 1,
+                tbod.USER_ID,
+                tbod.CREATED_AT,
+                tbod.QUANTITY,
+                (select count(*) from tmp_user_order_dates tbod2 where tbod2.USER_ID = tbod.USER_ID and tbod2.CREATED_AT < tbod.CREATED_AT ) as PRIOR_ORDERS
+            from tmp_user_order_dates tbod
+          )
+  
+          select
+            date_trunc('day', tpobd.CREATED_AT) as "Date",
+            case when tpobd.PRIOR_ORDERS > 0 then 'Return' else 'New' end as "Customer Type",
+            sum(QUANTITY) as "Items Sold"
+          from tmp_prior_orders_by_date tpobd
+          group by date_trunc('day', tpobd.CREATED_AT), "Customer Type"
+          order by date_trunc('day', tpobd.CREATED_AT) asc`,
       },
       display: "scalar",
-      visualization_settings: {},
     });
   });
 

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -115,29 +115,15 @@ describe("scenarios > question > null", () => {
   });
 
   it("dashboard should handle cards with null values (metabase#13801)", () => {
-    cy.log("Create Question 1");
-
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "13801_Q1",
-      dataset_query: {
-        database: 1,
-        native: { query: "SELECT null", "template-tags": {} },
-        type: "native",
-      },
+      native: { query: "SELECT null", "template-tags": {} },
       display: "scalar",
-      visualization_settings: {},
     }).then(({ body: { id: Q1_ID } }) => {
-      cy.log("Create Question 2");
-
-      cy.request("POST", "/api/card", {
+      cy.createNativeQuestion({
         name: "13801_Q2",
-        dataset_query: {
-          database: 1,
-          native: { query: "SELECT 0", "template-tags": {} },
-          type: "native",
-        },
+        native: { query: "SELECT 0", "template-tags": {} },
         display: "scalar",
-        visualization_settings: {},
       }).then(({ body: { id: Q2_ID } }) => {
         cy.createDashboard("13801D").then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add both previously created questions to the dashboard");

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -108,36 +108,31 @@ describe("scenarios > question > view", () => {
       // Native query saved in dasbhoard
       cy.createDashboard("Dashboard");
 
-      cy.request("POST", "/api/card", {
+      cy.createNativeQuestion({
         name: "Question",
-        dataset_query: {
-          type: "native",
-          native: {
-            query: "select * from products where {{category}} and {{vendor}}",
-            "template-tags": {
-              category: {
-                id: "6b8b10ef-0104-1047-1e5v-2492d5954555",
-                name: "category",
-                "display-name": "CATEGORY",
-                type: "dimension",
-                dimension: ["field-id", PRODUCTS.CATEGORY],
-                "widget-type": "id",
-              },
-              vendor: {
-                id: "6b8b10ef-0104-1047-1e5v-2492d5964545",
-                name: "vendor",
-                "display-name": "VENDOR",
-                type: "dimension",
-                dimension: ["field-id", PRODUCTS.VENDOR],
-                "widget-type": "id",
-              },
+        native: {
+          query: "select * from products where {{category}} and {{vendor}}",
+          "template-tags": {
+            category: {
+              id: "6b8b10ef-0104-1047-1e5v-2492d5954555",
+              name: "category",
+              "display-name": "CATEGORY",
+              type: "dimension",
+              dimension: ["field-id", PRODUCTS.CATEGORY],
+              "widget-type": "id",
+            },
+            vendor: {
+              id: "6b8b10ef-0104-1047-1e5v-2492d5964545",
+              name: "vendor",
+              "display-name": "VENDOR",
+              type: "dimension",
+              dimension: ["field-id", PRODUCTS.VENDOR],
+              "widget-type": "id",
             },
           },
-          database: 1,
         },
-        display: "table",
-        visualization_settings: {},
       });
+
       cy.request("POST", "/api/dashboard/2/cards", {
         id: 2,
         cardId: 4,

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -265,19 +265,14 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it.skip("should display correct value in a tooltip for unaggregated data (metabase#11907)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "11907",
-      dataset_query: {
-        type: "native",
-        native: {
-          query:
-            "SELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 5 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 2 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 3 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 1 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 4 AS \"c\"",
-          "template-tags": {},
-        },
-        database: 1,
+      native: {
+        query:
+          "SELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 5 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 2 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 3 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 1 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 4 AS \"c\"",
+        "template-tags": {},
       },
       display: "line",
-      visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}`);
 
@@ -314,16 +309,9 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       },
     );
 
-    // Create a native question
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "14495_SQL",
-      dataset_query: {
-        type: "native",
-        native: { query: "SELECT * FROM ORDERS", "template-tags": {} },
-        database: 1,
-      },
-      display: "table",
-      visualization_settings: {},
+      native: { query: "SELECT * FROM ORDERS", "template-tags": {} },
     }).then(({ body: { id: SQL_ID } }) => {
       const ALIAS = `Question ${SQL_ID}`;
 

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -62,16 +62,12 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it.skip("should suggest map visualization regardless of the first column type (metabase#14254)", () => {
-    cy.request("POST", "/api/card", {
+    cy.createNativeQuestion({
       name: "14254",
-      dataset_query: {
-        type: "native",
-        native: {
-          query:
-            'SELECT "PUBLIC"."PEOPLE"."LONGITUDE" AS "LONGITUDE", "PUBLIC"."PEOPLE"."LATITUDE" AS "LATITUDE", "PUBLIC"."PEOPLE"."CITY" AS "CITY"\nFROM "PUBLIC"."PEOPLE"\nLIMIT 10',
-          "template-tags": {},
-        },
-        database: 1,
+      native: {
+        query:
+          'SELECT "PUBLIC"."PEOPLE"."LONGITUDE" AS "LONGITUDE", "PUBLIC"."PEOPLE"."LATITUDE" AS "LATITUDE", "PUBLIC"."PEOPLE"."CITY" AS "CITY"\nFROM "PUBLIC"."PEOPLE"\nLIMIT 10',
+        "template-tags": {},
       },
       display: "map",
       visualization_settings: {

--- a/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
@@ -12,19 +12,14 @@ describe("scenarios > visualizations > rows", () => {
     "should not collapse rows when last value is 0 (metabase#14285)",
     { browser: "firefox" },
     () => {
-      cy.request("POST", "/api/card", {
+      cy.createNativeQuestion({
         name: "14285",
-        dataset_query: {
-          type: "native",
-          native: {
-            query:
-              "with temp as (\n select 'a' col1, 25 col2\n union all \n select 'b', 10\n union all \n select 'c', 15\n union all \n select 'd', 0\n union all\n select 'e', 30\n union all \n select 'f', 35\n)\nselect * from temp\norder by 2 desc",
-            "template-tags": {},
-          },
-          database: 1,
+        native: {
+          query:
+            "with temp as (\n select 'a' col1, 25 col2\n union all \n select 'b', 10\n union all \n select 'c', 15\n union all \n select 'd', 0\n union all\n select 'e', 30\n union all \n select 'f', 35\n)\nselect * from temp\norder by 2 desc",
+          "template-tags": {},
         },
         display: "row",
-        visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
         cy.visit(`/question/${QUESTION_ID}`);
       });


### PR DESCRIPTION
### Status:
PENDING REVIEW

### What does this PR accomplish?
- Adds Cypress custom command for creating (native) questions
- Updates all related occurrences of native question creation via API in all test files

### How to test this works?
- All tests should pass

### Additional notes:
- Log is now tucked inside a custom function so there is no need anymore to leave logs inside test itself
- It accepts 5 arguments:
    - `name` (string), default value = `native`: question's name
    - `native` (object), default value = `{}`: native query
    - `display` (string), default value = `table`: chosen visualization for the question
    - `database` (number | string), default value = `1` (sample dataset): database id
    - `visualization_settings` (object), default value = `{}`: as the name suggests, specific visualization settings; rarely explicitly set
- It makes test easier to read 
- Custom command is "chainable" with Cypress' `then`
