### PR TITLE
Fix BigQuery generated field aliases when table names contain non-alphanumeric characters

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -330,7 +330,7 @@
 
 (deftest e2e-fks-test
   (mt/test-drivers (row-level-restrictions-fk-drivers)
-    (enable-bigquery-fks
+    (mt/with-bigquery-fks
      (testing (str "1 - Creates a GTAP filtering question, looking for any checkins happening on or after 2014\n"
                    "2 - Apply the `user` attribute, looking for only our user (i.e. `user_id` =  5)\n"
                    "3 - Checkins are related to Venues, query for checkins, grouping by the Venue's price\n"

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -1,5 +1,7 @@
 (ns metabase.driver.bigquery.query-processor
-  (:require [clojure.string :as str]
+  (:require [buddy.core.codecs :as codecs]
+            [buddy.core.hash :as hash]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
             [honeysql.format :as hformat]
@@ -26,6 +28,9 @@
            metabase.driver.common.parameters.FieldFilter
            metabase.util.honeysql_extensions.Identifier))
 
+;; TODO -- I think this only applied to Fields now -- see
+;; https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language. It definitely doesn't apply
+;; to Tables. Not sure about project/dataset identifiers.
 (defn- valid-bigquery-identifier?
   "Is String `s` a valid BigQuery identifier? Identifiers are only allowed to contain letters, numbers, and underscores;
   cannot start with a number; and can be at most 128 characters long."
@@ -445,14 +450,46 @@
     (cond->> ((get-method sql.qp/->honeysql [:sql :relative-datetime]) driver clause)
       t (->temporal-type t))))
 
-;; From the dox: Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be
-;; at most 128 characters long.
+(defn- short-string-hash
+  "Create a 8-character hash of string `s` to be used as a unique suffix for Field identifiers that could otherwise be
+  ambiguous. For example, `résumé` and `resume` are both valid *table* names, but after converting these to valid
+  *field* identifiers for use as field aliases, we'd end up with `resume_id` for `id` regardless of which table it
+  came from. By appending a unique hash to the generated identifier, we can distinguish the two."
+  [s]
+  (str/join (take 8 (codecs/bytes->hex (hash/md5 s)))))
+
+(defn- substring-first-n-characters
+  "Return substring of `s` with just the first `n` characters."
+  [s n]
+  (subs s 0 (min n (count s))))
+
+(defn- ->valid-field-identifier
+  "Convert field alias `s` to a valid BigQuery field identifier. From the dox: Fields must contain only letters,
+  numbers, and underscores, start with a letter or underscore, and be at most 128 characters long."
+  [s]
+  (let [replaced-str (-> (str/trim s)
+                         u/remove-diacritical-marks
+                         (str/replace #"[^\w\d_]" "_")
+                         (str/replace #"(^\d)" "_$1")
+                         (substring-first-n-characters 128))]
+    (if (= s replaced-str)
+      s
+      ;; if we've done any sort of transformations to the string, append a short hash to the string so it's unique
+      ;; when compared to other strings that may have normalized to the same thing.
+      (str (substring-first-n-characters replaced-str 119) \_ (short-string-hash s)))))
+
 (defmethod driver/format-custom-field-name :bigquery
   [_ custom-field-name]
-  (let [replaced-str (-> (str/trim custom-field-name)
-                         (str/replace #"[^\w\d_]" "_")
-                         (str/replace #"(^\d)" "_$1"))]
-    (subs replaced-str 0 (min 128 (count replaced-str)))))
+  (->valid-field-identifier custom-field-name))
+
+(defmethod sql.qp/field->alias :bigquery
+  [driver field]
+  (->valid-field-identifier ((get-method sql.qp/field->alias :sql) driver field)))
+
+(defmethod sql.qp/prefix-field-alias :bigquery
+  [driver prefix field-alias]
+  (let [s ((get-method sql.qp/prefix-field-alias :sql) driver prefix field-alias)]
+    (->valid-field-identifier s)))
 
 ;; See:
 ;;

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -132,6 +132,9 @@
 
 (deftest join-alias-test
   (mt/test-driver :bigquery
+    (testing (str "Make sure that BigQuery properly aliases the names generated for Join Tables. It's important to use "
+                  "the right alias, e.g. something like `categories__via__category_id`, which is considerably "
+                  "different  what other SQL databases do. (#4218)"))
     (is (= (str "SELECT `categories__via__category_id`.`name` AS `categories__via__category_id__name`,"
                 " count(*) AS `count` "
                 "FROM `v3_test_data.venues` "
@@ -143,14 +146,11 @@
            ;; that and make it return `true` so this test proceeds as expected
            (with-redefs [driver/supports? (constantly true)]
              (mt/with-temp-vals-in-db Field (mt/id :venues :category_id) {:fk_target_field_id (mt/id :categories :id)
-                                                                            :special_type       "type/FK"}
+                                                                          :special_type       "type/FK"}
                (let [results (mt/run-mbql-query venues
                                {:aggregation [:count]
                                 :breakout    [$category_id->categories.name]})]
-                 (get-in results [:data :native_form :query] results)))))
-        (str "make sure that BigQuery properly aliases the names generated for Join Tables. It's important to use the "
-             "right alias, e.g. something like `categories__via__category_id`, which is considerably different from "
-             "what other SQL databases do. (#4218)"))))
+                 (get-in results [:data :native_form :query] results))))))))
 
 (defn- native-timestamp-query [db-or-db-id timestamp-str timezone-str]
   (-> (qp/process-query
@@ -668,5 +668,52 @@
                (mt/formatted-rows [int]
                  (qp/process-query
                   (mt/native-query
-                    {:query  "SELECT count(*) AS `count` FROM `v3_test_data.venues` WHERE `v3_test_data.venues`.`name` = ?"
+                    {:query  (str "SELECT count(*) AS `count` "
+                                  "FROM `v3_test_data.venues` "
+                                  "WHERE `v3_test_data.venues`.`name` = ?")
                      :params ["x\\\\' OR 1 = 1 -- "]})))))))))
+
+(deftest ->valid-field-identifier-test
+  (testing "`->valid-field-identifier` should generate valid field identifiers"
+    (testing "no need to change anything"
+      (is (= "abc"
+             (#'bigquery.qp/->valid-field-identifier "abc"))))
+    (testing "replace spaces with underscores"
+      (is (= "A_B_C_0ef78513"
+             (#'bigquery.qp/->valid-field-identifier "A B C"))))
+    (testing "trim spaces"
+      (is (= "A_B_61f5f1b3"
+             (#'bigquery.qp/->valid-field-identifier " A B "))))
+    (testing "diacritical marks"
+      (is (= "Organizacao_6c2736cd"
+             (#'bigquery.qp/->valid-field-identifier "Organização")))
+      (testing "we should generate unique suffixes for different strings that get normalized to the same thing"
+        (is (= "Organizacao_f3d24ea0"
+               (#'bigquery.qp/->valid-field-identifier "Organizacaó")))))
+    (testing "cannot start with a number"
+      (is (= "_123_202cb962"
+             (#'bigquery.qp/->valid-field-identifier "123"))))
+    (testing "replace non-letter characters with underscores"
+      (is (= "__02612e19"
+             (#'bigquery.qp/->valid-field-identifier "😍")))
+      (testing "we should generate unique suffixes for different strings that get normalized to the same thing"
+        (is (= "__e88ec744"
+               (#'bigquery.qp/->valid-field-identifier "🥰")))))
+    (testing "trim long strings"
+      (is (= (str (str/join (repeat 119 "a")) "_4e5475d1")
+             (#'bigquery.qp/->valid-field-identifier (str/join (repeat 300 "a"))))))))
+
+(deftest remove-diacriticals-from-field-aliases-test
+  (mt/test-driver :bigquery
+    (testing "We should remove diacriticals and other disallowed characters from field aliases (#14933)"
+      (mt/with-bigquery-fks
+        (let [query (mt/mbql-query checkins
+                      {:fields [$id $venue_id->venues.name]})]
+          (mt/with-temp-vals-in-db Table (mt/id :venues) {:name "Organização"}
+            (is (= (str "SELECT `v3_test_data.checkins`.`id` AS `id`,"
+                        " `Organização__via__venue_id`.`name` AS `Organizacao__via__venue_id__name_560a3449` "
+                        "FROM `v3_test_data.checkins` "
+                        "LEFT JOIN `v3_test_data.Organização` `Organização__via__venue_id`"
+                        " ON `v3_test_data.checkins`.`venue_id` = `Organização__via__venue_id`.`id` "
+                        "LIMIT 1048576")
+                   (:query (qp/query->native query))))))))))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -8,7 +8,8 @@
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.data.bigquery :as bigquery.tx]
-            [metabase.test.util :as tu]))
+            [metabase.test.util :as tu]
+            [metabase.util :as u]))
 
 (deftest table-rows-sample-test
   (mt/test-driver
@@ -98,14 +99,27 @@
                 [2 "Stout Burgers & Beers" "Burger"]
                 [3 "The Apple Pan" "Burger"]]
                (mt/rows
-                 (qp/process-query
-                  {:database (mt/id)
-                   :type     :query
-                   :query    {:source-table (mt/id view-name)
-                              :order-by     [[:asc (mt/id view-name :id)]]}}))))))))
+                 (mt/run-mbql-query nil
+                   {:source-table (mt/id view-name)
+                    :order-by     [[:asc (mt/id view-name :id)]]}))))))))
 
 (deftest query-integer-pk-or-fk-test
   (mt/test-driver :bigquery
     (testing "We should be able to query a Table that has a :type/Integer column marked as a PK or FK"
       (is (= [["1" "Plato Yeshua" "2014-04-01T08:30:00Z"]]
              (mt/rows (mt/user-http-request :rasta :post 202 "dataset" (mt/mbql-query users {:limit 1, :order-by [[:asc $id]]}))))))))
+
+(deftest return-errors-test
+  (mt/test-driver :bigquery
+    (testing "If a Query fails, we should return the error right away (#14918)"
+      (let [before-ms (System/currentTimeMillis)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Error executing query"
+             (qp/process-query
+              {:database (mt/id)
+               :type     :native
+               :native   {:query "SELECT abc FROM 123;"}})))
+        (testing "Should return the error *before* the query timeout"
+          (let [duration-ms (- (System/currentTimeMillis) before-ms)]
+            (is (< duration-ms (u/seconds->ms @#'bigquery/query-timeout-seconds)))))))))

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -79,7 +79,7 @@
     (cond-> (mbql.u/replace form
               [:fk-> [:field-id fk-field-id] dest-field]
               (let [join-alias (or (fk-field-id->join-alias fk-field-id)
-                                   (throw (ex-info (tru "Cannot find Table ID for Field {0}" fk-field-id)
+                                   (throw (ex-info (tru "Cannot find matching FK Table ID for FK Field {0}" fk-field-id)
                                                    {:resolving  &match
                                                     :candidates fk-field-id->join-alias})))]
                 [:joined-field (fk-field-id->join-alias fk-field-id) dest-field]))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -129,7 +129,8 @@
   normal-drivers-with-feature
   normal-drivers-without-feature
   rows
-  rows+column-names]
+  rows+column-names
+  with-bigquery-fks]
 
  [qp.test-util
   with-database-timezone-id


### PR DESCRIPTION
In 0.38.0 to fix some nested query bugs we changed the way we generate Field aliases when compiling SQL queries with joins. To disambiguate Field names we include the table name in the alias -- that caused queries to fail in BigQuery if the Table names contained diacritical marks. In BigQuery, table names are allowed to contain diacritical marks, but Field names are not; `Organização` is valid Table name but `Organização__id` is not a valid Field name. Sometimes I think people make their databases do things like this just to keep people on their toes.

Fixed by normalizing the field alias identifiers to remove diacriticals and satisfy other requirements. I've added hash suffixes to the normalized field alias identifiers as well so `Organização` and `Organizacaó` become `Organizacao_6c2736cd` and `Organizacao_f3d24ea0` respectively, rather than normalizing them both to `Organizacao`.

Also fixed an issue where errors weren't being properly returned right away.

Fixes #14918
Fixes #14933