### PR TITLE
Postgres regex match first subquery 0.36

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -167,10 +167,11 @@
 
 (defmethod sql.qp/->honeysql [:postgres :regex-match-first]
   [driver [_ arg pattern]]
-  (reify
-    hformat/ToSql
-    (to-sql [_]
-      (str "substring(" (hformat/to-sql (sql.qp/->honeysql driver arg)) " FROM " (hformat/to-sql pattern) ")"))))
+  (let [col-name (hformat/to-sql (sql.qp/->honeysql driver arg))]
+    (reify
+      hformat/ToSql
+      (to-sql [_]
+        (str "substring(" col-name " FROM " (hformat/to-sql pattern) ")")))))
 
 (defmethod sql.qp/->honeysql [:postgres Time]
   [_ time-value]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -311,3 +311,24 @@
                 :limit       3
                 :order-by    [[:asc $id]]})))
         "Make sure an expression with a / in its name works")))
+
+(deftest string-operations-from-subquery
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)
+    (testing "regex-match-first and replace work when evaluated against a subquery (#14873)"
+      (mt/dataset sample-dataset
+        (let [a-word  "a_word"
+              no-sp   "no_spaces"
+              ean     (mt/id :products :ean)
+              results (mt/run-mbql-query products
+                        {:expressions  {a-word
+                                         [:regex-match-first [:field-id (mt/id :products :title)] "^A[^ ]+"]
+                                        no-sp
+                                         [:replace [:field-id (mt/id :products :title)] " " ""]}
+                         :source-query {:source-table $$products}
+                         :fields       [$title [:expression a-word] [:expression no-sp]]
+                         :filter       [:= [:field-id ean] "0157967025871" "4893655420066"]})]
+          (is (= ["Title" a-word no-sp]
+                 (map :display_name (mt/cols results))))
+          (is (= [["Aerodynamic Linen Coat" "Aerodynamic" "AerodynamicLinenCoat"]
+                  ["Awesome Rubber Wallet" "Awesome" "AwesomeRubberWallet"]]
+                 (mt/formatted-rows [str str str] results))))))))

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -315,20 +315,19 @@
 (deftest string-operations-from-subquery
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)
     (testing "regex-match-first and replace work when evaluated against a subquery (#14873)"
-      (mt/dataset sample-dataset
-        (let [a-word  "a_word"
+      (mt/dataset test-data
+        (let [r-word  "r_word"
               no-sp   "no_spaces"
-              ean     (mt/id :products :ean)
-              results (mt/run-mbql-query products
-                        {:expressions  {a-word
-                                         [:regex-match-first [:field-id (mt/id :products :title)] "^A[^ ]+"]
-                                        no-sp
-                                         [:replace [:field-id (mt/id :products :title)] " " ""]}
-                         :source-query {:source-table $$products}
-                         :fields       [$title [:expression a-word] [:expression no-sp]]
-                         :filter       [:= [:field-id ean] "0157967025871" "4893655420066"]})]
-          (is (= ["Title" a-word no-sp]
+              id      (mt/id :venues :id)
+              results (mt/run-mbql-query venues
+                        {:expressions  {r-word [:regex-match-first [:field-id (mt/id :venues :name)] "^R[^ ]+"]
+                                        no-sp  [:replace [:field-id (mt/id :venues :name)] " " ""]}
+                         :source-query {:source-table $$venues}
+                         :fields       [$name [:expression r-word] [:expression no-sp]]
+                         :filter       [:= $id 1 95]
+                         :order-by     [[:asc $id]]})]
+          (is (= ["Name" r-word no-sp]
                  (map :display_name (mt/cols results))))
-          (is (= [["Aerodynamic Linen Coat" "Aerodynamic" "AerodynamicLinenCoat"]
-                  ["Awesome Rubber Wallet" "Awesome" "AwesomeRubberWallet"]]
+          (is (= [["Red Medicine" "Red" "RedMedicine"]
+                  ["Rush Street" "Rush" "RushStreet"]]
                  (mt/formatted-rows [str str str] results))))))))


### PR DESCRIPTION
Fix regex-match-first operator for Postgres to work properly when run against subqueries

Capture col-name at beginning of fn for :regex-match-first operator in Postgres driver to work around laziness problem (see PR #14858)

Adding test

Change string-operations-from-subquery to use test-data instead of sample-data, because the latter currently is incompatible with Redshift (see #14784)