### PR TITLE
Date range filters should respect the start-of-week Setting 📆 

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -8,6 +8,7 @@
             [honeysql.helpers :as h]
             [java-time :as t]
             [metabase.driver :as driver]
+            [metabase.driver.common :as driver.common]
             [metabase.driver.sql :as sql]
             [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
             [metabase.driver.sql.query-processor :as sql.qp]
@@ -347,9 +348,18 @@
 (defmethod sql.qp/date [:bigquery :quarter-of-year] [_ _ expr] (extract :quarter   expr))
 (defmethod sql.qp/date [:bigquery :year]            [_ _ expr] (trunc   :year      expr))
 
+;; BigQuery mod is a function like mod(x, y) rather than an operator like x mod y
+(defmethod hformat/fn-handler (u/qualified-name ::mod)
+  [_ x y]
+  (format "mod(%s, %s)" (hformat/to-sql x) (hformat/to-sql y)))
+
 (defmethod sql.qp/date [:bigquery :day-of-week]
-  [_ _ expr]
-  (sql.qp/adjust-day-of-week :bigquery (extract :dayofweek expr)))
+  [driver _ expr]
+  (sql.qp/adjust-day-of-week
+   driver
+   (extract :dayofweek expr)
+   (driver.common/start-of-week-offset driver)
+   (partial hsql/call (u/qualified-name ::mod))))
 
 (defmethod sql.qp/date [:bigquery :week]
   [_ _ expr]

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -14,6 +14,7 @@
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
+            [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.i18n :refer [trs]]
             [metabase.util.ssh :as ssh])
@@ -88,6 +89,11 @@
   [_]
   :sunday)
 
+;; Oracle mod is a function like mod(x, y) rather than an operator like x mod y
+(defmethod hformat/fn-handler (u/qualified-name ::mod)
+  [_ x y]
+  (format "mod(%s, %s)" (hformat/to-sql x) (hformat/to-sql y)))
+
 (defn- trunc
   "Truncate a date. See also this [table of format
   templates](http://docs.oracle.com/cd/B28359_01/olap.111/b28126/dml_functions_2071.htm#CJAEFAIA)
@@ -104,23 +110,33 @@
 (defmethod sql.qp/date [:oracle :day]            [_ _ v] (trunc :dd v))
 (defmethod sql.qp/date [:oracle :day-of-month]   [_ _ v] (hsql/call :extract :day v))
 ;; [SIC] The format template for truncating to start of week is 'day' in Oracle #WTF
-(defmethod sql.qp/date [:oracle :week]           [_ _ v] (sql.qp/adjust-start-of-week :oracle (partial trunc :day) v))
 (defmethod sql.qp/date [:oracle :month]          [_ _ v] (trunc :month v))
 (defmethod sql.qp/date [:oracle :month-of-year]  [_ _ v] (hsql/call :extract :month v))
 (defmethod sql.qp/date [:oracle :quarter]        [_ _ v] (trunc :q v))
 (defmethod sql.qp/date [:oracle :year]           [_ _ v] (trunc :year v))
 
-(defmethod sql.qp/date [:oracle :day-of-year] [driver _ v]
+(defmethod sql.qp/date [:oracle :week]
+  [driver _ v]
+  (sql.qp/adjust-start-of-week driver (partial trunc :day) v))
+
+(defmethod sql.qp/date [:oracle :day-of-year]
+  [driver _ v]
   (hx/inc (hx/- (sql.qp/date driver :day v) (trunc :year v))))
 
-(defmethod sql.qp/date [:oracle :quarter-of-year] [driver _ v]
+(defmethod sql.qp/date [:oracle :quarter-of-year]
+  [driver _ v]
   (hx// (hx/+ (sql.qp/date driver :month-of-year (sql.qp/date driver :quarter v))
               2)
         3))
 
 ;; subtract number of days between today and first day of week, then add one since first day of week = 1
-(defmethod sql.qp/date [:oracle :day-of-week] [driver _ v]
-  (sql.qp/adjust-day-of-week :oracle (hx/->integer (hsql/call :to_char v (hx/literal :d)))))
+(defmethod sql.qp/date [:oracle :day-of-week]
+  [driver _ v]
+  (sql.qp/adjust-day-of-week
+   driver
+   (hx/->integer (hsql/call :to_char v (hx/literal :d)))
+   (driver.common/start-of-week-offset driver)
+   (partial hsql/call (u/qualified-name ::mod))))
 
 (def ^:private now (hsql/raw "SYSDATE"))
 

--- a/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
@@ -89,21 +89,21 @@
 (defmethod sql.qp/date [:hive-like :year]            [_ _ expr] (hsql/call :trunc (hx/->timestamp expr) (hx/literal :year)))
 
 (defmethod sql.qp/date [:hive-like :day-of-week]
-  [_ _ expr]
-  (sql.qp/adjust-day-of-week :hive-like
+  [driver _ expr]
+  (sql.qp/adjust-day-of-week driver
                              (hx/->integer (date-format "u"
                                                         (hx/+ (hx/->timestamp expr)
                                                               (hsql/raw "interval '1' day"))))))
 
 (defmethod sql.qp/date [:hive-like :week]
-  [_ _ expr]
+  [driver _ expr]
   (let [week-extract-fn (fn [expr]
                           (hsql/call :date_sub
                             (hx/+ (hx/->timestamp expr)
                                   (hsql/raw "interval '1' day"))
                             (date-format "u" (hx/+ (hx/->timestamp expr)
                                                    (hsql/raw "interval '1' day")))))]
-    (sql.qp/adjust-start-of-week :hive-like week-extract-fn expr)))
+    (sql.qp/adjust-start-of-week driver week-extract-fn expr)))
 
 (defmethod sql.qp/date [:hive-like :quarter]
   [_ _ expr]

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -10,7 +10,8 @@
             [metabase.query-processor.context.default :as context.default]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [deferred-tru trs tru]])
