### PR TITLE
Backend search tweaks

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -23,6 +23,10 @@
   "Results in more dashboards than this are all considered to be equally popular."
   50)
 
+(def ^:const surrounding-match-context
+  "Show this many words of context before/after matches in long search results"
+  2)
+
 (def searchable-models
   "Models that can be searched. The order of this list also influences the order of the results: items earlier in the
   list will be ranked higher."

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -129,6 +129,7 @@
 
 (deftest match-context-test
   (let [context  #'search/match-context
+        tokens   (partial map str)
         match    (fn [text] {:text text :is_match true})
         no-match (fn [text] {:text text :is_match false})]
     (testing "it groups matches together"
@@ -145,7 +146,20 @@
       (is (= [(no-match "aviary stats")]
              (context
                  ["rasta" "toucan"]
-                 ["aviary" "stats"]))))))
+                 ["aviary" "stats"]))))
+    (testing "it abbreviates when necessary"
+      (is (= [(no-match "one two…eleven twelve")
+              (match "rasta toucan")
+              (no-match "alpha beta…the end")]
+             (context
+                 (tokens '(rasta toucan))
+                 (tokens '(one two
+                           this should not be included
+                           eleven twelve
+                           rasta toucan
+                           alpha beta
+                           some other noise
+                           the end))))))))
 
 (deftest test-largest-common-subseq-length
   (let [subseq-length (partial #'search/largest-common-subseq-length =)]


### PR DESCRIPTION
* ~~Tokenize differently. I was going to say "more sensibly", but there are some tradeoffs described in `#search-improvements`. Tagging @kdoh for his opinion~~ _reverted the commit_

* Limit how much context is returned so that long native queries don't take over the results page. Note the ellipsis below:
![image](https://user-images.githubusercontent.com/784417/109677211-0e6b4800-7b3f-11eb-8374-60870a5cdf2a.png)

