### PR TITLE
Click through migration

### DIFF
--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -388,17 +388,16 @@
                                          (get dashcard "click_behavior")))
         column-settings          (get merged "column_settings")
         updated-columns          (reduce-kv (fn [m col field-settings]
-                                              (if (and (contains? field-settings "view_as")
-                                                       (contains? field-settings "link_template"))
-                                                (assoc m col
-                                                       (merge
-                                                        field-settings
+                                              (assoc m col
+                                                     (merge
+                                                      field-settings
+                                                      (when (and (contains? field-settings "view_as")
+                                                                 (contains? field-settings "link_template"))
                                                         {"click_behavior"
                                                          {"type"             (get field-settings "view_as")
                                                           "linkType"         "url"
                                                           "linkTemplate"     (get field-settings "link_template")
-                                                          "linkTemplateText" (get field-settings "link_text")}}) )
-                                                m))
+                                                          "linkTemplateText" (get field-settings "link_text")}})) ))
                                             {}
                                             column-settings)]
     ;; don't return anything if we don't have new stuff or if we think the migration has already run since at least

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -352,7 +352,9 @@
   (let [fix-top-level  (fn [toplevel]
                          (if (= (get toplevel "click") "link")
                            (merge
+                            ;; remove old shape
                             (dissoc toplevel "click" "click_link_template")
+                            ;; add new shape top level
                             {"click_behavior"
                              {"type"         (get toplevel "click")
                               "linkType"     "url"
@@ -367,6 +369,7 @@
                                     ;; field settings as is
                                     (if (and (= (get field-settings "view_as") "link")
                                              (contains? field-settings "link_template"))
+                                      ;; remove old shape and add new shape under click_behavior
                                       (merge (dissoc field-settings
                                                      "view_as"
                                                      "link_template"
@@ -391,11 +394,12 @@
                                                                (m/filter-vals not-empty)
                                                                not-empty)]
                                   {"column_settings" col-click-info})))
-        fixed-dashcard (cond-> (fix-top-level dashcard)
-                         (contains? dashcard "column_settings")
-                         (update "column_settings" update-cols-fn))]
-    (when (or card-click-info
-              (not= fixed-dashcard dashcard))
+        fixed-dashcard (m/deep-merge card-click-info ;; deep merge card links underneath the fixed dashcard
+                                     (cond-> (fix-top-level dashcard) ;; fix toplevel
+                                       ;; if we have column settings, fix them
+                                       (contains? dashcard "column_settings")
+                                       (update "column_settings" update-cols-fn)))]
+    (when (not= fixed-dashcard dashcard)
       {:id id
        :visualization_settings (m/deep-merge card-click-info fixed-dashcard)})))
 

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -339,18 +339,18 @@
 (defn fix-click-through [{id :id card :card_visualization dashcard :dashcard_visualization}]
   (let [merged                   (merge dashcard card)
         top-level-click-behavior (when (contains? merged "click")
-                                   {"type"         (merged "click")
+                                   {"type"         (get merged "click")
                                     "linkType"     "url"
-                                    "linkTemplate" (merged "click_link_template")})
+                                    "linkTemplate" (get merged "click_link_template")})
         column-settings          (get merged "column_settings")
         updated-columns          (reduce-kv (fn [m col field-settings]
                                               (if (and (contains? field-settings "view_as")
                                                        (contains? field-settings "link_template"))
                                                 (assoc m col
-                                                       {"type"             (field-settings "view_as")
+                                                       {"type"             (get field-settings "view_as")
                                                         "linkType"         "url"
-                                                        "linkTemplate"     (field-settings "link_template")
-                                                        "linkTemplateText" (field-settings "link_text")} )
+                                                        "linkTemplate"     (get field-settings "link_template")
+                                                        "linkTemplateText" (get field-settings "link_text")} )
                                                 m))
                                             {}
                                             column-settings)]
@@ -368,7 +368,7 @@
             x
             ks)))
 
-(defmigration ^{:added "0.39.0"} migrate-click-through
+(defmigration ^{:author "dpsutton" :added "0.38.1"} migrate-click-through
   (transduce (comp (map (parse-to-json :card_visualization :dashcard_visualization))
                    (map fix-click-through)
                    (filter :visualization_settings))

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -389,10 +389,13 @@
                                               (if (and (contains? field-settings "view_as")
                                                        (contains? field-settings "link_template"))
                                                 (assoc m col
-                                                       {"type"             (get field-settings "view_as")
-                                                        "linkType"         "url"
-                                                        "linkTemplate"     (get field-settings "link_template")
-                                                        "linkTemplateText" (get field-settings "link_text")} )
+                                                       (merge
+                                                        field-settings
+                                                        {"click_behavior"
+                                                         {"type"             (get field-settings "view_as")
+                                                          "linkType"         "url"
+                                                          "linkTemplate"     (get field-settings "link_template")
+                                                          "linkTemplateText" (get field-settings "link_text")}}) )
                                                 m))
                                             {}
                                             column-settings)]

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -354,13 +354,15 @@
                                                 m))
                                             {}
                                             column-settings)]
-    {:id id
-     :visualization_settings
-     (merge dashcard
-            (when top-level-click-behavior
-              {"click_behavior" top-level-click-behavior})
-            (when (seq updated-columns)
-              {"column_settings" updated-columns}))}))
+    ;; don't return anything if we don't have new stuff
+    (when (or top-level-click-behavior (seq updated-columns))
+      {:id id
+       :visualization_settings
+       (merge dashcard
+              (when top-level-click-behavior
+                {"click_behavior" top-level-click-behavior})
+              (when (seq updated-columns)
+                {"column_settings" updated-columns}))})))
 
 (defn parse-to-json [& ks]
   (fn [x]

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -369,14 +369,12 @@
                              (u/select-non-nil-keys ["column_settings" "click_behavior"])))
         fix-top-level  (fn [toplevel]
                          (if (= (get toplevel "click") "link")
-                           (merge
-                            ;; remove old shape
-                            (dissoc toplevel "click" "click_link_template")
-                            ;; add new shape top level
-                            {"click_behavior"
-                             {"type"         (get toplevel "click")
-                              "linkType"     "url"
-                              "linkTemplate" (get toplevel "click_link_template")}})
+                           (assoc toplevel
+                                  ;; add new shape top level
+                                  "click_behavior"
+                                  {"type"         (get toplevel "click")
+                                   "linkType"     "url"
+                                   "linkTemplate" (get toplevel "click_link_template")})
                            toplevel))
         fix-cols       (fn [column-settings]
                          (reduce-kv
@@ -387,24 +385,21 @@
                                    (if (and (= (get field-settings "view_as") "link")
                                             (contains? field-settings "link_template"))
                                      ;; remove old shape and add new shape under click_behavior
-                                     (merge (dissoc field-settings
-                                                    "view_as"
-                                                    "link_template"
-                                                    "link_text")
-                                            {"click_behavior"
-                                             {"type"             (get field-settings "view_as")
-                                              "linkType"         "url"
-                                              "linkTemplate"     (get field-settings "link_template")
-                                              "linkTextTemplate" (get field-settings "link_text")}})
+                                     (assoc field-settings
+                                            "click_behavior"
+                                            {"type"             (get field-settings "view_as")
+                                             "linkType"         "url"
+                                             "linkTemplate"     (get field-settings "link_template")
+                                             "linkTextTemplate" (get field-settings "link_text")})
                                      field-settings)))
                           {}
                           column-settings))
         fixed-card     (-> (if (contains? dashcard "click")
                              (dissoc card "click_behavior") ;; throw away click behavior if dashcard has click
-                                                            ;; behavior added
+                             ;; behavior added
                              (fix-top-level card))
                            (update "column_settings" fix-cols) ;; fix columns and then select only the new shape from
-                                                               ;; the settings tree
+                           ;; the settings tree
                            existing-fixed)
         fixed-dashcard (update (fix-top-level dashcard) "column_settings" fix-cols)
         final-settings (->> (m/deep-merge fixed-card fixed-dashcard (existing-fixed dashcard))

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -336,7 +336,9 @@
       (db/update-where! model {:collection_id nil}
         :collection_id (u/get-id new-collection)))))
 