+            [metabase.util.i18n :refer [deferred-tru trs tru]]
+            [schema.core :as s])
   (:import java.text.SimpleDateFormat
            org.joda.time.DateTime
            org.joda.time.format.DateTimeFormatter))
@@ -301,7 +302,7 @@
 (def ^:private days-of-week
   [:monday :tuesday :wednesday :thursday :friday :saturday :sunday])
 
-(defn start-of-week-offset
+(s/defn start-of-week-offset :- s/Int
   "Return the offset for start of week to have the week start on `setting/start-of-week` given  `driver`."
   [driver]
   (let [db-start-of-week     (.indexOf ^clojure.lang.PersistentVector days-of-week (driver/db-start-of-week driver))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -116,15 +116,22 @@
                                   (- offset) :day)
       (truncate-fn expr))))
 
-(defn adjust-day-of-week
+(s/defn adjust-day-of-week
   "Adjust day of week wrt start of week setting."
   ([driver day-of-week]
    (adjust-day-of-week driver day-of-week (driver.common/start-of-week-offset driver)))
+
   ([driver day-of-week offset]
+   (adjust-day-of-week driver day-of-week offset hx/mod))
+
+  ([driver
+    day-of-week
+    offset :- s/Int
+    mod-fn :- (s/pred fn?)]
    (if (not= offset 0)
      (hsql/call :case
-       (hsql/call := (hx/mod (hx/+ day-of-week offset) 7) 0) 7
-       :else                                                 (hx/mod (hx/+ day-of-week offset) 7))
+       (hsql/call := (mod-fn (hx/+ day-of-week offset) 7) 0) 7
+       :else                                                 (mod-fn (hx/+ day-of-week offset) 7))
      day-of-week)))
 
 (defmulti field->identifier

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -14,6 +14,7 @@
             [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync]
             [metabase.mbql.util :as mbql.u]
             [metabase.query-processor.context :as context]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.interface :as qp.i]
             [metabase.query-processor.reducible :as qp.reducible]
             [metabase.query-processor.store :as qp.store]
