### PR TITLE
Improvements on development environment with docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-8
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+RUN apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com\
+  && apt-get update && export DEBIAN_FRONTEND=noninteractive \
   && apt-get -y install --no-install-recommends leiningen

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",
     "build": "yarn && webpack --bail",
     "build-watch": "yarn && webpack --watch",
-    "build-hot": "yarn && NODE_ENV=hot webpack-dev-server --progress",
+    "build-hot": "yarn && NODE_ENV=hot webpack-dev-server --progress --host 0.0.0.0",
     "build-stats": "yarn && webpack --json > stats.json",
     "build-shared": "yarn && webpack --config webpack.shared.config.js",
     "start": "yarn build && lein ring server",


### PR DESCRIPTION
* To be able to run a devcontainer its own network (not just --net
host), webpack-dev-server serves on 0.0.0.0.
* Fix expired signature (EXPKEYSIG):
  https://github.com/yarnpkg/yarn/issues/786
