### PR TITLE
replace prefix search with contains in parameter value search

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -33,7 +33,7 @@ const fetchParameterPossibleValues = async (
   dashboardId,
   { id: paramId, filteringParameters = [] } = {},
   parameters,
-  prefix,
+  query,
 ) => {
   // build a map of parameter ID -> value for parameters that this parameter is filtered by
   const otherValues = _.chain(parameters)
@@ -42,8 +42,8 @@ const fetchParameterPossibleValues = async (
     .object()
     .value();
 
-  const args = { paramId, prefix, dashId: dashboardId, ...otherValues };
-  const endpoint = prefix
+  const args = { paramId, query, dashId: dashboardId, ...otherValues };
+  const endpoint = query
     ? DashboardApi.parameterSearch
     : DashboardApi.parameterValues;
   // now call the new chain filter API endpoint
@@ -467,16 +467,16 @@ export class FieldValuesWidget extends Component {
               {this.renderOptions(props)}
             </div>
           )}
-          filterOption={(option, filterString) =>
-            (option[0] != null &&
-              String(option[0])
-                .toLowerCase()
-                .indexOf(filterString.toLowerCase()) === 0) ||
-            (option[1] != null &&
-              String(option[1])
-                .toLowerCase()
-                .indexOf(filterString.toLowerCase()) === 0)
-          }
+          filterOption={(option, filterString) => {
+            const lowerCaseFilterString = filterString.toLowerCase();
+            return option.some(
+              value =>
+                value != null &&
+                String(value)
+                  .toLowerCase()
+                  .includes(lowerCaseFilterString),
+            );
+          }}
           onInputChange={this.onInputChange}
           parseFreeformValue={v => {
             // trim whitespace

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -139,7 +139,7 @@ export const DashboardApi = {
   favorite: POST("/api/dashboard/:dashId/favorite"),
   unfavorite: DELETE("/api/dashboard/:dashId/favorite"),
   parameterValues: GET("/api/dashboard/:dashId/params/:paramId/values"),
-  parameterSearch: GET("/api/dashboard/:dashId/params/:paramId/search/:prefix"),
+  parameterSearch: GET("/api/dashboard/:dashId/params/:paramId/search/:query"),
   validFilterFields: GET("/api/dashboard/params/valid-filter-fields"),
 
   listPublic: GET("/api/dashboard/public"),
@@ -470,7 +470,7 @@ function setParamsEndpoints(prefix: string) {
     prefix + "/dashboard/:dashId/params/:paramId/values",
   );
   DashboardApi.parameterSearch = GET(
-    prefix + "/dashboard/:dashId/params/:paramId/search/:prefix",
+    prefix + "/dashboard/:dashId/params/:paramId/search/:query",
   );
 }
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -36,10 +36,10 @@
   (let [favorite-dashboard-ids (when (seq dashboards)
                                  (db/select-field :dashboard_id DashboardFavorite
                                    :user_id      api/*current-user-id*
-                                   :dashboard_id [:in (set (map u/get-id dashboards))]))]
+                                   :dashboard_id [:in (set (map u/the-id dashboards))]))]
     (for [dashboard dashboards]
       (assoc dashboard
-        :favorite (contains? favorite-dashboard-ids (u/get-id dashboard))))))
+        :favorite (contains? favorite-dashboard-ids (u/the-id dashboard))))))
 
 (defn- dashboards-list [filter-option]
   (as-> (db/select Dashboard {:where    [:and (case (or (keyword filter-option) :all)
@@ -198,7 +198,7 @@
   (assoc dashboard :param_values (->> param_fields
                                       vals
                                       (filter mi/can-read?)
-                                      (map u/get-id)
+                                      (map u/the-id)
                                       set
                                       params/field-ids->param-field-values
                                       not-empty)))
@@ -463,6 +463,10 @@
 
 ;;; ------------------------------------- Chain-filtering param value endpoints --------------------------------------
 
+(def ^:const result-limit
+  "How many results to return when chain filtering"
+  100)
+
 (def ^:private ParamMapping
   {:parameter_id su/NonBlankString
    #_:target     #_s/Any
@@ -548,7 +552,7 @@
   ([dashboard                   :- su/Map
     param-key                   :- su/NonBlankString
     constraint-param-key->value :- su/Map
-    prefix                      :- (s/maybe su/NonBlankString)]
+    query                       :- (s/maybe su/NonBlankString)]
    (let [dashboard (hydrate dashboard :resolved-params)]
      (when-not (get (:resolved-params dashboard) param-key)
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
@@ -561,9 +565,9 @@
        ;; TODO - we should combine these all into a single UNION ALL query against the data warehouse instead of doing a
        ;; separate query for each Field (for parameters that are mapped to more than one Field)
        (try
-         (let [results (distinct (mapcat (if (seq prefix)
-                                           #(chain-filter/chain-filter-search % constraints prefix)
-                                           #(chain-filter/chain-filter % constraints))
+         (let [results (distinct (mapcat (if (seq query)
+                                           #(chain-filter/chain-filter-search % constraints query :limit result-limit)
+                                           #(chain-filter/chain-filter % constraints :limit result-limit))
                                          field-ids))]
            ;; results can come back as [v ...] *or* as [[orig remapped] ...]. Sort by remapped value if that's the case
            (if (sequential? (first results))
@@ -584,16 +588,18 @@
   (let [dashboard (api/read-check Dashboard id)]
     (chain-filter dashboard param-key query-params)))
 
-(api/defendpoint GET "/:id/params/:param-key/search/:prefix"
-  "Fetch possible values of the parameter whose ID is `:param-key` that start with with `:prefix`. Optionally restrict
+(api/defendpoint GET "/:id/params/:param-key/search/:query"
+  "Fetch possible values of the parameter whose ID is `:param-key` that contain `:query`. Optionally restrict
   these values by passing query parameters like `other-parameter=value` e.g.
 
-    ;; fetch values for Dashboard 1 parameter 'abc' that start with 'Cam' and are possible when parameter 'def' is set
+    ;; fetch values for Dashboard 1 parameter 'abc' that contain 'Cam' and are possible when parameter 'def' is set
     ;; to 100
-     GET /api/dashboard/1/params/abc/search/Cam?def=100"
-  [id param-key prefix :as {:keys [query-params]}]
+     GET /api/dashboard/1/params/abc/search/Cam?def=100
+
+  Currently limited to first 100 results"
+  [id param-key query :as {:keys [query-params]}]
   (let [dashboard (api/read-check Dashboard id)]
-    (chain-filter dashboard param-key query-params prefix)))
+    (chain-filter dashboard param-key query-params query)))
 
 (api/defendpoint GET "/params/valid-filter-fields"
   "Utility endpoint for powering Dashboard UI. Given some set of `filtered` Field IDs (presumably Fields used in

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -478,12 +478,12 @@
     (binding [api/*current-user-permissions-set* (atom #{"/"})]
       (dashboard-api/chain-filter dashboard param-key query-params))))
 
-(api/defendpoint GET "/dashboard/:uuid/params/:param-key/search/:prefix"
-  "Fetch filter values for dashboard parameter `param-key`, with specified `prefix`."
-  [uuid param-key prefix :as {:keys [query-params]}]
+(api/defendpoint GET "/dashboard/:uuid/params/:param-key/search/:query"
+  "Fetch filter values for dashboard parameter `param-key`, containing specified `query`."
+  [uuid param-key query :as {:keys [query-params]}]
   (let [dashboard (dashboard-with-uuid uuid)]
     (binding [api/*current-user-permissions-set* (atom #{"/"})]
-      (dashboard-api/chain-filter dashboard param-key query-params prefix))))
+      (dashboard-api/chain-filter dashboard param-key query-params query))))
 
 ;;; ----------------------------------------------------- Pivot Tables -----------------------------------------------
 

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -719,13 +719,13 @@
 (defn- do-with-chain-filter-fixtures [f]
   (with-embedding-enabled-and-new-secret-key
     (dashboard-api-test/with-chain-filter-fixtures [{:keys [dashboard], :as m}]
-      (db/update! Dashboard (u/get-id dashboard) :enable_embedding true)
+      (db/update! Dashboard (u/the-id dashboard) :enable_embedding true)
       (letfn [(token [params]
                 (dash-token dashboard (when params {:params params})))
               (values-url [& [params]]
                 (format "embed/dashboard/%s/params/_CATEGORY_ID_/values" (token params)))
               (search-url [& [params]]
-                (format "embed/dashboard/%s/params/_CATEGORY_NAME_/search/s" (token params)))]
+                (format "embed/dashboard/%s/params/_CATEGORY_NAME_/search/food" (token params)))]
         (f (assoc m
                   :token token
                   :values-url values-url
@@ -737,11 +737,11 @@
 (deftest chain-filter-embedding-disabled-test
   (with-chain-filter-fixtures [{:keys [dashboard values-url search-url]}]
     (testing "without embedding enabled for dashboard"
-      (db/update! Dashboard (u/get-id dashboard) :enable_embedding false)
+      (db/update! Dashboard (u/the-id dashboard) :enable_embedding false)
       (testing "GET /api/embed/dashboard/:token/params/:param-key/values"
         (is (= "Embedding is not enabled for this object."
                (http/client :get 400 (values-url)))))
-      (testing "GET /api/embed/dashboard/:token/params/:param-key/search/:prefix"
+      (testing "GET /api/embed/dashboard/:token/params/:param-key/search/:query"
         (is (= "Embedding is not enabled for this object."
                (http/client :get 400 (search-url))))))))
 
@@ -751,7 +751,7 @@
       (testing "\nGET /api/embed/dashboard/:token/params/:param-key/values"
         (is (= "Cannot search for values: \"category_id\" is not an enabled parameter."
                (http/client :get 400 (values-url)))))
-      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:prefix"
+      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:query"
         (is (= "Cannot search for values: \"category_name\" is not an enabled parameter."
                (http/client :get 400 (search-url))))))))
 
@@ -763,24 +763,24 @@
       (testing "\nGET /api/embed/dashboard/:token/params/:param-key/values"
         (is (= [2 3 4 5 6]
                (take 5 (http/client :get 200 (values-url))))))
-      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:prefix"
-        (is (= ["Scandinavian" "Seafood" "South Pacific"]
+      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:query"
+        (is (= ["Fast Food" "Food Truck" "Seafood"]
                (take 3 (http/client :get 200 (search-url)))))))
 
     (testing "If an ENABLED constraint param is present in the JWT, that's ok"
       (testing "\nGET /api/embed/dashboard/:token/params/:param-key/values"
         (is (= [40 67]
                (http/client :get 200 (values-url {"price" 4})))))
-      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:prefix"
-        (is (= ["Steakhouse"]
+      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:query"
+        (is (= []
                (http/client :get 200 (search-url {"price" 4}))))))
 
     (testing "If an ENABLED param is present in query params but *not* the JWT, that's ok"
       (testing "\nGET /api/embed/dashboard/:token/params/:param-key/values"
         (is (= [40 67]
                (http/client :get 200 (str (values-url) "?_PRICE_=4")))))
-      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:prefix"
-        (is (= ["Steakhouse"]
+      (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:query"
+        (is (= []
                (http/client :get 200 (str (search-url) "?_PRICE_=4"))))))
 
     (testing "If ENABLED param is present in both JWT and the URL, the request should fail"
@@ -800,10 +800,10 @@
         (testing "Should work if the param we're fetching values for is enabled"
           (testing "\nGET /api/embed/dashboard/:token/params/:param-key/values"
             (is (= [2 3 4 5 6]
-                   (take 5 ((mt/user->client :rasta) :get 200 (values-url))))))
-          (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:prefix"
-            (is (= ["Scandinavian" "Seafood" "South Pacific"]
-                   (take 3 ((mt/user->client :rasta) :get 200 (search-url)))))))))))
+                   (take 5 (mt/user-http-request :rasta :get 200 (values-url))))))
+          (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:query"
+            (is (= ["Fast Food" "Food Truck" "Seafood"]
+                   (take 3 (mt/user-http-request :rasta :get 200 (search-url)))))))))))
 
 (deftest chain-filter-locked-params-test
   (with-chain-filter-fixtures [{:keys [dashboard param-keys values-url search-url]}]
@@ -829,8 +829,8 @@
         (testing "\nGET /api/embed/dashboard/:token/params/:param-key/values"
           (is (= [40 67]
                  (http/client :get 200 (values-url {"price" 4})))))
-        (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:prefix"
-          (is (= ["Steakhouse"]
+        (testing "\nGET /api/embed/dashboard/:token/params/:param-key/search/:query"
+          (is (= []
                  (http/client :get 200 (search-url {"price" 4}))))))
 
       (testing "if `:locked` parameter is present in URL params, request should fail"

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1008,9 +1008,9 @@
           (let [url (format "public/dashboard/%s/params/%s/values" uuid (:category-id param-keys))]
             (is (= [2 3 4 5 6]
                    (take 5 (http/client :get 200 url))))))
-        (testing "GET /api/public/dashboard/:uuid/params/:param-key/search/:prefix"
-          (let [url (format "public/dashboard/%s/params/%s/search/s" uuid (:category-name param-keys))]
-            (is (= ["Scandinavian" "Seafood" "South Pacific"]
+        (testing "GET /api/public/dashboard/:uuid/params/:param-key/search/:query"
+          (let [url (format "public/dashboard/%s/params/%s/search/food" uuid (:category-name param-keys))]
+            (is (= ["Fast Food" "Food Truck" "Seafood"]
                    (take 3 (http/client :get 200 url))))))))))
 
 (deftest chain-filter-ignore-current-user-permissions-test
@@ -1025,11 +1025,11 @@
             (testing "GET /api/public/dashboard/:uuid/params/:param-key/values"
               (let [url (format "public/dashboard/%s/params/%s/values" uuid (:category-id param-keys))]
                 (is (= [2 3 4 5 6]
-                       (take 5 ((mt/user->client :rasta) :get 200 url))))))
+                       (take 5 (mt/user-http-request :rasta :get 200 url))))))
             (testing "GET /api/public/dashboard/:uuid/params/:param-key/search/:prefix"
-              (let [url (format "public/dashboard/%s/params/%s/search/s" uuid (:category-name param-keys))]
-                (is (= ["Scandinavian" "Seafood" "South Pacific"]
-                       (take 3 ((mt/user->client :rasta) :get 200 url))))))))))))
+              (let [url (format "public/dashboard/%s/params/%s/search/food" uuid (:category-name param-keys))]
+                (is (= ["Fast Food" "Food Truck" "Seafood"]
+                       (take 3 (mt/user-http-request :rasta :get 200 url))))))))))))
 
 ;; Pivot tables
 

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -161,11 +161,11 @@
                (chain-filter/filterable-field-ids %venues.price #{})))))))
 
 (deftest chain-filter-search-test
-  (testing "Show me categories starting with s (case-insensitive) that have expensive restaurants"
+  (testing "Show me categories containing 'eak' (case-insensitive) that have expensive restaurants"
     (is (= ["Steakhouse"]
-           (mt/$ids (chain-filter/chain-filter-search %categories.name {%venues.price 4} "s")))))
-  (testing "Show me cheap restaurants starting with 'taco' (case-insensitive)"
-    (is (= ["Tacos Villa Corona"]
+           (mt/$ids (chain-filter/chain-filter-search %categories.name {%venues.price 4} "eak")))))
+  (testing "Show me cheap restaurants including with 'taco' (case-insensitive)"
+    (is (= ["Tacos Villa Corona" "Tito's Tacos"]
            (mt/$ids (chain-filter/chain-filter-search %venues.name {%venues.price 1} "tAcO")))))
   (testing "search for something crazy = should return empty results"
     (is (= []
@@ -209,15 +209,15 @@
 
 (deftest human-readable-values-remapped-chain-filter-search-test
   (with-human-readable-values-remapping
-    (testing "Show me category IDs [whose name] starts with s"
+    (testing "Show me category IDs [whose name] contains 'bar'"
       (doseq [constraints [nil {}]]
         (testing (format "\nconstraints = %s" (pr-str constraints))
-          (is (= [[64 "Southern"]
-                  [67 "Steakhouse"]]
-                 (mt/$ids (chain-filter/chain-filter-search %venues.category_id constraints "s")))))))
-    (testing "Show me category IDs [whose name] starts with s that have expensive restaurants"
+          (is (= [[7 "Bar"]
+                  [74 "Wine Bar"]]
+                 (mt/$ids (chain-filter/chain-filter-search %venues.category_id constraints "bar")))))))
+    (testing "Show me category IDs [whose name] contains 'house' that have expensive restaurants"
       (is (= [[67 "Steakhouse"]]
-             (mt/$ids (chain-filter/chain-filter-search %venues.category_id {%venues.price 4} "s")))))
+             (mt/$ids (chain-filter/chain-filter-search %venues.category_id {%venues.price 4} "house")))))
     (testing "search for something crazy: should return empty results"
       (is (= []
              (mt/$ids (chain-filter/chain-filter-search %venues.category_id {%venues.price 4} "zzzzz")))))))
@@ -241,15 +241,16 @@
 
 (deftest field-to-field-remapped-chain-filter-search-test
   (testing "Field-to-field remapping: venues.category_id -> categories.name\n"
-    (testing "Show me venue IDs that [have a remapped name that] start with s"
-      (is (= [[90 "Señor Fish"]
-              [46 "Shanghai Dumpling King"]
-              [65 "Slate"]]
-             (take 3 (chain-filter/chain-filter-search (mt/id :venues :id) nil "s")))))
-    (testing "Show me venue IDs that [have a remapped name that] start with s that are expensive"
+    (testing "Show me venue IDs that [have a remapped name that] contains 'sushi'"
+      (is (= [[76 "Beyond Sushi"]
+              [80 "Blue Ribbon Sushi"]
+              [77 "Sushi Nakazawa"]]
+             (take 3 (chain-filter/chain-filter-search (mt/id :venues :id) nil "sushi")))))
+    (testing "Show me venue IDs that [have a remapped name that] contain 'sushi' that are expensive"
       (is (= [[77 "Sushi Nakazawa"]
-              [79 "Sushi Yasuda"]]
-             (mt/$ids (chain-filter/chain-filter-search %venues.id {%venues.price 4} "s")))))
+              [79 "Sushi Yasuda"]
+              [81 "Tanoshi Sushi & Sake Bar"]]
+             (mt/$ids (chain-filter/chain-filter-search %venues.id {%venues.price 4} "sushi")))))
     (testing "search for something crazy = should return empty results"
       (is (= []
              (mt/$ids (chain-filter/chain-filter-search %venues.id {%venues.price 4} "zzzzz")))))))
@@ -281,15 +282,16 @@
 
 (deftest fk-field-to-field-remapped-chain-filter-search-test
   (with-fk-field-to-field-remapping
-    (testing "Show me categories starting with s"
+    (testing "Show me categories containing 'ar'"
       (doseq [constraints [nil {}]]
         (testing (format "\nconstraints = %s" (pr-str constraints))
-          (is (= [[64 "Southern"]
-                  [67 "Steakhouse"]]
-                 (take 3 (mt/$ids (chain-filter/chain-filter-search %venues.category_id constraints "s"))))))))
-    (testing "Show me categories starting with s that have expensive restaurants"
+          (is (= [[3 "Artisan"]
+                  [7 "Bar"]
+                  [14 "Caribbean"]]
+                 (take 3 (mt/$ids (chain-filter/chain-filter-search %venues.category_id constraints "ar"))))))))
+    (testing "Show me categories containing 'house' that have expensive restaurants"
       (is (= [[67 "Steakhouse"]]
-             (mt/$ids (chain-filter/chain-filter-search %venues.category_id {%venues.price 4} "s")))))
+             (mt/$ids (chain-filter/chain-filter-search %venues.category_id {%venues.price 4} "house")))))
     (testing "search for something crazy = should return empty results"
       (is (= []
              (mt/$ids (chain-filter/chain-filter-search %venues.category_id {%venues.price 4} "zzzzz")))))))


### PR DESCRIPTION
Resolves #8219

**Description**
1. Updates name of endpoint path variable to `query` to match what it is now named in the BE
2. Replaces client-side prefix search with `includes` search

**Verification**
cherry-picked the commit in this PR to https://github.com/metabase/metabase/pull/15153:

search endpoint:
<img width="443" alt="Screen Shot 2021-03-12 at 2 35 57 PM" src="https://user-images.githubusercontent.com/13057258/111005908-97a12c80-8340-11eb-910d-a47a86fe9047.png">

client-side:
<img width="433" alt="Screen Shot 2021-03-12 at 2 32 35 PM" src="https://user-images.githubusercontent.com/13057258/111005911-98d25980-8340-11eb-99df-61a2a6cc92e2.png">
