### PR TITLE
Incorporate visualization settings into export

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.js
+++ b/frontend/src/metabase/lib/formatting/date.js
@@ -2,6 +2,9 @@ import type { DateSeparator } from "metabase/lib/formatting";
 
 import type { DatetimeUnit } from "metabase-types/types/Query";
 
+/*
+ * WARNING: please update metabase.util.visualization-settings on the backend with any changes here
+ */
 export type DateStyle =
   | "M/D/YYYY"
   | "D/M/YYYY"

--- a/project.clj
+++ b/project.clj
@@ -90,6 +90,7 @@
     :exclusions [org.slf4j/slf4j-api
                  it.unimi.dsi/fastutil]]
    [com.draines/postal "2.0.3"]                                       ; SMTP library
+   [com.gfredericks/test.chuck "0.2.10"]                              ; A utility library for test.check (including generator for regex)
    [com.google.guava/guava "28.2-jre"]                                ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
    [com.h2database/h2 "1.4.197"]                                      ; embedded SQL database
    [com.taoensso/nippy "2.14.0"]                                      ; Fast serialization (i.e., GZIP) library for Clojure
@@ -163,8 +164,8 @@
                                  org.clojure/tools.namespace
                                  honeysql]]
    [user-agent "0.1.0"]                                               ; User-Agent string parser, for Login History page & elsewhere
-   [weavejester/dependency "0.2.1"]                                   ; Dependency graphs and topological sorting
-   ]
+   [weavejester/dependency "0.2.1"]]                                   ; Dependency graphs and topological sorting
+
 
   :main ^:skip-aot metabase.core
 
@@ -220,8 +221,8 @@
      [pjstadig/humane-test-output "0.10.0"]
      [reifyhealth/specmonstah "2.0.0"]                                ; Generate fixtures to test huge databases
      [ring/ring-mock "0.4.0"]
-     [talltale "0.5.4"]                                               ; Generate realistic data for fixtures
-     ]
+     [talltale "0.5.4"]]                                               ; Generate realistic data for fixtures
+
 
     :plugins
     [[lein-environ "1.1.0"] ; easy access to environment variables

--- a/shared/src/metabase/shared/visualization.cljc
+++ b/shared/src/metabase/shared/visualization.cljc
@@ -1,0 +1,47 @@
+(ns metabase.shared.visualization
+  "Shared code for dealing with visualization settings."
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]))
+
+(defn- field-id-key [col]
+  (keyword (format "[\"ref\",[\"field\",%d,null]]" (:id col))))
+
+(defn- expression-key [col]
+  (keyword (format "[\"ref\",[\"expression\",\"%s\"]]" (:expression_name col))))
+
+(def ^:private col-key-regex #"\[\"ref\",\[(?:\"field\",\d+,null|\"expression\",\".+\")\]\]")
+
+(s/def ::column-setting-v1-key #(->> %
+                                     (name)
+                                     (re-matches col-key-regex)))
+
+(s/def ::column_title string?)
+
+(s/def ::date_style #{"M/D/YYYY" "D/M/YYYY" "YYYY/M/D" "MMMM D, YYYY" "D MMMM, YYYY" "dddd, MMMM D, YYYY"})
+(s/def ::date_abbreviate boolean?)
+(s/def ::time_style #{"h:mm A" "k:mm" "h A"})
+(s/def ::time_enabled #{nil "minutes" "seconds" "milliseconds"})
+
+(s/def ::decimals pos-int?)
+(s/def ::number_separators #(and string? (= 2 (count %))))
+(s/def ::number_style #{"decimal" "percent" "scientific" "currency"})
+(s/def ::prefix string?)
+(s/def ::suffix string?)
+
+(s/def ::column-setting-v1-date-format
+  (s/keys :req-un [::date_style ::time_style ::time_enabled]
+          :opt-un [::column_title]))
+
+(s/def ::column-setting-v1-number-format
+  (s/keys :req-un [::decimals ::number_separators ::number_style]
+          :opt-un [::column_title ::prefix ::suffix]))
+
+(s/def ::column-setting-v1-value (s/or ::date-column-format ::column-setting-v1-date-format
+                                       ::number-column-format ::column-setting-v1-number-format
+                                       ::no-formatting (s/keys :opt-un [::column_title])))
+
+(s/def ::column_settings (s/map-of ::column-setting-v1-key ::column-setting-v1-value))
+
+(s/def ::visualization_settings (s/keys :opt-un [::column_settings]))
+
+(s/def ::visualization-settings-v1 ::visualization_settings)

--- a/shared/test/metabase/shared/visualization_test.cljc
+++ b/shared/test/metabase/shared/visualization_test.cljc
@@ -1,0 +1,7 @@
+(ns metabase.shared.visualization-test
+  (:require [clojure.test :as t]
+            [clojure.spec.gen.alpha :as gen]))
+
+(t/deftest test-vis-settings
+  (t/testing ""
+    (t/is (= 1 1))))

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -341,7 +341,8 @@
         (dorun
          (map-indexed
           (fn [i row]
-            (qp.streaming.i/write-row! w row i))
+            ;; TODO: figure out what metadata (last param) is here?
+            (qp.streaming.i/write-row! w row i nil))
           rows))
         (qp.streaming.i/finish! w results)))))
 

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -111,6 +111,7 @@
    #'add-timezone-info/add-timezone-info
    #'splice-params-in-response/splice-params-in-response
    #'resolve-database-and-driver/resolve-database-and-driver
