### PR TITLE
Optimize SQL Server GROUP BY and ORDER BY with :year, :month, or :day

### DIFF
--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -11,34 +11,28 @@
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.query-processor :as qp]
-            [metabase.query-processor-test :as qp.test]
-            [metabase.query-processor.test-util :as qp.test-util]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.test :as mt]
-            [metabase.test.data :as data]
-            [metabase.test.data.datasets :as datasets]
-            [metabase.test.data.interface :as tx]
-            [metabase.test.util :as tu :refer [obj->json->obj]]))
+            [metabase.test :as mt]))
 
 ;;; -------------------------------------------------- VARCHAR(MAX) --------------------------------------------------
 
-(def ^:private a-gene
+(defn- a-gene
   "Really long string representing a gene like \"GGAGCACCTCCACAAGTGCAGGCTATCCTGTCGAGTAAGGCCT...\""
+  []
   (apply str (repeatedly 1000 (partial rand-nth [\A \G \C \T]))))
 
-(tx/defdataset ^:private genetic-data
+(mt/defdataset ^:private genetic-data
   [["genetic-data"
     [{:field-name "gene", :base-type {:native "VARCHAR(MAX)"}}]
-    [[a-gene]]]])
+    [[(a-gene)]]]])
 
 (deftest clobs-should-come-back-as-text-test
   (mt/test-driver :sqlserver
     (testing "Make sure something long doesn't come back as some weird type like `ClobImpl`"
-      (is (= [[1 a-gene]]
-             (-> (data/dataset metabase.driver.sqlserver-test/genetic-data (data/run-mbql-query genetic-data))
-                 :data
-                 :rows
-                 obj->json->obj)))))) ; convert to JSON + back so the Clob gets stringified
+      (is (= [[1 (-> genetic-data :table-definitions first :rows ffirst)]]
+             (-> (mt/dataset genetic-data (mt/run-mbql-query genetic-data))
+                 mt/rows
+                 mt/obj->json->obj)))))) ; convert to JSON + back so the Clob gets stringified
 
 (deftest connection-spec-test
   (testing "Test that additional connection string options work (#5296)"
@@ -63,11 +57,6 @@
                ;; the MB version Is subject to change between test runs, so replace the part like `v.0.25.0` with
                ;; `<version>`
                (update :applicationName #(str/replace % #"\s.*$" " <version>")))))))
-
-(deftest timezone-id-test
-  (mt/test-driver :sqlserver
-    (is (= "UTC"
-           (tu/db-timezone-id)))))
 
 (deftest add-max-results-limit-test
   (mt/test-driver :sqlserver
@@ -120,7 +109,7 @@
                               :order-by     [[:asc $id]]})
                            qp/query->preprocessed
                            (m/dissoc-in [:query :limit]))]
-      (qp.test-util/with-everything-store
+      (mt/with-everything-store
         (is (= {:query  (str "SELECT \"source\".\"name\" AS \"name\" "
                              "FROM ("
                              "SELECT TOP 1048576 "
@@ -138,7 +127,7 @@
       (is (= [["Red Medicine"]
               ["Stout Burgers & Beers"]
               ["The Apple Pan"]]
-             (qp.test/rows
+             (mt/rows
                (qp/process-query
                 (mt/mbql-query venues
                   {:source-query {:source-table $$venues
@@ -148,7 +137,7 @@
                    :limit        3}))))))))
 
 (deftest locale-bucketing-test
-  (datasets/test-driver :sqlserver
+  (mt/test-driver :sqlserver
     (testing (str "Make sure datetime bucketing functions work properly with languages that format dates like "
                   "yyyy-dd-MM instead of yyyy-MM-dd (i.e. not American English) (#9057)")
       ;; we're doing things here with low-level calls to HoneySQL (emulating what the QP does) instead of using normal
@@ -176,7 +165,7 @@
             (.rollback conn)))))))
 
 (deftest unprepare-test
-  (datasets/test-driver :sqlserver
+  (mt/test-driver :sqlserver
     (let [date (t/local-date 2019 11 5)
           time (t/local-time 19 27)]
       ;; various types should come out the same as they went in (1 value per tuple) or something functionally
@@ -202,3 +191,67 @@
                   (is (= [expected]
                          (row-thunk))
                       (format "SQL %s should return %s" (colorize/blue (pr-str sql)) (colorize/green expected))))))))))))