@@ -390,7 +391,7 @@
                                (execute-query! driver stmt)
                                (catch Throwable e
                                  (throw (ex-info (tru "Error executing query")
-                                                 {:sql sql, :params params}
+                                                 {:sql sql, :params params, :type qp.error-type/driver}
                                                  e))))]
      (let [rsmeta           (.getMetaData rs)
            results-metadata {:cols (column-metadata driver rsmeta)}]

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -210,17 +210,20 @@
   (string->boolean (get-string setting-definition-or-name)))
 
 (defn get-integer
-  "Get integer value of (presumably `:integer`) `setting-definition-or-name`. This is the default getter for `:integer` settings."
+  "Get integer value of (presumably `:integer`) `setting-definition-or-name`. This is the default getter for `:integer`
+  settings."
   ^Integer [setting-definition-or-name]
   (some-> (get-string setting-definition-or-name) Integer/parseInt))
 
 (defn get-double
-  "Get double value of (presumably `:double`) `setting-definition-or-name`. This is the default getter for `:double` settings."
+  "Get double value of (presumably `:double`) `setting-definition-or-name`. This is the default getter for `:double`
+  settings."
   ^Double [setting-definition-or-name]
   (some-> (get-string setting-definition-or-name) Double/parseDouble))
 
 (defn get-keyword
-  "Get value of (presumably `:string`) `setting-definition-or-name` as keyword. This is the default getter for `:keyword` settings."
+  "Get value of (presumably `:string`) `setting-definition-or-name` as keyword. This is the default getter for
+  `:keyword` settings."
   ^clojure.lang.Keyword [setting-definition-or-name]
   (some-> setting-definition-or-name get-string keyword))
 
@@ -230,7 +233,8 @@
   (json/parse-string (get-string setting-definition-or-name) keyword))
 
 (defn get-timestamp
-  "Get the string value of `setting-definition-or-name` and parse it as an ISO-8601-formatted string, returning a Timestamp."
+  "Get the string value of `setting-definition-or-name` and parse it as an ISO-8601-formatted string, returning a
+  Timestamp."
   [setting-definition-or-name]
   (u.date/parse (get-string setting-definition-or-name)))
 
@@ -337,6 +341,11 @@
         ;; Now return the `new-value`.
         new-value))))
 
