### PR TITLE
Update `.gitignore` to reflect the one in `master`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ xcshareddata
 xcuserdata
 dev/src/dev/nocommit/
 *~
-
 **/cypress_sample_dataset.json
+/frontend/src/cljs
+.shadow-cljs


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Updates `.gitignore` to reflect the one in `master` branch
- This is needed so that we can avoid having to manually delete files or deal with tens of thousands of errors when switching between branches after cca03d22d461ba8fff83dfb53e7e31d40a79c5a2

![image](https://user-images.githubusercontent.com/31325167/110472049-2f064580-80dd-11eb-94db-c0aa09f63625.png)
