### PR TITLE
Fix flakiness in test-ssh-tunnel-reconnection-h2

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -28,7 +28,8 @@
             [toucan.util.test :as tt])
   (:import java.util.concurrent.TimeoutException
            java.util.Locale
-           [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]))
+           [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]
+           (java.net ServerSocket)))
 
 (comment tu.log/keep-me)
 
@@ -659,7 +660,7 @@
   `(do-with-non-admin-groups-no-collection-perms
     (assoc collection/root-collection
            :namespace (name ~collection-namespace))
-    (fn [] ~@body) ))
+    (fn [] ~@body)))
 
 (defn doall-recursive
   "Like `doall`, but recursively calls doall on map values and nested sequences, giving you a fully non-lazy object.
@@ -786,3 +787,10 @@
            cols)
     (fn []
       ~@body)))
+
+(defn find-free-port
+  "Finds and returns an available port number on the current host. Does so by briefly creating a ServerSocket, which
+  is closed when returning."
+  []
+  (with-open [socket (ServerSocket. 0)]
+    (.getLocalPort socket)))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -26,10 +26,10 @@
             [toucan.db :as db]
             [toucan.models :as t.models]
             [toucan.util.test :as tt])
-  (:import java.util.concurrent.TimeoutException
+  (:import java.net.ServerSocket
+           java.util.concurrent.TimeoutException
            java.util.Locale
-           [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]
-           (java.net ServerSocket)))
+           [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]))
 
 (comment tu.log/keep-me)
 

--- a/test/metabase/util/ssh_test.clj
+++ b/test/metabase/util/ssh_test.clj
@@ -12,7 +12,8 @@
             [metabase.util.ssh :as ssh]
             [metabase.sync :as sync]
             [metabase.test :as mt]
-            [metabase.test.data.interface :as tx])
+            [metabase.test.data.interface :as tx]
+            [metabase.test.util :as tu])
   (:import [java.io BufferedReader InputStreamReader PrintWriter]
            [java.net InetSocketAddress ServerSocket Socket]
            org.apache.sshd.server.forward.AcceptAllForwardingFilter
@@ -247,7 +248,7 @@
    native queries against that table."
   (mt/with-driver :h2
     (testing "ssh tunnel is reestablished if it becomes closed, so subsequent queries still succeed (H2 version)"
-      (let [h2-port (+ 49152 (rand-int (- 65535 49152))) ; https://stackoverflow.com/a/2675399
+      (let [h2-port (tu/find-free-port)
             server  (init-h2-tcp-server h2-port)
             uri     (format "tcp://localhost:%d/./test_resources/ssh/tiny-db;USER=GUEST;PASSWORD=guest" h2-port)
             h2-db   {:port               h2-port


### PR DESCRIPTION
Add test utility fn to find a free port, and call that from `test-ssh-tunnel-reconnection-h2` instead of picking a random one