-(defn fix-click-through [{id :id card :card_visualization dashcard :dashcard_visualization}]
+(defn- fix-click-through
+  "Updates the dashboard card by pulling and renaming column behavior from the card."
+  [{id :id card :card_visualization dashcard :dashcard_visualization}]
   (let [merged                   (merge dashcard card)
         top-level-click-behavior (when (contains? merged "click")
                                    {"type"         (get merged "click")
@@ -364,7 +366,7 @@
               (when (seq updated-columns)
                 {"column_settings" updated-columns}))})))
 
-(defn parse-to-json [& ks]
+(defn- parse-to-json [& ks]
   (fn [x]
     (reduce #(update %1 %2 json/parse-string)
             x

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -356,7 +356,6 @@
   Merging the following click behaviors in order (later merges on top of earlier):
   - fixed card click behavior
   - fixed dash click behavior
-  - existing new style card click behavior
   - existing new style dash click behavior"
   [{id :id card :card_visualization dashcard :dashcard_visualization}]
   (let [existing-fixed (fn [settings]
@@ -408,7 +407,7 @@
                                                                ;; the settings tree
                            existing-fixed)
         fixed-dashcard (update (fix-top-level dashcard) "column_settings" fix-cols)
-        final-settings (->> (m/deep-merge fixed-card fixed-dashcard (existing-fixed card) (existing-fixed dashcard))
+        final-settings (->> (m/deep-merge fixed-card fixed-dashcard (existing-fixed dashcard))
                             ;; remove nils and empty maps _AFTER_ deep merging so that the shapes are
                             ;; uniform. otherwise risk not fully clobbering an underlying form if the one going on top
                             ;; doesn't have link text

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -368,10 +368,12 @@
     }
   column_settings {
     [ref [field-id 6]] {
-      type:
-      linkType:
-      linkTemplate:
-      linkTemplateText:
+      click_behavior {
+        type:
+        linkType:
+        linkTemplate:
+        linkTemplateText:
+      }
     }
   ...
   }"

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -363,7 +363,7 @@
    click_behavior {
       type: \"link\"
       linkType: \"url\"
-      linkTemplate: \"http://example.com/{{ID}}\"
+      linkTemplate: \"http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}\"
       linkTextTemplate \"here's an id: {{ID}}\"
     }
   column_settings {

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -364,7 +364,7 @@
       type: \"link\"
       linkType: \"url\"
       linkTemplate: \"http://example.com/{{ID}}\"
-      linkTemplateText \"here's an id: {{ID}}\"
+      linkTextTemplate \"here's an id: {{ID}}\"
     }
   column_settings {
     [ref [field-id 6]] {
@@ -372,7 +372,7 @@
         type:
         linkType:
         linkTemplate:
-        linkTemplateText:
+        linkTextTemplate:
       }
     }
   ...
@@ -397,7 +397,7 @@
                                                          {"type"             (get field-settings "view_as")
                                                           "linkType"         "url"
                                                           "linkTemplate"     (get field-settings "link_template")
-                                                          "linkTemplateText" (get field-settings "link_text")}})) ))
+                                                          "linkTextTemplate" (get field-settings "link_text")}})) ))
                                             {}
                                             column-settings)]
     ;; don't return anything if we don't have new stuff or if we think the migration has already run since at least

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -338,7 +338,7 @@
         :collection_id (u/get-id new-collection)))))
 
 (defn- fix-click-through
-  "Fixes click behavior settings on dashcards. Format changed from:
+  "Fixes click behavior settings on dashcards, returns nil if no fix available. Format changed from:
 
   `{... click click_link_template ...}` to `{... click_behavior { type linkType linkTemplate } ...}`
 
@@ -347,7 +347,10 @@
 
   at the column_settings level. Scours the card to find all click behavior, reshapes it, and deep merges it into the
   reshapen dashcard.  scour for all links in the card, fixup the dashcard and then merge in any new click_behaviors
-  from the card. See extensive tests for different scenarios."
+  from the card. See extensive tests for different scenarios.
+
+  We are in a migration so this returns nil if there is nothing to do so that it is filtered and we aren't running sql
+  statements that are replacing data for no purpose."
   [{id :id card :card_visualization dashcard :dashcard_visualization}]
   (let [fix-top-level  (fn [toplevel]
                          (if (= (get toplevel "click") "link")

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -378,7 +378,7 @@
   ...
   }"
   [{id :id card :card_visualization dashcard :dashcard_visualization}]
-  (let [merged                   (merge dashcard card)
+  (let [merged                   (merge card dashcard)
         top-level-click-behavior (when (contains? merged "click")
                                    {"type"         (get merged "click")
                                     "linkType"     "url"

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -350,7 +350,9 @@
                                                        {"type"             (field-settings "view_as")
                                                         "linkType"         "url"
                                                         "linkTemplate"     (field-settings "link_template")
-                                                        "linkTemplateText" (field-settings "link_text")} ) m)) {}
+                                                        "linkTemplateText" (field-settings "link_text")} )
+                                                m))
+                                            {}
                                             column-settings)]
     {:id id
      :visualization_settings

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -382,18 +382,22 @@
                                       field-settings)))
                            {}
                            column-settings)))