+(defn set-keyword!
+  "Set the value of a keyword `setting-definition-or-name` `new-value` can be `nil`, a string, or a keyword."
+  [setting-definition-or-name new-value]
+  (set-string! setting-definition-or-name (u/qualified-name new-value)))
+
 (defn set-boolean!
   "Set the value of boolean `setting-definition-or-name`. `new-value` can be nil, a boolean, or a string representation of one,
   such as `\"true\"` or `\"false\"` (these strings are case-insensitive)."
@@ -399,7 +408,7 @@
 
 (def ^:private default-setter-for-type
   {:string    set-string!
-   :keyword   set-string!
+   :keyword   set-keyword!
    :boolean   set-boolean!
    :integer   set-integer!
    :json      set-json!

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -38,9 +38,8 @@
 (when-not *compile-files*
   (log/info (trs "Maximum memory available to JVM: {0}" (format-bytes (.maxMemory (Runtime/getRuntime))))))
 
-;; Set the default width for pprinting to 200 instead of 72. The default width is too narrow and wastes a lot of space
-;; for pprinting huge things like expanded queries
-(alter-var-root #'clojure.pprint/*print-right-margin* (constantly 200))
+;; Set the default width for pprinting to 120 instead of 72. The default width is too narrow and wastes a lot of space
+(alter-var-root #'clojure.pprint/*print-right-margin* (constantly 120))
 
 (defmacro ignore-exceptions
   "Simple macro which wraps the given expression in a try/catch block and ignores the exception if caught."

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -11,7 +11,7 @@
             [metabase.util.i18n :refer [tru]]
             [potemkin.types :as p.types]
             [schema.core :as s])
-  (:import [java.time Duration Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime Period ZonedDateTime]
+  (:import [java.time DayOfWeek Duration Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime Period ZonedDateTime]
            [java.time.temporal Temporal TemporalAdjuster WeekFields]
            org.threeten.extra.PeriodDuration))
 
@@ -67,7 +67,8 @@
 
      for a list of predefined formatters.
 
-  2. An instance of `java.time.format.DateTimeFormatter`. You can use utils in `metabase.util.date-2.parse.builder` to help create one of these formatters.
+  2. An instance of `java.time.format.DateTimeFormatter`. You can use utils in `metabase.util.date-2.parse.builder` to
+     help create one of these formatters.
 
   3. A format String e.g. `YYYY-MM-dd`"
   (^String [t]
@@ -121,24 +122,33 @@
   #{:minute-of-hour
     :hour-of-day
     :day-of-week
-    :iso-day-of-week
     :day-of-month
     :day-of-year
     :week-of-year
-    :iso-week-of-year
     :month-of-year
     :quarter-of-year
     ;; TODO - in this namespace `:year` is something you can both extract and truncate to. In MBQL `:year` is a truncation
     ;; operation. Maybe we should rename this unit to clear up the potential confusion (?)
     :year})
 
-(def ^:private week-fields*
-  (common/static-instances WeekFields))
+(defn- start-of-week []
+  (keyword ((requiring-resolve 'metabase.public-settings/start-of-week))))
 
-;; this function is separate from the map above mainly to appease Eastwood due to a bug in `clojure/tools.analyzer` —
-;; see https://clojure.atlassian.net/browse/TANAL-132
-(defn- week-fields ^WeekFields [k]
-  (get week-fields* k))
+(def ^:private ^{:arglists '(^java.time.DayOfWeek [k])} day-of-week*
+  (common/static-instances DayOfWeek))
+
+(defn- week-fields
+  "Create a new instance of a `WeekFields`, which is used for localized day-of-week, week-of-month, and week-of-year.
+
+    (week-fields :monday) ; -> #object[java.time.temporal.WeekFields \"WeekFields[TUESDAY,1]\"]"
+  (^WeekFields [first-day-of-week]
+   ;; TODO -- ISO weeks only consider a week to be in a year if it has 4+ days in that year... `:week-of-year`
+   ;; extraction is liable to be off for people who expect that definition of "week of year". We should probably make
+   ;; this a Setting. See #15039 for more information
+   (week-fields first-day-of-week 1))
+
+  (^WeekFields [first-day-of-week ^Integer minimum-number-of-days-in-first-week]
+   (WeekFields/of (day-of-week* first-day-of-week) minimum-number-of-days-in-first-week)))
 
 (s/defn extract :- Number
   "Extract a field such as `:minute-of-hour` from a temporal value `t`.
@@ -155,12 +165,10 @@
    (t/as t (case unit
              :minute-of-hour   :minute-of-hour
              :hour-of-day      :hour-of-day
-             :day-of-week      (.dayOfWeek (week-fields :sunday-start))
-             :iso-day-of-week  (.dayOfWeek (week-fields :iso))
+             :day-of-week      (.dayOfWeek (week-fields (start-of-week)))
              :day-of-month     :day-of-month
              :day-of-year      :day-of-year
-             :week-of-year     (.weekOfYear (week-fields :sunday-start))
-             :iso-week-of-year (.weekOfYear (week-fields :iso))
+             :week-of-year     (.weekOfYear (week-fields (start-of-week)))
              :month-of-year    :month-of-year
              :quarter-of-year  :quarter-of-year
              :year             :year))))
@@ -181,13 +189,7 @@
   [_]
   (reify TemporalAdjuster
     (adjustInto [_ t]
-      (t/adjust t :previous-or-same-day-of-week :sunday))))
-
-(defmethod adjuster :first-day-of-iso-week
-  [_]
-  (reify TemporalAdjuster
-    (adjustInto [_ t]
-      (t/adjust t :previous-or-same-day-of-week :monday))))
+      (t/adjust t :previous-or-same-day-of-week (start-of-week)))))
 
 (defmethod adjuster :first-day-of-quarter
   [_]
@@ -223,7 +225,7 @@
       :days    t)))
 
 (def truncate-units  "Valid date trucation units"
-  #{:millisecond :second :minute :hour :day :week :iso-week :month :quarter :year})
+  #{:millisecond :second :minute :hour :day :week :month :quarter :year})
 
 (s/defn truncate :- Temporal
   "Truncate a temporal value `t` to the beginning of `unit`, e.g. `:hour` or `:day`. Not all truncation units are
@@ -241,7 +243,7 @@
      :hour        (t/truncate-to t :hours)
      :day         (t/truncate-to t :days)
      :week        (-> (.with t (adjuster :first-day-of-week))     (t/truncate-to :days))
-     :iso-week    (-> (.with t (adjuster :first-day-of-iso-week)) (t/truncate-to :days))
+     ;; TODO -- we should remove this now that `:week` respects the `start-of-week` Setting.
      :month       (-> (t/adjust t :first-day-of-month)            (t/truncate-to :days))
      :quarter     (-> (.with t (adjuster :first-day-of-quarter))  (t/truncate-to :days))
      :year        (-> (t/adjust t :first-day-of-year)             (t/truncate-to :days)))))

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -140,7 +140,7 @@
 (defn- week-fields
   "Create a new instance of a `WeekFields`, which is used for localized day-of-week, week-of-month, and week-of-year.
 
-    (week-fields :monday) ; -> #object[java.time.temporal.WeekFields \"WeekFields[TUESDAY,1]\"]"
+    (week-fields :monday) ; -> #object[java.time.temporal.WeekFields \"WeekFields[MONDAY,1]\"]"
   (^WeekFields [first-day-of-week]
    ;; TODO -- ISO weeks only consider a week to be in a year if it has 4+ days in that year... `:week-of-year`
    ;; extraction is liable to be off for people who expect that definition of "week of year". We should probably make
@@ -243,7 +243,6 @@
      :hour        (t/truncate-to t :hours)
      :day         (t/truncate-to t :days)
      :week        (-> (.with t (adjuster :first-day-of-week))     (t/truncate-to :days))
-     ;; TODO -- we should remove this now that `:week` respects the `start-of-week` Setting.
      :month       (-> (t/adjust t :first-day-of-month)            (t/truncate-to :days))
      :quarter     (-> (.with t (adjuster :first-day-of-quarter))  (t/truncate-to :days))
      :year        (-> (t/adjust t :first-day-of-year)             (t/truncate-to :days)))))

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -510,6 +510,6 @@
 (deftest handlers-test
   (testing "Make sure we have handlers for all the units available"
     (doseq [unit (disj (set (concat u.date/extract-units u.date/truncate-units))
-                       :iso-day-of-week :iso-day-of-year :iso-week :iso-week-of-year :millisecond)]
+                       :iso-day-of-year :millisecond)]
       (testing unit
         (is (some? (#'magic/humanize-datetime "1990-09-09T12:30:00" unit)))))))

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [java-time :as t]
             [metabase.driver.common.parameters.dates :as dates]
+            [metabase.test :as mt]
             [metabase.util.date-2 :as u.date]))
 
 (deftest date-string->filter-test

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -102,3 +102,17 @@
           (is (= expected
                  (dates/date-string->range s options))
               (format "%s with options %s should parse to %s" (pr-str s) (pr-str options) (pr-str expected))))))))
