### PR TITLE
Add Cypress custom command for sandboxing tables

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -100,11 +100,9 @@ describeWithToken("formatting > sandboxes", () => {
       // Orders join Products
       createJoinedQuestion(QUESTION_NAME);
 
-      // Sandbox Orders table on "User ID"
-      cy.request("POST", "/api/mt/gtap", {
-        group_id: DATA_GROUP,
+      cy.sandbox({
         table_id: ORDERS_ID,
-        card_id: null,
+        group_id: DATA_GROUP,
         attribute_remappings: {
           [USER_ATTRIBUTE]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
@@ -126,11 +124,10 @@ describeWithToken("formatting > sandboxes", () => {
           },
         },
       }).then(({ body: { id: QUESTION_ID } }) => {
-        // Sandbox `People` table based on previously created SQL question
-        cy.request("POST", "/api/mt/gtap", {
-          group_id: DATA_GROUP,
+        cy.sandbox({
           table_id: PEOPLE_ID,
           card_id: QUESTION_ID,
+          group_id: DATA_GROUP,
           attribute_remappings: {
             [USER_ATTRIBUTE]: ["dimension", ["template-tag", TTAG_NAME]],
           },
@@ -214,15 +211,11 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {
-      cy.log("Sandbox `People` table on `user_id` attribute for `data` group");
-
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: PEOPLE_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", PEOPLE.ID]],
         },
-        card_id: null,
-        group_id: COLLECTION_GROUP,
-        table_id: PEOPLE_ID,
       });
 
       cy.updatePermissionsSchemas({
@@ -273,15 +266,11 @@ describeWithToken("formatting > sandboxes", () => {
       const QUESTION_NAME = "EE_548";
       const CC_NAME = "CC_548"; // Custom column
 
-      cy.log("Sandbox `Orders` table on `user_id` attribute");
-
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
-        card_id: null,
-        group_id: COLLECTION_GROUP,
-        table_id: ORDERS_ID,
       });
 
       cy.updatePermissionsSchemas({
@@ -342,15 +331,11 @@ describeWithToken("formatting > sandboxes", () => {
           });
         }
 
-        cy.log("Sandbox `Orders` table on `user_id` attribute");
-
-        cy.request("POST", "/api/mt/gtap", {
+        cy.sandbox({
+          table_id: ORDERS_ID,
           attribute_remappings: {
             [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
           },
-          card_id: null,
-          group_id: COLLECTION_GROUP,
-          table_id: ORDERS_ID,
         });
 
         cy.updatePermissionsSchemas({
@@ -415,15 +400,11 @@ describeWithToken("formatting > sandboxes", () => {
       const PRODUCTS_ALIAS = "Products";
       const QUESTION_NAME = "EE_535";
 
-      cy.log("Sandbox `Orders` table on `user_id` attribute");
-
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
-        card_id: null,
-        group_id: COLLECTION_GROUP,
-        table_id: ORDERS_ID,
       });
 
       cy.updatePermissionsSchemas({
@@ -515,17 +496,12 @@ describeWithToken("formatting > sandboxes", () => {
             filter: [">", ["field-id", ORDERS.TOTAL], 10],
           },
         }).then(({ body: { id: CARD_ID } }) => {
-          cy.log(
-            "Sandbox `Orders` table based on this QB question and user attribute",
-          );
-
-          cy.request("POST", "/api/mt/gtap", {
+          cy.sandbox({
+            table_id: ORDERS_ID,
+            card_id: CARD_ID,
             attribute_remappings: {
               [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
             },
-            card_id: CARD_ID,
-            group_id: COLLECTION_GROUP,
-            table_id: ORDERS_ID,
           });
         });
 
@@ -537,17 +513,12 @@ describeWithToken("formatting > sandboxes", () => {
             filter: [">", ["field-id", PRODUCTS.PRICE], 10],
           },
         }).then(({ body: { id: CARD_ID } }) => {
-          cy.log(
-            "Sandbox `Products` table based on this QB question and user attribute",
-          );
-
-          cy.request("POST", "/api/mt/gtap", {
+          cy.sandbox({
+            table_id: PRODUCTS_ID,
+            card_id: CARD_ID,
             attribute_remappings: {
               [ATTR_CAT]: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
             },
-            card_id: CARD_ID,
-            group_id: COLLECTION_GROUP,
-            table_id: PRODUCTS_ID,
           });
         });
 
@@ -617,15 +588,12 @@ describeWithToken("formatting > sandboxes", () => {
               ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
               : null;
 
-            cy.log("Sandbox `Orders` table based on this question");
-
-            cy.request("POST", "/api/mt/gtap", {
+            cy.sandbox({
+              table_id: ORDERS_ID,
+              card_id: CARD_ID,
               attribute_remappings: {
                 [ATTR_UID]: ["variable", ["template-tag", "sandbox"]],
               },
-              card_id: CARD_ID,
-              group_id: COLLECTION_GROUP,
-              table_id: ORDERS_ID,
             });
           });
 
@@ -651,15 +619,12 @@ describeWithToken("formatting > sandboxes", () => {
                 })
               : null;
 
-            cy.log("Sandbox `Products` table based on this question");
-
-            cy.request("POST", "/api/mt/gtap", {
+            cy.sandbox({
+              table_id: PRODUCTS_ID,
+              card_id: CARD_ID,
               attribute_remappings: {
                 [ATTR_CAT]: ["variable", ["template-tag", "sandbox"]],
               },
-              card_id: CARD_ID,
-              group_id: COLLECTION_GROUP,
-              table_id: PRODUCTS_ID,
             });
           });
 
@@ -716,12 +681,8 @@ describeWithToken("formatting > sandboxes", () => {
         cy.server();
         cy.route("POST", "/api/dataset").as("dataset");
 
-        cy.log("Sandbox `Orders` table based on user attribute `attr_uid`");
-
-        cy.request("POST", "/api/mt/gtap", {
+        cy.sandbox({
           table_id: ORDERS_ID,
-          group_id: COLLECTION_GROUP,
-          card_id: null,
           attribute_remappings: {
             [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
           },
@@ -762,26 +723,18 @@ describeWithToken("formatting > sandboxes", () => {
           });
         }
 
-        cy.log("Sandbox `Orders` table");
-
-        cy.request("POST", "/api/mt/gtap", {
+        cy.sandbox({
+          table_id: ORDERS_ID,
           attribute_remappings: {
             user_id: ["dimension", ["field-id", ORDERS.USER_ID]],
           },
-          card_id: null,
-          table_id: ORDERS_ID,
-          group_id: COLLECTION_GROUP,
         });
 
-        cy.log("Sandbox `Products` table");
-
-        cy.request("POST", "/api/mt/gtap", {
+        cy.sandbox({
+          table_id: PRODUCTS_ID,
           attribute_remappings: {
             user_cat: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
           },
-          card_id: null,
-          table_id: PRODUCTS_ID,
-          group_id: COLLECTION_GROUP,
         });
 
         cy.updatePermissionsSchemas({
@@ -911,24 +864,18 @@ describeWithToken("formatting > sandboxes", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
-      cy.log("Sandbox `Orders` table");
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
-        card_id: null,
-        table_id: ORDERS_ID,
-        group_id: COLLECTION_GROUP,
       });
 
-      cy.log("Sandbox `Products` table");
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: PRODUCTS_ID,
         attribute_remappings: {
           [ATTR_CAT]: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
         },
-        card_id: null,
-        table_id: PRODUCTS_ID,
-        group_id: COLLECTION_GROUP,
       });
 
       cy.updatePermissionsSchemas({
@@ -970,34 +917,25 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should work with pivot tables (metabase#14969)", () => {
-      cy.log("Sandbox `Orders` table");
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
-        card_id: null,
-        table_id: ORDERS_ID,
-        group_id: COLLECTION_GROUP,
       });
 
-      cy.log("**-- 2. Sandbox `People` table --**");
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: PEOPLE_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", PEOPLE.ID]],
         },
-        card_id: null,
-        table_id: PEOPLE_ID,
-        group_id: COLLECTION_GROUP,
       });
 
-      cy.log("**-- 3. Sandbox `Products` table --**");
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandbox({
+        table_id: PRODUCTS_ID,
         attribute_remappings: {
           [ATTR_CAT]: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
         },
-        card_id: null,
-        table_id: PRODUCTS_ID,
-        group_id: COLLECTION_GROUP,
       });
 
       cy.updatePermissionsSchemas({

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -134,16 +134,6 @@ describeWithToken("formatting > sandboxes", () => {
         });
       });
 
-      cy.updatePermissionsSchemas({
-        schemas: {
-          PUBLIC: {
-            [ORDERS_ID]: { query: "segmented", read: "all" },
-            [PEOPLE_ID]: { query: "segmented", read: "all" },
-          },
-        },
-        user_group: DATA_GROUP,
-      });
-
       signOut();
       signInAsNormalUser();
     });
@@ -222,7 +212,6 @@ describeWithToken("formatting > sandboxes", () => {
         schemas: {
           PUBLIC: {
             [ORDERS_ID]: "all",
-            [PEOPLE_ID]: { query: "segmented", read: "all" },
             [PRODUCTS_ID]: "all",
             [REVIEWS_ID]: "all",
           },
@@ -270,14 +259,6 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
-        },
-      });
-
-      cy.updatePermissionsSchemas({
-        schemas: {
-          PUBLIC: {
-            [ORDERS_ID]: { query: "segmented", read: "all" },
-          },
         },
       });
 
@@ -342,7 +323,6 @@ describeWithToken("formatting > sandboxes", () => {
           schemas: {
             PUBLIC: {
               [PRODUCTS_ID]: "all",
-              [ORDERS_ID]: { query: "segmented", read: "all" },
             },
           },
         });
@@ -411,7 +391,6 @@ describeWithToken("formatting > sandboxes", () => {
         schemas: {
           PUBLIC: {
             [PRODUCTS_ID]: "all",
-            [ORDERS_ID]: { query: "segmented", read: "all" },
           },
         },
       });
@@ -522,15 +501,6 @@ describeWithToken("formatting > sandboxes", () => {
           });
         });
 
-        cy.updatePermissionsSchemas({
-          schemas: {
-            PUBLIC: {
-              [PRODUCTS_ID]: { query: "segmented", read: "all" },
-              [ORDERS_ID]: { query: "segmented", read: "all" },
-            },
-          },
-        });
-
         signOut();
         signInAsSandboxedUser();
 
@@ -628,15 +598,6 @@ describeWithToken("formatting > sandboxes", () => {
             });
           });
 
-          cy.updatePermissionsSchemas({
-            schemas: {
-              PUBLIC: {
-                [PRODUCTS_ID]: { query: "segmented", read: "all" },
-                [ORDERS_ID]: { query: "segmented", read: "all" },
-              },
-            },
-          });
-
           signOut();
           signInAsSandboxedUser();
 
@@ -691,7 +652,6 @@ describeWithToken("formatting > sandboxes", () => {
         cy.updatePermissionsSchemas({
           schemas: {
             PUBLIC: {
-              [ORDERS_ID]: { query: "segmented", read: "all" },
               [PRODUCTS_ID]: "all",
             },
           },
@@ -736,17 +696,6 @@ describeWithToken("formatting > sandboxes", () => {
             user_cat: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
           },
         });
-
-        cy.updatePermissionsSchemas({
-          schemas: {
-            PUBLIC: {
-              [PRODUCTS_ID]: { query: "segmented", read: "all" },
-              [ORDERS_ID]: { query: "segmented", read: "all" },
-            },
-          },
-        });
-
-        cy.log("Create question with joins");
 
         cy.createQuestion({
           name: QUESTION_NAME,
@@ -878,15 +827,6 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      cy.updatePermissionsSchemas({
-        schemas: {
-          PUBLIC: {
-            [PRODUCTS_ID]: { query: "segmented", read: "all" },
-            [ORDERS_ID]: { query: "segmented", read: "all" },
-          },
-        },
-      });
-
       signOut();
       signInAsSandboxedUser();
       createJoinedQuestion("14841").then(({ body: { id: QUESTION_ID } }) => {
@@ -935,16 +875,6 @@ describeWithToken("formatting > sandboxes", () => {
         table_id: PRODUCTS_ID,
         attribute_remappings: {
           [ATTR_CAT]: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
-        },
-      });
-
-      cy.updatePermissionsSchemas({
-        schemas: {
-          PUBLIC: {
-            [PRODUCTS_ID]: { query: "segmented", read: "all" },
-            [ORDERS_ID]: { query: "segmented", read: "all" },
-            [PEOPLE_ID]: { query: "segmented", read: "all" },
-          },
         },
       });
 
@@ -1001,23 +931,13 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it.skip("should show dashboard subscriptions for sandboxed user (metabase#14990)", () => {
-      cy.log("Sandbox `Orders` table");
-      cy.request("POST", "/api/mt/gtap", {
+      cy.sandboxTable({
+        table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
-        card_id: null,
-        table_id: ORDERS_ID,
-        group_id: COLLECTION_GROUP,
       });
 
-      cy.updatePermissionsSchemas({
-        schemas: {
-          PUBLIC: {
-            [ORDERS_ID]: { query: "segmented", read: "all" },
-          },
-        },
-      });
       signInAsSandboxedUser();
       cy.visit("/dashboard/1");
       cy.icon("share").click();

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -100,7 +100,7 @@ describeWithToken("formatting > sandboxes", () => {
       // Orders join Products
       createJoinedQuestion(QUESTION_NAME);
 
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: ORDERS_ID,
         group_id: DATA_GROUP,
         attribute_remappings: {
@@ -124,7 +124,7 @@ describeWithToken("formatting > sandboxes", () => {
           },
         },
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.sandbox({
+        cy.sandboxTable({
           table_id: PEOPLE_ID,
           card_id: QUESTION_ID,
           group_id: DATA_GROUP,
@@ -211,7 +211,7 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: PEOPLE_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", PEOPLE.ID]],
@@ -266,7 +266,7 @@ describeWithToken("formatting > sandboxes", () => {
       const QUESTION_NAME = "EE_548";
       const CC_NAME = "CC_548"; // Custom column
 
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
@@ -331,7 +331,7 @@ describeWithToken("formatting > sandboxes", () => {
           });
         }
 
-        cy.sandbox({
+        cy.sandboxTable({
           table_id: ORDERS_ID,
           attribute_remappings: {
             [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
@@ -400,7 +400,7 @@ describeWithToken("formatting > sandboxes", () => {
       const PRODUCTS_ALIAS = "Products";
       const QUESTION_NAME = "EE_535";
 
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
@@ -496,7 +496,7 @@ describeWithToken("formatting > sandboxes", () => {
             filter: [">", ["field-id", ORDERS.TOTAL], 10],
           },
         }).then(({ body: { id: CARD_ID } }) => {
-          cy.sandbox({
+          cy.sandboxTable({
             table_id: ORDERS_ID,
             card_id: CARD_ID,
             attribute_remappings: {
@@ -513,7 +513,7 @@ describeWithToken("formatting > sandboxes", () => {
             filter: [">", ["field-id", PRODUCTS.PRICE], 10],
           },
         }).then(({ body: { id: CARD_ID } }) => {
-          cy.sandbox({
+          cy.sandboxTable({
             table_id: PRODUCTS_ID,
             card_id: CARD_ID,
             attribute_remappings: {
@@ -588,7 +588,7 @@ describeWithToken("formatting > sandboxes", () => {
               ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
               : null;
 
-            cy.sandbox({
+            cy.sandboxTable({
               table_id: ORDERS_ID,
               card_id: CARD_ID,
               attribute_remappings: {
@@ -619,7 +619,7 @@ describeWithToken("formatting > sandboxes", () => {
                 })
               : null;
 
-            cy.sandbox({
+            cy.sandboxTable({
               table_id: PRODUCTS_ID,
               card_id: CARD_ID,
               attribute_remappings: {
@@ -681,7 +681,7 @@ describeWithToken("formatting > sandboxes", () => {
         cy.server();
         cy.route("POST", "/api/dataset").as("dataset");
 
-        cy.sandbox({
+        cy.sandboxTable({
           table_id: ORDERS_ID,
           attribute_remappings: {
             [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
@@ -723,14 +723,14 @@ describeWithToken("formatting > sandboxes", () => {
           });
         }
 
-        cy.sandbox({
+        cy.sandboxTable({
           table_id: ORDERS_ID,
           attribute_remappings: {
             user_id: ["dimension", ["field-id", ORDERS.USER_ID]],
           },
         });
 
-        cy.sandbox({
+        cy.sandboxTable({
           table_id: PRODUCTS_ID,
           attribute_remappings: {
             user_cat: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
@@ -864,14 +864,14 @@ describeWithToken("formatting > sandboxes", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
       });
 
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: PRODUCTS_ID,
         attribute_remappings: {
           [ATTR_CAT]: ["dimension", ["field-id", PRODUCTS.CATEGORY]],
@@ -917,21 +917,21 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("should work with pivot tables (metabase#14969)", () => {
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: ORDERS_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", ORDERS.USER_ID]],
         },
       });
 
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: PEOPLE_ID,
         attribute_remappings: {
           [ATTR_UID]: ["dimension", ["field-id", PEOPLE.ID]],
         },
       });
 
-      cy.sandbox({
+      cy.sandboxTable({
         table_id: PRODUCTS_ID,
         attribute_remappings: {
           [ATTR_CAT]: ["dimension", ["field-id", PRODUCTS.CATEGORY]],

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -53,6 +53,32 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  "sandbox",
+  ({
+    attribute_remappings = {},
+    card_id = null,
+    group_id = 4,
+    table_id = 2,
+  } = {}) => {
+    // Extract the name of the table
+    cy.request("GET", "/api/table").then(({ body: tables }) => {
+      const [{ name }] = tables.filter(table => {
+        return table.id === table_id;
+      });
+      const [attr] = Object.keys(attribute_remappings);
+
+      cy.log(`Sandbox "${name}" table on "${attr}" attribute`);
+      cy.request("POST", "/api/mt/gtap", {
+        attribute_remappings,
+        card_id,
+        group_id,
+        table_id,
+      });
+    });
+  },
+);
+
 /**
  * PERMISSIONS
  *

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -143,10 +143,12 @@ Cypress.Commands.add(
   } = {}) => {
     // Extract the name of the table, as well as `schema` and `db_id` that we'll need later on for `cy.updatePermissionsSchemas()`
     cy.request("GET", "/api/table").then(({ body: tables }) => {
-      const { name, schema, db_id } = tables.find(table => table.id === table_id);
-      const [attr] = Object.keys(attribute_remappings);
+      const { name, schema, db_id } = tables.find(
+        table => table.id === table_id,
+      );
+      const attr = Object.keys(attribute_remappings).join(", "); // Account for the possiblity of passing multiple user attributes
 
-      cy.log(`Sandbox "${name}" table on "${attr}" attribute`);
+      cy.log(`Sandbox "${name}" table on "${attr}"`);
       cy.request("POST", "/api/mt/gtap", {
         attribute_remappings,
         card_id,

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -94,7 +94,6 @@ Cypress.Commands.add(
       throw new Error("`schemas` must be an object!");
     }
 
-    cy.log("Fetch permissions graph");
     cy.request("GET", "/api/permissions/graph").then(
       ({ body: { groups, revision } }) => {
         const UPDATED_GROUPS = Object.assign(groups, {
@@ -142,9 +141,9 @@ Cypress.Commands.add(
     group_id = 4,
     table_id = 2,
   } = {}) => {
-    // Extract the name of the table
+    // Extract the name of the table, as well as `schema` and `db_id` that we'll need later on for `cy.updatePermissionsSchemas()`
     cy.request("GET", "/api/table").then(({ body: tables }) => {
-      const [{ name }] = tables.filter(table => {
+      const [{ name, schema, db_id }] = tables.filter(table => {
         return table.id === table_id;
       });
       const [attr] = Object.keys(attribute_remappings);
@@ -155,6 +154,16 @@ Cypress.Commands.add(
         card_id,
         group_id,
         table_id,
+      });
+
+      cy.updatePermissionsSchemas({
+        schemas: {
+          [schema]: {
+            [table_id]: { query: "segmented", read: "all" },
+          },
+        },
+        user_group: group_id,
+        database_id: db_id,
       });
     });
   },

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -53,32 +53,6 @@ Cypress.Commands.add(
   },
 );
 
-Cypress.Commands.add(
-  "sandbox",
-  ({
-    attribute_remappings = {},
-    card_id = null,
-    group_id = 4,
-    table_id = 2,
-  } = {}) => {
-    // Extract the name of the table
-    cy.request("GET", "/api/table").then(({ body: tables }) => {
-      const [{ name }] = tables.filter(table => {
-        return table.id === table_id;
-      });
-      const [attr] = Object.keys(attribute_remappings);
-
-      cy.log(`Sandbox "${name}" table on "${attr}" attribute`);
-      cy.request("POST", "/api/mt/gtap", {
-        attribute_remappings,
-        card_id,
-        group_id,
-        table_id,
-      });
-    });
-  },
-);
-
 /**
  * PERMISSIONS
  *
@@ -159,6 +133,32 @@ Cypress.Commands.add("updateCollectionGraph", (groupsCollectionObject = {}) => {
     },
   );
 });
+
+Cypress.Commands.add(
+  "sandboxTable",
+  ({
+    attribute_remappings = {},
+    card_id = null,
+    group_id = 4,
+    table_id = 2,
+  } = {}) => {
+    // Extract the name of the table
+    cy.request("GET", "/api/table").then(({ body: tables }) => {
+      const [{ name }] = tables.filter(table => {
+        return table.id === table_id;
+      });
+      const [attr] = Object.keys(attribute_remappings);
+
+      cy.log(`Sandbox "${name}" table on "${attr}" attribute`);
+      cy.request("POST", "/api/mt/gtap", {
+        attribute_remappings,
+        card_id,
+        group_id,
+        table_id,
+      });
+    });
+  },
+);
 
 /**
  * OVERWRITES

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -143,9 +143,7 @@ Cypress.Commands.add(
   } = {}) => {
     // Extract the name of the table, as well as `schema` and `db_id` that we'll need later on for `cy.updatePermissionsSchemas()`
     cy.request("GET", "/api/table").then(({ body: tables }) => {
-      const [{ name, schema, db_id }] = tables.filter(table => {
-        return table.id === table_id;
-      });
+      const { name, schema, db_id } = tables.find(table => table.id === table_id);
       const [attr] = Object.keys(attribute_remappings);
 
       cy.log(`Sandbox "${name}" table on "${attr}" attribute`);

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -79,14 +79,11 @@ describeWithToken("postgres > user > query", () => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
 
-        cy.log("Sandbox `People` table");
-        cy.request("POST", "/api/mt/gtap", {
+        cy.sandbox({
+          table_id: PEOPLE_ID,
           attribute_remappings: {
             user_id: ["dimension", ["field-id", PEOPLE.ID]],
           },
-          card_id: null,
-          table_id: PEOPLE_ID,
-          group_id: COLLECTION_GROUP,
         });
 
         cy.updatePermissionsSchemas({

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -79,7 +79,7 @@ describeWithToken("postgres > user > query", () => {
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
 
-        cy.sandbox({
+        cy.sandboxTable({
           table_id: PEOPLE_ID,
           attribute_remappings: {
             user_id: ["dimension", ["field-id", PEOPLE.ID]],

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -86,15 +86,6 @@ describeWithToken("postgres > user > query", () => {
           },
         });
 
-        cy.updatePermissionsSchemas({
-          database_id: PG_DB_ID,
-          schemas: {
-            public: {
-              [PEOPLE_ID]: { query: "segmented", read: "all" },
-            },
-          },
-        });
-
         signOut();
         signInAsSandboxedUser();
         cy.visit(`/question/${QUESTION_ID}`);


### PR DESCRIPTION
### Status:
PENDING REVIEW

### What does this PR accomplish?
- Adds Cypress custom command for sandboxing tables `cy.sandboxTable()`
- Updates all related occurrences of sandboxes

### How to test this works?
- All tests should pass

### Additional notes:
- Log is now tucked inside a custom function so there is no need anymore to leave logs inside test itself
- It accepts 4 arguments:

| Argument              |            Type            | Default value | Description |
|-----------------------|:--------------------------:|:-------------:|:-----------:|
| `attribute_remapping` |           Object           |       {}      |             |
| `card_id`             | (null \| Number \| String) |      null     |             |
| `group_id`            |     (Number \| String)     |       4*       |             |
| `table_id`            | (Number \| String)         |       2**       |             |

_* "collections" group id_
_** "Orders" table id_

- It makes test easier to read 
- Custom command is "chainable" with Cypress' `then`
- Logs are now easier to read in the Cypress runner sidebar
![image](https://user-images.githubusercontent.com/31325167/109862476-c5abb000-7c60-11eb-86e2-34930d484cbe.png)