-        card-click-info (not-empty
+        card-click-info (u/select-non-nil-keys
+                         ;; we look in top level and column settings for click behavior but we want nothing other than
+                         ;; click stuff thus selecting non-nil-keys click_behavior and column_settings (non-nil so we
+                         ;; don't introduce `:column_settings {}` if the card doesn't have any and the dashcard
+                         ;; doesn't either.
                          (merge (when-not (contains? dashcard "click")
                                   ;; if dashcard has click: menu we don't want to clobber this even though it won't
                                   ;; get moved to the new shape
-                                  (select-keys (fix-top-level card) ["click_behavior"]))
-                                (when-let [col-click-info (->> (get card "column_settings")
-                                                               update-cols-fn
-                                                               ;; only interested in click behavior from the card
-                                                               (m/map-vals #(select-keys % ["click_behavior"]))
-                                                               (m/filter-vals not-empty)
-                                                               not-empty)]
-                                  {"column_settings" col-click-info})))
+                                  (fix-top-level card))
+                                {"column_settings" (->> (get card "column_settings")
+                                                        update-cols-fn
+                                                        ;; only interested in click behavior from the card
+                                                        (m/map-vals #(select-keys % ["click_behavior"]))
+                                                        (m/filter-vals not-empty)
+                                                        not-empty)})
+                         ["click_behavior" "column_settings"])
         fixed-dashcard (m/deep-merge card-click-info ;; deep merge card links underneath the fixed dashcard
                                      (cond-> (fix-top-level dashcard) ;; fix toplevel
                                        ;; if we have column settings, fix them

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -248,11 +248,7 @@
                   "click_behavior" {"type"         "link"
                                     "linkType"     "url"
                                     "linkTemplate" "http://example.com/{{other_col_name}}"}}]
-        (is (= {"other_setting"  {"bar" 123},
-                "click_behavior" {"type"         "link",
-                                  "linkType"     "url",
-                                  "linkTemplate" "http://example.com/{{other_col_name}}"}}
-               (migrate card dash))))))
+        (is (nil? (migrate card dash))))))
   (let [card-vis              {"column_settings"
                                {"[\"ref\",[\"field-id\",2]]"
                                 {"view_as"       "link",
@@ -303,9 +299,10 @@
     (testing "won't fix if fix is already applied"
       ;; a customer got a custom script from flamber (for which this is making that fix available for everyone. See
       ;; #15014)
-      (is (= nil (#'migrations/fix-click-through {:id                     1
-                                                  :card_visualization     card-vis
-                                                  :dashcard_visualization (:visualization_settings fixed)})))))
+      (is (= nil (#'migrations/fix-click-through
+                  {:id                     1
+                   :card_visualization     card-vis
+                   :dashcard_visualization (:visualization_settings fixed)})))))
   (testing "ignores columns when `view_as` is null"
     (let [card-viz {"column_settings"
                     {"normal"

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -311,7 +311,7 @@
                                  :click_behavior
                                  {:type         "link",
                                   :linkType     "url",
-                                  :linkTemplate "http://example.com/{{count}}"},
+                                  :linkTemplate "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}"},
                                  :column_settings
                                  ;; the model keywordizes the json parsing yielding this monstrosity below
                                  {(keyword "[\"ref\",[\"field-id\",2]]")

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -283,29 +283,98 @@
                    "linkType"     "url",
                    "linkTemplate" "http://example.com/{{something_else}}"}}}}
                (migrate card dash)))))
-    (testing "If there is migration eligible on dash but new style on card, card wins"
+    (testing "If there is migration eligible on dash but also new style on dash, new style wins"
       (let [dash {"column_settings"
                   {"[\"ref\",[\"field-id\",4]]"
                    {"view_as"       "link"
-                    "link_template" "http://from/dash"
-                    "link_text"     "from dash"
-                    "column_title"  "column title from dash"}}}
-            card {"column_settings"
-                  {"[\"ref\",[\"field-id\",4]]"
-                   {"click_behavior"
-                    {"type"             "link",
-                     "linkType"         "url",
-                     "linkTemplate"     "http://from/card",
-                     "linkTextTemplate" "from card"}
-                    "column_title" "column title from card"}}}]
+                    "link_template" "http://old"  ;; this stuff could be migrated
+                    "link_text"     "old"
+                    "column_title"  "column title"
+                    "click_behavior"
+                    {"type" "link",
+                     "linkType" "url",            ;; but there is already a new style and it wins
+                     "linkTemplate" "http://new",
+                     "linkTextTemplate" "new"}}}}]
         (is (= {"column_settings"
                 {"[\"ref\",[\"field-id\",4]]"
                  {"click_behavior"
                   {"type" "link",
                    "linkType" "url",
-                   "linkTemplate" "http://from/card",
-                   "linkTextTemplate" "from card"},
-                  "column_title" "column title from dash"}}}
+                   "linkTemplate" "http://new",
+                   "linkTextTemplate" "new"},
+                  "column_title" "column title"}}}
+               (migrate nil dash)))))
+    (testing "flamber case"
+      (let [card {"column_settings"
+                  {"[\"ref\",[\"field-id\",4]]"
+                   {"view_as" "link"
+                    "link_template" "http//localhost/?QCDT&{{CATEGORY}}"
+                    "link_text" "MyQCDT {{CATEGORY}}"
+                    "column_title" "QCDT Category"}
+                   "[\"ref\",[\"field-id\",6]]"
+                   {"view_as" "link"
+                    "column_title" "QCDT Rating"
+                    "link_text" "Rating {{RATING}}"
+                    "link_template" "http//localhost/?QCDT&{{RATING}}"
+                    "prefix" "prefix-"
+                    "suffix" "-suffix"}
+                   "[\"ref\",[\"field-id\",5]]"
+                   {"view_as" nil
+                    "link_text" "QCDT was disabled"
+                    "link_template" "http//localhost/?QCDT&{{TITLE}}"
+                    "column_title" "(QCDT disabled) Title"}}
+                  "table.pivot_column" "CATEGORY"
+                  "table.cell_column""PRICE"}
+            dash {"table.cell_column" "PRICE"
+                  "table.pivot_column" "CATEGORY"
+                  "column_settings"
+                  {"[\"ref\",[\"field-id\",5]]"
+                   {"view_as" nil
+                    "link_text" "QCDT was disabled"
+                    "link_template" "http//localhost/?QCDT&{{TITLE}}"
+                    "column_title" "(QCDT disabled) Title"}
+                   "[\"ref\",[\"field-id\",4]]"
+                   {"view_as" "link"
+                    "link_template" "http//localhost/?QCDT&{{CATEGORY}}"
+                    "link_text" "MyQCDT {{CATEGORY}}"
+                    "column_title" "QCDT Category"
+                    "click_behavior"
+                    {"type" "link"
+                     "linkType" "url"
+                     "linkTemplate" "http//localhost/?CB&{{CATEGORY}}"
+                     "linkTextTemplate" "MyCB {{CATEGORY}}"}}
+                   "[\"ref\",[\"field-id\",6]]"
+                   {"view_as" "link"
+                    "column_title" "QCDT Rating"
+                    "link_text" "Rating {{RATING}}"
+                    "link_template" "http//localhost/?QCDT&{{RATING}}"
+                    "prefix" "prefix-"
+                    "suffix" "-suffix"}}
+                  "card.title" "Table with QCDT - MANUALLY ADDED CB 37"}]
+        (is (= {"card.title" "Table with QCDT - MANUALLY ADDED CB 37"
+                "column_settings"
+                {"[\"ref\",[\"field-id\",4]]"
+                 {"column_title" "QCDT Category"
+                  "click_behavior"
+                  {"type" "link"
+                   "linkType" "url"
+                   "linkTemplate" "http//localhost/?CB&{{CATEGORY}}"
+                   "linkTextTemplate" "MyCB {{CATEGORY}}"}}
+                 "[\"ref\",[\"field-id\",5]]"
+                 {"link_text" "QCDT was disabled"
+                  "column_title" "(QCDT disabled) Title"
+                  "link_template" "http//localhost/?QCDT&{{TITLE}}"}
+                 "[\"ref\",[\"field-id\",6]]"
+                 {"prefix" "prefix-"
+                  "suffix" "-suffix"
+                  "column_title" "QCDT Rating"
+                  "click_behavior"
+                  {"type" "link"
+                   "linkType" "url"
+                   "linkTemplate" "http//localhost/?QCDT&{{RATING}}"
+                   "linkTextTemplate" "Rating {{RATING}}"}}}
+                "table.cell_column" "PRICE"
+                "table.pivot_column" "CATEGORY"}
                (migrate card dash))))))
   (testing "general case"
     (let [card-vis              {"column_settings"

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -215,7 +215,7 @@
              "linkType" "url",
              "linkTemplate" "http://example.com//{{id}}",
              "linkTemplateText" "here is my id: {{id}}"}}}}