+
+(deftest custom-start-of-week-test
+  (testing "Relative filters should respect the custom `start-of-week` Setting (#14294)"
+    (mt/with-clock #t "2021-03-01T14:15:00-08:00[US/Pacific]"
+      (doseq [[first-day-of-week expected] {"sunday"    {:start "2021-02-21", :end "2021-02-27"}
+                                            "monday"    {:start "2021-02-22", :end "2021-02-28"}
+                                            "tuesday"   {:start "2021-02-16", :end "2021-02-22"}
+                                            "wednesday" {:start "2021-02-17", :end "2021-02-23"}
+                                            "thursday"  {:start "2021-02-18", :end "2021-02-24"}
+                                            "friday"    {:start "2021-02-19", :end "2021-02-25"}
+                                            "saturday"  {:start "2021-02-20", :end "2021-02-26"}}]
+        (mt/with-temporary-setting-values [start-of-week first-day-of-week]
+          (is (= expected
+                 (dates/date-string->range "past1weeks"))))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -136,7 +136,7 @@
             (sync!)
             (is (= [["Bird Hat"]]
                    (mt/rows (qp/process-query
-                              {:database (u/get-id database)
+                              {:database (u/the-id database)
                                :type     :query
                                :query    {:source-table (db/select-one-id Table :name "presents-and-gifts")}}))))))))))
 
