### PR TITLE
Release script improvements

### DIFF
--- a/bin/release/src/release.clj
+++ b/bin/release/src/release.clj
@@ -3,20 +3,19 @@
             [environ.core :as env]
             [flatland.ordered.map :as ordered-map]
             [metabuild-common.core :as u]
-            [release
-             [check-prereqs :as check-prereqs]
-             [checkout-latest :as checkout-latest]
-             [common :as c]
-             [docker :as docker]
-             [draft-release :as draft-release]
-             [elastic-beanstalk :as eb]
-             [git-tags :as git-tags]
-             [heroku :as heroku]
-             [set-build-options :as set-build-options]
-             [uberjar :as uberjar]
-             [update-website :as update-website]
-             [version-info :as version-info]]
-            [release.common.slack :as slack]))
+            [release.check-prereqs :as check-prereqs]
+            [release.checkout-latest :as checkout-latest]
+            [release.common :as c]
+            [release.common.slack :as slack]
+            [release.docker :as docker]
+            [release.draft-release :as draft-release]
+            [release.elastic-beanstalk :as eb]
+            [release.git-tags :as git-tags]
+            [release.heroku :as heroku]
+            [release.set-build-options :as set-build-options]
+            [release.uberjar :as uberjar]
+            [release.update-website :as update-website]
+            [release.version-info :as version-info]))
 
 (set! *warn-on-reflection* true)
 
@@ -41,12 +40,12 @@
                        (c/version)
                        (c/branch))
   (doseq [step-name steps]
-    (slack/post-message! "Starting step `%s` :flushed:" step-name)
+    (slack/post-message! "Starting step `%s` for `%s` :flushed:" (c/version) step-name)
     (let [thunk (or (get steps* step-name)
                     (throw (ex-info (format "Invalid step name: %s" step-name)
                                     {:found (set (keys steps*))})))]
       (thunk))
-    (slack/post-message! "Finished `%s` :partyparrot:" step-name))
+    (slack/post-message! "Finished `%s` for `%s` :partyparrot:" step-name (c/version)))
   (u/announce "Success."))
 
 (defn -main [& steps]

--- a/bin/release/src/release/common/upload.clj
+++ b/bin/release/src/release/common/upload.clj
@@ -1,6 +1,7 @@
 (ns release.common.upload
   (:require [metabuild-common.core :as u]
-            [release.common :as c]))
+            [release.common :as c]
+            [release.common.slack :as slack]))
 
 (defn upload-artifact!
   "Upload an artifact to downloads.metabase.com and create a CloudFront invalidation."
@@ -10,4 +11,5 @@
   ([source-file version filename]
    (u/step (format "Upload %s to %s" source-file (c/artifact-download-url version filename))
      (u/s3-copy! (u/assert-file-exists source-file) (c/s3-artifact-url version filename))
-     (u/create-cloudfront-invalidation! c/cloudfront-distribution-id (c/s3-artifact-path version filename)))))
+     (u/create-cloudfront-invalidation! c/cloudfront-distribution-id (c/s3-artifact-path version filename))
+     (slack/post-message! "Uploaded %s" (c/artifact-download-url version filename)))))

--- a/bin/release/src/release/set_build_options.clj
+++ b/bin/release/src/release/set_build_options.clj
@@ -1,11 +1,13 @@
 (ns release.set-build-options
-  (:require [metabuild-common.core :as u]
+  (:require [clojure.string :as str]
+            [metabuild-common.core :as u]
             [release.common :as c]))
 
 (defn prompt-and-set-build-options! []
   (let [[current-branch] (u/step "Determine current branch"
                            (u/sh "git" "symbolic-ref" "--short" "HEAD"))]
     (loop []
+      (println "Most recent releases:" (str/join ", " (c/recent-releases-by-minor-version-from-github)))
       (let [version (u/read-line-with-prompt "What version are we building (e.g. 0.36.0)?")
             branch  current-branch
             edition (case (first version)


### PR DESCRIPTION
1. Log latest versions on GH when prompting for version
2. Post notifications to Slack when artifacts/Docker images are uploaded
3. Include version number for Slack step notifications