+   #'fetch-source-query/add-card-visualization-settings
    #'fetch-source-query/resolve-card-id-source-tables
    #'store/initialize-store
    #'validate/validate-query

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -28,6 +28,7 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.card :refer [Card]]
+            [metabase.models.interface :as mi]
             [metabase.query-processor.interface :as i]
             [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.util :as u]
@@ -272,3 +273,16 @@
         (binding [qp.perms/*card-id* (or card-id qp.perms/*card-id*)]
           (qp query rff context))
         (qp query rff context)))))
+
+(defn add-card-visualization-settings
+  "Middleware that adds visualization settings for cards."
+  [qp]
+  (fn [query rff context]
+    (if-let [card-id (:card-id (:info query))]
+      (qp
+       query
+       (fn [metadata]
+         (rff (assoc metadata :visualization_settings
+                              (db/select-one-field :visualization_settings Card :id card-id))))
+       context)
+      (qp query rff context))))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -29,7 +29,7 @@
 
       (write-row! [_ row _ {{:keys [cols indexed-column-viz-settings]} :data}]
         (letfn [(fmt-row [idx val]
-                  (let [fmt-fn (:format-fn (nth indexed-column-viz-settings idx))]
+                  (let [fmt-fn (::viz/format-fn (nth indexed-column-viz-settings idx))]
                     (fmt-fn val)))]
           (csv/write-csv writer [(map-indexed fmt-row row)])
           (.flush writer)))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -1,9 +1,9 @@
 (ns metabase.query-processor.streaming.csv
   (:require [clojure.data.csv :as csv]
             [java-time :as t]
-            [metabase.query-processor.streaming.common :as common]
             [metabase.query-processor.streaming.interface :as i]
-            [metabase.util.date-2 :as u.date])
+            [metabase.util.date-2 :as u.date]
+            [metabase.util.visualization-settings :as viz])
   (:import [java.io BufferedWriter OutputStream OutputStreamWriter]
            java.nio.charset.StandardCharsets))
 
@@ -19,13 +19,20 @@
   [_ ^OutputStream os]
   (let [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
     (reify i/StreamingResultsWriter
-      (begin! [_ {{:keys [cols]} :data}]
-        (csv/write-csv writer [(map (some-fn :display_name :name) cols)])
+      (begin! [_ {{:keys [cols indexed-column-title-overrides]} :data}]
+        (letfn [(col-nm-fn [idx col]
+                  (if-some [col-title (nth indexed-column-title-overrides idx)]
+                    col-title
+                    ((some-fn :display_name :name) col)))]
+          (csv/write-csv writer [(map-indexed col-nm-fn cols)]))
         (.flush writer))
 
-      (write-row! [_ row row-num]
-        (csv/write-csv writer [(map common/format-value row)])
-        (.flush writer))
+      (write-row! [_ row _ {{:keys [cols indexed-column-viz-settings]} :data}]
+        (letfn [(fmt-row [idx val]
+                  (let [fmt-fn (:format-fn (nth indexed-column-viz-settings idx))]
+                    (fmt-fn val)))]
+          (csv/write-csv writer [(map-indexed fmt-row row)])
+          (.flush writer)))
 
       (finish! [_ _]
          ;; TODO -- not sure we need to flush both

--- a/src/metabase/query_processor/streaming/interface.clj
+++ b/src/metabase/query_processor/streaming/interface.clj
@@ -14,7 +14,7 @@
     "Write anything needed before writing the first row. `initial-metadata` is incomplete metadata provided before
     rows begin reduction; some metadata such as insights won't be available until we finish.")
 
-  (write-row! [this row row-num]
+  (write-row! [this row row-num metadata]
     "Write a row. `row` is a sequence of values in the row. `row-num` is the zero-indexed row number.")
 
   (finish! [this final-metadata]

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -27,7 +27,7 @@
         (vreset! col-names (mapv (some-fn :display_name :name) cols))
         (.write writer "[\n"))
 
-      (write-row! [_ row row-num]
+      (write-row! [_ row row-num _]
         (when-not (zero? row-num)
           (.write writer ",\n"))
         (json/generate-stream (zipmap @col-names (map common/format-value row))
@@ -58,7 +58,7 @@
       (begin! [_ _]
         (.write writer "{\"data\":{\"rows\":[\n"))
 
-      (write-row! [_ row row-num]
+      (write-row! [_ row row-num _]
         (when-not (zero? row-num)
           (.write writer ",\n"))
         (json/generate-stream row writer)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -123,7 +123,7 @@
       (begin! [_ {{:keys [cols]} :data}]
         (spreadsheet/add-row! sheet (map (some-fn :display_name :name) cols)))
 
-      (write-row! [_ row _]
+      (write-row! [_ row _ _]
         (binding [*cell-styles* cell-styles]
           (spreadsheet/add-row! sheet row)))
 

--- a/src/metabase/util/visualization_settings.clj
+++ b/src/metabase/util/visualization_settings.clj
@@ -1,0 +1,169 @@
+(ns metabase.util.visualization-settings
+  "Utility functions for dealing with visualization settings on the backend."
+  (:require [clojure.string :as str]
+            [schema.core :as s]
+            [metabase.util.schema :as su]
+            [metabase.query-processor.streaming.common :as common])
+  (:import (java.time.format DateTimeFormatter)
+           (java.time.temporal TemporalAccessor)
+           (java.text DecimalFormat)))
+
+;; a column map can look like any of these
+;; from an export test
+;; {:name CAM, :base_type :type/Text}
+;; from a custom column added in query builder
+;; { :base_type :type/BigInteger,
+;    :semantic_type :type/Number,
+;    :name "negative_id",
+;    :display_name "negative_id",
+;    :expression_name "negative_id",
+;    :field_ref [:expression "negative_id"],
+;    :source :fields}
+;; from a "regular" column
+;; {:description The total billed amount., :semantic_type nil, :table_id 37, :name TOTAL, :settings nil,
+;;  :source :fields, :field_ref [:field 143 nil], :parent_id nil, :id 143, :visibility_type :normal,
+;;  :display_name Total, :fingerprint {:global {:distinct-count 4426, :nil% 0.0},
+;;  :type {:type/Number {:min 8.93914247937167, :q1 51.34535490743823, :q3 110.29428389265787, :max 159.34900526552292,
+;;                       :sd 34.26469575709948, :avg 80.35871658771228}}},
+;;  :base_type :type/Float}
+
+(def Column (su/open-schema
+              {(s/optional-key :id) su/IntGreaterThanZero
+               (s/optional-key :expression_name) s/Str
+               (s/optional-key :name) s/Str}))
+
+(def ColSetting s/Any)
+
+;; the :column_settings map can look like this:
+;; {:["ref",["field",140,null]]           {:date_style "YYYY/M/D", :time_enabled "minutes", :time_style "k:mm"},
+;   :["ref",["field",145,null]]           {:column_title "Renamed_ID"},
+;   :["ref",["expression","negative_id"]] {:number_separators ", "}}}
+(def ColSettings {s/Keyword ColSetting})
+
+(def VizSettings (s/maybe (su/open-schema
+                            {(s/required-key :column_settings) ColSettings})))
+
+(defn- field-id-key [col]
+  (format "[\"ref\",[\"field\",%d,null]]" (:id col)))
+
+(defn- expression-key [col]
+  (format "[\"ref\",[\"expression\",\"%s\"]]" (:expression_name col)))
+
+(defn- find-col-setting [{:keys [column_settings]} col]
+  (or (get column_settings (field-id-key col))
+      (get column_settings (expression-key col))))
+
+;;export type DateStyle =
+;  | "M/D/YYYY"
+;  | "D/M/YYYY"
+;  | "YYYY/M/D"
+;  | "MMMM D, YYYY"
+;  | "MMMM D, YYYY"
+;  | "D MMMM, YYYY"
+;  | "dddd, MMMM D, YYYY";
+;
+;export type TimeStyle = "h:mm A" | "k:mm" | "h A";
+
+;; see: https://github.com/MadMG/moment-jdateformatparser
+(defn momentjs-to-java-format
+  "Parameter names are deliberately chosen to match what the frontend sends."
+  [date_style date_abbreviate time_style time_enabled]
+  (let [dt-str (case date_style
+                 "M/D/YYYY" "M/d/YYYY"
+                 "D/M/YYYY" "d/M/YYYY"
+                 "YYYY/M/D" "YYYY/M/d"
+                 ;; Jan 7, 2018 or January 7, 2018
+                 "MMMM D, YYYY" (if date_abbreviate "MMM d YYYY" "MMMM d YYYY")
+                 ;; 7 Jan, 2018 or 7 January, 2018
+                 "D MMMM, YYYY" (if date_abbreviate "d MMM YYYY" "d MMMM YYYY")
+                 ;; Sun, Jan 7, 2018 or Sunday, January 7, 2018
+                 "dddd, MMMM D, YYYY" (if date_abbreviate "EEE, MMM d, YYYY" "EEEE, MMMM d, YYYY"))
+        sub-day  (case time_enabled
+                   nil            ""
+                   "minutes"      ""
+                   "seconds"      ":ss"
+                   "milliseconds" ":ss:SSS")
+        time-str (when (some? time_enabled)
+                   (case time_style
+                     nil      nil
+                     ;; 17:24 (with seconds/millis as per time-enabled)
+                     "k:mm"   (format "H:mm%s" sub-day)
+                     ;; 5:24 PM (with seconds/millis as per above)
+                     "h:mm A" (format "h:mm%s a" sub-day)
+                     "HH:mm" (format "H:mm%s" sub-day)))]
+    (format "%s%s" dt-str (if (some? time-str) (str ", " time-str) ""))))
+
+(defn date-format-fn [{:keys [date_style date_abbreviate time_style time_enabled]}]
+  (let [fmt-str   (momentjs-to-java-format date_style date_abbreviate time_style time_enabled)
+        formatter (DateTimeFormatter/ofPattern fmt-str)]
+    #(.format formatter %)))
+
+(defn number-format-fn [{:keys [decimals number_separators number_style prefix suffix]}]
+  ;; decimals is the number of decimal digits to show
+  ;; number_separators is a two-char string; decimal point character then group (thousands) separator
+  ;; number_style is either "decimal" "percent" "scientific" or "currency"
+  ;; prefix and suffix are just strings to prepend and append, respectively
+  (let [quote-lit  (fn [val]
+                     (if (str/blank? val)
+                       ""
+                       ;; literals in DecimalFormat need single quoted, with a literal single quote needing escaped
+                       (format "'%s'" (str/replace val "'" "''"))))
+        dec-sep    (or (first number_separators) ".")
+        group-sep  (or (last number_separators) ",")
+        dec-part   (if (pos-int? decimals) (apply str (conj (repeat decimals \0) dec-sep)) "")
+        formatter  (DecimalFormat. (format "%s%s###%s%s" (quote-lit prefix) group-sep dec-part (quote-lit suffix)))]
+    #(.format formatter %)))
+
+(defn- always-dispatch-on-first-val-pred
+  "Returns a stateful function of a single `arg` that will invoke `(fn-if arg)` when `(pred arg)` returns true, and
+  `(fn-else arg)` otherwise. Only the first `arg` value ever passed to this `fn` is checked against the predicate `fn`;
+  all subsequent values passed for `arg` to the returned `fn` are assumed to also satisfy the predicate. This is a
+  reasonable assumption for certain scenarios, such as subsequent rows, at the same column position, from a single JDBC
+  `ResultSet`"
+  [pred fn-if fn-else]
+  (let [res (atom nil)]
+    (fn [val]
+      (if (nil? @res)
+        ;; predicate never checked; call it now
+        (reset! res (pred val)))
+      (if @res (fn-if val) (fn-else val)))))
+
+(defn- fmt-fn-or-default
+  "Returns a function that will call fmt-fn if pred is true for the first value passed, else will call the
+  common/format-value protocol fn."
+  [pred fmt-fn]
+  (always-dispatch-on-first-val-pred pred fmt-fn common/format-value))
+
+(defn make-format-metadata [visualization-settings col]
+  ;; always provide a default format fn
+  (let [fmt-md {:format-fn common/format-value}]
+    (if-some [col-settings (find-col-setting visualization-settings col)]
+      (let [number-keys (select-keys col-settings [:decimals :number_separator :number_style])]
+        (-> (merge col-settings fmt-md) ; merge in col-settings with our format metadata
+            ;; if a date_style exists, add a date specific format fn
+            (cond-> (:date_style col-settings) (assoc :format-fn (fmt-fn-or-default
+                                                                  #(instance? TemporalAccessor %)
+                                                                  (date-format-fn col-settings))))
+            (cond-> (not-empty number-keys) (assoc :format-fn (fmt-fn-or-default
+                                                               #(instance? Number %)
+                                                               (number-format-fn col-settings))))))
+      fmt-md)))
+
+(defn column-title-override [visualization-settings col]
+  (when-some [col-settings (find-col-setting visualization-settings col)]
+    (:column_title col-settings)))
+
+(s/defn col-settings-key
+  "Gets the key that would be mapped under :column_settings for the given col (a Column domain object)."
+  [col :- Column]
+  (keyword (format "[\"ref\",[\"field\",%d,null]]" (:id col))))
+
+(s/defn col-settings :- (s/maybe ColSetting)
+  "Gets the column_settings value mapped by the given col (a Column domain object) as a key (a Column domain object)."
+  [{:keys [column_settings] :as visualization-settings} :- VizSettings col :- Column]
+  (get column_settings (col-settings-key col)))
+
+(s/defn date-format-from-col-settings [visualization-settings :- VizSettings col  :- Column] :- (s/maybe s/Str)
+  (let [settings (find-col-setting visualization-settings col)]
+    (if-let [date-style (:date_style settings)]
+      (str date-style (if-let [time-style (:time_style settings)] (str " " time-style) "")))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -104,7 +104,7 @@
 
 ;;; ------------------------------------------ Circular Reference Detection ------------------------------------------
 
-(defn- card-with-source-table
+(defn card-with-source-table
   "Generate values for a Card with `source-table` for use with `with-temp`."
   {:style/indent 1}
   [source-table & {:as kvs}]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -394,7 +394,10 @@
                      (m/dissoc-in [:data :results_metadata :checksum]))
                  (-> (qp/process-query query)
                      (dissoc :updated_at)
-                     (m/dissoc-in [:data :results_metadata :checksum])))
+                     (m/dissoc-in [:data :results_metadata :checksum]
+                                  ;; col viz settings are cached with the metadata, so ignore it for the purpose of test
+                                  [:data :indexed-column-viz-settings]
+                                  [:data :indexed-column-title-overrides])))
               "Query should be cached and results should match those ran without cache"))))))
 
 (deftest caching-big-resultsets

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -12,11 +12,14 @@
             [metabase.query-processor :as qp]
             [metabase.query-processor.streaming :as qp.streaming]
             [metabase.test :as mt]
+            [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
-            [toucan.db :as db]
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [toucan.db :as db])
   (:import [java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream InputStream
             InputStreamReader]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defmulti ^:private parse-result*
   {:arglists '([export-format ^InputStream input-stream column-names])}
@@ -284,9 +287,9 @@
   (doseq [export-format [:csv]]
     (testing export-format
       (testing "A CSV export takes into account custom visualization settings"
-        (let [tbl-id (db/select-one-id Table :name "CHECKINS")
-              f1-id  (db/select-one-id Field :table_id tbl-id :name "ID")
-              f2-id  (db/select-one-id Field :table_id tbl-id :name "DATE")
+        (let [tbl-id (mt/id :checkins)
+              f1-id  (mt/id :checkins :id)
+              f2-id  (mt/id :checkins :date)
               cs-1   [:ref [:field f1-id nil]]
               cs-2   [:ref [:field f2-id nil]]
               cs-map {cs-1 {:column_title "Checkin ID"}
@@ -295,7 +298,7 @@
                             :time_enabled    nil
                             :time_style      nil}}]
           (mt/with-temp Card [card (card-test/card-with-source-table
-                                    (mt/id :checkins)
+                                    tbl-id
                                     :visualization_settings
                                     (make-col-settings cs-map))]
             (let [card-id     (u/the-id card)

--- a/test/metabase/util/stats_test.clj
+++ b/test/metabase/util/stats_test.clj
@@ -139,7 +139,7 @@
                   PulseCard    [_ {:pulse_id (u/get-id p3), :card_id (u/get-id c), :include_csv true, :include_xls true}]
                   ;; ---------- Alerts ----------
                   Pulse        [a1 {:alert_condition "rows", :alert_first_only false}]
-                  Pulse        [a2 {:alert_condition "rows", :alert_first_only true }]
+                  Pulse        [a2 {:alert_condition "rows", :alert_first_only true}]
                   Pulse        [a3 {:alert_condition "goal", :alert_first_only false}]
                   Pulse        [a4 {:alert_condition "goal", :alert_first_only false, :alert_above_goal true}]
                   ;; Alert 1 is Email, Alert 2 is Email & Slack, Alert 3 is Slack-only

--- a/test/metabase/util/visualization_settings_test.clj
+++ b/test/metabase/util/visualization_settings_test.clj
@@ -1,0 +1,94 @@
+(ns metabase.util.visualization-settings-test
+  (:require [clojure.test :refer :all]
+            [metabase.util.visualization-settings :as viz]
+            [java-time :as t]))
+
+(deftest name-for-column
+  (let [viz-settings {:column_settings {"[\"ref\",[\"field\",14,null]]" {:column_title "Renamed Column"
+                                                                         :date_style   "YYYY/MM/D"
+                                                                         :time_enabled "minutes"
+                                                                         :time_style   "k:mm"}}}
+        col          {:id 14}]
+    (testing "name-from-col-settings works as expected"
+             (is (= "Renamed Column"
+                    (viz/column-title-override viz-settings col))))
+    (testing "date-format-from-col-settings works as expected"
+      (is (= "YYYY/MM/D k:mm"
+             (viz/date-format-from-col-settings viz-settings col))))))
+
+(deftest momentjs-format-strings-test
+  (let [test-date (t/local-date-time 2021 3 3 14 39 27 876000000)]
+    (doseq [[expected date_style date_abbreviate time_style time_enabled]
+            [["Wednesday, March 3, 2021" "dddd, MMMM D, YYYY" false "h:mm A" nil]
+             ["Wed, Mar 3, 2021" "dddd, MMMM D, YYYY" true "h:mm A" nil]
+             ["Wednesday, March 3, 2021, 2:39 PM" "dddd, MMMM D, YYYY" false "h:mm A" "minutes"]
+             ["Wed, Mar 3, 2021, 2:39 PM" "dddd, MMMM D, YYYY" true "h:mm A" "minutes"]
+             ["Wed, Mar 3, 2021, 14:39:27:876" "dddd, MMMM D, YYYY" true "k:mm" "milliseconds"]]]
+      (testing (format "Formatting date results in \"%s\"" expected)
+        (let [col-setting {:date_style date_style :date_abbreviate date_abbreviate
+                           :time_style time_style :time_enabled time_enabled}]
+          (is (= expected
+                 ((viz/date-format-fn col-setting) test-date))))))))
+
+(deftest format-functions-from-vis-settings-test
+  (let [field-id-1   143
+        field-id-2   299
+        col-ref-id   (format "[\"ref\",[\"field\",%s,null]]" field-id-1)
+        col-ref-id-2 (format "[\"ref\",[\"field\",%s,null]]" field-id-2)
+        col-ref-expr "[\"ref\",[\"expression\",\"CREATED_AT_MINUS_ONE_DAY\"]]"
+        viz-settings {:column_settings {col-ref-id   {:column_title "Grand Total"}
+                                        col-ref-expr {:date_style   "YYYY/M/D"
+                                                      :time_enabled "minutes"
+                                                      :time_style   "k:mm"}
+                                        col-ref-id-2 {:decimals          2
+                                                      :number_separators ".,"
+                                                      :number_style      "decimal"
+                                                      :prefix            "<"
+                                                      :suffix            ">"}}}
+        id-col       {:description     "The total billed amount."
+                      :semantic_type   nil,
+                      :table_id        37,
+                      :name            "TOTAL",
+                      :settings        nil,
+                      :source          :fields,
+                      :field_ref       [:field field-id-1 nil],
+                      :parent_id       nil,
+                      :id              field-id-1,
+                      :visibility_type :normal,
+                      :display_name    "Total",
+                      :fingerprint     {:global {:distinct-count 4426, :nil% 0.0}}
+                      :type            {:type/Number {:min 8.93914247937167, :q1 51.34535490743823,
+                                                      :q3 110.29428389265787, :max 159.34900526552292,
+                                                      :sd 34.26469575709948, :avg 80.35871658771228}},
+                      :base_type       :type/Float}
+        id-col-2     (assoc id-col :description  "The subtotal before tax"
+                                   :id           field-id-2
+                                   :field_ref    [:field field-id-2 nil]
+                                   :display_name "Subtotal"
+                                   :name         "SUBTOTAL")
+        expr-col     {:base_type       :type/DateTime,
+                      :semantic_type   :type/CreationTimestamp,
+                      :name            "CREATED_AT_MINUS_ONE_DAY",
+                      :display_name    "CREATED_AT_MINUS_ONE_DAY",
+                      :expression_name "CREATED_AT_MINUS_ONE_DAY",
+                      :field_ref       [:expression "CREATED_AT_MINUS_ONE_DAY"],
+                      :source          :fields}
+        test-date    (t/local-date-time 2021 1 21 13 5)
+        test-total   12124.43
+        test-subtot  10941.9]
+    (testing "correct format function for dates created for column"
+      (let [fmt-md-expr (viz/make-format-metadata viz-settings expr-col)
+            fmt-md-id   (viz/make-format-metadata viz-settings id-col)
+            fmt-md-id-2 (viz/make-format-metadata viz-settings id-col-2)]
+        ;; format fn should be defined in both cases
+        (is (contains? fmt-md-expr :format-fn))
+        (is (contains? fmt-md-id :format-fn))
+        ;; format fn for the expr column should work based on the viz settings
+        (is (= "2021/1/21, 13:05" ((:format-fn fmt-md-expr) test-date)))
+        ;; format fn for the id column should use a default impl from protocol fn
+        (is (= test-total ((:format-fn fmt-md-id) test-total)))
+        ;; format fn for id column 2 should use the decimal formatting viz settings
+        (is (= "<10,941.90>" ((:format-fn fmt-md-id-2) test-subtot)))))
+    (testing ":column_title picked up for expression"
+      (is (= "Grand Total"
+             (viz/column-title-override viz-settings id-col))))))

--- a/test/metabase/util/visualization_settings_test.clj
+++ b/test/metabase/util/visualization_settings_test.clj
@@ -5,7 +5,7 @@
 
 (deftest name-for-column
   (let [viz-settings {:column_settings {"[\"ref\",[\"field\",14,null]]" {:column_title "Renamed Column"
-                                                                         :date_style   "YYYY/MM/D"
+                                                                         :date_style   "YYYY/M/D"
                                                                          :time_enabled "minutes"
                                                                          :time_style   "k:mm"}}}
         col          {:id 14}]
@@ -19,8 +19,8 @@
 (deftest momentjs-format-strings-test
   (let [test-date (t/local-date-time 2021 3 3 14 39 27 876000000)]
     (doseq [[expected date_style date_abbreviate time_style time_enabled]
-            [["Wednesday, March 3, 2021" "dddd, MMMM D, YYYY" false "h:mm A" nil]
-             ["Wed, Mar 3, 2021" "dddd, MMMM D, YYYY" true "h:mm A" nil]
+            [["Wednesday, March 3, 2021" "dddd, MMMM D, YYYY" false nil nil]
+             ["Wed, Mar 3, 2021" "dddd, MMMM D, YYYY" true nil nil]
              ["Wednesday, March 3, 2021, 2:39 PM" "dddd, MMMM D, YYYY" false "h:mm A" "minutes"]
              ["Wed, Mar 3, 2021, 2:39 PM" "dddd, MMMM D, YYYY" true "h:mm A" "minutes"]
              ["Wed, Mar 3, 2021, 14:39:27:876" "dddd, MMMM D, YYYY" true "k:mm" "milliseconds"]]]
@@ -81,14 +81,14 @@
             fmt-md-id   (viz/make-format-metadata viz-settings id-col)
             fmt-md-id-2 (viz/make-format-metadata viz-settings id-col-2)]
         ;; format fn should be defined in both cases
-        (is (contains? fmt-md-expr :format-fn))
-        (is (contains? fmt-md-id :format-fn))
+        (is (contains? fmt-md-expr ::viz/format-fn))
+        (is (contains? fmt-md-id ::viz/format-fn))
         ;; format fn for the expr column should work based on the viz settings
-        (is (= "2021/1/21, 13:05" ((:format-fn fmt-md-expr) test-date)))
+        (is (= "2021/1/21, 13:05" ((::viz/format-fn fmt-md-expr) test-date)))
         ;; format fn for the id column should use a default impl from protocol fn
-        (is (= test-total ((:format-fn fmt-md-id) test-total)))
+        (is (= test-total ((::viz/format-fn fmt-md-id) test-total)))
         ;; format fn for id column 2 should use the decimal formatting viz settings
-        (is (= "<10,941.90>" ((:format-fn fmt-md-id-2) test-subtot)))))
+        (is (= "<10,941.90>" ((::viz/format-fn fmt-md-id-2) test-subtot)))))
     (testing ":column_title picked up for expression"
       (is (= "Grand Total"
              (viz/column-title-override viz-settings id-col))))))


### PR DESCRIPTION
WORK IN PROGRESS

Adding middleware fn to populate :visualization_settings for a card into the reducer fn

Adding metadata as last param to metabase.query-processor.streaming.common.FormatValue/format-value protocol fn, to allow for passing of formatter specific metadata (i.e. date format)

Adding metadata as last param to metabase.query-processor.streaming.interface.StreamingResultsWriter/write-row! protocol fn, to allow for passing of :visualization_settings into the row specific writing fn

Adding visualization_settings.clj utility functions to handle backend specific functionality around :visualization_settings values

Modifying CSV exporter to look up renamed columns and date formats from column-specific :visualization_settings