@@ -232,7 +232,7 @@
             ;; now take a look at the Tables in the database related to the view. THERE SHOULD BE ONLY ONE!
             (is (= [{:name "angry_birds", :active true}]
                    (map (partial into {})
-                        (db/select [Table :name :active] :db_id (u/get-id database), :name "angry_birds"))))))))))
+                        (db/select [Table :name :active] :db_id (u/the-id database), :name "angry_birds"))))))))))
 
 
 ;;; ----------------------------------------- Tests for exotic column types ------------------------------------------
@@ -429,7 +429,7 @@
                  (driver/describe-table :postgres db {:name "birds"}))))
 
         (testing "check that when syncing the DB the enum types get recorded appropriately"
-          (let [table-id (db/select-one-id Table :db_id (u/get-id db), :name "birds")]
+          (let [table-id (db/select-one-id Table :db_id (u/the-id db), :name "birds")]
             (is (= #{{:name "name", :database_type "varchar", :base_type :type/Text}
                      {:name "type", :database_type "bird type", :base_type :type/PostgresEnum}
                      {:name "status", :database_type "bird_status", :base_type :type/PostgresEnum}}
@@ -437,7 +437,7 @@
                              (db/select [Field :name :database_type :base_type] :table_id table-id)))))))
 
         (testing "End-to-end check: make sure everything works as expected when we run an actual query"
-          (let [table-id           (db/select-one-id Table :db_id (u/get-id db), :name "birds")
+          (let [table-id           (db/select-one-id Table :db_id (u/the-id db), :name "birds")
                 bird-type-field-id (db/select-one-id Field :table_id table-id, :name "type")]
             (is (= {:rows        [["Rasta" "good bird" "toucan"]]
                     :native_form {:query  (str "SELECT \"public\".\"birds\".\"name\" AS \"name\","
@@ -448,10 +448,10 @@
                                                "LIMIT 10")
                                   :params nil}}
                    (-> (qp/process-query
-                        {:database (u/get-id db)
+                        {:database (u/the-id db)
                          :type     :query
                          :query    {:source-table table-id
-                                    :filter       [:= [:field-id (u/get-id bird-type-field-id)] "toucan"]
+                                    :filter       [:= [:field-id (u/the-id bird-type-field-id)] "toucan"]
                                     :limit        10}})
                        :data
                        (select-keys [:rows :native_form]))))))))))
@@ -511,7 +511,7 @@
                                                      :percent-state  0.0
                                                      :average-length 12.0}}}}
                  (db/select-field->field :name :fingerprint Field
-                   :table_id (db/select-one-id Table :db_id (u/get-id database))))))))))
+                   :table_id (db/select-one-id Table :db_id (u/the-id database))))))))))
 
 
 ;;; ----------------------------------------------------- Other ------------------------------------------------------
