### PR TITLE
Allow users to more easiy explore saved SQL results

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -8,6 +8,7 @@ import Link from "metabase/components/Link";
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 
+import Question from "metabase-lib/lib/Question";
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
 
 import QuestionDataSource from "./QuestionDataSource";
@@ -259,6 +260,24 @@ export class ViewTitleHeader extends React.Component {
                 data-metabase-event={`Notebook Mode; Convert to SQL Click`}
               />
             </Box>
+          )}
+          {isNative && isSaved && (
+            <Link
+              to={new Question(
+                {
+                  dataset_query: {
+                    database: question.query().database().id,
+                    query: { "source-table": `card__${question.id()}` },
+                    type: "query",
+                  },
+                  display: "table",
+                  visualization_settings: {},
+                },
+                question.metadata(),
+              ).getUrl()}
+            >
+              <div className="Button Button--primary">Explore results</div>
+            </Link>
           )}
           {isRunnable && !isNativeEditorOpen && (
             <RunButtonWithTooltip

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -5,6 +5,7 @@ import { Box } from "grid-styled";
 
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
+import ViewButton from "metabase/query_builder/components/view/ViewButton"
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 
@@ -276,7 +277,10 @@ export class ViewTitleHeader extends React.Component {
                 question.metadata(),
               ).getUrl()}
             >
-              <div className="Button Button--primary">Explore results</div>
+              <ViewButton className="flex align-center">
+                <Icon name="insight" mr="4px" />
+                {t`Explore results`}
+              </ViewButton>
             </Link>
           )}
           {isRunnable && !isNativeEditorOpen && (
@@ -298,7 +302,7 @@ export class ViewTitleHeader extends React.Component {
             />
           )}
         </div>
-      </ViewSection>
+      </ViewSection >
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -5,7 +5,7 @@ import { Box } from "grid-styled";
 
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
-import ViewButton from "metabase/query_builder/components/view/ViewButton"
+import ViewButton from "metabase/query_builder/components/view/ViewButton";
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 
@@ -277,8 +277,7 @@ export class ViewTitleHeader extends React.Component {
                 question.metadata(),
               ).getUrl()}
             >
-              <ViewButton className="flex align-center">
-                <Icon name="insight" mr="4px" />
+              <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
                 {t`Explore results`}
               </ViewButton>
             </Link>
@@ -302,7 +301,7 @@ export class ViewTitleHeader extends React.Component {
             />
           )}
         </div>
-      </ViewSection >
+      </ViewSection>
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -262,7 +262,7 @@ export class ViewTitleHeader extends React.Component {
               />
             </Box>
           )}
-          {isNative && isSaved && (
+          {question.query().database() && isNative && isSaved && (
             <Link
               to={new Question(
                 {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -263,20 +263,7 @@ export class ViewTitleHeader extends React.Component {
             </Box>
           )}
           {question.query().database() && isNative && isSaved && (
-            <Link
-              to={new Question(
-                {
-                  dataset_query: {
-                    database: question.query().database().id,
-                    query: { "source-table": `card__${question.id()}` },
-                    type: "query",
-                  },
-                  display: "table",
-                  visualization_settings: {},
-                },
-                question.metadata(),
-              ).getUrl()}
-            >
+            <Link to={getExploreResultsUrl(question)}>
               <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
                 {t`Explore results`}
               </ViewButton>
@@ -304,6 +291,21 @@ export class ViewTitleHeader extends React.Component {
       </ViewSection>
     );
   }
+}
+
+function getExploreResultsUrl(question) {
+  return new Question(
+    {
+      dataset_query: {
+        database: question.query().database().id,
+        query: { "source-table": `card__${question.id()}` },
+        type: "query",
+      },
+      display: "table",
+      visualization_settings: {},
+    },
+    question.metadata(),
+  ).getUrl();
 }
 
 export class ViewSubHeader extends React.Component {


### PR DESCRIPTION
## What this does
- Adds an action to the header for saved SQL questions that opens the current saved question in the "simple mode" query builder to let users explore the results using more comfortable tools. In the long term I'd prefer you be able to interact right where you are without having to click another action, but this addition acts as a shortcut to let you effectively start a new question from this "table" like you can if you select "Saved questions" when starting a new question. 
  
https://user-images.githubusercontent.com/5248953/111812078-1c92c580-88ae-11eb-8ffc-2f0d3f4fffc2.mp4

