### PR TITLE
Handle React errors [WIP]

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -94,6 +94,9 @@ export default class DatabaseEditApp extends Component {
     this.state = {
       currentTab: TABS[0].value,
     };
+
+    this.discardSavedFieldValuesModal = React.createRef();
+    this.deleteDatabaseModal = React.createRef();
   }
 
   static propTypes = {
@@ -233,14 +236,14 @@ export default class DatabaseEditApp extends Component {
                   <ol>
                     <li>
                       <ModalWithTrigger
-                        ref="discardSavedFieldValuesModal"
+                        ref={this.discardSavedFieldValuesModal}
                         triggerClasses="Button Button--danger Button--discardSavedFieldValues"
                         triggerElement={t`Discard saved field values`}
                       >
                         <ConfirmContent
                           title={t`Discard saved field values`}
                           onClose={() =>
-                            this.refs.discardSavedFieldValuesModal.toggle()
+                            this.discardSavedFieldValuesModal.current.toggle()
                           }
                           onAction={() =>
                             this.props.discardSavedFieldValues(database.id)
@@ -251,13 +254,15 @@ export default class DatabaseEditApp extends Component {
 
                     <li className="mt2">
                       <ModalWithTrigger
-                        ref="deleteDatabaseModal"
+                        ref={this.deleteDatabaseModal}
                         triggerClasses="Button Button--deleteDatabase Button--danger"
                         triggerElement={t`Remove this database`}
                       >
                         <DeleteDatabaseModal
                           database={database}
-                          onClose={() => this.refs.deleteDatabaseModal.toggle()}
+                          onClose={() =>
+                            this.deleteDatabaseModal.current.toggle()
+                          }
                           onDelete={() =>
                             this.props.deleteDatabase(database.id, true)
                           }

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -50,6 +50,15 @@ const mapDispatchToProps = {
   mapDispatchToProps,
 )
 export default class DatabaseList extends Component {
+  constructor(props) {
+    super(props);
+
+    this.createdDatabaseModal = React.createRef();
+    props.databases.map(database => {
+      this["deleteDatabaseModal_" + database.id] = React.createRef();
+    });
+  }
+
   static propTypes = {
     databases: PropTypes.array,
     hasSampleDataset: PropTypes.bool,
@@ -60,7 +69,7 @@ export default class DatabaseList extends Component {
 
   UNSAFE_componentWillReceiveProps(newProps) {
     if (!this.props.created && newProps.created) {
-      this.refs.createdDatabaseModal.open();
+      this.createdDatabaseModal.current.open();
     }
   }
 
@@ -129,16 +138,16 @@ export default class DatabaseList extends Component {
                         ) : (
                           <td className="Table-actions">
                             <ModalWithTrigger
-                              ref={"deleteDatabaseModal_" + database.id}
+                              ref={this["deleteDatabaseModal_" + database.id]}
                               triggerClasses="Button Button--danger"
                               triggerElement={t`Delete`}
                             >
                               <DeleteDatabaseModal
                                 database={database}
                                 onClose={() =>
-                                  this.refs[
+                                  this[
                                     "deleteDatabaseModal_" + database.id
-                                  ].close()
+                                  ].current.close()
                                 }
                                 onDelete={() =>
                                   this.props.deleteDatabase(database.id)
@@ -184,11 +193,14 @@ export default class DatabaseList extends Component {
             </div>
           ) : null}
         </section>
-        <ModalWithTrigger ref="createdDatabaseModal" isInitiallyOpen={created}>
+        <ModalWithTrigger
+          ref={this.createdDatabaseModal}
+          isInitiallyOpen={created}
+        >
           <CreatedDatabaseModal
             databaseId={parseInt(created)}
-            onDone={() => this.refs.createdDatabaseModal.toggle()}
-            onClose={() => this.refs.createdDatabaseModal.toggle()}
+            onDone={() => this.createdDatabaseModal.current.toggle()}
+            onClose={() => this.createdDatabaseModal.current.toggle()}
           />
         </ModalWithTrigger>
       </div>

--- a/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
@@ -34,6 +34,8 @@ export default class FieldRemapping extends React.Component {
 
   constructor(props, context) {
     super(props, context);
+
+    this.fkPopover = React.createRef();
   }
 
   getMappingTypeForField = field => {
@@ -192,7 +194,7 @@ export default class FieldRemapping extends React.Component {
 
       await fetchTableMetadata({ id: table.id }, { reload: true });
 
-      this.refs.fkPopover.close();
+      this.fkPopover.current.close();
     } else {
       throw new Error(t`The selected field isn't a foreign key`);
     }
@@ -269,7 +271,7 @@ export default class FieldRemapping extends React.Component {
           {mappingType === MAP_OPTIONS.foreign && [
             <SelectSeparator classname="flex" key="foreignKeySeparator" />,
             <PopoverWithTrigger
-              ref="fkPopover"
+              ref={this.fkPopover}
               triggerElement={
                 <SelectButton
                   hasValue={hasFKMappingValue}

--- a/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
@@ -11,6 +11,11 @@ import ObjectRetireModal from "./ObjectRetireModal";
 import { capitalize } from "metabase/lib/formatting";
 
 export default class ObjectActionsSelect extends Component {
+  constructor(props) {
+    super(props);
+
+    this.retireModal = React.createRef();
+  }
   static propTypes = {
     object: PropTypes.object.isRequired,
     objectType: PropTypes.string.isRequired,
@@ -19,7 +24,7 @@ export default class ObjectActionsSelect extends Component {
 
   async onRetire(object) {
     await this.props.onRetire(object);
-    this.refs.retireModal.close();
+    this.retireModal.current.close();
   }
 
   render() {
@@ -27,7 +32,6 @@ export default class ObjectActionsSelect extends Component {
     return (
       <div>
         <PopoverWithTrigger
-          ref="popover"
           triggerElement={
             <span className="text-light text-brand-hover">
               <Icon name={"ellipsis"} />
@@ -61,7 +65,7 @@ export default class ObjectActionsSelect extends Component {
             </li>
             <li className="mt1 border-top">
               <ModalWithTrigger
-                ref="retireModal"
+                ref={this.retireModal}
                 triggerElement={"Retire " + capitalize(objectType)}
                 triggerClasses="block p2 bg-error-hover text-error text-white-hover cursor-pointer"
               >
@@ -69,7 +73,7 @@ export default class ObjectActionsSelect extends Component {
                   object={object}
                   objectType={objectType}
                   onRetire={this.onRetire.bind(this)}
-                  onClose={() => this.refs.retireModal.close()}
+                  onClose={() => this.retireModal.current.close()}
                 />
               </ModalWithTrigger>
             </li>

--- a/frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import ActionButton from "metabase/components/ActionButton";
 import ModalContent from "metabase/components/ModalContent";
@@ -13,12 +12,13 @@ export default class ObjectRetireModal extends Component {
     this.state = {
       valid: false,
     };
+    this.revisionMessage = React.createRef();
   }
 
   async handleSubmit() {
     const payload = {
       id: this.props.object.id,
-      revision_message: ReactDOM.findDOMNode(this.refs.revision_message).value,
+      revision_message: this.revisionMessage.current.value,
     };
 
     await this.props.onRetire(payload);
@@ -38,7 +38,7 @@ export default class ObjectRetireModal extends Component {
             <p className="text-paragraph">{t`Saved questions and other things that depend on this ${objectType} will continue to work, but this ${objectType} will no longer be selectable from the query builder.`}</p>
             <p className="text-paragraph">{t`If you're sure you want to retire this ${objectType}, please write a quick explanation of why it's being retired:`}</p>
             <textarea
-              ref="revision_message"
+              ref={this.revisionMessage}
               className="input full"
               placeholder={t`This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this ${objectType}.`}
               onChange={e => this.setState({ valid: !!e.target.value })}

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -125,6 +125,7 @@ export default class PartialQueryBuilder extends Component {
             <a
               data-metabase-event={"Data Model;Preview Click"}
               target={window.OSX ? null : "_blank"}
+              rel="noopener noreferrer"
               className={cx("Button Button--primary")}
               href={previewUrl}
             >{t`Preview`}</a>

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -37,18 +37,6 @@ export default class MetadataHeader extends Component {
     this.setDatabaseIdIfUnset();
   }
 
-  setSaving() {
-    this.refs.status.setSaving.apply(this, arguments);
-  }
-
-  setSaved() {
-    this.refs.status.setSaved.apply(this, arguments);
-  }
-
-  setSaveError() {
-    this.refs.status.setSaveError.apply(this, arguments);
-  }
-
   // Show a gear to access Table settings page if we're currently looking at a Table. Otherwise show nothing.
   // TODO - it would be nicer just to disable the gear so the page doesn't jump around once you select a Table.
   renderTableSettingsButton() {
@@ -81,7 +69,7 @@ export default class MetadataHeader extends Component {
           />
         </div>
         <div className="MetadataEditor-headerSection flex flex-align-right align-center flex-no-shrink">
-          <SaveStatus ref="status" />
+          <SaveStatus />
           <div className="mr1 text-medium">{t`Show original schema`}</div>
           <Toggle
             value={this.props.isShowingSchema}

--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -82,7 +82,7 @@ export default class Revision extends Component {
               {moment(revision.timestamp).format("MMMM DD, YYYY")}
             </span>
           </div>
-          {message && <p>"{message}"</p>}
+          {message && <p>&quot;{message}&quot;</p>}
           {diffKeys.map(key => (
             <RevisionDiff
               key={key}

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -44,7 +44,7 @@ export default class RevisionHistory extends Component {
             />
             <div className="wrapper py4" style={{ maxWidth: 950 }}>
               <h2 className="mb4">
-                {t`Revision History for`} "{object.name}"
+                {t`Revision History for`} &quot;{object.name}&quot;
               </h2>
               <ol>
                 {revisions.map(revision => (

--- a/frontend/src/metabase/admin/datamodel/components/revisions/TextDiff.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/TextDiff.jsx
@@ -16,7 +16,7 @@ export default class TextDiff extends Component {
     } = this.props;
     return (
       <div>
-        "
+        &quot;
         {before != null && after != null ? (
           diffWords(before, after).map((section, index) => (
             <span>
@@ -36,7 +36,7 @@ export default class TextDiff extends Component {
         ) : (
           <strong>{after}</strong>
         )}
-        "
+        &quot;
       </div>
     );
   }

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -79,7 +79,6 @@ export default class MetadataEditor extends Component {
     return (
       <div className="p4">
         <MetadataHeader
-          ref="header"
           databaseId={databaseId}
           selectDatabase={this.props.selectDatabase}
           isShowingSchema={this.state.isShowingSchema}

--- a/frontend/src/metabase/admin/people/components/UserGroupSelect.jsx
+++ b/frontend/src/metabase/admin/people/components/UserGroupSelect.jsx
@@ -19,10 +19,6 @@ export default class UserGroupSelect extends Component {
     isInitiallyOpen: false,
   };
 
-  toggle() {
-    this.refs.popover.toggle();
-  }
-
   render() {
     const {
       user,

--- a/frontend/src/metabase/admin/permissions/components/PermissionsGrid.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsGrid.jsx
@@ -209,6 +209,7 @@ class GroupPermissionCell extends Component {
       confirmAction: null,
       hovered: false,
     };
+    this.popover = React.createRef();
   }
   hoverEnter() {
     // only change the hover state if the group is not the admin
@@ -249,7 +250,7 @@ class GroupPermissionCell extends Component {
 
     return (
       <PopoverWithTrigger
-        ref="popover"
+        ref={this.popover}
         disabled={!isEditable}
         triggerClasses="cursor-pointer flex flex-full layout-centered border-column-divider"
         triggerElement={
@@ -337,7 +338,7 @@ class GroupPermissionCell extends Component {
             } else {
               confirmAction();
             }
-            this.refs.popover.close();
+            this.popover.current.close();
           }}
         />
         {actions && actions.length > 0 ? (

--- a/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
@@ -6,6 +6,7 @@ import { t, jt } from "ttag";
 
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import InputBlurChange from "metabase/components/InputBlurChange";
+import ExternalLink from "metabase/components/ExternalLink";
 
 export default class SettingsSingleSignOnForm extends Component {
   constructor(props, context) {
@@ -121,13 +122,12 @@ export default class SettingsSingleSignOnForm extends Component {
           </p>
           <p className="text-medium">
             {jt`To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found ${(
-              <a
-                className="link"
+              <ExternalLink
                 href="https://developers.google.com/identity/sign-in/web/devconsole-project"
                 target="_blank"
               >
-                here
-              </a>
+                {t`here`}
+              </ExternalLink>
             )}.`}
           </p>
           <p className="text-medium">

--- a/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
@@ -9,6 +9,7 @@ import { updateSlackSettings } from "../settings";
 
 import Button from "metabase/components/Button";
 import Icon from "metabase/components/Icon";
+import ExternalLink from "metabase/components/ExternalLink";
 
 import _ from "underscore";
 import { t, jt } from "ttag";
@@ -250,7 +251,7 @@ export default class SettingsSlackForm extends Component {
           <h3 className="text-light">{t`Answers sent right to your Slack #channels`}</h3>
 
           <div className="pt3">
-            <a
+            <ExternalLink
               href="https://my.slack.com/services/new/bot"
               target="_blank"
               className="Button Button--primary"
@@ -263,7 +264,7 @@ export default class SettingsSlackForm extends Component {
                 name="external"
                 size={18}
               />
-            </a>
+            </ExternalLink>
           </div>
           <div className="py2">
             {jt`Once you're there, give it a name and click ${(

--- a/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
@@ -268,7 +268,7 @@ export default class SettingsSlackForm extends Component {
           </div>
           <div className="py2">
             {jt`Once you're there, give it a name and click ${(
-              <strong>"Add bot integration"</strong>
+              <strong>&quot;{t`Add bot integration`}&quot;</strong>
             )}. Then copy and paste the Bot API Token into the field below. Once you are done, create a "metabase_files" channel in Slack. Metabase needs this to upload graphs.`}
           </div>
         </div>

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -9,6 +9,7 @@ import SettingsSetting from "./SettingsSetting";
 import HostingInfoLink from "metabase/admin/settings/components/widgets/HostingInfoLink";
 import Icon from "metabase/components/Icon";
 import Text from "metabase/components/type/Text";
+import ExternalLink from "metabase/components/ExternalLink";
 
 export default class SettingsUpdatesForm extends Component {
   static propTypes = {
@@ -41,8 +42,8 @@ export default class SettingsUpdatesForm extends Component {
               {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
               {jt`You're running ${formatVersion(currentVersion)}`}
             </span>
-            <a
-              data-metabase-event={
+            <ExternalLink
+              dataMetabaseEvent={
                 "Updates Settings; Update link clicked; " + latestVersion
               }
               className="Button Button--white Button--medium borderless"
@@ -50,7 +51,7 @@ export default class SettingsUpdatesForm extends Component {
               target="_blank"
             >
               {t`Update`}
-            </a>
+            </ExternalLink>
           </div>
 
           <div

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx
@@ -2,19 +2,19 @@
 import React from "react";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import { t } from "ttag";
+import ExternalLink from "metabase/components/ExternalLink";
 
 const EmbeddingLegalese = ({ onChange }) => (
   <div className="bordered rounded text-measure p4">
     <h3 className="text-brand">{t`Using embedding`}</h3>
     <p className="text-medium" style={{ lineHeight: 1.48 }}>
       {t`By enabling embedding you're agreeing to the embedding license located at`}{" "}
-      <a
-        className="link"
+      <ExternalLink
         href="https://metabase.com/license/embedding"
         target="_blank"
       >
         metabase.com/license/embedding
-      </a>
+      </ExternalLink>
       .
     </p>
     <p className="text-medium" style={{ lineHeight: 1.48 }}>

--- a/frontend/src/metabase/components/AdminHeader.jsx
+++ b/frontend/src/metabase/components/AdminHeader.jsx
@@ -11,7 +11,7 @@ export default class AdminHeader extends Component {
           {this.props.title}
         </div>
         <div className="MetadataEditor-headerSection absolute right float-right top bottom flex layout-centered">
-          <SaveStatus ref="status" />
+          <SaveStatus />
         </div>
       </div>
     );

--- a/frontend/src/metabase/components/AdminLayout.jsx
+++ b/frontend/src/metabase/components/AdminLayout.jsx
@@ -4,21 +4,11 @@ import React, { Component } from "react";
 import AdminHeader from "./AdminHeader";
 
 export default class AdminLayout extends Component {
-  setSaving = () => {
-    this.refs.header.refs.status.setSaving();
-  };
-  setSaved = () => {
-    this.refs.header.refs.status.setSaved();
-  };
-  setSaveError = error => {
-    this.refs.header.refs.status.setSaveError(error);
-  };
-
   render() {
     const { title, sidebar, children } = this.props;
     return (
       <div className="MetadataEditor full-height flex flex-column flex-full p4">
-        <AdminHeader ref="header" title={title} />
+        <AdminHeader title={title} />
         <div className="MetadataEditor-main flex flex-row flex-full mt2">
           {sidebar}
           <div className="px2 full">{children}</div>

--- a/frontend/src/metabase/components/ColorPicker.jsx
+++ b/frontend/src/metabase/components/ColorPicker.jsx
@@ -23,6 +23,11 @@ const ColorSquare = ({ color, size }) => (
 );
 
 class ColorPicker extends Component {
+  constructor(props) {
+    super(props);
+
+    this.colorPopover = React.createRef();
+  }
   static defaultProps = {
     size: DEFAULT_COLOR_SQUARE_SIZE,
     triggerSize: DEFAULT_COLOR_SQUARE_SIZE,
@@ -43,7 +48,7 @@ class ColorPicker extends Component {
     return (
       <div className="inline-block">
         <PopoverWithTrigger
-          ref="colorPopover"
+          ref={this.colorPopover}
           triggerElement={
             <div
               className="bordered rounded flex align-center"
@@ -65,7 +70,7 @@ class ColorPicker extends Component {
                 />
               </div>
               <div className="p1 border-top">
-                <Button onClick={() => this.refs.colorPopover.close()}>
+                <Button onClick={() => this.colorPopover.current.close()}>
                   Done
                 </Button>
               </div>
@@ -85,7 +90,7 @@ class ColorPicker extends Component {
                     key={index}
                     onClick={() => {
                       onChange(color);
-                      this.refs.colorPopover.close();
+                      this.colorPopover.current.close();
                     }}
                   >
                     <ColorSquare color={color} size={size} />

--- a/frontend/src/metabase/components/Confirm.jsx
+++ b/frontend/src/metabase/components/Confirm.jsx
@@ -6,6 +6,12 @@ import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ConfirmContent from "./ConfirmContent";
 
 export default class Confirm extends Component {
+  constructor(props) {
+    super(props);
+
+    this.modal = React.createRef();
+  }
+
   static propTypes = {
     action: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
@@ -18,7 +24,7 @@ export default class Confirm extends Component {
     const { action, children, title, content, triggerClasses } = this.props;
     return (
       <ModalWithTrigger
-        ref="modal"
+        ref={this.modal}
         triggerElement={children}
         triggerClasses={triggerClasses}
       >
@@ -26,7 +32,7 @@ export default class Confirm extends Component {
           title={title}
           content={content}
           onClose={() => {
-            this.refs.modal.close();
+            this.modal.current.close();
           }}
           onAction={action}
         />

--- a/frontend/src/metabase/components/EditBar.jsx
+++ b/frontend/src/metabase/components/EditBar.jsx
@@ -22,7 +22,6 @@ class EditBar extends Component {
         className={cx("EditHeader wrapper py1 flex align-center", {
           "EditHeader--admin": admin,
         })}
-        ref="editHeader"
       >
         <span className="EditHeader-title">{title}</span>
         {subtitle && (

--- a/frontend/src/metabase/components/ExternalLink.jsx
+++ b/frontend/src/metabase/components/ExternalLink.jsx
@@ -7,12 +7,14 @@ const ExternalLink = ({
   href,
   target = getUrlTarget(href),
   className,
+  dataMetabaseEvent,
   children,
   ...props
 }) => (
   <a
     href={href}
     className={className || "link"}
+    data-metabase-event={dataMetabaseEvent}
     target={target}
     // prevent malicious pages from navigating us away
     rel="noopener noreferrer"

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 import HeaderModal from "metabase/components/HeaderModal";
@@ -25,6 +24,7 @@ export default class Header extends Component {
     this.state = {
       headerHeight: 0,
     };
+    this.header = React.createRef();
   }
 
   componentDidMount() {
@@ -39,11 +39,11 @@ export default class Header extends Component {
   }
 
   updateHeaderHeight() {
-    if (!this.refs.header) {
+    if (!this.header.current) {
       return;
     }
 
-    const rect = ReactDOM.findDOMNode(this.refs.header).getBoundingClientRect();
+    const rect = this.header.current.getBoundingClientRect();
     const headerHeight = rect.top + getScrollY();
     if (this.state.headerHeight !== headerHeight) {
       this.setState({ headerHeight });
@@ -142,7 +142,7 @@ export default class Header extends Component {
             "QueryBuilder-section flex align-center " +
             this.props.headerClassName
           }
-          ref="header"
+          ref={this.header}
         >
           <div className="Entity py3">
             <span className="inline-block mb1">{titleAndDescription}</span>

--- a/frontend/src/metabase/components/NewsletterForm.jsx
+++ b/frontend/src/metabase/components/NewsletterForm.jsx
@@ -1,7 +1,6 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
@@ -27,6 +26,8 @@ export default class NewsletterForm extends Component {
         top: "-12px",
       },
     };
+
+    this.email = React.createRef();
   }
 
   static propTypes = {
@@ -37,7 +38,7 @@ export default class NewsletterForm extends Component {
     e.preventDefault();
 
     const formData = new FormData();
-    formData.append("EMAIL", ReactDOM.findDOMNode(this.refs.email).value);
+    formData.append("EMAIL", this.email.current.value);
     formData.append("b_869fec0e4689e8fd1db91e795_b9664113a8", "");
 
     const req = new XMLHttpRequest();
@@ -86,7 +87,7 @@ export default class NewsletterForm extends Component {
                 {!submitted ? (
                   <div className="">
                     <input
-                      ref="email"
+                      ref={this.email}
                       style={this.styles.input}
                       className="AdminInput bordered rounded h3 inline-block"
                       type="email"

--- a/frontend/src/metabase/components/PasswordReveal.jsx
+++ b/frontend/src/metabase/components/PasswordReveal.jsx
@@ -46,7 +46,6 @@ export default class PasswordReveal extends Component {
 
         {visible ? (
           <input
-            ref="input"
             style={styles.input}
             className="text-light text-normal mr3 borderless"
             value={password}

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -106,6 +106,8 @@ export default class TokenField extends Component {
       isAllSelected: false,
       listIsHovered: false,
     };
+
+    this.inputRef = React.createRef();
   }
 
   static defaultProps = {
@@ -325,7 +327,7 @@ export default class TokenField extends Component {
 
   onInputBlur = () => {
     if (this.props.updateOnInputBlur && this.props.parseFreeformValue) {
-      const input = findDOMNode(this.refs.input);
+      const input = this.inputRef.current;
       const value = this.props.parseFreeformValue(input.value);
       if (
         value != null &&
@@ -358,7 +360,7 @@ export default class TokenField extends Component {
   };
 
   onMouseDownCapture = e => {
-    const input = findDOMNode(this.refs.input);
+    const input = this.inputRef.current;
     input.focus();
     // prevents clicks from blurring input while still allowing text selection:
     if (input !== e.target) {
@@ -373,7 +375,7 @@ export default class TokenField extends Component {
   addSelectedOption(e) {
     const { multi } = this.props;
     const { filteredOptions, selectedOptionValue } = this.state;
-    const input = findDOMNode(this.refs.input);
+    const input = this.inputRef.current;
     const option = _.find(filteredOptions, option =>
       this._valueIsEqual(selectedOptionValue, this._value(option)),
     );
@@ -461,7 +463,7 @@ export default class TokenField extends Component {
     }
     // if we added a value then scroll to the last item (the input)
     if (this.props.value.length > prevProps.value.length) {
-      const input = findDOMNode(this.refs.input);
+      const input = this.inputRef.current;
       if (input && isObscured(input)) {
         input.scrollIntoView({ block: "nearest" });
       }
@@ -566,7 +568,7 @@ export default class TokenField extends Component {
         ))}
         <li className={cx("flex-full flex align-center mr1 mb1 p1")}>
           <input
-            ref="input"
+            ref={this.inputRef}
             style={{ ...defaultStyleValue, ...valueStyle }}
             className={cx("full no-focus borderless px1")}
             // set size to be small enough that it fits in a parameter.
@@ -598,11 +600,6 @@ export default class TokenField extends Component {
           {filteredOptions.map(option => (
             <li className="mr1" key={this._key(option)}>
               <div
-                ref={
-                  this._valueIsEqual(selectedOptionValue, this._value(option))
-                    ? _ => (this.scrollElement = _)
-                    : null
-                }
                 className={cx(
                   `py1 pl1 pr2 block rounded text-bold text-${color}-hover inline-block full cursor-pointer`,
                   `bg-light-hover`,

--- a/frontend/src/metabase/components/Tooltip.jsx
+++ b/frontend/src/metabase/components/Tooltip.jsx
@@ -124,13 +124,9 @@ export default class Tooltip extends Component {
       <React.Fragment>
         {React.Children.only(this.props.children)}
         {tooltip && isEnabled && isOpen && (
-          <TooltipPopover
-            isOpen={true}
-            target={this}
-            hasArrow
-            {...this.props}
-            children={this.props.tooltip}
-          />
+          <TooltipPopover isOpen={true} target={this} hasArrow {...this.props}>
+            {this.props.tooltip}
+          </TooltipPopover>
         )}
       </React.Fragment>
     );

--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import { isObscured } from "metabase/lib/dom";
 
@@ -27,6 +26,7 @@ export default ComposedComponent =>
       this._startCheckObscured = this._startCheckObscured.bind(this);
       this._stopCheckObscured = this._stopCheckObscured.bind(this);
       this.onClose = this.onClose.bind(this);
+      this.trigger = React.createRef();
     }
 
     static defaultProps = {
@@ -47,11 +47,7 @@ export default ComposedComponent =>
 
     onClose(e) {
       // don't close if clicked the actual trigger, it will toggle
-      if (
-        e &&
-        e.target &&
-        ReactDOM.findDOMNode(this.refs.trigger).contains(e.target)
-      ) {
+      if (e && e.target && this.trigger.current.contains(e.target)) {
         return;
       }
 
@@ -66,7 +62,7 @@ export default ComposedComponent =>
       if (this.props.target) {
         return this.props.target();
       } else {
-        return this.refs.trigger;
+        return this.trigger.current;
       }
     }
 
@@ -89,7 +85,7 @@ export default ComposedComponent =>
     _startCheckObscured() {
       if (this._offscreenTimer == null) {
         this._offscreenTimer = setInterval(() => {
-          const trigger = ReactDOM.findDOMNode(this.refs.trigger);
+          const trigger = this.trigger.current;
           if (isObscured(trigger)) {
             this.close();
           }
@@ -139,7 +135,7 @@ export default ComposedComponent =>
       return (
         <a
           id={triggerId}
-          ref="trigger"
+          ref={this.trigger}
           onClick={event => {
             event.preventDefault();
             !this.props.disabled && this.toggle();

--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -158,11 +158,12 @@ export default ComposedComponent =>
           {triggerElement}
           <ComposedComponent
             {...this.props}
-            children={children}
             isOpen={isOpen}
             onClose={this.onClose}
             target={() => this.target()}
-          />
+          >
+            {children}
+          </ComposedComponent>
         </a>
       );
     }

--- a/frontend/src/metabase/containers/CollectionItemsLoader.jsx
+++ b/frontend/src/metabase/containers/CollectionItemsLoader.jsx
@@ -9,15 +9,14 @@ type Props = {
 };
 
 const CollectionItemsLoader = ({ collectionId, children, ...props }: Props) => (
-  <Collection.Loader
-    {...props}
-    id={collectionId}
-    children={({ object }) => (
+  <Collection.Loader {...props} id={collectionId}>
+    {({ object }) => (
       <Search.ListLoader
         {...props}
         query={{ collection: collectionId }}
         wrapped
-        children={({ list }) =>
+      >
+        {({ list }) =>
           object &&
           list &&
           children({
@@ -25,9 +24,9 @@ const CollectionItemsLoader = ({ collectionId, children, ...props }: Props) => (
             items: list,
           })
         }
-      />
+      </Search.ListLoader>
     )}
-  />
+  </Collection.Loader>
 );
 
 export default CollectionItemsLoader;

--- a/frontend/src/metabase/containers/QuestionLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionLoader.jsx
@@ -64,16 +64,19 @@ const QuestionLoader = ({
   children,
 }: Props) =>
   questionObject != null ? (
-    <AdHocQuestionLoader
-      questionHash={serializeCardForUrl(questionObject)}
-      children={children}
-    />
+    <AdHocQuestionLoader questionHash={serializeCardForUrl(questionObject)}>
+      {children}
+    </AdHocQuestionLoader>
   ) : // if there's a questionHash it means we're in ad-hoc land
   questionHash != null && questionHash !== "" ? (
-    <AdHocQuestionLoader questionHash={questionHash} children={children} />
+    <AdHocQuestionLoader questionHash={questionHash}>
+      {children}
+    </AdHocQuestionLoader>
   ) : // otherwise if there's a non-null questionId it means we're in saved land
   questionId != null ? (
-    <SavedQuestionLoader questionId={questionId} children={children} />
+    <SavedQuestionLoader questionId={questionId}>
+      {children}
+    </SavedQuestionLoader>
   ) : // finally, if neither is present, just don't do anything
   null;
 

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-string-refs */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -76,7 +76,12 @@ type State = {
 };
 
 export default class DashboardHeader extends Component {
-  props: Props;
+  constructor(props: Props) {
+    super(props);
+
+    this.addQuestionModal = React.createRef();
+  }
+
   state: State = {
     modal: null,
   };
@@ -197,7 +202,7 @@ export default class DashboardHeader extends Component {
       buttons.push(
         <ModalWithTrigger
           key="add-a-question"
-          ref="addQuestionModal"
+          ref={this.addQuestionModal}
           triggerElement={
             <Tooltip tooltip={t`Add question`}>
               <Icon name="add" data-metabase-event="Dashboard;Add Card Modal" />
@@ -208,7 +213,7 @@ export default class DashboardHeader extends Component {
             dashboard={dashboard}
             addCardToDashboard={this.props.addCardToDashboard}
             onEditingChange={this.props.onEditingChange}
-            onClose={() => this.refs.addQuestionModal.toggle()}
+            onClose={() => this.addQuestionModal.current.toggle()}
           />
         </ModalWithTrigger>,
       );

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -21,6 +21,11 @@ const OPTIONS = [
 ];
 
 export default class RefreshWidget extends Component {
+  constructor(props) {
+    super(props);
+
+    this.popover = React.createRef();
+  }
   state = { elapsed: null };
 
   UNSAFE_componentWillMount() {
@@ -46,7 +51,7 @@ export default class RefreshWidget extends Component {
     const remaining = period - elapsed;
     return (
       <PopoverWithTrigger
-        ref="popover"
+        ref={this.popover}
         triggerElement={
           elapsed == null ? (
             <Tooltip tooltip={t`Auto-refresh`}>
@@ -84,7 +89,7 @@ export default class RefreshWidget extends Component {
                 period={option.period}
                 selected={option.period === period}
                 onClick={() => {
-                  this.refs.popover.close();
+                  this.popover.current.close();
                   onChangePeriod(option.period);
                 }}
               />

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -181,12 +181,9 @@ export default class EntityListLoader extends React.Component {
     const { allFetched, allError } = this.props;
     const { loadingAndErrorWrapper } = this.props;
     return loadingAndErrorWrapper ? (
-      <LoadingAndErrorWrapper
-        loading={!allFetched}
-        error={allError}
-        children={this.renderChildren}
-        noWrapper
-      />
+      <LoadingAndErrorWrapper loading={!allFetched} error={allError} noWrapper>
+        {this.renderChildren}
+      </LoadingAndErrorWrapper>
     ) : (
       this.renderChildren()
     );

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -142,9 +142,10 @@ export default class EntityObjectLoader extends React.Component {
       <LoadingAndErrorWrapper
         loading={!fetched && entityId != null}
         error={error}
-        children={this.renderChildren}
         noWrapper
-      />
+      >
+        {this.renderChildren}
+      </LoadingAndErrorWrapper>
     ) : (
       this.renderChildren()
     );

--- a/frontend/src/metabase/hoc/RenderPropToHOC.jsx
+++ b/frontend/src/metabase/hoc/RenderPropToHOC.jsx
@@ -3,11 +3,8 @@ import React from "react";
 export default function renderPropToHoc(RenderPropComponent) {
   // eslint-disable-next-line react/display-name
   return ComposedComponent => props => (
-    <RenderPropComponent
-      {...props}
-      children={childrenProps => (
-        <ComposedComponent {...props} {...childrenProps} />
-      )}
-    />
+    <RenderPropComponent {...props}>
+      {childrenProps => <ComposedComponent {...props} {...childrenProps} />}
+    </RenderPropComponent>
   );
 }

--- a/frontend/src/metabase/internal/pages/TypePage.jsx
+++ b/frontend/src/metabase/internal/pages/TypePage.jsx
@@ -80,7 +80,7 @@ const TypePage = () => (
         <Text>Used for page headings, etc</Text>
 
         <Example>
-          <Heading>Title o' the page</Heading>
+          <Heading>Title o&apos; the page</Heading>
         </Example>
       </Box>
       <Box mb={3}>

--- a/frontend/src/metabase/internal/pages/WelcomePage.jsx
+++ b/frontend/src/metabase/internal/pages/WelcomePage.jsx
@@ -21,9 +21,9 @@ const WelcomePage = () => {
 
       <Subhead>Documentation progress</Subhead>
       <Text>
-        Documenting our component library is an ongoing process. Here's what
-        percentage of the code in <code>metabase/components</code> has some form
-        of documentation so far.
+        Documenting our component library is an ongoing process. Here&apos;s
+        what percentage of the code in <code>metabase/components</code> has some
+        form of documentation so far.
       </Text>
 
       <Box mt={3}>

--- a/frontend/src/metabase/parameters/components/ParameterTargetWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterTargetWidget.jsx
@@ -21,7 +21,11 @@ type Props = {
 };
 
 export default class ParameterTargetWidget extends React.Component {
-  props: Props;
+  constructor(props: Props) {
+    super(props);
+
+    this.popover = React.createRef();
+  }
 
   static defaultProps = {
     children: ({ selected, placeholder }) => (
@@ -45,7 +49,7 @@ export default class ParameterTargetWidget extends React.Component {
 
     return (
       <PopoverWithTrigger
-        ref="popover"
+        ref={this.popover}
         triggerClasses={cx({ disabled: disabled })}
         sizeToFit
         triggerElement={
@@ -57,7 +61,7 @@ export default class ParameterTargetWidget extends React.Component {
         <ParameterTargetList
           onChange={target => {
             onChange(target);
-            this.refs.popover.close();
+            this.popover.current.close();
           }}
           target={target}
           mappingOptions={mappingOptions}

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -98,6 +98,9 @@ export default class ParameterValueWidget extends Component {
     if (_.isEmpty(this.props.values)) {
       this.updateFieldValues(this.props);
     }
+
+    this.valuePopover = React.createRef();
+    this.trigger = React.createRef();
   }
 
   componentDidUpdate(prevProps) {
@@ -127,13 +130,13 @@ export default class ParameterValueWidget extends Component {
   };
 
   onPopoverClose = () => {
-    if (this.refs.valuePopover) {
-      this.refs.valuePopover.close();
+    if (this.valuePopover.current) {
+      this.valuePopover.current.close();
     }
   };
 
   getTargetRef = () => {
-    return this.refs.trigger;
+    return this.trigger.current;
   };
 
   render() {
@@ -185,10 +188,10 @@ export default class ParameterValueWidget extends Component {
 
       return (
         <PopoverWithTrigger
-          ref="valuePopover"
+          ref={this.valuePopover}
           triggerElement={
             <div
-              ref="trigger"
+              ref={this.trigger}
               className={cx(S.parameter, className, { [S.selected]: hasValue })}
             >
               {showTypeIcon && <ParameterTypeIcon parameter={parameter} />}

--- a/frontend/src/metabase/public/components/LogoBadge.jsx
+++ b/frontend/src/metabase/public/components/LogoBadge.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import LogoIcon from "metabase/components/LogoIcon";
+import ExternalLink from "metabase/components/ExternalLink";
 
 import { t, jt } from "ttag";
 
@@ -8,7 +9,7 @@ type Props = {
 };
 
 const LogoBadge = ({ dark }: Props) => (
-  <a
+  <ExternalLink
     href="https://metabase.com/"
     target="_blank"
     className="h4 flex text-bold align-center no-decoration"
@@ -21,7 +22,7 @@ const LogoBadge = ({ dark }: Props) => (
         </span>
       )}`}</span>
     </span>
-  </a>
+  </ExternalLink>
 );
 
 export default LogoBadge;

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -42,6 +42,12 @@ export default class PulseEdit extends Component {
     initialCollectionId: PropTypes.number,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.pulseInfo = React.createRef();
+  }
+
   componentDidMount() {
     this.props.setEditingPulse(
       this.props.pulseId,
@@ -140,18 +146,18 @@ export default class PulseEdit extends Component {
         <div className="PulseEdit-header flex align-center border-bottom py3">
           <h1>{pulse && pulse.id != null ? t`Edit pulse` : t`New pulse`}</h1>
           <ModalWithTrigger
-            ref="pulseInfo"
+            ref={this.pulseInfo}
             className="Modal WhatsAPulseModal"
             triggerElement={t`What's a Pulse?`}
             triggerClasses="text-brand text-bold flex-align-right"
           >
-            <ModalContent onClose={() => this.refs.pulseInfo.close()}>
+            <ModalContent onClose={() => this.pulseInfo.current.close()}>
               <div className="mx4 mb4">
                 <WhatsAPulse
                   button={
                     <button
                       className="Button Button--primary"
-                      onClick={() => this.refs.pulseInfo.close()}
+                      onClick={() => this.pulseInfo.current.close()}
                     >{t`Got it`}</button>
                   }
                 />

--- a/frontend/src/metabase/pulse/components/PulseEditName.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditName.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import { t } from "ttag";
 
 import _ from "underscore";
@@ -14,6 +13,8 @@ export default class PulseEditName extends Component {
       valid: true,
     };
 
+    this.name = React.createRef();
+
     _.bindAll(this, "setName", "validate");
   }
 
@@ -26,7 +27,7 @@ export default class PulseEditName extends Component {
   }
 
   validate() {
-    this.setState({ valid: !!ReactDOM.findDOMNode(this.refs.name).value });
+    this.setState({ valid: !!this.name.current.value });
   }
 
   render() {
@@ -39,14 +40,14 @@ export default class PulseEditName extends Component {
         </p>
         <div className="my3">
           <input
-            ref="name"
+            ref={this.name}
             className={cx("input text-bold", {
               "border-error": !this.state.valid,
             })}
             style={{ width: "400px" }}
             value={pulse.name || ""}
             onChange={this.setName}
-            onBlur={this.refs.name && this.validate}
+            onBlur={this.name.current && this.validate}
             placeholder={t`Important metrics`}
             autoFocus
           />

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -154,6 +154,7 @@ export class UnconnectedDataSelector extends Component {
       ...state,
       ...computedState,
     };
+    this.popover = React.createRef();
   }
 
   static propTypes = {
@@ -432,7 +433,7 @@ export class UnconnectedDataSelector extends Component {
     const nextStep = this.getNextStep();
     if (!nextStep) {
       await this.setStateWithComputedState(stateChange);
-      this.refs.popover.toggle();
+      this.popover.current.toggle();
     } else {
       await this.switchToStep(nextStep, stateChange, skipSteps);
     }
@@ -664,7 +665,7 @@ export class UnconnectedDataSelector extends Component {
     return (
       <PopoverWithTrigger
         id="DataPopover"
-        ref="popover"
+        ref={this.popover}
         isInitiallyOpen={this.props.isInitiallyOpen}
         triggerElement={this.getTriggerElement()}
         triggerClasses={this.getTriggerClasses()}

--- a/frontend/src/metabase/query_builder/components/FieldWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldWidget.jsx
@@ -50,7 +50,7 @@ export default class FieldWidget extends React.Component {
   renderPopover() {
     if (this.state.isOpen) {
       return (
-        <Popover ref="popover" className="FieldPopover" onClose={this.toggle}>
+        <Popover className="FieldPopover" onClose={this.toggle}>
           <FieldList
             className={"text-" + this.props.color}
             field={this.props.field}

--- a/frontend/src/metabase/query_builder/components/FilterList.jsx
+++ b/frontend/src/metabase/query_builder/components/FilterList.jsx
@@ -39,8 +39,9 @@ export default class FilterList extends Component {
             filter={filter}
             metadata={metadata}
             maxDisplayValues={this.props.maxDisplayValues}
-            children={filterRenderer}
-          />
+          >
+            {filterRenderer}
+          </Filter>
         ))}
       </div>
     );

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+/* eslint-disable react/no-string-refs */
 import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
@@ -48,7 +49,13 @@ type State = {
 };
 
 export default class GuiQueryEditor extends React.Component {
-  props: Props;
+  constructor(props: Props) {
+    super(props);
+
+    this.filterPopover = React.createRef();
+    this.guiBuilder = React.createRef();
+  }
+
   state: State = {
     expanded: true,
   };
@@ -151,10 +158,9 @@ export default class GuiQueryEditor extends React.Component {
         <div className="mx2">
           <PopoverWithTrigger
             id="FilterPopover"
-            ref="filterPopover"
+            ref={this.filterPopover}
             triggerElement={addFilterButton}
             triggerClasses="flex align-center"
-            getTarget={() => this.refs.addFilterTarget}
             horizontalAttachments={["left", "center"]}
             autoWidth
           >
@@ -164,7 +170,7 @@ export default class GuiQueryEditor extends React.Component {
               onChangeFilter={filter =>
                 query.filter(filter).update(setDatasetQuery)
               }
-              onClose={() => this.refs.filterPopover.close()}
+              onClose={() => this.filterPopover.current.close()}
               showCustom={false}
             />
           </PopoverWithTrigger>
@@ -334,7 +340,7 @@ export default class GuiQueryEditor extends React.Component {
     return (
       <div
         className="GuiBuilder-section GuiBuilder-filtered-by flex align-center"
-        ref="filterSection"
+        ref={this.filterSection}
       >
         <span className="GuiBuilder-section-label Query-label">{t`Filtered by`}</span>
         {this.renderFilters()}
@@ -377,7 +383,7 @@ export default class GuiQueryEditor extends React.Component {
   }
 
   componentDidUpdate() {
-    const guiBuilder = ReactDOM.findDOMNode(this.refs.guiBuilder);
+    const guiBuilder = this.guiBuilder.current;
     if (!guiBuilder) {
       return;
     }
@@ -405,7 +411,7 @@ export default class GuiQueryEditor extends React.Component {
         className={cx("GuiBuilder rounded shadowed", {
           "GuiBuilder--expand": this.state.expanded,
         })}
-        ref="guiBuilder"
+        ref={this.guiBuilder}
       >
         <div className="GuiBuilder-row flex">
           {this.renderDataSection()}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -1,7 +1,6 @@
 /*global ace*/
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import cx from "classnames";
 
 import "./NativeQueryEditor.css";
@@ -148,6 +147,9 @@ export default class NativeQueryEditor extends Component {
     // e.x. https://github.com/metabase/metabase/issues/2801
     // $FlowFixMe
     this.onChange = _.debounce(this.onChange.bind(this), 1);
+
+    this.editor = React.createRef();
+    this.resizeBox = React.createRef();
   }
 
   maxAutoSizeLines() {
@@ -218,7 +220,7 @@ export default class NativeQueryEditor extends Component {
       this._localUpdate = false;
     }
 
-    const editorElement = ReactDOM.findDOMNode(this.refs.editor);
+    const editorElement = this.editor.current;
     if (query.hasWritePermission()) {
       this._editor.setReadOnly(false);
       editorElement.classList.remove("read-only");
@@ -310,7 +312,7 @@ export default class NativeQueryEditor extends Component {
   loadAceEditor() {
     const { query } = this.props;
 
-    const editorElement = ReactDOM.findDOMNode(this.refs.editor);
+    const editorElement = this.editor.current;
 
     // $FlowFixMe
     if (typeof ace === "undefined" || !ace || !ace.edit) {
@@ -412,7 +414,7 @@ export default class NativeQueryEditor extends Component {
 
   _updateSize() {
     const doc = this._editor.getSession().getDocument();
-    const element = ReactDOM.findDOMNode(this.refs.resizeBox);
+    const element = this.resizeBox.current;
     // set the newHeight based on the line count, but ensure it's within
     // [MIN_HEIGHT_LINES, this.maxAutoSizeLines()]
     const newHeight = getEditorLineHeight(
@@ -605,7 +607,7 @@ export default class NativeQueryEditor extends Component {
           )}
         </div>
         <ResizableBox
-          ref="resizeBox"
+          ref={this.resizeBox}
           className={cx("border-top flex ", { hide: !isNativeEditorOpen })}
           height={this.state.initialHeight}
           minConstraints={[Infinity, getEditorLineHeight(MIN_HEIGHT_LINES)]}
@@ -617,14 +619,10 @@ export default class NativeQueryEditor extends Component {
           }}
           resizeHandles={["s"]}
         >
-          <div className="flex-full" id="id_sql" ref="editor" />
+          <div className="flex-full" id="id_sql" ref={this.editor} />
           <Popover
             isOpen={this.state.isSelectedTextPopoverOpen}
-            target={() =>
-              ReactDOM.findDOMNode(this.refs.editor).querySelector(
-                ".ace_selection",
-              )
-            }
+            target={() => this.editor.current.querySelector(".ace_selection")}
           >
             <div className="flex flex-column">
               <a className="p2 bg-medium-hover flex" onClick={this.runQuery}>

--- a/frontend/src/metabase/query_builder/components/SearchBar.jsx
+++ b/frontend/src/metabase/query_builder/components/SearchBar.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 import { t } from "ttag";
 
 export default class SearchBar extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.handleInputChange = this.handleInputChange.bind(this);
+    this.filterTextInput = React.createRef();
   }
 
   static propTypes = {
@@ -15,7 +15,7 @@ export default class SearchBar extends React.Component {
   };
 
   handleInputChange() {
-    this.props.onFilter(ReactDOM.findDOMNode(this.refs.filterTextInput).value);
+    this.props.onFilter(this.filterTextInput.current.value);
   }
 
   render() {
@@ -23,7 +23,7 @@ export default class SearchBar extends React.Component {
       <input
         className="SearchBar"
         type="text"
-        ref="filterTextInput"
+        ref={this.filterTextInput}
         value={this.props.filter}
         placeholder={t`Search for`}
         onChange={this.handleInputChange}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 
 import { t } from "ttag";
 import _ from "underscore";
@@ -103,6 +102,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       // except currently we exclude `startRule` and `query` since they shouldn't change
       [source, targetOffset].join(","),
     );
+    this.input = React.createRef();
   }
 
   static propTypes = {
@@ -263,14 +263,14 @@ export default class ExpressionEditorTextfield extends React.Component {
   };
 
   _setCaretPosition = (position, autosuggest) => {
-    setCaretPosition(ReactDOM.findDOMNode(this.refs.input), position);
+    setCaretPosition(this.input.current, position);
     if (autosuggest) {
       setTimeout(() => this._triggerAutosuggest());
     }
   };
 
   onExpressionChange(source) {
-    const inputElement = ReactDOM.findDOMNode(this.refs.input);
+    const inputElement = this.input.current;
     if (!inputElement) {
       return;
     }
@@ -361,7 +361,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           {"= "}
         </div>
         <TokenizedInput
-          ref="input"
+          ref={this.input}
           type="text"
           className={cx(inputClassName, {
             "border-error": compileError,

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -105,7 +105,6 @@ export default class FilterWidget extends Component {
       return (
         <Popover
           id="FilterPopover"
-          ref="filterPopover"
           className="FilterPopover"
           isInitiallyOpen={this.props.filter[1] === null}
           onClose={this.close}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
@@ -98,7 +98,6 @@ export default class SpecificDatePicker extends Component {
                 this.onChange(null);
               }
             }}
-            ref="value"
           />
 
           {calendar && (

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -299,7 +299,7 @@ const TagEditorHelp = ({
         <ExternalLink
           href={MetabaseSettings.docsUrl("users-guide/13-sql-parameters")}
           target="_blank"
-          data-metabase-event="QueryBuilder;Template Tag Documentation Click"
+          dataMetabaseEvent="QueryBuilder;Template Tag Documentation Click"
         >{t`Read the full documentation`}</ExternalLink>
       </p>
     </div>

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
@@ -212,13 +211,6 @@ export default class QueryBuilder extends Component {
     }
   }
 
-  componentDidUpdate() {
-    const viz = ReactDOM.findDOMNode(this.refs.viz);
-    if (viz) {
-      viz.style.opacity = 1.0;
-    }
-  }
-
   componentWillUnmount() {
     // cancel the query if one is running
     this.props.cancelQuery();
@@ -234,10 +226,6 @@ export default class QueryBuilder extends Component {
   // Debounce the function to improve resizing performance.
   handleResize = e => {
     this.forceUpdateDebounced();
-    const viz = ReactDOM.findDOMNode(this.refs.viz);
-    if (viz) {
-      viz.style.opacity = 0.2;
-    }
   };
 
   // NOTE: these were lifted from QueryHeader. Move to Redux?

--- a/frontend/src/metabase/reference/components/RevisionMessageModal.jsx
+++ b/frontend/src/metabase/reference/components/RevisionMessageModal.jsx
@@ -15,11 +15,17 @@ export default class RevisionMessageModal extends Component {
     children: PropTypes.any,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.modal = React.createRef();
+  }
+
   render() {
     const { action, children, field, submitting } = this.props;
 
     const onClose = () => {
-      this.refs.modal.close();
+      this.modal.current.close();
     };
 
     const onAction = () => {
@@ -28,7 +34,7 @@ export default class RevisionMessageModal extends Component {
     };
 
     return (
-      <ModalWithTrigger ref="modal" triggerElement={children}>
+      <ModalWithTrigger ref={this.modal} triggerElement={children}>
         <ModalContent title={t`Reason for changes`} onClose={onClose}>
           <div className={S.modalBody}>
             <textarea

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -1,6 +1,5 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import ExternalLink from "metabase/components/ExternalLink";
@@ -31,6 +30,12 @@ export default class Setup extends Component {
     setActiveStep: PropTypes.func.isRequired,
     databaseDetails: PropTypes.object,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.databaseSchedulingStepContainer = React.createRef();
+  }
 
   completeWelcome() {
     this.props.setActiveStep(LANGUAGE_STEP_NUMBER);
@@ -77,10 +82,8 @@ export default class Setup extends Component {
       nextProps.activeStep === 3
     ) {
       setTimeout(() => {
-        if (this.refs.databaseSchedulingStepContainer) {
-          const node = ReactDOM.findDOMNode(
-            this.refs.databaseSchedulingStepContainer,
-          );
+        if (this.databaseSchedulingStepContainer.current) {
+          const node = this.databaseSchedulingStepContainer.current;
           node && node.scrollIntoView && node.scrollIntoView();
         }
       }, 10);
@@ -145,7 +148,7 @@ export default class Setup extends Component {
               />
 
               {/* Have the ref for scrolling in UNSAFE_componentWillReceiveProps */}
-              <div ref="databaseSchedulingStepContainer">
+              <div ref={this.databaseSchedulingStepContainer}>
                 {/* Show db scheduling step only if the user has explicitly set the "Let me choose when Metabase syncs and scans" toggle to true */}
                 {databaseDetails &&
                   databaseDetails.details &&

--- a/frontend/src/metabase/setup/containers/PostSetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/PostSetupApp.jsx
@@ -40,9 +40,8 @@ export default class PostSetupApp extends Component {
           style={{ maxWidth: 587 }}
           className="ml-auto mr-auto mt-auto mb-auto py2"
         >
-          <CandidateListLoader
-            databaseId={this.props.params.databaseId}
-            children={({ candidates, sampleCandidates, isSample }) => {
+          <CandidateListLoader databaseId={this.props.params.databaseId}>
+            {({ candidates, sampleCandidates, isSample }) => {
               if (!candidates) {
                 return (
                   <div>
@@ -87,7 +86,7 @@ export default class PostSetupApp extends Component {
                 </Card>
               );
             }}
-          />
+          </CandidateListLoader>
           <div className="m4 text-centered">
             <Link
               to="/"

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -16,9 +15,15 @@ import Question from "metabase-lib/lib/Question";
 import { updateLatLonFilter } from "metabase/modes/lib/actions";
 
 export default class LeafletMap extends Component {
+  constructor(props) {
+    super(props);
+
+    this.mapRef = React.createRef();
+  }
+
   componentDidMount() {
     try {
-      const element = ReactDOM.findDOMNode(this.refs.map);
+      const element = this.mapRef.current;
 
       const map = (this.map = L.map(element, {
         scrollWheelZoom: false,
@@ -164,7 +169,7 @@ export default class LeafletMap extends Component {
 
   render() {
     const { className } = this.props;
-    return <div className={className} ref="map" />;
+    return <div className={className} ref={this.mapRef} />;
   }
 
   _getLatLonIndexes() {

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import styles from "./Legend.css";
 
 import LegendItem from "./LegendItem";
@@ -8,17 +7,21 @@ import LegendItem from "./LegendItem";
 import cx from "classnames";
 
 export default class LegendHorizontal extends Component {
+  constructor(props) {
+    super(props);
+
+    props.titles.map((title, index) => {
+      this["legendItem" + index] = React.createRef();
+    });
+  }
   render() {
     const { className, titles, colors, hovered, onHoverChange } = this.props;
     return (
-      <ol
-        ref="container"
-        className={cx(className, styles.Legend, styles.horizontal)}
-      >
+      <ol className={cx(className, styles.Legend, styles.horizontal)}>
         {titles.map((title, index) => (
           <li key={index}>
             <LegendItem
-              ref={"legendItem" + index}
+              ref={this["legendItem" + index]}
               title={title}
               color={colors[index % colors.length]}
               isMuted={
@@ -29,9 +32,7 @@ export default class LegendHorizontal extends Component {
                 onHoverChange &&
                 onHoverChange({
                   index,
-                  element: ReactDOM.findDOMNode(
-                    this.refs["legendItem" + index],
-                  ),
+                  element: this["legendItem" + index].current,
                 })
               }
               onMouseLeave={() => onHoverChange && onHoverChange(null)}

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+/* eslint-disable react/no-string-refs */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import styles from "./Legend.css";
@@ -64,10 +65,7 @@ export default class LegendVertical extends Component {
       items = titles;
     }
     return (
-      <ol
-        ref="container"
-        className={cx(className, styles.Legend, styles.vertical)}
-      >
+      <ol className={cx(className, styles.Legend, styles.vertical)}>
         {items.map((title, index) => (
           <li
             key={index}

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 
 import styles from "./Table.css";
 
@@ -62,6 +61,10 @@ export default class TableSimple extends Component {
       sortColumn: null,
       sortDescending: false,
     };
+
+    this.headerRef = React.createRef();
+    this.footerRef = React.createRef();
+    this.firstRowRef = React.createRef();
   }
 
   static propTypes = {
@@ -81,15 +84,12 @@ export default class TableSimple extends Component {
   }
 
   componentDidUpdate() {
-    const headerHeight = ReactDOM.findDOMNode(
-      this.refs.header,
-    ).getBoundingClientRect().height;
-    const footerHeight = this.refs.footer
-      ? ReactDOM.findDOMNode(this.refs.footer).getBoundingClientRect().height
+    const headerHeight = this.headerRef.current.getBoundingClientRect().height;
+    const footerHeight = this.footerRef.current
+      ? this.footerRef.current.getBoundingClientRect().height
       : 0;
     const rowHeight =
-      ReactDOM.findDOMNode(this.refs.firstRow).getBoundingClientRect().height +
-      1;
+      this.firstRowRef.current.getBoundingClientRect().height + 1;
     const pageSize = Math.max(
       1,
       Math.floor((this.props.height - headerHeight - footerHeight) / rowHeight),
@@ -163,7 +163,7 @@ export default class TableSimple extends Component {
                 "fullscreen-night-text",
               )}
             >
-              <thead ref="header">
+              <thead ref={this.headerRef}>
                 <tr>
                   {cols.map((col, colIndex) => (
                     <th
@@ -197,7 +197,10 @@ export default class TableSimple extends Component {
               </thead>
               <tbody>
                 {rowIndexes.slice(start, end + 1).map((rowIndex, index) => (
-                  <tr key={rowIndex} ref={index === 0 ? "firstRow" : null}>
+                  <tr
+                    key={rowIndex}
+                    ref={index === 0 ? this.firstRowRef : null}
+                  >
                     {rows[rowIndex].map((value, columnIndex) => {
                       const column = cols[columnIndex];
                       const clicked = getTableCellClickedObject(
@@ -289,7 +292,7 @@ export default class TableSimple extends Component {
         </div>
         {pageSize < rows.length ? (
           <div
-            ref="footer"
+            ref={this.footerRef}
             className="p1 flex flex-no-shrink flex-align-right fullscreen-normal-text fullscreen-night-text"
           >
             <span className="text-bold">{paginateMessage}</span>

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import styles from "./PieChart.css";
 import { t } from "ttag";
 import ChartTooltip from "../components/ChartTooltip";
@@ -42,7 +41,12 @@ const PERCENT_REGEX = /percent/i;
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
 export default class PieChart extends Component {
-  props: VisualizationProps;
+  constructor(props: VisualizationProps) {
+    super(props);
+
+    this.chartDetail = React.createRef();
+    this.chartGroup = React.createRef();
+  }
 
   static uiName = t`Pie`;
   static identifier = "pie";
@@ -193,8 +197,8 @@ export default class PieChart extends Component {
   };
 
   componentDidUpdate() {
-    const groupElement = ReactDOM.findDOMNode(this.refs.group);
-    const detailElement = ReactDOM.findDOMNode(this.refs.detail);
+    const groupElement = this.chartGroup.current;
+    const detailElement = this.chartDetail.current;
     if (groupElement.getBoundingClientRect().width < 120) {
       detailElement.classList.add("hide");
     } else {
@@ -418,7 +422,7 @@ export default class PieChart extends Component {
         isDashboard={this.props.isDashboard}
       >
         <div className={styles.ChartAndDetail}>
-          <div ref="detail" className={styles.Detail}>
+          <div ref={this.chartDetail} className={styles.Detail}>
             <div
               className={cx(
                 styles.Value,
@@ -435,7 +439,7 @@ export default class PieChart extends Component {
               viewBox="0 0 100 100"
               style={{ maxWidth: MAX_PIE_SIZE, maxHeight: MAX_PIE_SIZE }}
             >
-              <g ref="group" transform={`translate(50,50)`}>
+              <g ref={this.chartGroup} transform={`translate(50,50)`}>
                 {pie(slices).map((slice, index) => (
                   <path
                     key={index}

--- a/frontend/src/metabase/visualizations/visualizations/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress.jsx
@@ -20,7 +20,14 @@ const MAX_BAR_HEIGHT = 65;
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
 export default class Progress extends Component {
-  props: VisualizationProps;
+  constructor(props: VisualizationProps) {
+    super(props);
+
+    this.containerRef = React.createRef();
+    this.labelRef = React.createRef();
+    this.pointerRef = React.createRef();
+    this.barRef = React.createRef();
+  }
 
   static uiName = t`Progress`;
   static identifier = "progress";
@@ -75,10 +82,10 @@ export default class Progress extends Component {
 
   componentDidUpdate() {
     const component = ReactDOM.findDOMNode(this);
-    const pointer = ReactDOM.findDOMNode(this.refs.pointer);
-    const label = ReactDOM.findDOMNode(this.refs.label);
-    const container = ReactDOM.findDOMNode(this.refs.container);
-    const bar = ReactDOM.findDOMNode(this.refs.bar);
+    const pointer = this.pointerRef.current;
+    const label = this.labelRef.current;
+    const container = this.containerRef.current;
+    const bar = this.barRef.current;
 
     // Safari not respecting `height: 25%` so just do it here ¯\_(ツ)_/¯
     bar.style.height = Math.min(MAX_BAR_HEIGHT, component.offsetHeight) + "px";
@@ -171,17 +178,17 @@ export default class Progress extends Component {
           style={{ padding: 10, paddingTop: 0 }}
         >
           <div
-            ref="container"
+            ref={this.containerRef}
             className="relative text-bold text-medium"
             style={{ height: 20 }}
           >
-            <div ref="label" style={{ position: "absolute" }}>
+            <div ref={this.labelRef} style={{ position: "absolute" }}>
               {formatValue(value, settings.column(column))}
             </div>
           </div>
           <div className="relative" style={{ height: 10, marginBottom: 5 }}>
             <div
-              ref="pointer"
+              ref={this.pointerRef}
               style={{
                 width: 0,
                 height: 0,
@@ -195,7 +202,7 @@ export default class Progress extends Component {
             />
           </div>
           <div
-            ref="bar"
+            ref={this.barRef}
             className={cx("relative", { "cursor-pointer": isClickable })}
             style={{
               backgroundColor: restColor,

--- a/frontend/test/metabase/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/test/metabase/containers/AdHocQuestionLoader.unit.spec.js
@@ -29,8 +29,9 @@ describe("AdHocQuestionLoader", () => {
       <AdHocQuestionLoader
         questionHash={questionHash}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </AdHocQuestionLoader>,
     );
     expect(mockChild.mock.calls[0][0].loading).toEqual(true);
     expect(mockChild.mock.calls[0][0].error).toEqual(null);
@@ -57,8 +58,9 @@ describe("AdHocQuestionLoader", () => {
       <AdHocQuestionLoader
         questionHash={originalQuestionHash}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </AdHocQuestionLoader>,
     );
 
     expect(loadQuestionSpy).toHaveBeenCalledWith(originalQuestionHash);
@@ -69,8 +71,9 @@ describe("AdHocQuestionLoader", () => {
       <AdHocQuestionLoader
         questionHash={newQuestionHash}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </AdHocQuestionLoader>,
     );
 
     // question loading should begin with the new ID

--- a/frontend/test/metabase/containers/SavedQuestionLoader.unit.spec.js
+++ b/frontend/test/metabase/containers/SavedQuestionLoader.unit.spec.js
@@ -34,8 +34,9 @@ describe("SavedQuestionLoader", () => {
       <SavedQuestionLoader
         questionId={questionId}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </SavedQuestionLoader>,
     );
     expect(mockChild.mock.calls[0][0].loading).toEqual(true);
     expect(mockChild.mock.calls[0][0].error).toEqual(null);
@@ -60,8 +61,9 @@ describe("SavedQuestionLoader", () => {
       <SavedQuestionLoader
         questionId={originalQuestionId}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </SavedQuestionLoader>,
     );
 
     expect(loadQuestionSpy).toHaveBeenCalledWith(originalQuestionId);
@@ -71,8 +73,9 @@ describe("SavedQuestionLoader", () => {
       <SavedQuestionLoader
         questionId={newQuestionId}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </SavedQuestionLoader>,
     );
 
     // question loading should begin with the new ID

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "eslint-loader": "4.0.2",
     "eslint-plugin-cypress": "^2.7.0",
     "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-react": "^6.10.3",
+    "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "extract-text-webpack-plugin": "^3.0.1",
     "file-loader": "^0.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1589,6 +1589,17 @@ array-includes@^3.0.3, array-includes@^3.1.1:
     es-abstract "^1.17.0"
     is-string "^1.0.5"
 
+array-includes@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a"
+  integrity sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.5"
+
 array-parallel@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/array-parallel/-/array-parallel-0.1.3.tgz#8f785308926ed5aa478c47e64d1b334b6c0c947d"
@@ -1621,14 +1632,6 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-array.prototype.find@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.1.1.tgz#3baca26108ca7affb08db06bf0be6cb3115a969c"
-  integrity sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.4"
-
 array.prototype.flat@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
@@ -1636,6 +1639,16 @@ array.prototype.flat@^1.2.3:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
+
+array.prototype.flatmap@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9"
+  integrity sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    function-bind "^1.1.1"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -3159,7 +3172,7 @@ cachedir@^2.3.0:
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.3.0.tgz#0c75892a052198f0b21c7c1804d8331edfcae0e8"
   integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
 
-call-bind@^1.0.0:
+call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -4703,13 +4716,20 @@ doctrine-temporary-fork@2.0.0-alpha-allowarrayindex:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@1.5.0, doctrine@^1.2.2:
+doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -5022,7 +5042,7 @@ error@^7.0.0:
   dependencies:
     string-template "~0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.4, es-abstract@^1.17.5:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.5:
   version "1.17.7"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
   integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
@@ -5056,6 +5076,28 @@ es-abstract@^1.18.0-next.0, es-abstract@^1.18.0-next.1:
     object.assign "^4.1.1"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.2:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0.tgz#ab80b359eecb7ede4c298000390bc5ac3ec7b5a4"
+  integrity sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.2"
+    is-string "^1.0.5"
+    object-inspect "^1.9.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.0"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -5255,16 +5297,22 @@ eslint-plugin-react-hooks@^4.2.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
-eslint-plugin-react@^6.10.3:
-  version "6.10.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
-  integrity sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=
+eslint-plugin-react@^7.22.0:
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz#3d1c542d1d3169c45421c1215d9470e341707269"
+  integrity sha512-p30tuX3VS+NWv9nQot9xIGAHBXR0+xJVaZriEsHoJrASGCJZDJ8JLNM0YqKqI0AKm6Uxaa1VUHoNEibxRCMQHA==
   dependencies:
-    array.prototype.find "^2.0.1"
-    doctrine "^1.2.2"
-    has "^1.0.1"
-    jsx-ast-utils "^1.3.4"
-    object.assign "^4.0.4"
+    array-includes "^3.1.1"
+    array.prototype.flatmap "^1.2.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    object.entries "^1.1.2"
+    object.fromentries "^2.0.2"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    resolve "^1.18.1"
+    string.prototype.matchall "^4.0.2"
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -6084,7 +6132,7 @@ get-comments@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-comments/-/get-comments-1.0.1.tgz#196759101bbbc4facf13060caaedd4870dee55be"
   integrity sha1-GWdZEBu7xPrPEwYMqu3Uhw3uVb4=
 
-get-intrinsic@^1.0.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -6391,6 +6439,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-bigints@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
@@ -6410,6 +6463,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.0.0, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-symbols@^1.0.1:
   version "1.0.1"
@@ -6944,6 +7002,15 @@ internal-ip@1.2.0:
   dependencies:
     meow "^3.3.0"
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
@@ -7039,6 +7106,11 @@ is-arrayish@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
+is-bigint@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.1.tgz#6923051dfcbc764278540b9ce0e6b3213aa5ebc2"
+  integrity sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -7053,6 +7125,13 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-boolean-object@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0"
+  integrity sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -7062,6 +7141,11 @@ is-callable@^1.1.4, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
   integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+
+is-callable@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
 is-ci@^1.0.9:
   version "1.2.1"
@@ -7076,6 +7160,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -7235,6 +7326,16 @@ is-negative-zero@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
   integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
 
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-number-object@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
+  integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -7334,6 +7435,14 @@ is-regex@^1.0.4, is-regex@^1.1.1:
   dependencies:
     has-symbols "^1.0.1"
 
+is-regex@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
+  integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-symbols "^1.0.1"
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -7382,7 +7491,7 @@ is-svg@^2.0.0:
   dependencies:
     html-comment-regex "^1.1.0"
 
-is-symbol@^1.0.2:
+is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
@@ -8055,10 +8164,13 @@ jsrsasign@10.0.4:
   resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.0.4.tgz#45f62cb9088c5948cd804181d3484c7ab48165e0"
   integrity sha512-G08GDeAwgVkN5PGE9TnJ/4ixV3zkq560RigOoqrRvVc8H4GjfPVTz54/qGPLHK1KGHGP36/2eaLU1HuXmOJgug==
 
-jsx-ast-utils@^1.3.4:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
-  integrity sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=
+"jsx-ast-utils@^2.4.1 || ^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz#41108d2cec408c3453c1bbe8a4aae9e1e2bd8f82"
+  integrity sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==
+  dependencies:
+    array-includes "^3.1.2"
+    object.assign "^4.1.2"
 
 just-curry-it@^3.1.0:
   version "3.1.0"
@@ -9322,6 +9434,11 @@ object-inspect@^1.8.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
+object-inspect@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
+  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+
 object-is@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.3.tgz#2e3b9e65560137455ee3bd62aec4d90a2ea1cc81"
@@ -9342,16 +9459,6 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.4:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
-  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
-    has-symbols "^1.0.1"
-    object-keys "^1.1.1"
-
 object.assign@^4.1.0, object.assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
@@ -9361,6 +9468,36 @@ object.assign@^4.1.0, object.assign@^4.1.1:
     es-abstract "^1.18.0-next.0"
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
+
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.entries@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.3.tgz#c601c7f168b62374541a07ddbd3e2d5e4f7711a6"
+  integrity sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+    has "^1.0.3"
+
+object.fromentries@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.4.tgz#26e1ba5c4571c5c6f0890cef4473066456a120b8"
+  integrity sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    has "^1.0.3"
 
 object.getownpropertydescriptors@^2.1.0:
   version "2.1.0"
@@ -11549,6 +11686,14 @@ regexp.prototype.flags@^1.2.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
+regexp.prototype.flags@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -11883,6 +12028,14 @@ resolve@^1.1.3, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.18.1:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 restore-cursor@^1.0.1:
@@ -12251,6 +12404,15 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -12634,6 +12796,19 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string.prototype.matchall@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz#608f255e93e072107f5de066f81a2dfb78cf6b29"
+  integrity sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    has-symbols "^1.0.1"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.3.1"
+    side-channel "^1.0.4"
+
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
@@ -12642,6 +12817,14 @@ string.prototype.trimend@^1.0.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 string.prototype.trimstart@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
@@ -12649,6 +12832,14 @@ string.prototype.trimstart@^1.0.1:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 string_decoder@0.10, string_decoder@~0.10.x:
   version "0.10.31"
@@ -13348,6 +13539,16 @@ ultron@~1.1.0:
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
+unbox-primitive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.0.tgz#eeacbc4affa28e9b3d36b5eaeccc50b3251b1d3f"
+  integrity sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.0"
+    has-symbols "^1.0.0"
+    which-boxed-primitive "^1.0.1"
+
 unc-path-regex@^0.1.0, unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -13986,6 +14187,17 @@ whet.extend@~0.9.9:
   version "0.9.9"
   resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
   integrity sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=
+
+which-boxed-primitive@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
*Reabased on `master` when it was on e8c347b849c0020fdd2267aa74fc66c456a07c5f.

This is going to be an aggregate PR.

Running `yarn lint` after d8acaa89f9c7c8562936a29c5cabe21e0d3dfdc7 produces:
- `✖ 260 problems (257 errors, 3 warnings)`

However, if we enable `"react/prop-types"` rule and set it to `1` (warn), we get: 
- `✖ 4328 problems (257 errors, 4071 warnings)`

### Groups of errors/warnings:
#### Error
- [x] Missing "key" prop for element in iterator  `react/jsx-key`
- [x] Missing "key" prop for element in array  `react/jsx-key`
- [x] Using this.refs is deprecated `react/no-string-refs`
- [x] Using string literals in ref attributes is deprecated  `react/no-string-refs`
- [x] Do not pass children as props. Instead, nest children between the opening and closing tags  `react/no-children-prop`
- [x] Using target="_blank" without rel="noreferrer" is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener  `react/jsx-no-target-blank`
- [x] `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`  `react/no-unescaped-entities`
- [x] `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`

#### Warning
- [x] Component definition is missing display name `react/display-name`
    - There are numerous `// eslint-disable-next-line react/display-name` and `// eslint-disable-line react/display-name` comments throughout the code base
    - We should handle that as well in this PR
- [x] warning  'setPulseArchived' is missing in props validation `react/prop-types`