### PR TITLE
Custom expression completion: test that "case" is offered as a choice

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -722,6 +722,20 @@ describe("scenarios > question > filter", () => {
     });
   });
 
+  it("should offer case expression in the auto-complete suggestions", () => {
+    openReviewsTable({ mode: "notebook" });
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+    popover().contains(/case/i);
+
+    // "case" is still there after typing a bit
+    cy.get("[contenteditable='true']")
+      .as("inputField")
+      .click()
+      .type("c");
+    popover().contains(/case/i);
+  });
+
   it.skip("should provide accurate auto-complete custom-expression suggestions based on the aggregated column name (metabase#14776)", () => {
     cy.viewport(1400, 1000); // We need a bit taller window for this repro to see all custom filter options in the popover
     cy.request("POST", "/api/card", {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -730,7 +730,6 @@ describe("scenarios > question > filter", () => {
 
     // "case" is still there after typing a bit
     cy.get("[contenteditable='true']")
-      .as("inputField")
       .click()
       .type("c");
     popover().contains(/case/i);


### PR DESCRIPTION
The feature is already implemented in PR #14721.

How to verify? Run the entire Cypress tests, or:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js
```