-         (migrations/fix-click-through
+         (#'migrations/fix-click-through
           {:id 1,
            :card_visualization
            {"column_settings"

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -231,15 +231,23 @@
              "column_settings"
              ;; note none of this keywordizes keys in json parsing since these structures are gross as keywords
              {"[\"ref\",[\"field-id\",2]]"
-              {"type" "link",
-               "linkType" "url",
-               "linkTemplate" "http://example.com/{{ID}}",
-               "linkTemplateText" "here's an id: {{ID}}"},
+              {"view_as" "link",
+               "link_template" "http://example.com/{{ID}}",
+               "link_text" "here's an id: {{ID}}"
+               "click_behavior"
+               {"type" "link",
+                "linkType" "url",
+                "linkTemplate" "http://example.com/{{ID}}",
+                "linkTemplateText" "here's an id: {{ID}}"}},
               "[\"ref\",[\"field-id\",6]]"
-              {"type" "link",
-               "linkType" "url",
-               "linkTemplate" "http://example.com//{{id}}",
-               "linkTemplateText" "here is my id: {{id}}"}}}}
+              {"view_as" "link",
+               "link_template" "http://example.com//{{id}}",
+               "link_text" "here is my id: {{id}}"
+               "click_behavior"
+               {"type" "link",
+                "linkType" "url",
+                "linkTemplate" "http://example.com//{{id}}",
+                "linkTemplateText" "here is my id: {{id}}"}}}}}
            fixed))
     (testing "won't fix if fix is already applied"
       ;; a customer got a custom script from flamber (for which this is making that fix available for everyone. See
@@ -290,15 +298,23 @@
                                  :column_settings
                                  ;; the model keywordizes the json parsing yielding this monstrosity below
                                  {(keyword "[\"ref\",[\"field-id\",2]]")
-                                  {:type             "link",
-                                   :linkType         "url",
-                                   :linkTemplate     "http://example.com/{{ID}}",
-                                   :linkTemplateText "here's an id: {{ID}}"},
+                                  {:view_as       "link",
+                                   :link_template "http://example.com/{{ID}}",
+                                   :link_text     "here's an id: {{ID}}"
+                                   :click_behavior
+                                   {:type             "link",
+                                    :linkType         "url",
+                                    :linkTemplate     "http://example.com/{{ID}}",
+                                    :linkTemplateText "here's an id: {{ID}}"}},
                                   (keyword "[\"ref\",[\"field-id\",6]]")
-                                  {:type             "link",
-                                   :linkType         "url",
-                                   :linkTemplate     "http://example.com//{{id}}",
-                                   :linkTemplateText "here is my id: {{id}}"}}}
+                                  {:view_as       "link",
+                                   :link_template "http://example.com//{{id}}",
+                                   :link_text     "here is my id: {{id}}"
+                                   :click_behavior
+                                   {:type             "link",
+                                    :linkType         "url",
+                                    :linkTemplate     "http://example.com//{{id}}",
+                                    :linkTemplateText "here is my id: {{id}}"}}}}
               get-settings!     #(:visualization_settings (db/select-one DashboardCard :id dashcard-id))]
           (#'migrations/migrate-click-through)
           (is (= expected-settings (get-settings!)))

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -287,93 +287,92 @@
       (let [dash {"column_settings"
                   {"[\"ref\",[\"field-id\",4]]"
                    {"view_as"       "link"
-                    "link_template" "http://old"  ;; this stuff could be migrated
+                    "link_template" "http://old" ;; this stuff could be migrated
                     "link_text"     "old"
                     "column_title"  "column title"
                     "click_behavior"
-                    {"type" "link",
-                     "linkType" "url",            ;; but there is already a new style and it wins
-                     "linkTemplate" "http://new",
+                    {"type"             "link",
+                     "linkType"         "url", ;; but there is already a new style and it wins
+                     "linkTemplate"     "http://new",
                      "linkTextTemplate" "new"}}}}]
-        (is (= {"column_settings"
-                {"[\"ref\",[\"field-id\",4]]"
-                 {"click_behavior"
-                  {"type" "link",
-                   "linkType" "url",
-                   "linkTemplate" "http://new",
-                   "linkTextTemplate" "new"},
-                  "column_title" "column title"}}}
-               (migrate nil dash)))))
+        ;; no change
+        (is (nil? (migrate nil dash)))))
     (testing "flamber case"
       (let [card {"column_settings"
                   {"[\"ref\",[\"field-id\",4]]"
-                   {"view_as" "link"
+                   {"view_as"       "link"
                     "link_template" "http//localhost/?QCDT&{{CATEGORY}}"
-                    "link_text" "MyQCDT {{CATEGORY}}"
-                    "column_title" "QCDT Category"}
+                    "link_text"     "MyQCDT {{CATEGORY}}"
+                    "column_title"  "QCDT Category"}
                    "[\"ref\",[\"field-id\",6]]"
-                   {"view_as" "link"
-                    "column_title" "QCDT Rating"
-                    "link_text" "Rating {{RATING}}"
+                   {"view_as"       "link"
+                    "column_title"  "QCDT Rating"
+                    "link_text"     "Rating {{RATING}}"
                     "link_template" "http//localhost/?QCDT&{{RATING}}"
-                    "prefix" "prefix-"
-                    "suffix" "-suffix"}
+                    "prefix"        "prefix-"
+                    "suffix"        "-suffix"}
                    "[\"ref\",[\"field-id\",5]]"
-                   {"view_as" nil
-                    "link_text" "QCDT was disabled"
+                   {"view_as"       nil
+                    "link_text"     "QCDT was disabled"
                     "link_template" "http//localhost/?QCDT&{{TITLE}}"
-                    "column_title" "(QCDT disabled) Title"}}
+                    "column_title"  "(QCDT disabled) Title"}}
                   "table.pivot_column" "CATEGORY"
-                  "table.cell_column""PRICE"}
-            dash {"table.cell_column" "PRICE"
+                  "table.cell_column"  "PRICE"}
+            dash {"table.cell_column"  "PRICE"
                   "table.pivot_column" "CATEGORY"
                   "column_settings"
                   {"[\"ref\",[\"field-id\",5]]"
-                   {"view_as" nil
-                    "link_text" "QCDT was disabled"
+                   {"view_as"       nil
+                    "link_text"     "QCDT was disabled"
                     "link_template" "http//localhost/?QCDT&{{TITLE}}"
-                    "column_title" "(QCDT disabled) Title"}
+                    "column_title"  "(QCDT disabled) Title"}
                    "[\"ref\",[\"field-id\",4]]"
-                   {"view_as" "link"
+                   {"view_as"       "link"
                     "link_template" "http//localhost/?QCDT&{{CATEGORY}}"
-                    "link_text" "MyQCDT {{CATEGORY}}"
-                    "column_title" "QCDT Category"
+                    "link_text"     "MyQCDT {{CATEGORY}}"
+                    "column_title"  "QCDT Category"
                     "click_behavior"
-                    {"type" "link"
-                     "linkType" "url"
-                     "linkTemplate" "http//localhost/?CB&{{CATEGORY}}"
+                    {"type"             "link"
+                     "linkType"         "url"
+                     "linkTemplate"     "http//localhost/?CB&{{CATEGORY}}"
                      "linkTextTemplate" "MyCB {{CATEGORY}}"}}
                    "[\"ref\",[\"field-id\",6]]"
-                   {"view_as" "link"
-                    "column_title" "QCDT Rating"
-                    "link_text" "Rating {{RATING}}"
+                   {"view_as"       "link"
+                    "column_title"  "QCDT Rating"
+                    "link_text"     "Rating {{RATING}}"
                     "link_template" "http//localhost/?QCDT&{{RATING}}"
-                    "prefix" "prefix-"
-                    "suffix" "-suffix"}}
-                  "card.title" "Table with QCDT - MANUALLY ADDED CB 37"}]
-        (is (= {"card.title" "Table with QCDT - MANUALLY ADDED CB 37"
+                    "prefix"        "prefix-"
+                    "suffix"        "-suffix"}}
+                  "card.title"         "Table with QCDT - MANUALLY ADDED CB 37"}]
+        (is (= {"card.title"         "Table with QCDT - MANUALLY ADDED CB 37"
                 "column_settings"
                 {"[\"ref\",[\"field-id\",4]]"
-                 {"column_title" "QCDT Category"
+                 {"column_title"  "QCDT Category"
+                  "view_as"       "link"
+                  "link_template" "http//localhost/?QCDT&{{CATEGORY}}"
+                  "link_text"     "MyQCDT {{CATEGORY}}"
                   "click_behavior"
-                  {"type" "link"
-                   "linkType" "url"
-                   "linkTemplate" "http//localhost/?CB&{{CATEGORY}}"
+                  {"type"             "link"
+                   "linkType"         "url"
+                   "linkTemplate"     "http//localhost/?CB&{{CATEGORY}}"
                    "linkTextTemplate" "MyCB {{CATEGORY}}"}}
                  "[\"ref\",[\"field-id\",5]]"
-                 {"link_text" "QCDT was disabled"
-                  "column_title" "(QCDT disabled) Title"
+                 {"link_text"     "QCDT was disabled"
+                  "column_title"  "(QCDT disabled) Title"
                   "link_template" "http//localhost/?QCDT&{{TITLE}}"}
                  "[\"ref\",[\"field-id\",6]]"
-                 {"prefix" "prefix-"
-                  "suffix" "-suffix"
-                  "column_title" "QCDT Rating"
+                 {"prefix"        "prefix-"
+                  "suffix"        "-suffix"
+                  "column_title"  "QCDT Rating"
+                  "view_as"       "link"
+                  "link_text"     "Rating {{RATING}}"
+                  "link_template" "http//localhost/?QCDT&{{RATING}}"
                   "click_behavior"
-                  {"type" "link"
-                   "linkType" "url"
-                   "linkTemplate" "http//localhost/?QCDT&{{RATING}}"
+                  {"type"             "link"
+                   "linkType"         "url"
+                   "linkTemplate"     "http//localhost/?QCDT&{{RATING}}"
                    "linkTextTemplate" "Rating {{RATING}}"}}}
-                "table.cell_column" "PRICE"
+                "table.cell_column"  "PRICE"
                 "table.pivot_column" "CATEGORY"}
                (migrate card dash))))))
   (testing "general case"
@@ -403,8 +402,10 @@
                                                                  :dashcard_visualization original-dashcard-vis})]
       (is (= {:id 1,
               :visualization_settings
-              {"graph.dimensions" ["CREATED_AT" "CATEGORY"],
-               "graph.metrics"    ["count"],
+              {"graph.dimensions"    ["CREATED_AT" "CATEGORY"],
+               "graph.metrics"       ["count"],
+               "click"               "link",
+               "click_link_template" "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}",
                "click_behavior"
                {"type"         "link",
                 "linkType"     "url",

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -283,60 +283,61 @@
                    "linkType" "url",
                    "linkTemplate" "http://example.com/{{something_else}}"}}}}
                (migrate card dash))))))
