### PR TITLE
#14989 Repro: Pivot Table does not work for users without data permissions

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1,4 +1,5 @@
 import {
+  signIn,
   signInAsAdmin,
   restore,
   visitQuestionAdhoc,
@@ -664,6 +665,33 @@ describe("scenarios > visualizations > pivot tables", () => {
     createAndVisitTestQuestion();
     cy.icon("download").click();
     popover().within(() => cy.findByText("Download full results"));
+  });
+
+  it.skip("should work for user without data permissions (metabase#14989)", () => {
+    cy.request("POST", "/api/card", {
+      name: "14989",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["datetime-field", ["field-id", PRODUCTS.CREATED_AT], "year"],
+            ["field-id", PRODUCTS.CATEGORY],
+          ],
+        },
+        type: "query",
+      },
+      display: "pivot",
+      visualization_settings: {},
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      signIn("nodata");
+      cy.visit(`/question/${QUESTION_ID}`);
+    });
+
+    cy.findByText("Grand totals");
+    cy.findByText("Row totals");
+    cy.findByText("200");
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #14989

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/109542617-8dbc3580-7ac5-11eb-8503-e3f12197892b.png)