+
+(defn- pretty-sql [s]
+  (str/replace s #"\"" ""))
+
+(deftest optimal-filter-clauses-test
+  (mt/test-driver :sqlserver
+    (testing "Should use efficient functions like year() for date bucketing (#9934)"
+      (letfn [(query-with-bucketing [unit]
+                (mt/mbql-query checkins
+                  {:aggregation [[:count]]
+                   :breakout    [[:field $date {:temporal-unit unit}]]}))]
+        (doseq [[unit {:keys [expected-sql expected-rows]}]
+                {"year"
+                 {:expected-sql
+                  (str "SELECT DateFromParts(year(dbo.checkins.date), 1, 1) AS date,"
+                       " count(*) AS count "
+                       "FROM dbo.checkins "
+                       "GROUP BY year(dbo.checkins.date) "
+                       "ORDER BY year(dbo.checkins.date) ASC")
+
+                  :expected-rows
+                  [["2013-01-01T00:00:00Z" 235]
+                   ["2014-01-01T00:00:00Z" 498]
+                   ["2015-01-01T00:00:00Z" 267]]}
+
+                 "month"
+                 {:expected-sql
+                  (str "SELECT DateFromParts(year(dbo.checkins.date), month(dbo.checkins.date), 1) AS date,"
+                       " count(*) AS count "
+                       "FROM dbo.checkins "
+                       "GROUP BY year(dbo.checkins.date), month(dbo.checkins.date) "
+                       "ORDER BY year(dbo.checkins.date) ASC, month(dbo.checkins.date) ASC")
+
+                  :expected-rows
+                  [["2013-01-01T00:00:00Z" 8]
+                   ["2013-02-01T00:00:00Z" 11]
+                   ["2013-03-01T00:00:00Z" 21]
+                   ["2013-04-01T00:00:00Z" 26]
+                   ["2013-05-01T00:00:00Z" 23]]}
+
+                 "day"
+                 {:expected-sql
+                  (str "SELECT DateFromParts(year(dbo.checkins.date), month(dbo.checkins.date), day(dbo.checkins.date)) AS date,"
+                       " count(*) AS count "
+                       "FROM dbo.checkins "
+                       "GROUP BY year(dbo.checkins.date), month(dbo.checkins.date), day(dbo.checkins.date) "
+                       "ORDER BY year(dbo.checkins.date) ASC, month(dbo.checkins.date) ASC, day(dbo.checkins.date) ASC")
+
+                  :expected-rows
+                  [["2013-01-03T00:00:00Z" 1]
+                   ["2013-01-10T00:00:00Z" 1]
+                   ["2013-01-19T00:00:00Z" 1]
+                   ["2013-01-22T00:00:00Z" 1]
+                   ["2013-01-23T00:00:00Z" 1]]}}]
+          (testing (format "\nUnit = %s\n" unit)
+            (testing "Should generate the correct SQL query"
+              (is (= expected-sql
+                     (pretty-sql (:query (qp/query->native (query-with-bucketing unit)))))))
+            (testing "Should still return correct results"
+              (is (= expected-rows
+                     (take 5 (mt/rows
+                               (mt/run-mbql-query checkins
+                                 {:aggregation [[:count]]
+                                  :breakout    [[:field $date {:temporal-unit unit}]]}))))))))))))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -332,16 +332,22 @@
       (hx/* bin-width)
       (hx/+ min-value)))
 
+(def ^:dynamic *field-options*
+  "Bound to the `options` part of a `:field` clause when that clause is being compiled to HoneySQL. Useful if you store
+  additional keys there and need to access them."
+  nil)
+
 (defmethod ->honeysql [:sql :field]
   [driver [_ field-id-or-name options :as field-clause]]
-  (if (:join-alias options)
-    (compile-field-with-join-aliases driver field-clause)
-    (let [honeysql-form (if (integer? field-id-or-name)
-                          (->honeysql driver (qp.store/field field-id-or-name))
-                          (->honeysql driver (hx/identifier :field *table-alias* field-id-or-name)))]
-      (cond->> honeysql-form
-        (:temporal-unit options) (apply-temporal-bucketing driver options)
-        (:binning options)       (apply-binning options)))))
+  (binding [*field-options* options]
+    (if (:join-alias options)
+      (compile-field-with-join-aliases driver field-clause)
+      (let [honeysql-form (if (integer? field-id-or-name)
+                            (->honeysql driver (qp.store/field field-id-or-name))
+                            (->honeysql driver (hx/identifier :field *table-alias* field-id-or-name)))]
+        (cond->> honeysql-form
+          (:temporal-unit options) (apply-temporal-bucketing driver options)
+          (:binning options)       (apply-binning options))))))
 
 
 (defmethod ->honeysql [:sql :count]


### PR DESCRIPTION
Resolves #9934

Made possible by the new `:field` clause from #14897

If `field-clause` is being truncated temporally to `:year`, `:month`, or `:day` in `:aggregation` or `:order-by`, generate more efficient SQL by using multiple `GROUP BY` or `ORDER BY` clauses.  Without optimization, we used to generate SQL like

```sql
SELECT DateFromParts(year(field), month(field), 1), count(*)
FROM table
GROUP BY DateFromParts(year(field), month(field), 1)
ORDER BY DateFromParts(year(field), month(field), 1) ASC
```

The optimized SQL we generate instead looks like

```sql
SELECT DateFromParts(year(field), month(field), 1), count(*)
FROM table
GROUP BY year(field), month(field)
ORDER BY year(field) ASC, month(field) ASC
```

The `year`, `month`, and `day` functions can make use of indexes whereas `DateFromParts` cannot. 