-  (let [card-vis              {"column_settings"
-                               {"[\"ref\",[\"field-id\",2]]"
-                                {"view_as"       "link",
-                                 "link_template" "http://example.com/{{ID}}",
-                                 "link_text"     "here's an id: {{ID}}"},
-                                "[\"ref\",[\"field-id\",6]]"
-                                {"view_as"       "link",
-                                 "link_template" "http://example.com//{{id}}",
-                                 "link_text"     "here is my id: {{id}}"}},
-                               "table.pivot_column"  "QUANTITY",
-                               "table.cell_column"   "DISCOUNT",
-                               "click"               "link",
-                               "click_link_template" "http://example.com/{{count}}",
-                               "graph.dimensions"    ["CREATED_AT"],
-                               "graph.metrics"       ["count"],
-                               "graph.show_values"   true}
-        original-dashcard-vis {"click"            "link",
-                               "click_link_template"
-                               "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}",
-                               "graph.dimensions" ["CREATED_AT" "CATEGORY"],
-                               "graph.metrics"    ["count"]}
-        fixed                 (#'migrations/fix-click-through {:id                     1,
-                                                               :card_visualization     card-vis
-                                                               :dashcard_visualization original-dashcard-vis})]
-    (is (= {:id 1,
-            :visualization_settings
-            {"graph.dimensions" ["CREATED_AT" "CATEGORY"],
-             "graph.metrics"    ["count"],
-             "click_behavior"
-             {"type"         "link",
-              "linkType"     "url",
-              "linkTemplate" "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}"},
-             "column_settings"
-             ;; note none of this keywordizes keys in json parsing since these structures are gross as keywords
-             {"[\"ref\",[\"field-id\",2]]"
-              {"click_behavior"
-               {"type"             "link",
-                "linkType"         "url",
-                "linkTemplate"     "http://example.com/{{ID}}",
-                "linkTextTemplate" "here's an id: {{ID}}"}},
-              "[\"ref\",[\"field-id\",6]]"
-              {"click_behavior"
-               {"type"             "link",
-                "linkType"         "url",
-                "linkTemplate"     "http://example.com//{{id}}",
-                "linkTextTemplate" "here is my id: {{id}}"}}}}}
-           fixed))
-    (testing "won't fix if fix is already applied"
-      ;; a customer got a custom script from flamber (for which this is making that fix available for everyone. See
-      ;; #15014)
-      (is (= nil (#'migrations/fix-click-through
-                  {:id                     1
-                   :card_visualization     card-vis
-                   :dashcard_visualization (:visualization_settings fixed)})))))
+  (testing "general case"
+    (let [card-vis              {"column_settings"
+                                 {"[\"ref\",[\"field-id\",2]]"
+                                  {"view_as"       "link",
+                                   "link_template" "http://example.com/{{ID}}",
+                                   "link_text"     "here's an id: {{ID}}"},
+                                  "[\"ref\",[\"field-id\",6]]"
+                                  {"view_as"       "link",
+                                   "link_template" "http://example.com//{{id}}",
+                                   "link_text"     "here is my id: {{id}}"}},
+                                 "table.pivot_column"  "QUANTITY",
+                                 "table.cell_column"   "DISCOUNT",
+                                 "click"               "link",
+                                 "click_link_template" "http://example.com/{{count}}",
+                                 "graph.dimensions"    ["CREATED_AT"],
+                                 "graph.metrics"       ["count"],
+                                 "graph.show_values"   true}
+          original-dashcard-vis {"click"            "link",
+                                 "click_link_template"
+                                 "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}",
+                                 "graph.dimensions" ["CREATED_AT" "CATEGORY"],
+                                 "graph.metrics"    ["count"]}
+          fixed                 (#'migrations/fix-click-through {:id                     1,
+                                                                 :card_visualization     card-vis
+                                                                 :dashcard_visualization original-dashcard-vis})]
+      (is (= {:id 1,
+              :visualization_settings
+              {"graph.dimensions" ["CREATED_AT" "CATEGORY"],
+               "graph.metrics"    ["count"],
+               "click_behavior"
+               {"type"         "link",
+                "linkType"     "url",
+                "linkTemplate" "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}"},
+               "column_settings"
+               ;; note none of this keywordizes keys in json parsing since these structures are gross as keywords
+               {"[\"ref\",[\"field-id\",2]]"
+                {"click_behavior"
+                 {"type"             "link",
+                  "linkType"         "url",
+                  "linkTemplate"     "http://example.com/{{ID}}",
+                  "linkTextTemplate" "here's an id: {{ID}}"}},
+                "[\"ref\",[\"field-id\",6]]"
+                {"click_behavior"
+                 {"type"             "link",
+                  "linkType"         "url",
+                  "linkTemplate"     "http://example.com//{{id}}",
+                  "linkTextTemplate" "here is my id: {{id}}"}}}}}
+             fixed))
+      (testing "won't fix if fix is already applied"
+        ;; a customer got a custom script from flamber (for which this is making that fix available for everyone. See
+        ;; #15014)
+        (is (= nil (#'migrations/fix-click-through
+                    {:id                     1
+                     :card_visualization     card-vis
+                     :dashcard_visualization (:visualization_settings fixed)}))))))
   (testing "ignores columns when `view_as` is null"
     (let [card-viz {"column_settings"
                     {"normal"

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -248,7 +248,41 @@
                   "click_behavior" {"type"         "link"
                                     "linkType"     "url"
                                     "linkTemplate" "http://example.com/{{other_col_name}}"}}]
-        (is (nil? (migrate card dash))))))
+        (is (nil? (migrate card dash)))))
+    (testing "Manually updated to new behavior on Column"
+      (let [card {"some_setting" {"foo" 123},
+                  "column_settings"
+                  {"[\"ref\",[\"field-id\",1]]"
+                   {"view_as" "link"
+                    "link_template" "http://example.com/{{id}}"
+                    "other_special_formatting" "currency"}
+                   "[\"ref\",[\"field-id\",2]]"
+                   {"view_as" "link",
+                    "link_template" "http://example.com/{{something_else}}",
+                    "other_fun_formatting" 0}}}
+            dash {"other_setting" {"bar" 123}
+                  "column_settings"
+                  {"[\"ref\",[\"field-id\",1]]"
+                   {"click_behavior"
+                    {"type" "link"
+                     "linkType" "url"
+                     "linkTemplate" "http://example.com/{{id}}"}}
+                   "[\"ref\",[\"field-id\",2]]"
+                   {"other_fun_formatting" 123}}}]
+        (is (= {"other_setting" {"bar" 123}
+                "column_settings"
+                {"[\"ref\",[\"field-id\",1]]"
+                 {"click_behavior"
+                  {"type" "link",
+                   "linkType" "url",
+                   "linkTemplate" "http://example.com/{{id}}"}}
+                 "[\"ref\",[\"field-id\",2]]"
+                 {"other_fun_formatting" 123,
+                  "click_behavior"
+                  {"type" "link",
+                   "linkType" "url",
+                   "linkTemplate" "http://example.com/{{something_else}}"}}}}
+               (migrate card dash))))))
   (let [card-vis              {"column_settings"
                                {"[\"ref\",[\"field-id\",2]]"
                                 {"view_as"       "link",

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -271,7 +271,29 @@
              (get-in (#'migrations/fix-click-through {:id 1
                                                       :card_visualization (f card-viz)
                                                       :dashcard_visualization (f dash-viz)})
-                     [:visualization_settings "column_settings" "[:ref [:field-id 2]]" "click_behavior" "linkTemplate"]))))))
+                     [:visualization_settings "column_settings" "[:ref [:field-id 2]]" "click_behavior" "linkTemplate"])))))
+  (testing "ignores columns when `view_as` is null"
+    (let [card-viz {:column_settings
+                    {[:ref [:field-id 2]]
+                     {:view_as "link",
+                      :link_template "card",
+                      :link_text "here's an id: {{ID}}"}}}
+          dash-viz {:column_settings
+                    {:normal
+                     {:view_as "link",
+                      :link_template "dash",
+                      :link_text "here's an id: {{ID}}"}
+                     :null-view-as
+                     {:view_as nil
+                      :link_template "i should not be present",
+                      :link_text "i should not be present"}}}
+          f #(-> % json/generate-string json/parse-string)]
+      (is (= ["normal"]
+             (keys (get-in
+                    (#'migrations/fix-click-through {:id 1
+                                                     :card_visualization (f card-viz)
+                                                     :dashcard_visualization (f dash-viz)})
+                    [:visualization_settings "column_settings"])))))))
 
 (deftest migrate-click-through-test
   (testing "Migrate old style click through behavior to new (#15014)"

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -238,7 +238,7 @@
                {"type" "link",
                 "linkType" "url",
                 "linkTemplate" "http://example.com/{{ID}}",
-                "linkTemplateText" "here's an id: {{ID}}"}},
+                "linkTextTemplate" "here's an id: {{ID}}"}},
               "[\"ref\",[\"field-id\",6]]"
               {"view_as" "link",
                "link_template" "http://example.com//{{id}}",
@@ -247,7 +247,7 @@
                {"type" "link",
                 "linkType" "url",
                 "linkTemplate" "http://example.com//{{id}}",
-                "linkTemplateText" "here is my id: {{id}}"}}}}}
+                "linkTextTemplate" "here is my id: {{id}}"}}}}}
            fixed))
     (testing "won't fix if fix is already applied"
       ;; a customer got a custom script from flamber (for which this is making that fix available for everyone. See
@@ -305,7 +305,7 @@
                                    {:type             "link",
                                     :linkType         "url",
                                     :linkTemplate     "http://example.com/{{ID}}",
-                                    :linkTemplateText "here's an id: {{ID}}"}},
+                                    :linkTextTemplate "here's an id: {{ID}}"}},
                                   (keyword "[\"ref\",[\"field-id\",6]]")
                                   {:view_as       "link",
                                    :link_template "http://example.com//{{id}}",
@@ -314,7 +314,7 @@
                                    {:type             "link",
                                     :linkType         "url",
                                     :linkTemplate     "http://example.com//{{id}}",
-                                    :linkTemplateText "here is my id: {{id}}"}}}}
+                                    :linkTextTemplate "here is my id: {{id}}"}}}}
               get-settings!     #(:visualization_settings (db/select-one DashboardCard :id dashcard-id))]
           (#'migrations/migrate-click-through)
           (is (= expected-settings (get-settings!)))

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -355,10 +355,7 @@
                       DashboardCard [{dashcard-id :id} {:dashboard_id           dashboard-id
                                                         :card_id                card-id
                                                         :visualization_settings dashcard-vis}]]
