### PR TITLE
Add AWS and Azure PEMs for SSL in connecting to managed databases

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,13 +3,17 @@ FROM adoptopenjdk/openjdk11:alpine-jre
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk -U upgrade && apk add --update --no-cache bash ttf-dejavu fontconfig
+RUN apk -U upgrade &&  \
+    apk add --update --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+    mkdir -p /app/certs && \
+    curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
+    /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
+    curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /app/certs/DigiCertGlobalRootG2.crt.pem  && \
+    /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
+    mkdir -p /plugins && chmod a+rwx /plugins
 
 # add Metabase jar & add our run script to the image
 COPY ./metabase.jar ./run_metabase.sh /app/
-
-# create the plugins directory, with writable permissions
-RUN mkdir -p /plugins && chmod a+rwx /plugins
 
 # expose our default runtime port
 EXPOSE 3000


### PR DESCRIPTION
I'm adding to the release container(s) the java-cacerts package + RDS and Azure PEM files + importing them to the keystore so anyone can set up SSL connections to any db in AWS and Azure that might require certs.

I really don't like the keystore with a 'changeit' password and I'm trying hard to figure out the consequences of leaving it as it is on a container, but I'm all ears (or eyes in this case)