### PR TITLE
#15077 Repro: Dashboard sharing is not possible for dashboards with text cards only

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -24,6 +24,24 @@ describe("scenarios > dashboard > subscriptions", () => {
       .should("have.class", "cursor-default");
   });
 
+  it.skip("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
+    cy.createDashboard("15077D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.visit(`/dashboard/${DASHBOARD_ID}`);
+    });
+    cy.icon("pencil").click();
+    cy.icon("string").click();
+    cy.findByPlaceholderText("Write here, and use Markdown if you'd like")
+      .click()
+      .type("Foo");
+    cy.findByRole("button", { name: "Save" }).click();
+    cy.findByText("You're editing this dashboard.").should("not.exist");
+    cy.icon("share")
+      .closest("a")
+      .should("have.class", "cursor-pointer")
+      .click();
+    cy.findByText("Dashboard subscriptions").click();
+  });
+
   describe("with no channels set up", () => {
     it("should instruct user to connect email or slack", () => {
       openDashboardSubscriptions();


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15077

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/110365676-9670b680-8045-11eb-8b87-86595ae213b3.png)