@@ -521,12 +521,20 @@
     (testing (str "If the DB throws an exception, is it properly returned by the query processor? Is it status "
                   ":failed? (#9942)")
       (is (thrown-with-msg?
-           org.postgresql.util.PSQLException
-           #"ERROR: column \"adsasdasd\" does not exist\s+Position: 20"
+           clojure.lang.ExceptionInfo
+           #"Error executing query"
            (qp/process-query
             {:database (mt/id)
              :type     :native
-             :native   {:query "SELECT adsasdasd;"}}))))))
+             :native   {:query "SELECT adsasdasd;"}})))
+      (try
+        (qp/process-query
+         {:database (mt/id)
+          :type     :native
+          :native   {:query "SELECT adsasdasd;"}})
+        (catch Throwable e
+          (is (= "ERROR: column \"adsasdasd\" does not exist\n  Position: 20"
+                 (.. e getCause getMessage))))))))
 
 (deftest pgobject-test
   (mt/test-driver :postgres

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -34,7 +34,6 @@
 (defn normal-drivers-with-feature
   "Set of engines that support a given `feature`. If additional features are given, it will ensure all features are
   supported."
-  {:arglists (list (into ['&] (sort driver/driver-features)))}
   [feature & more-features]
   (let [features (set (cons feature more-features))]
     (set (for [driver (normal-drivers)
@@ -42,12 +41,15 @@
                :when  (set/subset? features (driver.u/features driver))]
            driver))))
 
+(alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))
+
 (defn normal-drivers-without-feature
   "Return a set of all non-timeseries engines (e.g., everything except Druid and Google Analytics) that DO NOT support
   `feature`."
-  {:arglists (list (into ['&] (sort driver/driver-features)))}
   [feature]
   (set/difference (normal-drivers) (normal-drivers-with-feature feature)))
+
+(alter-meta! #'normal-drivers-without-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))
 
 (defn normal-drivers-except
   "Return the set of all drivers except Druid, Google Analytics, and those in `excluded-drivers`."

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -34,6 +34,7 @@
 (defn normal-drivers-with-feature
   "Set of engines that support a given `feature`. If additional features are given, it will ensure all features are
   supported."
+  {:arglists (list (into ['&] (sort driver/driver-features)))}
   [feature & more-features]
   (let [features (set (cons feature more-features))]
     (set (for [driver (normal-drivers)
@@ -44,6 +45,7 @@
 (defn normal-drivers-without-feature
   "Return a set of all non-timeseries engines (e.g., everything except Druid and Google Analytics) that DO NOT support
   `feature`."
+  {:arglists (list (into ['&] (sort driver/driver-features)))}
   [feature]
   (set/difference (normal-drivers) (normal-drivers-with-feature feature)))
 

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1088,13 +1088,13 @@
                                                      :name   "created_at"
                                                      :target [:dimension [:template-tag "date_range"]]
                                                      :value  "past1weeks"}]})]
-        (doseq [[first-day-of-week expected] {"sunday"    [7 "Sunday"]
-                                              "monday"    [8 "Monday"]
-                                              "tuesday"   [9 "Tuesday"]
-                                              "wednesday" [10 "Wednesday"]
-                                              "thursday"  [4 "Thursday"]
-                                              "friday"    [5 "Friday"]
-                                              "saturday"  [6 "Saturday"]}]
+        (doseq [[first-day-of-week expected] {"sunday"    [6 "Sunday"]
+                                              "monday"    [7 "Monday"]
+                                              "tuesday"   [8 "Tuesday"]
+                                              "wednesday" [9 "Wednesday"]
+                                              "thursday"  [3 "Thursday"]
+                                              "friday"    [4 "Friday"]
+                                              "saturday"  [5 "Saturday"]}]
           (mt/with-temporary-setting-values [start-of-week first-day-of-week]
             (is (= expected
                    (mt/first-row

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1102,7 +1102,7 @@
 
 (deftest day-of-week-custom-start-of-week-test
   ;; sample-dataset doesn't work on Redshift yet -- see #14784
-  (mt/test-drivers (disj (mt/normal-drivers) :redshift)
+  (mt/test-drivers (disj (mt/normal-drivers) :presto :redshift)
     (testing "`:day-of-week` bucketing should respect the `start-of-week` Setting (#13604)"
       (doseq [[day [monday tuesday]] {:sunday  [2 3]
                                       :monday  [1 2]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1101,20 +1101,19 @@
                      (qp/process-query query))))))))))
 
 (deftest day-of-week-custom-start-of-week-test
-  ;; sample-dataset doesn't work on Redshift yet -- see #14784
-  (mt/test-drivers (disj (mt/normal-drivers) :presto :redshift)
+  (mt/test-drivers (mt/normal-drivers)
     (testing "`:day-of-week` bucketing should respect the `start-of-week` Setting (#13604)"
-      (doseq [[day [monday tuesday]] {:sunday  [2 3]
-                                      :monday  [1 2]
-                                      :tuesday [7 1]}]
-        (mt/with-temporary-setting-values [start-of-week day]
-          (mt/dataset sample-dataset
+      (testing "filter by `:day-of-week` should work correctly (#15044)"
+        (doseq [[day [thursday-day-of-week saturday-day-of-week]] {:sunday  [5 7]
+                                                                   :monday  [4 6]
+                                                                   :tuesday [3 5]}]
+          (mt/with-temporary-setting-values [start-of-week day]
             (is (= (sort-by
                     first
-                    [[ monday 13]
-                     [tuesday 16]])
+                    [[thursday-day-of-week 2]
+                     [saturday-day-of-week 1]])
                    (mt/formatted-rows [int int]
-                     (mt/run-mbql-query orders
+                     (mt/run-mbql-query checkins
                        {:aggregation [[:count]]
-                        :breakout    [!day-of-week.created_at]
-                        :filter      [:between $created_at "2020-03-02" "2020-03-03"]}))))))))))
+                        :breakout    [!day-of-week.date]
+                        :filter      [:between $date "2013-01-03" "2013-01-20"]}))))))))))

--- a/test/metabase/query_processor_test/native_test.clj
+++ b/test/metabase/query_processor_test/native_test.clj
@@ -27,6 +27,6 @@
                  :name         "NAME"
                  :base_type    :type/Text}]}
          (qp.test/rows-and-cols
-           (qp/process-query
-            (mt/native-query
-              {:query "select name from users;"}))))))
+          (qp/process-query
+           (mt/native-query
+            {:query "select name from users;"}))))))

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -168,9 +168,6 @@
     (testing "adjust temporal value to first day of week (Sunday)"
       (is (= (t/zoned-date-time "2019-12-08T17:17-08:00[US/Pacific]")
              (t/adjust now (u.date/adjuster :first-day-of-week)))))
-    (testing "adjust temporal value to first day of ISO week (Monday)"
-      (is (= (t/zoned-date-time "2019-12-09T17:17-08:00[US/Pacific]")
-             (t/adjust now (u.date/adjuster :first-day-of-iso-week)))))
     (testing "adjust temporal value to first day of first week of year (previous or same Sunday as first day of year)"
       (is (= (t/zoned-date-time "2018-12-30T17:17-08:00[US/Pacific]")
              (t/adjust now (u.date/adjuster :first-week-of-year))

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -400,13 +400,13 @@
 
 (deftest comparison-range-start-of-week-test
   (testing "`comparison-range` for week should respect the `start-of-week` Setting (#14294)"
-    (doseq [[first-day-of-week expected] {"sunday" {:start #t "2021-02-21", :end #t "2021-02-27"}
-                                          "monday" {:start #t "2021-02-22", :end #t "2021-02-28"}
-                                          #_       "tuesday"   #_ [9 "Tuesday"]
-                                          #_       "wednesday" #_ [10 "Wednesday"]
-                                          #_       "thursday"  #_ [11 "Thursday"]
-                                          #_       "friday"    #_ [12 "Friday"]
-                                          #_       "saturday"  #_ [13 "Saturday"]}]
+    (doseq [[first-day-of-week expected] {"sunday"    {:start #t "2021-02-21", :end #t "2021-02-27"}
+                                          "monday"    {:start #t "2021-02-22", :end #t "2021-02-28"}
+                                          "tuesday"   {:start #t "2021-02-23", :end #t "2021-03-01"}
+                                          "wednesday" {:start #t "2021-02-17", :end #t "2021-02-23"}
+                                          "thursday"  {:start #t "2021-02-18", :end #t "2021-02-24"}
+                                          "friday"    {:start #t "2021-02-19", :end #t "2021-02-25"}
+                                          "saturday"  {:start #t "2021-02-20", :end #t "2021-02-26"}}]
       (mt/with-temporary-setting-values [start-of-week first-day-of-week]
         (let [t #t "2021-02-23"]
           (is (= expected


### PR DESCRIPTION
Fixes #14294
Fixes #13604
Fixes #15044

`:day-of-week`  and `:week-of-year` now use the `start-of-week` Setting. I removed `:iso-day-of-week` and `:iso-week` from the date utils since they weren't actually used anywhere and you can just use the other units now instead. 

While working on this I realized #15039 is something we need to address in the future.