-        (let [expected-settings {:click            "link",
-                                 :click_link_template
-                                 "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}",
-                                 :graph.dimensions ["CREATED_AT" "CATEGORY"],
+        (let [expected-settings {:graph.dimensions ["CREATED_AT" "CATEGORY"],
                                  :graph.metrics    ["count"],
                                  :click_behavior
                                  {:type         "link",
@@ -367,19 +364,13 @@
                                  :column_settings
                                  ;; the model keywordizes the json parsing yielding this monstrosity below
                                  {(keyword "[\"ref\",[\"field-id\",2]]")
-                                  {:view_as       "link",
-                                   :link_template "http://example.com/{{ID}}",
-                                   :link_text     "here's an id: {{ID}}"
-                                   :click_behavior
+                                  {:click_behavior
                                    {:type             "link",
                                     :linkType         "url",
                                     :linkTemplate     "http://example.com/{{ID}}",
                                     :linkTextTemplate "here's an id: {{ID}}"}},
                                   (keyword "[\"ref\",[\"field-id\",6]]")
-                                  {:view_as       "link",
-                                   :link_template "http://example.com//{{id}}",
-                                   :link_text     "here is my id: {{id}}"
-                                   :click_behavior
+                                  {:click_behavior
                                    {:type             "link",
                                     :linkType         "url",
                                     :linkTemplate     "http://example.com//{{id}}",

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -213,7 +213,7 @@
       (let [card {"some_setting:"       {"foo" 123}
                   "click_link_template" "http://example.com/{{col_name}}"
                   "click"               "link"}
-            dash {"other_setting" {"bar" 123}
+            dash {"other_setting"       {"bar" 123}
                   "click_link_template" "http://example.com/{{col_name}}"
                   "click"               "menu"}]
         ;;click: "menu" turned off the custom drill through so it's not migrated. Dropping click and click_link_template would be fine but isn't needed.
@@ -222,9 +222,9 @@
       (let [card {"some_setting" {"foo" 123}
                   "column_settings"
                   {"[\"ref\",[\"field-id\",1]]"
-                   {"view_as" "link"
+                   {"view_as"       "link"
                     "link_template" "http://example.com/{{id}}"
-                    "link_text" "here is my id: {{id}}"}}}
+                    "link_text"     "here is my id: {{id}}"}}}
             dash {"other_setting" {"bar" 123}
                   "column_settings"
                   {"[\"ref\",[\"field-id\",1]]" {"fun_formatting" "foo"}
@@ -233,9 +233,9 @@
                 "column_settings"
                 {"[\"ref\",[\"field-id\",1]]"
                  {"fun_formatting" "foo"
-                  "click_behavior" {"type" "link"
-                                    "linkType" "url"
-                                    "linkTemplate" "http://example.com/{{id}}"
+                  "click_behavior" {"type"             "link"
+                                    "linkType"         "url"
+                                    "linkTemplate"     "http://example.com/{{id}}"
                                     "linkTextTemplate" "here is my id: {{id}}"}}
                  "[\"ref\",[\"field-id\",2]]"
                  {"other_fun_formatting" 123}}}
@@ -243,7 +243,7 @@
     (testing "manually updated new behavior"
       (let [card {"some_setting"        {"foo" 123}
                   "click_link_template" "http://example.com/{{col_name}}"
-                  "click"              "link"}
+                  "click"               "link"}
             dash {"other_setting"  {"bar" 123}
                   "click_behavior" {"type"         "link"
                                     "linkType"     "url"
@@ -253,19 +253,19 @@
       (let [card {"some_setting" {"foo" 123},
                   "column_settings"
                   {"[\"ref\",[\"field-id\",1]]"
-                   {"view_as" "link"
-                    "link_template" "http://example.com/{{id}}"
+                   {"view_as"                  "link"
+                    "link_template"            "http://example.com/{{id}}"
                     "other_special_formatting" "currency"}
                    "[\"ref\",[\"field-id\",2]]"
-                   {"view_as" "link",
-                    "link_template" "http://example.com/{{something_else}}",
+                   {"view_as"              "link",
+                    "link_template"        "http://example.com/{{something_else}}",
                     "other_fun_formatting" 0}}}
             dash {"other_setting" {"bar" 123}
                   "column_settings"
                   {"[\"ref\",[\"field-id\",1]]"
                    {"click_behavior"
-                    {"type" "link"
-                     "linkType" "url"
+                    {"type"         "link"
+                     "linkType"     "url"
                      "linkTemplate" "http://example.com/{{id}}"}}
                    "[\"ref\",[\"field-id\",2]]"
                    {"other_fun_formatting" 123}}}]
@@ -273,15 +273,39 @@
                 "column_settings"
                 {"[\"ref\",[\"field-id\",1]]"
                  {"click_behavior"
-                  {"type" "link",
-                   "linkType" "url",
+                  {"type"         "link",
+                   "linkType"     "url",
                    "linkTemplate" "http://example.com/{{id}}"}}
                  "[\"ref\",[\"field-id\",2]]"
                  {"other_fun_formatting" 123,
                   "click_behavior"
+                  {"type"         "link",
+                   "linkType"     "url",
+                   "linkTemplate" "http://example.com/{{something_else}}"}}}}
+               (migrate card dash)))))
+    (testing "If there is migration eligible on dash but new style on card, card wins"
+      (let [dash {"column_settings"
+                  {"[\"ref\",[\"field-id\",4]]"
+                   {"view_as"       "link"
+                    "link_template" "http://from/dash"
+                    "link_text"     "from dash"
+                    "column_title"  "column title from dash"}}}
+            card {"column_settings"
+                  {"[\"ref\",[\"field-id\",4]]"
+                   {"click_behavior"
+                    {"type"             "link",
+                     "linkType"         "url",
+                     "linkTemplate"     "http://from/card",
+                     "linkTextTemplate" "from card"}
+                    "column_title" "column title from card"}}}]
+        (is (= {"column_settings"
+                {"[\"ref\",[\"field-id\",4]]"
+                 {"click_behavior"
                   {"type" "link",
                    "linkType" "url",
-                   "linkTemplate" "http://example.com/{{something_else}}"}}}}
+                   "linkTemplate" "http://from/card",
+                   "linkTextTemplate" "from card"},
+                  "column_title" "column title from dash"}}}
                (migrate card dash))))))
   (testing "general case"
     (let [card-vis              {"column_settings"

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -483,6 +483,9 @@
                                                         :visualization_settings dashcard-vis}]]
         (let [expected-settings {:graph.dimensions ["CREATED_AT" "CATEGORY"],
                                  :graph.metrics    ["count"],
+                                 :click            "link",
+                                 :click_link_template
+                                 "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}"
                                  :click_behavior
                                  {:type         "link",
                                   :linkType     "url",


### PR DESCRIPTION
Fixes #15014 

Updates the dashboard card click through behavior.

Would love eyes from @paulrosenzweig and @flamber .

One particular thing to note, is that the original postgres script threw away column info if it didn't have values for `view_as` and `link_template`. 

```sql
FROM (
      SELECT
        key as field,
        value::jsonb->'view_as' as clickType,
        value::jsonb->'link_template' as linkTemplate,
        value::jsonb->'link_text' as linkTextTemplate
      FROM jsonb_each_text(jsonb_merge(card.visualization_settings::jsonb, dashcard.visualization_settings::jsonb)::jsonb->'column_settings')
    ) as json_table
WHERE jsonb_typeof(clickType)!='null' AND jsonb_typeof(linkTemplate)!='null'
```

I've kept this behavior but just wanted to call it out and make sure this was intentional. It would be trivial to preserve these as well.

```clojure
(reduce-kv (fn [m col field-settings]
             (if (and (contains? field-settings "view_as")
                      (contains? field-settings "link_template"))
               (assoc m col
                      {"type"             (field-settings "view_as")
                       "linkType"         "url"
                       "linkTemplate"     (field-settings "link_template")
                       "linkTemplateText" (field-settings "link_text")} )
               m))
           {}
           column-settings)
```

Note this also leaves the old top level stuff on the dashcard after moving it under "click_behavior"
```
"click" "link",
"click_link_template" "http://example.com/{{count}}",
```
The original migration did not remove these. Might help for future that we leave the old datashape? Note we _do_ clobber the `column_settings` so this "original" information is gone though. It would be possible to preserve this just in case in a "column_settings_backup" or other name.

The tests have a good before and after which i'll include here as well:

### Before
```clojure
:card_visualization
{"column_settings"
 {"[\"ref\",[\"field-id\",2]]"
  {"view_as" "link",
   "link_template" "http://example.com/{{ID}}",
   "link_text" "here's an id: {{ID}}"},
  "[\"ref\",[\"field-id\",6]]"
  {"view_as" "link",
   "link_template" "http://example.com//{{id}}",
   "link_text" "here is my id: {{id}}"}},
 "table.pivot_column" "QUANTITY",
 "table.cell_column" "DISCOUNT",
 "click" "link",
 "click_link_template" "http://example.com/{{count}}",
 "graph.dimensions" ["CREATED_AT"],
 "graph.metrics" ["count"],
 "graph.show_values" true},
:dashcard_visualization
{"click" "link",
 "click_link_template"
 "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}",
 "graph.dimensions" ["CREATED_AT" "CATEGORY"],
 "graph.metrics" ["count"]}
```

### After
```clojure
{"click" "link", ;; note old stuff here
 "click_link_template" ;; old stuff here
 "http://localhost:3001/?year={{CREATED_AT}}&cat={{CATEGORY}}&count={{count}}",
 "graph.dimensions" ["CREATED_AT" "CATEGORY"],
 "graph.metrics" ["count"],
 "click_behavior" ;; new stuff under heading
 {"type" "link",
  "linkType" "url",
  "linkTemplate" "http://example.com/{{count}}"},
 "column_settings" ;; new column settings but these throw away any without the specific info we're looking for
 ;; note none of this keywordizes keys in json parsing since these structures are gross as keywords
 {"[\"ref\",[\"field-id\",2]]"
  {"type" "link",
   "linkType" "url",
   "linkTemplate" "http://example.com/{{ID}}",
   "linkTemplateText" "here's an id: {{ID}}"},
  "[\"ref\",[\"field-id\",6]]"
  {"type" "link",
   "linkType" "url",
   "linkTemplate" "http://example.com//{{id}}",
   "linkTemplateText" "here is my id: {{id}}"}}}
```