### PR TITLE
Search visual tweaks

### DIFF
--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -134,7 +134,7 @@ export default class SearchApp extends React.Component {
 }
 
 const SearchResultSection = ({ title, items }) => (
-  <Card>
+  <Card pt={2}>
     {items.map(item => {
       return <SearchResult result={item} />;
     })}

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -143,7 +143,11 @@ export default class SearchBar extends React.Component {
           {active && (
             <div className="absolute left right text-dark" style={{ top: 60 }}>
               {searchText.length > 0 ? (
-                <Card className="overflow-y-auto" style={{ maxHeight: 400 }}>
+                <Card
+                  className="overflow-y-auto"
+                  style={{ maxHeight: 400 }}
+                  py={1}
+                >
                   <Search.ListLoader
                     query={{ q: searchText }}
                     wrapped

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -28,11 +28,11 @@ const ResultLink = styled(Link)`
   justify-content: center;
   background-color: transparent;
   border-radius: 6px;
-  min-height: 54px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 8px;
-  padding-right: 8px;
+  min-height: ${props => (props.compact ? "36px" : "54px")};
+  padding-top: ${props => (props.compact ? "6px" : "8px")};
+  padding-bottom: ${props => (props.compact ? "6px" : "8px")};
+  padding-left: 14px;
+  padding-right: ${props => (props.compact ? "20px" : "32px")};
 
   &:hover {
     background-color: #fafafa;
@@ -43,6 +43,7 @@ const ResultLink = styled(Link)`
   }
 
   h3 {
+    font-size: ${props => (props.compact ? "14px" : "16px")};
     line-height: 1.2em;
     word-wrap: break-word;
   }
@@ -131,19 +132,25 @@ function CollectionResult({ collection }) {
 function contextText(context) {
   return context.map(function({ is_match, text }) {
     if (is_match) {
-      return <strong> {text}</strong>;
+      return <strong style={{ color: color("brand") }}> {text}</strong>;
     } else {
       return <span> {text}</span>;
     }
   });
 }
 
+const Context = styled("p")`
+  line-height: 1.4em;
+  color: ${color("text-medium")};
+  margin-top: 0;
+`;
+
 function formatContext(context, compact) {
   return (
     !compact &&
     context && (
-      <Box ml="42px" mt="12px">
-        {contextText(context)}
+      <Box ml="42px" mt="12px" style={{ maxWidth: 620 }}>
+        <Context>{contextText(context)}</Context>
       </Box>
     )
   );
@@ -155,7 +162,7 @@ function formatCollection(collection) {
 
 function DashboardResult({ dashboard, options }) {
   return (
-    <ResultLink to={dashboard.getUrl()}>
+    <ResultLink to={dashboard.getUrl()} compact={options.compact}>
       <Flex align="center">
         <ItemIcon item={dashboard} />
         <Box>
@@ -171,7 +178,7 @@ function DashboardResult({ dashboard, options }) {
 
 function QuestionResult({ question, options }) {
   return (
-    <ResultLink to={question.getUrl()}>
+    <ResultLink to={question.getUrl()} compact={options.compact}>
       <Flex align="center">
         <ItemIcon item={question} />
         <Box>
@@ -194,7 +201,7 @@ function QuestionResult({ question, options }) {
 
 function DefaultResult({ result, options }) {
   return (
-    <ResultLink to={result.getUrl()}>
+    <ResultLink to={result.getUrl()} compact={options.compact}>
       <Flex align="center">
         <ItemIcon item={result} />
         <Box>


### PR DESCRIPTION
## What this does
- Tightens up the spacing for "compact" search result items in type ahead to fit more items
- Improve styling / spacing for additional context on search results page

Before
<details>
<summary>View before</summary>

![image](https://user-images.githubusercontent.com/5248953/110029014-fc85d280-7d01-11eb-8cad-08156af398fd.png)
</details>

After
![image](https://user-images.githubusercontent.com/5248953/110028882-d19b7e80-7d01-11eb-9d91-0c214bcd0b07.png)
