### PR TITLE
Extract Cypress user data

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/ad-hoc.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/ad-hoc.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsAdmin,
   signInAsNormalUser,
   describeWithToken,
 } from "__support__/cypress";
@@ -23,7 +22,7 @@ describeWithToken("audit > ad-hoc", () => {
       cy.get(".ScalarValue").contains("123");
 
       // Sign in as admin to be able to access audit logs in tests
-      signInAsAdmin();
+      cy.signInAsAdmin();
     });
 
     it.skip("should appear in audit log (metabase-enterprise#486)", () => {

--- a/enterprise/frontend/test/metabase-enterprise/audit/ad-hoc.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/ad-hoc.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  signInAsNormalUser,
-  describeWithToken,
-} from "__support__/cypress";
+import { restore, describeWithToken } from "__support__/cypress";
 
 describeWithToken("audit > ad-hoc", () => {
   describe("native query with JOIN", () => {
@@ -10,7 +6,7 @@ describeWithToken("audit > ad-hoc", () => {
       restore();
 
       cy.log("Run ad hoc native query as normal user");
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/question/new");
       cy.findByText("Native query").click();
       cy.get(".ace_content").type("SELECT 123");

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  signIn,
-  signInAsAdmin,
-  describeWithToken,
-} from "__support__/cypress";
+import { restore, signInAsAdmin, describeWithToken } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 import _ from "underscore";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -46,7 +41,7 @@ describeWithToken("audit > auditing", () => {
   before(() => {
     restore();
     ["admin", "normal"].forEach(user => {
-      signIn(user);
+      cy.signIn(user);
       generateQuestions(user);
       generateDashboards(user);
     });
@@ -56,7 +51,7 @@ describeWithToken("audit > auditing", () => {
     cy.icon("download").click();
     cy.request("POST", "/api/card/1/query/json");
 
-    signIn("nodata");
+    cy.signIn("nodata");
 
     cy.log("View normal user's dashboard");
     cy.visit("/collection/root?type=dashboard");

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsAdmin, describeWithToken } from "__support__/cypress";
+import { restore, describeWithToken } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 import _ from "underscore";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -69,7 +69,7 @@ describeWithToken("audit > auditing", () => {
     cy.findByPlaceholderText(/ID/i);
   });
 
-  beforeEach(signInAsAdmin);
+  beforeEach(cy.signInAsAdmin);
 
   describe("See expected info on team member pages", () => {
     it("should load the Overview tab", () => {

--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -2,9 +2,9 @@ import {
   restore,
   signIn,
   signInAsAdmin,
-  USERS,
   describeWithToken,
 } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
 import _ from "underscore";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { normal } = USERS;

--- a/enterprise/frontend/test/metabase-enterprise/auth/sso.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/auth/sso.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signOut, describeWithToken } from "__support__/cypress";
+import { restore, describeWithToken } from "__support__/cypress";
 
 describeWithToken("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
@@ -12,7 +12,7 @@ describeWithToken("scenarios > auth > signin > SSO", () => {
     cy.request("PUT", "api/setting/enable-password-login", {
       value: false,
     });
-    signOut();
+    cy.signOut();
   });
 
   it("should show the SSO button without an option to use password", () => {

--- a/enterprise/frontend/test/metabase-enterprise/auth/sso.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/auth/sso.cy.spec.js
@@ -1,14 +1,9 @@
-import {
-  restore,
-  signOut,
-  signInAsAdmin,
-  describeWithToken,
-} from "__support__/cypress";
+import { restore, signOut, describeWithToken } from "__support__/cypress";
 
 describeWithToken("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     // Set fake Google client ID
     cy.request("PUT", "/api/setting/google-auth-client-id", {
       value: "123",

--- a/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
@@ -1,4 +1,4 @@
-import { signIn, signInAsAdmin, restore, modal } from "__support__/cypress";
+import { signInAsAdmin, restore, modal } from "__support__/cypress";
 
 // Drill-through support has been replaced with custom dashboard destinations
 describe.skip("drill through", () => {
@@ -35,7 +35,7 @@ describe.skip("drill through", () => {
   });
 
   it("should allow custom drill through without data permissions", () => {
-    signIn("nodata");
+    cy.signIn("nodata");
     cy.visit("/question/3");
     cy.get(".dot:first").click({ force: true });
     cy.url().should("match", /\?count=744/);

--- a/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/custom_drill_through/drill_through.cy.spec.js
@@ -1,10 +1,10 @@
-import { signInAsAdmin, restore, modal } from "__support__/cypress";
+import { restore, modal } from "__support__/cypress";
 
 // Drill-through support has been replaced with custom dashboard destinations
 describe.skip("drill through", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("sets drill through link for dots in a line graph", () => {

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signOut,
   openOrdersTable,
   describeWithToken,
 } from "__support__/cypress";
@@ -112,7 +111,7 @@ describeWithToken("formatting > whitelabel", () => {
       cy.findByText("Metabase is up and running.").should("not.exist");
 
       cy.log("New company should show up when logged out");
-      signOut();
+      cy.signOut();
       cy.visit("/");
       cy.findByText(`Sign in to ${COMPANY_NAME}`);
 
@@ -142,7 +141,7 @@ describeWithToken("formatting > whitelabel", () => {
     });
 
     it("should reflect color changes", () => {
-      signOut();
+      cy.signOut();
       cy.visit("/");
 
       // Note that if we have modified the logo, the entire background turns the brand color.
@@ -223,7 +222,7 @@ describeWithToken("formatting > whitelabel", () => {
     });
 
     it("changes should reflect while signed out", () => {
-      signOut();
+      cy.signOut();
       cy.visit("/");
       checkLogo();
     });

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   signOut,
-  signInAsNormalUser,
   openOrdersTable,
   describeWithToken,
 } from "__support__/cypress";
@@ -118,7 +117,7 @@ describeWithToken("formatting > whitelabel", () => {
       cy.findByText(`Sign in to ${COMPANY_NAME}`);
 
       cy.log("New company should show up for a normal user");
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/activity");
       cy.findByText(`${COMPANY_NAME} is up and running.`);
       cy.findByText("Metabase is up and running.").should("not.exist");
@@ -164,7 +163,7 @@ describeWithToken("formatting > whitelabel", () => {
       );
 
       cy.log("Normal users should have a green header");
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/");
       cy.get(".Nav").should(
         "have.css",
@@ -192,7 +191,7 @@ describeWithToken("formatting > whitelabel", () => {
 
     it.skip("should show color changes reflected in q visualizations (metabase-enterprise #470)", () => {
       // *** Test should pass when issue #470 is resolved
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       openOrdersTable();
       cy.findAllByText("Summarize")
         .first()
@@ -230,7 +229,7 @@ describeWithToken("formatting > whitelabel", () => {
     });
 
     it("changes should reflect on user's dashboard", () => {
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/");
       checkLogo();
     });
@@ -251,7 +250,7 @@ describeWithToken("formatting > whitelabel", () => {
       checkFavicon();
     });
     it("should show up in user's HTML", () => {
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/");
       cy.get('head link[rel="icon"]')
         .get('[href="https://cdn.ecosia.org/assets/images/ico/favicon.ico"]')

--- a/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/formatting/whitelabel.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsAdmin,
   signOut,
   signInAsNormalUser,
   openOrdersTable,
@@ -47,7 +46,7 @@ function checkLogo() {
 describeWithToken("formatting > whitelabel", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   describe("admin", () => {
@@ -176,7 +175,7 @@ describeWithToken("formatting > whitelabel", () => {
       cy.log(
         "Admin users should also have a green header, but yellow in the admin panel",
       );
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/");
       cy.get(".Nav").should(
         "have.css",

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -5,7 +5,6 @@ import {
   popover,
   modal,
   restore,
-  signInAsNormalUser,
   signOut,
   remapDisplayValueToFK,
   sidebar,
@@ -115,7 +114,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
 
       signOut();
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
     });
 
     describe("table sandboxed on a user attribute", () => {

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -5,7 +5,6 @@ import {
   popover,
   modal,
   restore,
-  signInAsAdmin,
   signInAsNormalUser,
   signOut,
   remapDisplayValueToFK,
@@ -33,7 +32,7 @@ describeWithToken("formatting > sandboxes", () => {
   describe("admin", () => {
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/admin/people");
     });
 
@@ -71,7 +70,7 @@ describeWithToken("formatting > sandboxes", () => {
 
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
 
       // Add user attribute to existing ("normal" / id:2) user
       cy.request("PUT", "/api/user/2", {
@@ -174,7 +173,7 @@ describeWithToken("formatting > sandboxes", () => {
   describe("Sandboxing reproductions", () => {
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.createUser("sandboxed");
     });
 

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -8,13 +8,12 @@ import {
   signInAsAdmin,
   signInAsNormalUser,
   signOut,
-  USERS,
-  USER_GROUPS,
   remapDisplayValueToFK,
   sidebar,
   signInAsSandboxedUser,
   createUser,
 } from "__support__/cypress";
+import { USERS, USER_GROUPS } from "__support__/cypress_data";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -8,7 +8,6 @@ import {
   signOut,
   remapDisplayValueToFK,
   sidebar,
-  signInAsSandboxedUser,
 } from "__support__/cypress";
 import { USERS, USER_GROUPS } from "__support__/cypress_data";
 
@@ -195,7 +194,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
 
       signOut();
-      signInAsSandboxedUser();
+      cy.signInAsSandboxedUser();
 
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Summarize").click();
@@ -257,7 +256,7 @@ describeWithToken("formatting > sandboxes", () => {
         },
       }).then(({ body: { id: QUESTION_ID } }) => {
         signOut();
-        signInAsSandboxedUser();
+        cy.signInAsSandboxedUser();
 
         cy.server();
         cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
@@ -323,7 +322,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
 
         signOut();
-        signInAsSandboxedUser();
+        cy.signInAsSandboxedUser();
 
         cy.server();
         cy.route("POST", "/api/card/*/query").as("cardQuery");
@@ -399,7 +398,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
 
       signOut();
-      signInAsSandboxedUser();
+      cy.signInAsSandboxedUser();
 
       cy.server();
       cy.route("POST", "/api/card/*/query").as("cardQuery");
@@ -478,7 +477,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
 
         signOut();
-        signInAsSandboxedUser();
+        cy.signInAsSandboxedUser();
 
         openOrdersTable();
 
@@ -575,7 +574,7 @@ describeWithToken("formatting > sandboxes", () => {
           });
 
           signOut();
-          signInAsSandboxedUser();
+          cy.signInAsSandboxedUser();
 
           openOrdersTable();
 
@@ -634,7 +633,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
 
         signOut();
-        signInAsSandboxedUser();
+        cy.signInAsSandboxedUser();
         openOrdersTable();
 
         cy.wait("@dataset").then(xhr => {
@@ -698,7 +697,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
 
         signOut();
-        signInAsSandboxedUser();
+        cy.signInAsSandboxedUser();
 
         cy.server();
         cy.route("POST", "/api/card/*/query").as("cardQuery");
@@ -804,7 +803,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
 
       signOut();
-      signInAsSandboxedUser();
+      cy.signInAsSandboxedUser();
       createJoinedQuestion("14841").then(({ body: { id: QUESTION_ID } }) => {
         cy.visit(`/question/${QUESTION_ID}`);
       });
@@ -893,7 +892,7 @@ describeWithToken("formatting > sandboxes", () => {
         );
 
         signOut();
-        signInAsSandboxedUser();
+        cy.signInAsSandboxedUser();
 
         cy.visit(`/question/${QUESTION_ID}`);
 
@@ -914,7 +913,7 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      signInAsSandboxedUser();
+      cy.signInAsSandboxedUser();
       cy.visit("/dashboard/1");
       cy.icon("share").click();
       cy.findByText("Dashboard subscriptions").click();
@@ -938,7 +937,7 @@ describeWithToken("formatting > sandboxes", () => {
       });
 
       signOut();
-      signInAsSandboxedUser();
+      cy.signInAsSandboxedUser();
 
       cy.visit("/pulse/create");
       cy.wait("@collection");

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -5,7 +5,6 @@ import {
   popover,
   modal,
   restore,
-  signOut,
   remapDisplayValueToFK,
   sidebar,
 } from "__support__/cypress";
@@ -112,7 +111,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
       });
 
-      signOut();
+      cy.signOut();
       cy.signInAsNormalUser();
     });
 
@@ -193,7 +192,7 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      signOut();
+      cy.signOut();
       cy.signInAsSandboxedUser();
 
       openOrdersTable({ mode: "notebook" });
@@ -255,7 +254,7 @@ describeWithToken("formatting > sandboxes", () => {
           "source-table": ORDERS_ID,
         },
       }).then(({ body: { id: QUESTION_ID } }) => {
-        signOut();
+        cy.signOut();
         cy.signInAsSandboxedUser();
 
         cy.server();
@@ -321,7 +320,7 @@ describeWithToken("formatting > sandboxes", () => {
           display: "bar",
         });
 
-        signOut();
+        cy.signOut();
         cy.signInAsSandboxedUser();
 
         cy.server();
@@ -397,7 +396,7 @@ describeWithToken("formatting > sandboxes", () => {
         display: "bar",
       });
 
-      signOut();
+      cy.signOut();
       cy.signInAsSandboxedUser();
 
       cy.server();
@@ -476,7 +475,7 @@ describeWithToken("formatting > sandboxes", () => {
           });
         });
 
-        signOut();
+        cy.signOut();
         cy.signInAsSandboxedUser();
 
         openOrdersTable();
@@ -573,7 +572,7 @@ describeWithToken("formatting > sandboxes", () => {
             });
           });
 
-          signOut();
+          cy.signOut();
           cy.signInAsSandboxedUser();
 
           openOrdersTable();
@@ -632,7 +631,7 @@ describeWithToken("formatting > sandboxes", () => {
           },
         });
 
-        signOut();
+        cy.signOut();
         cy.signInAsSandboxedUser();
         openOrdersTable();
 
@@ -696,7 +695,7 @@ describeWithToken("formatting > sandboxes", () => {
           display: "bar",
         });
 
-        signOut();
+        cy.signOut();
         cy.signInAsSandboxedUser();
 
         cy.server();
@@ -802,7 +801,7 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      signOut();
+      cy.signOut();
       cy.signInAsSandboxedUser();
       createJoinedQuestion("14841").then(({ body: { id: QUESTION_ID } }) => {
         cy.visit(`/question/${QUESTION_ID}`);
@@ -891,7 +890,7 @@ describeWithToken("formatting > sandboxes", () => {
           "cardQuery",
         );
 
-        signOut();
+        cy.signOut();
         cy.signInAsSandboxedUser();
 
         cy.visit(`/question/${QUESTION_ID}`);
@@ -936,7 +935,7 @@ describeWithToken("formatting > sandboxes", () => {
         },
       });
 
-      signOut();
+      cy.signOut();
       cy.signInAsSandboxedUser();
 
       cy.visit("/pulse/create");

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -11,7 +11,6 @@ import {
   remapDisplayValueToFK,
   sidebar,
   signInAsSandboxedUser,
-  createUser,
 } from "__support__/cypress";
 import { USERS, USER_GROUPS } from "__support__/cypress_data";
 
@@ -176,7 +175,7 @@ describeWithToken("formatting > sandboxes", () => {
     beforeEach(() => {
       restore();
       signInAsAdmin();
-      createUser("sandboxed");
+      cy.createUser("sandboxed");
     });
 
     it("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {

--- a/enterprise/frontend/test/metabase-enterprise/scenarios/admin/databases/add.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/scenarios/admin/databases/add.cy.spec.js
@@ -1,15 +1,10 @@
-import {
-  describeWithToken,
-  popover,
-  restore,
-  signInAsAdmin,
-} from "__support__/cypress";
+import { describeWithToken, popover, restore } from "__support__/cypress";
 
 describeWithToken("scenarios > admin > databases > add", () => {
   describe("EE should ship with Oracle and Vertica as options", () => {
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.server();
 
       cy.visit("/admin/databases/create");

--- a/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsNormalUser,
   restore,
   modal,
   popover,
@@ -36,7 +35,7 @@ describeWithToken("scenarios > question > snippets", () => {
     // users have to be granted explicit access.
     // See metabase-enterprise#543 for more details
 
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
 
     cy.request({
       method: "POST",
@@ -90,7 +89,7 @@ describeWithToken("scenarios > question > snippets", () => {
       .contains("Save")
       .click();
     // Now the user should be able to create a snippet
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
 
     cy.request({
       method: "POST",

--- a/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/snippets/snippet-permissions.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   signInAsNormalUser,
-  signInAsAdmin,
   restore,
   modal,
   popover,
@@ -11,7 +10,7 @@ import {
 describeWithToken("scenarios > question > snippets", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("can create a snippet", () => {

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -26,6 +26,11 @@ Cypress.Commands.add("signInAsSandboxedUser", () => {
   cy.signIn("sandboxed");
 });
 
+Cypress.Commands.add("signOut", () => {
+  cy.log("Signing out");
+  cy.clearCookie("metabase.SESSION");
+});
+
 Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -22,6 +22,10 @@ Cypress.Commands.add("signInAsNormalUser", () => {
   cy.signIn("normal");
 });
 
+Cypress.Commands.add("signInAsSandboxedUser", () => {
+  cy.signIn("sandboxed");
+});
+
 Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -14,6 +14,10 @@ Cypress.Commands.add("signIn", (user = "admin") => {
   cy.request("POST", "/api/session", { username, password });
 });
 
+Cypress.Commands.add("signInAsAdmin", () => {
+  cy.signIn("admin");
+});
+
 Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -18,6 +18,10 @@ Cypress.Commands.add("signInAsAdmin", () => {
   cy.signIn("admin");
 });
 
+Cypress.Commands.add("signInAsNormalUser", () => {
+  cy.signIn("normal");
+});
+
 Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -8,6 +8,12 @@ Cypress.Commands.add("createUser", user => {
   });
 });
 
+Cypress.Commands.add("signIn", (user = "admin") => {
+  const { email: username, password } = USERS[user];
+  cy.log(`Logging in as ${user}`);
+  cy.request("POST", "/api/session", { username, password });
+});
+
 Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });

--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -1,3 +1,13 @@
+import { USERS } from "__support__/cypress_data";
+
+Cypress.Commands.add("createUser", user => {
+  cy.log(`Create ${user} user`);
+  return cy.request("POST", "/api/user", USERS[user]).then(({ body }) => {
+    // Dismiss `it's ok to play around` modal for the created user
+    cy.request("PUT", `/api/user/${body.id}/qbnewb`, {});
+  });
+});
+
 Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -1,14 +1,7 @@
-import { USERS } from "__support__/cypress_data";
 import "@testing-library/cypress/add-commands";
 import "./commands";
 
 export const version = require("../../../version.json");
-
-export function signIn(user = "admin") {
-  const { email: username, password } = USERS[user];
-  cy.log(`Logging in as ${user}`);
-  cy.request("POST", "/api/session", { username, password });
-}
 
 export function signOut() {
   cy.log("Signing out");
@@ -16,15 +9,15 @@ export function signOut() {
 }
 
 export function signInAsAdmin() {
-  signIn("admin");
+  cy.signIn("admin");
 }
 
 export function signInAsNormalUser() {
-  signIn("normal");
+  cy.signIn("normal");
 }
 
 export function signInAsSandboxedUser() {
-  signIn("sandboxed");
+  cy.signIn("sandboxed");
 }
 
 export function snapshot(name) {

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -8,10 +8,6 @@ export function signOut() {
   cy.clearCookie("metabase.SESSION");
 }
 
-export function signInAsAdmin() {
-  cy.signIn("admin");
-}
-
 export function signInAsNormalUser() {
   cy.signIn("normal");
 }

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -1,17 +1,8 @@
-import { USERS, USER_GROUPS } from "__support__/cypress_data";
+import { USERS } from "__support__/cypress_data";
 import "@testing-library/cypress/add-commands";
 import "./commands";
 
 export const version = require("../../../version.json");
-
-
-export function createUser(user) {
-  cy.log(`Create ${user} user`);
-  return cy.request("POST", "/api/user", USERS[user]).then(({ body }) => {
-    // Dismiss `it's ok to play around` modal for the created user
-    cy.request("PUT", `/api/user/${body.id}/qbnewb`, {});
-  });
-}
 
 export function signIn(user = "admin") {
   const { email: username, password } = USERS[user];

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -3,11 +3,6 @@ import "./commands";
 
 export const version = require("../../../version.json");
 
-export function signOut() {
-  cy.log("Signing out");
-  cy.clearCookie("metabase.SESSION");
-}
-
 export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -8,10 +8,6 @@ export function signOut() {
   cy.clearCookie("metabase.SESSION");
 }
 
-export function signInAsNormalUser() {
-  cy.signIn("normal");
-}
-
 export function signInAsSandboxedUser() {
   cy.signIn("sandboxed");
 }

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -8,10 +8,6 @@ export function signOut() {
   cy.clearCookie("metabase.SESSION");
 }
 
-export function signInAsSandboxedUser() {
-  cy.signIn("sandboxed");
-}
-
 export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -1,64 +1,9 @@
+import { USERS, USER_GROUPS } from "__support__/cypress_data";
 import "@testing-library/cypress/add-commands";
 import "./commands";
 
 export const version = require("../../../version.json");
 
-export const USER_GROUPS = {
-  ALL_USERS_GROUP: 1,
-  ADMIN_GROUP: 2,
-  COLLECTION_GROUP: 4,
-  DATA_GROUP: 5,
-};
-
-const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
-
-export const USERS = {
-  admin: {
-    first_name: "Bobby",
-    last_name: "Tables",
-    email: "admin@metabase.com",
-    password: "12341234",
-  },
-  normal: {
-    first_name: "Robert",
-    last_name: "Tableton",
-    email: "normal@metabase.com",
-    password: "12341234",
-    group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP],
-  },
-  nodata: {
-    first_name: "No Data",
-    last_name: "Tableton",
-    email: "nodata@metabase.com",
-    password: "12341234",
-    group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
-  },
-  nocollection: {
-    first_name: "No Collection",
-    last_name: "Tableton",
-    email: "nocollection@metabase.com",
-    password: "12341234",
-    group_ids: [ALL_USERS_GROUP, DATA_GROUP],
-  },
-  none: {
-    first_name: "None",
-    last_name: "Tableton",
-    email: "none@metabase.com",
-    password: "12341234",
-    group_ids: [ALL_USERS_GROUP],
-  },
-  sandboxed: {
-    first_name: "User",
-    last_name: "1",
-    email: "u1@metabase.test",
-    password: "12341234",
-    login_attributes: {
-      attr_uid: "1",
-      attr_cat: "Widget",
-    },
-    group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
-  },
-};
 
 export function createUser(user) {
   cy.log(`Create ${user} user`);

--- a/frontend/test/__support__/cypress_data.js
+++ b/frontend/test/__support__/cypress_data.js
@@ -1,0 +1,56 @@
+export const USER_GROUPS = {
+  ALL_USERS_GROUP: 1,
+  ADMIN_GROUP: 2,
+  COLLECTION_GROUP: 4,
+  DATA_GROUP: 5,
+};
+
+const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
+
+export const USERS = {
+  admin: {
+    first_name: "Bobby",
+    last_name: "Tables",
+    email: "admin@metabase.com",
+    password: "12341234",
+  },
+  normal: {
+    first_name: "Robert",
+    last_name: "Tableton",
+    email: "normal@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP],
+  },
+  nodata: {
+    first_name: "No Data",
+    last_name: "Tableton",
+    email: "nodata@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
+  },
+  nocollection: {
+    first_name: "No Collection",
+    last_name: "Tableton",
+    email: "nocollection@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP, DATA_GROUP],
+  },
+  none: {
+    first_name: "None",
+    last_name: "Tableton",
+    email: "none@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP],
+  },
+  sandboxed: {
+    first_name: "User",
+    last_name: "1",
+    email: "u1@metabase.test",
+    password: "12341234",
+    login_attributes: {
+      attr_uid: "1",
+      attr_cat: "Widget",
+    },
+    group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
+  },
+};

--- a/frontend/test/metabase-db/mongo/add.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/add.cy.spec.js
@@ -1,14 +1,9 @@
-import {
-  signInAsAdmin,
-  restore,
-  modal,
-  typeAndBlurUsingLabel,
-} from "__support__/cypress";
+import { restore, modal, typeAndBlurUsingLabel } from "__support__/cypress";
 
 describe("mongodb > admin > add", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
   });
 

--- a/frontend/test/metabase-db/mongo/query.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/query.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   modal,
   signInAsNormalUser,
@@ -11,7 +10,7 @@ const MONGO_DB_NAME = "QA Mongo4";
 describe("mongodb > user > query", () => {
   before(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     addMongoDatabase(MONGO_DB_NAME);
   });
 

--- a/frontend/test/metabase-db/mongo/query.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/query.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  modal,
-  signInAsNormalUser,
-  addMongoDatabase,
-} from "__support__/cypress";
+import { restore, modal, addMongoDatabase } from "__support__/cypress";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
@@ -22,7 +17,7 @@ describe("mongodb > user > query", () => {
 
   context("as a user", () => {
     beforeEach(() => {
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
     });
 
     it("can query a Mongo database", () => {

--- a/frontend/test/metabase-db/mysql/add.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/add.cy.spec.js
@@ -1,14 +1,9 @@
-import {
-  signInAsAdmin,
-  restore,
-  modal,
-  typeAndBlurUsingLabel,
-} from "__support__/cypress";
+import { restore, modal, typeAndBlurUsingLabel } from "__support__/cypress";
 
 describe("mysql > admin > add", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
   });
 

--- a/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/custom-column.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  signInAsAdmin,
-  addMySQLDatabase,
-  withDatabase,
-} from "__support__/cypress";
+import { restore, addMySQLDatabase, withDatabase } from "__support__/cypress";
 
 const MYSQL_DB_NAME = "QA MySQL8";
 
@@ -11,7 +6,7 @@ const MYSQL_DB_NAME = "QA MySQL8";
 describe.skip("mysql > user > question > custom column", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     addMySQLDatabase(MYSQL_DB_NAME);
   });
 

--- a/frontend/test/metabase-db/mysql/query.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/query.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  modal,
-  signInAsNormalUser,
-  addMySQLDatabase,
-} from "__support__/cypress";
+import { restore, modal, addMySQLDatabase } from "__support__/cypress";
 
 const MYSQL_DB_NAME = "QA MySQL8";
 
@@ -15,7 +10,7 @@ describe("mysql > user > query", () => {
   });
 
   beforeEach(() => {
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   it("can query a MySQL database as a user", () => {

--- a/frontend/test/metabase-db/mysql/query.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/query.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   modal,
   signInAsNormalUser,
@@ -11,7 +10,7 @@ const MYSQL_DB_NAME = "QA MySQL8";
 describe("mysql > user > query", () => {
   before(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     addMySQLDatabase(MYSQL_DB_NAME);
   });
 

--- a/frontend/test/metabase-db/postgres/add.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/add.cy.spec.js
@@ -1,14 +1,9 @@
-import {
-  signInAsAdmin,
-  restore,
-  modal,
-  typeAndBlurUsingLabel,
-} from "__support__/cypress";
+import { restore, modal, typeAndBlurUsingLabel } from "__support__/cypress";
 
 describe("postgres > admin > add", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
   });
 

--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -1,16 +1,11 @@
-import {
-  signInAsAdmin,
-  restore,
-  addPostgresDatabase,
-  popover,
-} from "__support__/cypress";
+import { restore, addPostgresDatabase, popover } from "__support__/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
 describe("postgres > question > custom columns", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);
   });
 

--- a/frontend/test/metabase-db/postgres/native.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/native.cy.spec.js
@@ -1,16 +1,11 @@
-import {
-  signInAsAdmin,
-  restore,
-  addPostgresDatabase,
-  modal,
-} from "__support__/cypress";
+import { restore, addPostgresDatabase, modal } from "__support__/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
 describe("postgres > question > native", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);
   });
 

--- a/frontend/test/metabase-db/postgres/query.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/query.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   addPostgresDatabase,
   withDatabase,
@@ -12,7 +11,7 @@ const PG_DB_ID = 2;
 describe("postgres > user > query", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);
   });
 

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signOut,
   restore,
   addPostgresDatabase,
   withDatabase,
@@ -64,7 +63,7 @@ describeWithToken("postgres > user > query", () => {
           },
         });
 
-        signOut();
+        cy.signOut();
         cy.signInAsSandboxedUser();
         cy.visit(`/question/${QUESTION_ID}`);
 

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -4,7 +4,6 @@ import {
   addPostgresDatabase,
   withDatabase,
   describeWithToken,
-  signInAsSandboxedUser,
 } from "__support__/cypress";
 import { USER_GROUPS } from "__support__/cypress_data";
 
@@ -66,7 +65,7 @@ describeWithToken("postgres > user > query", () => {
         });
 
         signOut();
-        signInAsSandboxedUser();
+        cy.signInAsSandboxedUser();
         cy.visit(`/question/${QUESTION_ID}`);
 
         cy.wait("@cardQuery").then(xhr => {

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -4,11 +4,11 @@ import {
   restore,
   addPostgresDatabase,
   withDatabase,
-  USER_GROUPS,
   describeWithToken,
   createUser,
   signInAsSandboxedUser,
 } from "__support__/cypress";
+import { USER_GROUPS } from "__support__/cypress_data";
 
 const PG_DB_NAME = "QA Postgres12";
 const PG_DB_ID = 2;

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -5,7 +5,6 @@ import {
   addPostgresDatabase,
   withDatabase,
   describeWithToken,
-  createUser,
   signInAsSandboxedUser,
 } from "__support__/cypress";
 import { USER_GROUPS } from "__support__/cypress_data";
@@ -20,7 +19,7 @@ describeWithToken("postgres > user > query", () => {
     restore();
     signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);
-    createUser("sandboxed");
+    cy.createUser("sandboxed");
     // Update basic permissions (the same starting "state" as we have for the "Sample Dataset")
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   signOut,
   restore,
   addPostgresDatabase,
@@ -17,7 +16,7 @@ const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 describeWithToken("postgres > user > query", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);
     cy.createUser("sandboxed");
     // Update basic permissions (the same starting "state" as we have for the "Sample Dataset")

--- a/frontend/test/metabase-smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin.cy.spec.js
@@ -1,5 +1,5 @@
 import path from "path";
-import { restore, signInAsAdmin, signOut, sidebar } from "__support__/cypress";
+import { restore, signOut, sidebar } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 
 const { admin } = USERS;
@@ -76,7 +76,7 @@ describe("metabase-smoketest > admin", () => {
   });
 
   describe("Admin has basic functionality", () => {
-    beforeEach(signInAsAdmin);
+    beforeEach(cy.signInAsAdmin);
 
     it.skip("should add a simple summarized question as admin", () => {
       cy.visit("/");

--- a/frontend/test/metabase-smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin.cy.spec.js
@@ -1,11 +1,6 @@
 import path from "path";
-import {
-  USERS,
-  restore,
-  signInAsAdmin,
-  signOut,
-  sidebar,
-} from "__support__/cypress";
+import { restore, signInAsAdmin, signOut, sidebar } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
 
 const { admin } = USERS;
 const new_user = {

--- a/frontend/test/metabase-smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin.cy.spec.js
@@ -1,5 +1,5 @@
 import path from "path";
-import { restore, signOut, sidebar } from "__support__/cypress";
+import { restore, sidebar } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 
 const { admin } = USERS;
@@ -293,7 +293,7 @@ describe("metabase-smoketest > admin", () => {
       // == NEW USER ==
       // ==============
 
-      signOut();
+      cy.signOut();
       cy.get("@password").then(pass => {
         cy.visit("/");
         cy.findByLabelText("Email address").type(new_user.email);

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -3,7 +3,6 @@ import {
   popover,
   restore,
   setupLocalHostEmail,
-  signOut,
 } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 
@@ -247,13 +246,13 @@ describe("smoketest > admin_setup", () => {
 
   describe("data model changes by admin reflected with user", () => {
     beforeEach(() => {
-      signOut();
+      cy.signOut();
       cy.signInAsAdmin();
     });
 
     it("should check table and question names as user", () => {
       // Log out as admin and sign in as user
-      signOut();
+      cy.signOut();
       cy.signInAsNormalUser();
       cy.visit("/");
 
@@ -525,7 +524,7 @@ describe("smoketest > admin_setup", () => {
     });
 
     it("should see changes to visibility, formatting, and foreign key mapping as user", () => {
-      signOut();
+      cy.signOut();
       cy.signInAsNormalUser();
       cy.visit("/");
 
@@ -596,7 +595,7 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Native query");
 
       // Cannot see Review table as no collection user
-      signOut();
+      cy.signOut();
       cy.signIn("nocollection");
       cy.visit("/");
 
@@ -613,7 +612,7 @@ describe("smoketest > admin_setup", () => {
     it("should modify user permissions for data access and SQL queries, both on a database/schema level as well as at a table level as admin", () => {
       // *** Need multible databases to test their permissions.
 
-      signOut();
+      cy.signOut();
       cy.signInAsAdmin();
       cy.visit("/");
 
@@ -683,7 +682,7 @@ describe("smoketest > admin_setup", () => {
     it.skip("should add sub-collection and change its permissions as admin", () => {
       const subCollectionName = "test sub-collection";
 
-      signOut();
+      cy.signOut();
       cy.signInAsAdmin();
 
       cy.visit("/collection/root");
@@ -736,7 +735,7 @@ describe("smoketest > admin_setup", () => {
     });
 
     it.skip("should modify Collection permissions for top-level collections and sub-collections as admin", () => {
-      signOut();
+      cy.signOut();
       cy.signInAsAdmin();
       cy.visit("/admin/permissions/databases");
 
@@ -793,7 +792,7 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Simple question");
       cy.findByText("Native query").should("not.exist");
 
-      signOut();
+      cy.signOut();
       cy.signIn("nocollection");
       cy.visit("/");
 
@@ -836,7 +835,7 @@ describe("smoketest > admin_setup", () => {
       // Normal user should not see changes that no collection user made
       // *** Problem: Normal user still sees these changes
 
-      signOut();
+      cy.signOut();
       cy.signInAsNormalUser();
       cy.visit("/question/1");
 
@@ -935,7 +934,7 @@ describe("smoketest > admin_setup", () => {
     it("should deactivate a user admin and subsequently user should be unable to login", () => {
       // Admin deactiviates user
 
-      signOut();
+      cy.signOut();
       cy.signInAsAdmin();
       cy.visit("/admin/settings/setup");
 
@@ -956,7 +955,7 @@ describe("smoketest > admin_setup", () => {
 
       // User tries to log in
 
-      signOut();
+      cy.signOut();
       cy.visit("/");
       cy.findByLabelText("Email address").type(normal.email);
       cy.findByLabelText("Password").type(normal.password);

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -3,7 +3,6 @@ import {
   popover,
   restore,
   setupLocalHostEmail,
-  signInAsNormalUser,
   signOut,
 } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
@@ -255,7 +254,7 @@ describe("smoketest > admin_setup", () => {
     it("should check table and question names as user", () => {
       // Log out as admin and sign in as user
       signOut();
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/");
 
       // Check names
@@ -527,7 +526,7 @@ describe("smoketest > admin_setup", () => {
 
     it("should see changes to visibility, formatting, and foreign key mapping as user", () => {
       signOut();
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/");
 
       // Check table names and visibility
@@ -581,7 +580,7 @@ describe("smoketest > admin_setup", () => {
   });
 
   describe("permission changes reflected", () => {
-    beforeEach(signInAsNormalUser);
+    beforeEach(cy.signInAsNormalUser);
 
     it("should check current permissions as users", () => {
       // Access to all tables as user
@@ -838,7 +837,7 @@ describe("smoketest > admin_setup", () => {
       // *** Problem: Normal user still sees these changes
 
       signOut();
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/question/1");
 
       // cy.findByText("Product ID");

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -3,7 +3,6 @@ import {
   popover,
   restore,
   setupLocalHostEmail,
-  signInAsAdmin,
   signInAsNormalUser,
   signOut,
 } from "__support__/cypress";
@@ -20,7 +19,7 @@ describe("smoketest > admin_setup", () => {
   before(restore);
 
   describe("successful setup by admin", () => {
-    beforeEach(signInAsAdmin);
+    beforeEach(cy.signInAsAdmin);
 
     it("should add a new database", () => {
       // *** Need faux databases to hook up to
@@ -250,7 +249,7 @@ describe("smoketest > admin_setup", () => {
   describe("data model changes by admin reflected with user", () => {
     beforeEach(() => {
       signOut();
-      signInAsAdmin();
+      cy.signInAsAdmin();
     });
 
     it("should check table and question names as user", () => {
@@ -616,7 +615,7 @@ describe("smoketest > admin_setup", () => {
       // *** Need multible databases to test their permissions.
 
       signOut();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/");
 
       cy.icon("gear").click();
@@ -686,7 +685,7 @@ describe("smoketest > admin_setup", () => {
       const subCollectionName = "test sub-collection";
 
       signOut();
-      signInAsAdmin();
+      cy.signInAsAdmin();
 
       cy.visit("/collection/root");
 
@@ -739,7 +738,7 @@ describe("smoketest > admin_setup", () => {
 
     it.skip("should modify Collection permissions for top-level collections and sub-collections as admin", () => {
       signOut();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/admin/permissions/databases");
 
       // Modify permissions for top-level collection
@@ -938,7 +937,7 @@ describe("smoketest > admin_setup", () => {
       // Admin deactiviates user
 
       signOut();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/admin/settings/setup");
 
       cy.findByText("People").click();

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -3,7 +3,6 @@ import {
   popover,
   restore,
   setupLocalHostEmail,
-  signIn,
   signInAsAdmin,
   signInAsNormalUser,
   signOut,
@@ -600,7 +599,7 @@ describe("smoketest > admin_setup", () => {
 
       // Cannot see Review table as no collection user
       signOut();
-      signIn("nocollection");
+      cy.signIn("nocollection");
       cy.visit("/");
 
       cy.wait(2000).findByText("Try these x-rays based on your data.");
@@ -797,7 +796,7 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Native query").should("not.exist");
 
       signOut();
-      signIn("nocollection");
+      cy.signIn("nocollection");
       cy.visit("/");
 
       // No collection user sees Test Table and People table
@@ -913,7 +912,7 @@ describe("smoketest > admin_setup", () => {
 
       // Check access as no collection user
 
-      signIn("nocollection");
+      cy.signIn("nocollection");
       cy.visit("/");
 
       cy.findByText("test sub-collection").should("not.exist");
@@ -928,7 +927,7 @@ describe("smoketest > admin_setup", () => {
 
     it.skip("should be unable to access question with URL (if access not permitted)", () => {
       // This test will fail whenever the previous test fails
-      signIn("nocollection");
+      cy.signIn("nocollection");
 
       cy.visit("/question/4");
       cy.contains("sub-collection question").should("not.exist");

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -7,8 +7,8 @@ import {
   signInAsAdmin,
   signInAsNormalUser,
   signOut,
-  USERS,
 } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
 
 const { admin, normal, nocollection, nodata } = USERS;
 const new_user = {

--- a/frontend/test/metabase-smoketest/user.cy.spec.js
+++ b/frontend/test/metabase-smoketest/user.cy.spec.js
@@ -1,14 +1,9 @@
-import {
-  restore,
-  signInAsNormalUser,
-  sidebar,
-  popover,
-} from "__support__/cypress";
+import { restore, sidebar, popover } from "__support__/cypress";
 
 describe("smoketest > user", () => {
   // Goal: user can use all the features of the simple question and notebook editor
   before(restore);
-  beforeEach(signInAsNormalUser);
+  beforeEach(cy.signInAsNormalUser);
 
   it("should be able to ask a custom questions", () => {
     cy.visit("/");

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, restore, popover } from "__support__/cypress";
+import { restore, popover } from "__support__/cypress";
 
 function typeField(label, value) {
   cy.findByLabelText(label)
@@ -17,7 +17,7 @@ function toggleFieldWithDisplayName(displayName) {
 describe("scenarios > admin > databases > add", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
   });
 

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore, popover, modal } from "__support__/cypress";
+import { restore, popover, modal } from "__support__/cypress";
 
 describe("scenarios > admin > databases > edit", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
     cy.route("GET", "/api/database/*").as("databaseGet");
     cy.route("PUT", "/api/database/*").as("databaseUpdate");

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > admin > databases > list", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
   });
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  signInAsAdmin,
-  restore,
-  popover,
-  visitAlias,
-} from "__support__/cypress";
+import { restore, popover, visitAlias } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -15,7 +10,7 @@ const SAMPLE_DB_URL = "/admin/datamodel/database/1";
 describe.skip("scenarios > admin > datamodel > editor", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
     cy.route("PUT", "/api/table/*").as("tableUpdate");
     cy.route("PUT", "/api/field/*").as("fieldUpdate");

--- a/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   withDatabase,
   visitAlias,
@@ -13,7 +12,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 // [quarantine] - intermittently failing, possibly due to a "flickering" element (re-rendering)
 describe.skip("scenarios > admin > datamodel > field", () => {
   beforeEach(() => {
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     ["CREATED_AT", "PRODUCT_ID", "QUANTITY"].forEach(name => {
       cy.wrap(
@@ -151,7 +150,7 @@ describe.skip("scenarios > admin > datamodel > field", () => {
     // [quarantined]: flake, blocking 3rd party PR
     it.skip("allows 'Custom mapping' null values", () => {
       restore("withSqlite");
-      signInAsAdmin();
+      cy.signInAsAdmin();
       const dbId = 2;
       withDatabase(
         dbId,

--- a/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsNormalUser } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 const ORDERS_URL = "/admin/datamodel/database/1/table/2";
 
@@ -21,7 +21,7 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
     cy.contains("Orders").should("not.exist");
 
     // It shouldn't show up as a normal user either
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
     cy.visit("/browse/1");
     cy.contains("Products");
     cy.contains("Orders").should("not.exist");
@@ -38,7 +38,7 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
     cy.wait("@tableUpdate");
 
     // It shouldn't show up as a normal user either
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
     cy.visit("/question/new");
     cy.contains("Simple question").click();
     cy.contains("Sample Dataset").click();

--- a/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/hide_tables.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  signInAsNormalUser,
-  signInAsAdmin,
-} from "__support__/cypress";
+import { restore, signInAsNormalUser } from "__support__/cypress";
 
 const ORDERS_URL = "/admin/datamodel/database/1/table/2";
 
@@ -14,7 +10,7 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
     cy.route("PUT", "/api/table/*").as("tableUpdate");
 
     // Toggle the table to be hidden as admin user
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.visit(ORDERS_URL);
     cy.contains(/^Hidden$/).click();
     cy.wait("@tableUpdate");
@@ -36,7 +32,7 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
     cy.route("PUT", "/api/table/*").as("tableUpdate");
 
     // Toggle the table to be hidden as admin user
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.visit(ORDERS_URL);
     cy.contains(/^Hidden$/).click();
     cy.wait("@tableUpdate");

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsAdmin,
   openOrdersTable,
   openReviewsTable,
   popover,
@@ -12,7 +11,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 describe("scenarios > admin > datamodel > metadata", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should correctly show remapped column value", () => {

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsAdmin, popover, modal } from "__support__/cypress";
+import { restore, popover, modal } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
@@ -6,7 +6,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 describe("scenarios > admin > datamodel > metrics", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.viewport(1400, 860);
   });
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/segments.cy.spec.js
@@ -1,11 +1,5 @@
 // Ported from `segments.e2e.spec.js`
-import {
-  restore,
-  signInAsAdmin,
-  popover,
-  modal,
-  sidebar,
-} from "__support__/cypress";
+import { restore, popover, modal, sidebar } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -14,7 +8,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 describe("scenarios > admin > datamodel > segments", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.viewport(1400, 860);
   });
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -1,10 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
-// Ported from `databases.e2e.spec.js`
+import { restore } from "__support__/cypress";
 
 describe("scenarios > admin > databases > table", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should see four tables in sample database", () => {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -1,12 +1,7 @@
 // Includes migrations from integration tests:
 // https://github.com/metabase/metabase/pull/14174
 
-import {
-  signInAsAdmin,
-  restore,
-  popover,
-  setupDummySMTP,
-} from "__support__/cypress";
+import { restore, popover, setupDummySMTP } from "__support__/cypress";
 import { USERS, USER_GROUPS } from "__support__/cypress_data";
 const { normal, admin } = USERS;
 const { DATA_GROUP } = USER_GROUPS;
@@ -14,7 +9,7 @@ const { DATA_GROUP } = USER_GROUPS;
 describe("scenarios > admin > people", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   const TEST_USER = {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -5,11 +5,9 @@ import {
   signInAsAdmin,
   restore,
   popover,
-  USERS,
-  USER_GROUPS,
   setupDummySMTP,
 } from "__support__/cypress";
-
+import { USERS, USER_GROUPS } from "__support__/cypress_data";
 const { normal, admin } = USERS;
 const { DATA_GROUP } = USER_GROUPS;
 

--- a/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > admin > permissions", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should display error on failed save", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
@@ -6,7 +6,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 describe("scenarios > admin > permissions", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     setFirstWeekDayTo("monday");
   });
 

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   openOrdersTable,
   version,
@@ -11,7 +10,7 @@ import {
 describe("scenarios > admin > settings", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   itOpenSourceOnly(

--- a/frontend/test/metabase/scenarios/admin/settings/spinner.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/spinner.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > admin > spinner", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   describe("API request", () => {

--- a/frontend/test/metabase/scenarios/admin/troubleshooting/tasks.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/troubleshooting/tasks.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > admin > troubleshooting > tasks", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it.skip("pagination should work (metabase#14636)", () => {

--- a/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsAdmin,
   setupLocalHostEmail,
   signInAsNormalUser,
   createBasicAlert,
@@ -30,7 +29,7 @@ describe("scenarios > alert", () => {
   describe("with nothing set", () => {
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
     });
 
     it("should prompt you to add email/slack credentials", () => {
@@ -55,7 +54,7 @@ describe("scenarios > alert", () => {
   describe.skip("educational screen", () => {
     before(() => {
       // NOTE: Must run `python -m smtpd -n -c DebuggingServer localhost:1025` before these tests
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/admin/settings/email");
       setupLocalHostEmail();
       cy.server();
@@ -84,7 +83,7 @@ describe("scenarios > alert", () => {
   describe.skip("types of alerts", () => {
     before(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/admin/settings/email");
       setupLocalHostEmail();
     });
@@ -148,7 +147,7 @@ describe("scenarios > alert", () => {
   describe.skip("time-multiseries questions with a set goal", () => {
     before(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/admin/settings/email");
       setupLocalHostEmail();
     });

--- a/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/alert.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   setupLocalHostEmail,
-  signInAsNormalUser,
   createBasicAlert,
   popover,
   openPeopleTable,
@@ -41,7 +40,7 @@ describe("scenarios > alert", () => {
     });
 
     it("should say to non-admins that admin must add email credentials", () => {
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/question/1");
       cy.icon("bell").click();
       cy.findByText(

--- a/frontend/test/metabase/scenarios/alert/alert_auth.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/alert_auth.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsAdmin,
   signInAsNormalUser,
   setupLocalHostEmail,
   createBasicAlert,
@@ -13,11 +12,11 @@ import {
 describe.skip("scenarios > alert > auth for alerts", () => {
   before(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     // Setup email
     // NOTE: Must run `python -m smtpd -n -c DebuggingServer localhost:1025` before these tests
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.visit("/admin/settings/email");
     setupLocalHostEmail();
 
@@ -36,7 +35,7 @@ describe.skip("scenarios > alert > auth for alerts", () => {
   });
 
   describe("as an admin", () => {
-    beforeEach(signInAsAdmin);
+    beforeEach(cy.signInAsAdmin);
 
     it("should let you see all created alerts", () => {
       cy.request("/api/alert").then(response => {

--- a/frontend/test/metabase/scenarios/alert/alert_auth.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/alert_auth.cy.spec.js
@@ -1,9 +1,8 @@
 import {
   restore,
-  signInAsNormalUser,
   setupLocalHostEmail,
   createBasicAlert,
-} from "../../../__support__/cypress";
+} from "__support__/cypress";
 // Port from alert.e2e.spec.js
 
 // [quarantine]: cannot run tests that rely on email setup in CI (yet)
@@ -29,7 +28,7 @@ describe.skip("scenarios > alert > auth for alerts", () => {
     createBasicAlert({ includeNormal: true });
 
     // Create alert as normal user
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
     cy.visit("/question/3");
     createBasicAlert();
   });
@@ -69,7 +68,7 @@ describe.skip("scenarios > alert > auth for alerts", () => {
     });
   });
   describe("as a non-admin / normal user", () => {
-    beforeEach(signInAsNormalUser);
+    beforeEach(cy.signInAsNormalUser);
 
     it("should not let you see other people's alerts", () => {
       cy.visit("/question/1");

--- a/frontend/test/metabase/scenarios/alert/email_alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/alert/email_alert.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  signInAsAdmin,
-  setupLocalHostEmail,
-} from "../../../__support__/cypress";
+import { restore, setupLocalHostEmail } from "__support__/cypress";
 
 function setUpHourlyAlert(question_num) {
   cy.visit(`/question/${question_num}`);
@@ -14,7 +10,7 @@ function setUpHourlyAlert(question_num) {
 
 describe("scenarios > alert > email_alert", () => {
   beforeEach(restore);
-  beforeEach(signInAsAdmin);
+  beforeEach(cy.signInAsAdmin);
 
   it("should have no alerts set up initially", () => {
     cy.server();

--- a/frontend/test/metabase/scenarios/auth/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/search.cy.spec.js
@@ -1,15 +1,11 @@
-import {
-  restore,
-  signInAsAdmin,
-  signInAsNormalUser,
-} from "__support__/cypress";
+import { restore, signInAsNormalUser } from "__support__/cypress";
 
 describe("scenarios > auth > search", () => {
   beforeEach(restore);
 
   describe("universal search", () => {
     it("should work for admin", () => {
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
       cy.findByText("PRODUCTS");

--- a/frontend/test/metabase/scenarios/auth/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/search.cy.spec.js
@@ -2,7 +2,6 @@ import {
   restore,
   signInAsAdmin,
   signInAsNormalUser,
-  signIn,
 } from "__support__/cypress";
 
 describe("scenarios > auth > search", () => {
@@ -24,7 +23,7 @@ describe("scenarios > auth > search", () => {
     });
 
     it("should not work for user without permissions", () => {
-      signIn("nodata");
+      cy.signIn("nodata");
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
       cy.findByText("PRODUCTS").should("not.exist");

--- a/frontend/test/metabase/scenarios/auth/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/search.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsNormalUser } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > auth > search", () => {
   beforeEach(restore);
@@ -12,7 +12,7 @@ describe("scenarios > auth > search", () => {
     });
 
     it("should work for user with permissions (metabase#12332)", () => {
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
       cy.findByText("PRODUCTS");

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -1,4 +1,5 @@
-import { browse, restore, signIn, signOut, USERS } from "__support__/cypress";
+import { browse, restore, signIn, signOut } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
 
 const sizes = [[1280, 800], [640, 360]];
 const { admin } = USERS;

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -1,4 +1,4 @@
-import { browse, restore, signIn, signOut } from "__support__/cypress";
+import { browse, restore, signInAsAdmin, signOut } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 
 const sizes = [[1280, 800], [640, 360]];
@@ -50,7 +50,7 @@ describe("scenarios > auth > signin", () => {
   });
 
   it("should redirect to a unsaved question after login", () => {
-    signIn();
+    signInAsAdmin();
     cy.visit("/");
     // Browse data moved to an icon
     browse().click();

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -1,4 +1,4 @@
-import { browse, restore, signOut } from "__support__/cypress";
+import { browse, restore } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 
 const sizes = [[1280, 800], [640, 360]];
@@ -7,7 +7,7 @@ const { admin } = USERS;
 describe("scenarios > auth > signin", () => {
   beforeEach(() => {
     restore();
-    signOut();
+    cy.signOut();
   });
 
   it("should redirect to  /auth/login", () => {
@@ -59,7 +59,7 @@ describe("scenarios > auth > signin", () => {
     cy.contains("37.65");
 
     // signout and reload page with question hash in url
-    signOut();
+    cy.signOut();
     cy.reload();
 
     cy.contains("Sign in to Metabase");

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -1,4 +1,4 @@
-import { browse, restore, signInAsAdmin, signOut } from "__support__/cypress";
+import { browse, restore, signOut } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 
 const sizes = [[1280, 800], [640, 360]];
@@ -50,7 +50,7 @@ describe("scenarios > auth > signin", () => {
   });
 
   it("should redirect to a unsaved question after login", () => {
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.visit("/");
     // Browse data moved to an icon
     browse().click();

--- a/frontend/test/metabase/scenarios/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/sso.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, signOut, signInAsAdmin } from "__support__/cypress";
+import { restore, signOut } from "__support__/cypress";
 
 describe("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
     // Set fake Google client ID
     cy.request("PUT", "/api/setting/google-auth-client-id", {
       value: "123",

--- a/frontend/test/metabase/scenarios/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/sso.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signOut } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
@@ -8,7 +8,7 @@ describe("scenarios > auth > signin > SSO", () => {
     cy.request("PUT", "/api/setting/google-auth-client-id", {
       value: "123",
     });
-    signOut();
+    cy.signOut();
   });
 
   it("should show SSO button", () => {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -3,7 +3,6 @@ import {
   signInAsAdmin,
   setupLocalHostEmail,
   signInAsNormalUser,
-  signIn,
   signOut,
   modal,
   popover,
@@ -343,7 +342,7 @@ describe("scenarios > collection_defaults", () => {
         });
 
         signOut();
-        signIn("nocollection");
+        cy.signIn("nocollection");
       });
 
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -7,11 +7,9 @@ import {
   signOut,
   modal,
   popover,
-  USERS,
-  USER_GROUPS,
   openOrdersTable,
 } from "__support__/cypress";
-// Ported from initial_collection.e2e.spec.js
+import { USERS, USER_GROUPS } from "__support__/cypress_data";
 
 const { nocollection } = USERS;
 const { DATA_GROUP } = USER_GROUPS;

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   setupLocalHostEmail,
-  signOut,
   modal,
   popover,
   openOrdersTable,
@@ -339,7 +338,7 @@ describe("scenarios > collection_defaults", () => {
           });
         });
 
-        signOut();
+        cy.signOut();
         cy.signIn("nocollection");
       });
 

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   setupLocalHostEmail,
-  signInAsNormalUser,
   signOut,
   modal,
   popover,
@@ -269,7 +268,7 @@ describe("scenarios > collection_defaults", () => {
   describe("for users", () => {
     beforeEach(() => {
       restore();
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
     });
 
     // [quarantine]: cannot run tests that rely on email setup in CI (yet)

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsAdmin,
   setupLocalHostEmail,
   signInAsNormalUser,
   signOut,
@@ -36,7 +35,7 @@ describe("scenarios > collection_defaults", () => {
   describe("for admins", () => {
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
     });
 
     describe("new collections", () => {
@@ -117,7 +116,7 @@ describe("scenarios > collection_defaults", () => {
     describe("sidebar behavior", () => {
       beforeEach(() => {
         restore();
-        signInAsAdmin();
+        cy.signInAsAdmin();
       });
 
       it("should allow a user to expand a collection without navigating to it", () => {
@@ -305,7 +304,7 @@ describe("scenarios > collection_defaults", () => {
   describe("Collection related issues reproductions", () => {
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
     });
 
     describe("nested collections with revoked parent access", () => {

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -1,4 +1,4 @@
-import { signIn, restore, popover } from "__support__/cypress";
+import { signInAsAdmin, restore, popover } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { PEOPLE } = SAMPLE_DATASET;
@@ -110,7 +110,7 @@ function createDashboard({ dashboardName, questionId }, callback) {
 describe("scenarios > dashboard > chained filter", () => {
   beforeEach(() => {
     restore();
-    signIn();
+    signInAsAdmin();
   });
 
   for (const has_field_values of ["search", "list"]) {

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, restore, popover } from "__support__/cypress";
+import { restore, popover } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { PEOPLE } = SAMPLE_DATASET;
@@ -110,7 +110,7 @@ function createDashboard({ dashboardName, questionId }, callback) {
 describe("scenarios > dashboard > chained filter", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   for (const has_field_values of ["search", "list"]) {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   modal,
   popover,
@@ -13,7 +12,7 @@ const { ORDERS, PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATASET;
 describe("scenarios > dashboard > dashboard drill", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should handle URL click through on a table", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  signIn,
+  signInAsAdmin,
   restore,
   modal,
   popover,
@@ -13,7 +13,7 @@ const { ORDERS, PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATASET;
 describe("scenarios > dashboard > dashboard drill", () => {
   beforeEach(() => {
     restore();
-    signIn();
+    signInAsAdmin();
   });
 
   it("should handle URL click through on a table", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -3,7 +3,6 @@
 import {
   popover,
   restore,
-  signIn,
   signInAsAdmin,
   selectDashboardFilter,
   expectedRouteCalls,
@@ -393,7 +392,7 @@ describe("scenarios > dashboard", () => {
     cy.server();
     cy.route("POST", "/api/card/*/query").as("cardQuery");
 
-    signIn("nodata");
+    cy.signIn("nodata");
 
     clickThrough("12720_SQL");
     clickThrough("Orders");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -3,7 +3,6 @@
 import {
   popover,
   restore,
-  signInAsAdmin,
   selectDashboardFilter,
   expectedRouteCalls,
 } from "__support__/cypress";
@@ -27,7 +26,7 @@ function saveDashboard() {
 describe("scenarios > dashboard", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should create new dashboard", () => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  signInAsAdmin,
-  restore,
-  popover,
-  selectDashboardFilter,
-} from "__support__/cypress";
+import { restore, popover, selectDashboardFilter } from "__support__/cypress";
 
 function filterDashboard(suggests = true) {
   cy.visit("/dashboard/1");
@@ -27,7 +22,7 @@ function filterDashboard(suggests = true) {
 describe("support > permissions (metabase#8472)", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     // Setup a dashboard with a text filter
     cy.visit("/dashboard/1");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  signIn,
+  signInAsAdmin,
   restore,
   popover,
   selectDashboardFilter,
@@ -27,7 +27,7 @@ function filterDashboard(suggests = true) {
 describe("support > permissions (metabase#8472)", () => {
   beforeEach(() => {
     restore();
-    signIn("admin");
+    signInAsAdmin();
 
     // Setup a dashboard with a text filter
     cy.visit("/dashboard/1");
@@ -58,7 +58,7 @@ describe("support > permissions (metabase#8472)", () => {
       "/api/dashboard/1/params/*/search/Aerodynamic Bronze Hat",
     ).as("search");
 
-    signIn("nodata");
+    cy.signIn("nodata");
     filterDashboard(false);
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore, popover, modal } from "__support__/cypress";
+import { restore, popover, modal } from "__support__/cypress";
 
 describe("scenarios > dashboard > embed", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it.skip("should have the correct embed snippet", () => {

--- a/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore, popover } from "__support__/cypress";
+import { restore, popover } from "__support__/cypress";
 
 describe("scenarios > dashboard > nested cards", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should show fields on nested cards", () => {

--- a/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/nested-cards.cy.spec.js
@@ -1,9 +1,9 @@
-import { signIn, restore, popover } from "__support__/cypress";
+import { signInAsAdmin, restore, popover } from "__support__/cypress";
 
 describe("scenarios > dashboard > nested cards", () => {
   beforeEach(() => {
     restore();
-    signIn();
+    signInAsAdmin();
   });
 
   it("should show fields on nested cards", () => {

--- a/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, signOut, restore, popover } from "__support__/cypress";
+import { signOut, restore, popover } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -21,7 +21,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
 
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     cy.request("POST", `/api/field/${ORDERS.USER_ID}/dimension`, {
       type: "external",
@@ -74,7 +74,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
   });
 
   describe("private question", () => {
-    beforeEach(signInAsAdmin);
+    beforeEach(cy.signInAsAdmin);
 
     sharedParametersTests(() => {
       cy.visit(`/question/${questionId}`);
@@ -124,7 +124,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
   });
 
   describe("private dashboard", () => {
-    beforeEach(signInAsAdmin);
+    beforeEach(cy.signInAsAdmin);
 
     sharedParametersTests(() => {
       cy.visit(`/dashboard/${dashboardId}`);

--- a/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
@@ -1,4 +1,4 @@
-import { signOut, restore, popover } from "__support__/cypress";
+import { restore, popover } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -90,7 +90,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
       cy.request("POST", `/api/card/${questionId}/public_link`).then(
         res => (uuid = res.body.uuid),
       );
-      signOut();
+      cy.signOut();
     });
 
     sharedParametersTests(() => {
@@ -112,7 +112,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
         },
         enable_embedding: true,
       });
-      signOut();
+      cy.signOut();
     });
 
     sharedParametersTests(() => {
@@ -140,7 +140,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
       cy.request("POST", `/api/dashboard/${dashboardId}/public_link`).then(
         res => (uuid = res.body.uuid),
       );
-      signOut();
+      cy.signOut();
     });
 
     sharedParametersTests(() => {
@@ -162,7 +162,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
         },
         enable_embedding: true,
       });
-      signOut();
+      cy.signOut();
     });
 
     sharedParametersTests(() => {

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -1,10 +1,10 @@
-import { signInAsAdmin, modal, popover, restore } from "__support__/cypress";
+import { modal, popover, restore } from "__support__/cypress";
 // NOTE: some overlap with parameters-embedded.cy.spec.js
 
 describe("scenarios > dashboard > parameters", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should be visible if previously added", () => {

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 import { assoc } from "icepick";
-import { signInAsAdmin, signIn, restore } from "__support__/cypress";
+import { signInAsAdmin, restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > permissions", () => {
   let dashboardId;
@@ -104,7 +104,7 @@ describe("scenarios > dashboard > permissions", () => {
   });
 
   it("should display dashboards with some cards locked down", () => {
-    signIn("nodata");
+    cy.signIn("nodata");
     cy.visit(`/dashboard/${dashboardId}`);
     cy.findByText("Sorry, you don't have permission to see this card.");
     cy.findByText("Second Question");
@@ -112,7 +112,7 @@ describe("scenarios > dashboard > permissions", () => {
   });
 
   it("should display an error if they don't have perms for the dashboard", () => {
-    signIn("nocollection");
+    cy.signIn("nocollection");
     cy.visit(`/dashboard/${dashboardId}`);
     cy.findByText("Sorry, you don’t have permission to see that.");
   });

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 import { assoc } from "icepick";
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > permissions", () => {
   let dashboardId;
@@ -9,7 +9,7 @@ describe("scenarios > dashboard > permissions", () => {
     restore();
     // This first test creates a dashboard with two questions.
     // One is in Our Analytics the other is in a more locked down collection.
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     // The setup is a bunch of nested API calls to create the questions, dashboard, dashcards, collections and link them all up together.
     let firstQuestionId, secondQuestionId;

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -1,9 +1,5 @@
-import {
-  restore,
-  signInAsAdmin,
-  setupDummySMTP,
-  USERS,
-} from "__support__/cypress";
+import { restore, signInAsAdmin, setupDummySMTP } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
 const { admin } = USERS;
 
 describe("scenarios > dashboard > subscriptions", () => {

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -1,11 +1,11 @@
-import { restore, signInAsAdmin, setupDummySMTP } from "__support__/cypress";
+import { restore, setupDummySMTP } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 const { admin } = USERS;
 
 describe("scenarios > dashboard > subscriptions", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should not allow creation if there are no dashboard cards", () => {

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 function addTextBox(string) {
   cy.icon("pencil").click();
@@ -11,7 +11,7 @@ function addTextBox(string) {
 describe("scenarios > dashboard > text-box", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   describe("Editing", () => {

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > title drill", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should let you click through the title to the query builder", () => {

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,9 +1,9 @@
-import { signIn, restore } from "__support__/cypress";
+import { signInAsAdmin, restore } from "__support__/cypress";
 
 describe("scenarios > dashboard > title drill", () => {
   beforeEach(() => {
     restore();
-    signIn();
+    signInAsAdmin();
   });
 
   it("should let you click through the title to the query builder", () => {

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
@@ -6,7 +6,7 @@ const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
 describe("scenarios > x-rays", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should exist on homepage when person first signs in", () => {

--- a/frontend/test/metabase/scenarios/home/activity-page.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/activity-page.cy.spec.js
@@ -1,10 +1,5 @@
-import {
-  restore,
-  openProductsTable,
-  signInAsNormalUser,
-  popover,
-} from "__support__/cypress";
 //Replaces HomepageApp.e2e.spec.js
+import { restore, openProductsTable, popover } from "__support__/cypress";
 
 describe("metabase > scenarios > home > activity-page", () => {
   beforeEach(() => {
@@ -20,7 +15,7 @@ describe("metabase > scenarios > home > activity-page", () => {
   });
 
   it("should show new activity", () => {
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
 
     // Make and a save new question
     openProductsTable();

--- a/frontend/test/metabase/scenarios/home/activity-page.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/activity-page.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsAdmin,
   openProductsTable,
   signInAsNormalUser,
   popover,
@@ -10,7 +9,7 @@ import {
 describe("metabase > scenarios > home > activity-page", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should show test startup activity ", () => {
@@ -46,7 +45,7 @@ describe("metabase > scenarios > home > activity-page", () => {
     cy.get(".Card").should("have.length", 1);
 
     // See activity on activity page
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.visit("/activity");
 
     cy.findAllByText("joined!").should("have.length", 2);

--- a/frontend/test/metabase/scenarios/home/overworld.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/overworld.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  signInAsAdmin,
-  signInAsNormalUser,
-  restore,
-} from "__support__/cypress";
+import { signInAsNormalUser, restore } from "__support__/cypress";
 
 describe("scenarios > home > overworld", () => {
   beforeEach(restore);
@@ -10,7 +6,7 @@ describe("scenarios > home > overworld", () => {
   describe("content management", () => {
     describe("as admin", () => {
       beforeEach(() => {
-        signInAsAdmin();
+        cy.signInAsAdmin();
         cy.request("PUT", "api/setting/show-homepage-data", { value: true });
         cy.request("PUT", "api/setting/show-homepage-xrays", { value: true });
       });

--- a/frontend/test/metabase/scenarios/home/overworld.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/overworld.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsNormalUser, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > home > overworld", () => {
   beforeEach(restore);
@@ -39,7 +39,7 @@ describe("scenarios > home > overworld", () => {
       });
     });
     describe("as regular folk", () => {
-      beforeEach(signInAsNormalUser);
+      beforeEach(cy.signInAsNormalUser);
       it("should not be possible for them to see the controls", () => {
         cy.visit("/");
         cy.contains("Our data")

--- a/frontend/test/metabase/scenarios/internal/question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/internal/question.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsAdmin, adhocQuestionHash } from "__support__/cypress";
+import { restore, adhocQuestionHash } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 // This is really a test of the QuestionLoader component
@@ -6,7 +6,7 @@ import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 describe("scenarios > internal > question", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should load saved questions", () => {

--- a/frontend/test/metabase/scenarios/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions.cy.spec.js
@@ -1,4 +1,4 @@
-import { signIn, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > permissions", () => {
   beforeEach(restore);
@@ -14,7 +14,7 @@ describe("scenarios > permissions", () => {
 
   for (const path of PATHS) {
     it(`should display the permissions screen on ${path}`, () => {
-      signIn("none");
+      cy.signIn("none");
       cy.visit(path);
       cy.icon("key");
       cy.contains("Sorry, you don’t have permission to see that.");
@@ -24,7 +24,7 @@ describe("scenarios > permissions", () => {
   // There's no pulse in the fixture data, so we stub out the api call to
   // replace the 404 with a 403.
   it("should display the permissions screen for pulses", () => {
-    signIn("none");
+    cy.signIn("none");
     cy.server();
     cy.route({ url: /\/api\/pulse\/1/, status: 403, response: {} });
     cy.visit("/pulse/1");
@@ -33,7 +33,7 @@ describe("scenarios > permissions", () => {
   });
 
   it("should let a user with no data permissions view questions", () => {
-    signIn("nodata");
+    cy.signIn("nodata");
     cy.visit("/question/1");
     cy.contains("February 11, 2019, 9:40 PM"); // check that the data loads
   });

--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -1,10 +1,4 @@
-import {
-  signInAsAdmin,
-  signOut,
-  restore,
-  popover,
-  modal,
-} from "__support__/cypress";
+import { signOut, restore, popover, modal } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -16,7 +10,7 @@ const COUNT_DOOHICKEY = "42";
 const PUBLIC_URL_REGEX = /\/public\/(question|dashboard)\/[0-9a-f-]+$/;
 
 const USERS = {
-  "admin user": () => signInAsAdmin(),
+  "admin user": () => cy.signInAsAdmin(),
   "user with no permissions": () => cy.signIn("none"),
   "anonymous user": () => signOut(),
 };
@@ -28,7 +22,7 @@ describe.skip("scenarios > public", () => {
   let questionId;
   before(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     // setup parameterized question
     cy.createNativeQuestion({
@@ -54,7 +48,7 @@ describe.skip("scenarios > public", () => {
   });
 
   beforeEach(() => {
-    signInAsAdmin();
+    cy.signInAsAdmin();
     cy.server();
   });
 

--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   signInAsAdmin,
-  signIn,
   signOut,
   restore,
   popover,
@@ -18,7 +17,7 @@ const PUBLIC_URL_REGEX = /\/public\/(question|dashboard)\/[0-9a-f-]+$/;
 
 const USERS = {
   "admin user": () => signInAsAdmin(),
-  "user with no permissions": () => signIn("none"),
+  "user with no permissions": () => cy.signIn("none"),
   "anonymous user": () => signOut(),
 };
 

--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -1,4 +1,4 @@
-import { signOut, restore, popover, modal } from "__support__/cypress";
+import { restore, popover, modal } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -12,7 +12,7 @@ const PUBLIC_URL_REGEX = /\/public\/(question|dashboard)\/[0-9a-f-]+$/;
 const USERS = {
   "admin user": () => cy.signInAsAdmin(),
   "user with no permissions": () => cy.signIn("none"),
-  "anonymous user": () => signOut(),
+  "anonymous user": () => cy.signOut(),
 };
 
 // [quarantine]: failing almost consistently in CI

--- a/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
+++ b/frontend/test/metabase/scenarios/pulse/pulse.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 const MOCK_PULSE_FORM_INPUT = {
   channels: {
@@ -16,7 +16,7 @@ const MOCK_PULSE_FORM_INPUT = {
 describe("scenarios > pulse", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
   it("should be able get to the new pulse page from the nav bar", () => {
     cy.visit("/");

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -4,7 +4,6 @@ import {
   popover,
   _typeUsingGet,
   _typeUsingPlaceholder,
-  signInAsAdmin,
   openOrdersTable,
   visitQuestionAdhoc,
 } from "__support__/cypress";
@@ -203,7 +202,7 @@ describe("scenarios > question > custom columns", () => {
     const CE_NAME = "13857_CE";
     const CC_NAME = "13857_CC";
 
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     cy.createQuestion({
       name: "13857",
@@ -238,7 +237,7 @@ describe("scenarios > question > custom columns", () => {
 
   it("should work with implicit joins (metabase#14080)", () => {
     const CC_NAME = "OneisOne";
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     cy.createQuestion({
       name: "14080",

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  signInAsNormalUser,
   popover,
   _typeUsingGet,
   _typeUsingPlaceholder,
@@ -23,7 +22,7 @@ const customFormulas = [
 describe("scenarios > question > custom columns", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   it("can create a custom column (metabase#13241)", () => {

--- a/frontend/test/metabase/scenarios/question/data_ref.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/data_ref.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > question > data reference sidebar", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should load needed data", () => {

--- a/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/downloads.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 const xlsx = require("xlsx");
 
@@ -29,7 +29,7 @@ function testWorkbookDatetimes(workbook, download_type, sheetName) {
 describe("scenarios > question > download", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("downloads Excel and CSV files", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   openOrdersTable,
   openProductsTable,
@@ -23,7 +22,7 @@ const {
 describe("scenarios > question > filter", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   describe("dashboard filter dropdown/search (metabase#12985)", () => {

--- a/frontend/test/metabase/scenarios/question/loading.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/loading.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > question > loading behavior", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should preload tables on the new question page", () => {

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -1,10 +1,4 @@
-import {
-  signInAsNormalUser,
-  restore,
-  popover,
-  modal,
-} from "__support__/cypress";
-
+import { restore, popover, modal } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { ORDERS } = SAMPLE_DATASET;
@@ -12,7 +6,7 @@ const { ORDERS } = SAMPLE_DATASET;
 describe("scenarios > question > native", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   it("lets you create and run a SQL question", () => {

--- a/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > question > native subquery", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should allow a user with no data access to execute a native subquery", () => {

--- a/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native_subquery.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, restore, signIn } from "__support__/cypress";
+import { signInAsAdmin, restore } from "__support__/cypress";
 
 describe("scenarios > question > native subquery", () => {
   beforeEach(() => {
@@ -42,7 +42,7 @@ describe("scenarios > question > native subquery", () => {
       });
 
     // Now sign in as a user w/no data access
-    signIn("nodata");
+    cy.signIn("nodata");
 
     // They should be able to access both questions
     cy.get("@nestedQuestionId").then(nestedQuestionId => {

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   popover,
   createNativeQuestion,
@@ -14,7 +13,7 @@ const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
 describe("scenarios > question > nested (metabase#12568)", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     // Create a simple question of orders by week
     cy.createQuestion({
@@ -130,7 +129,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
 describe("scenarios > question > nested", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should handle duplicate column names in nested queries (metabase#10511)", () => {

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   browse,
   restore,
-  signInAsAdmin,
   popover,
   openOrdersTable,
   openReviewsTable,
@@ -16,7 +15,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 describe("scenarios > question > new", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   describe("browse data", () => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   createNativeQuestion,
   restore,
-  signInAsAdmin,
   openOrdersTable,
   openProductsTable,
   popover,
@@ -25,7 +24,7 @@ const {
 describe("scenarios > question > notebook", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it.skip("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  signInAsAdmin,
-  openOrdersTable,
-  popover,
-} from "__support__/cypress";
+import { restore, openOrdersTable, popover } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -12,7 +7,7 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 describe("scenarios > question > null", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should display rows whose value is `null` (metabase#13571)", () => {

--- a/frontend/test/metabase/scenarios/question/operators.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/operators.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, signInAsNormalUser, popover } from "__support__/cypress";
+import { restore, popover } from "__support__/cypress";
 
 describe("operators in questions", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   const expected = {

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -1,15 +1,9 @@
-import {
-  restore,
-  signInAsNormalUser,
-  popover,
-  modal,
-  openOrdersTable,
-} from "__support__/cypress";
+import { restore, popover, modal, openOrdersTable } from "__support__/cypress";
 
 describe("scenarios > question > saved", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   it.skip("should should correctly display 'Save' modal (metabase#13817)", () => {

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   browse,
-  signInAsAdmin,
   restore,
   openOrdersTable,
   visitQuestionAdhoc,
@@ -12,7 +11,7 @@ const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
 describe("scenarios > question > settings", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   describe("column settings", () => {

--- a/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, restore, modal } from "__support__/cypress";
+import { restore, modal } from "__support__/cypress";
 
 // HACK which lets us type (even very long words) without losing focus
 // this is needed for fields where autocomplete suggestions are enabled
@@ -20,7 +20,7 @@ function _clearAndIterativelyTypeUsingLabel(label, string) {
 describe("scenarios > question > snippets", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should let you create and use a snippet", () => {

--- a/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/snippets.cy.spec.js
@@ -16,7 +16,7 @@ function _clearAndIterativelyTypeUsingLabel(label, string) {
 //       - Normal users don't have permission to create/edit snippets in `ee` version.
 //       - CI runs this test twice (both contexts), so it fails on `ee`.
 //       - There is a related issue: https://github.com/metabase/metabase-enterprise/issues/543
-// TODO: Once the above issue is (re)solved, change back to `signInAsNormalUser`
+// TODO: Once the above issue is (re)solved, change back to `cy.signInAsNormalUser`
 describe("scenarios > question > snippets", () => {
   beforeEach(() => {
     restore();

--- a/frontend/test/metabase/scenarios/question/trendline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/trendline.cy.spec.js
@@ -1,14 +1,9 @@
-import {
-  restore,
-  signInAsNormalUser,
-  openOrdersTable,
-  sidebar,
-} from "__support__/cypress";
+import { restore, openOrdersTable, sidebar } from "__support__/cypress";
 
 describe("scenarios > question > trendline", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   it.skip("displays trendline when there are multiple numeric outputs (for simple question) (metabase#12781)", () => {

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -1,10 +1,4 @@
-import {
-  signInAsAdmin,
-  restore,
-  openOrdersTable,
-  popover,
-} from "__support__/cypress";
-
+import { restore, openOrdersTable, popover } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { PRODUCTS } = SAMPLE_DATASET;
@@ -12,7 +6,7 @@ const { PRODUCTS } = SAMPLE_DATASET;
 describe("scenarios > question > view", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   describe("summarize sidebar", () => {

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -3,7 +3,6 @@ import {
   restore,
   openOrdersTable,
   popover,
-  signIn,
 } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -166,7 +165,7 @@ describe("scenarios > question > view", () => {
     });
 
     it("should be able to filter Q by Category as no data user (from Q link) (metabase#12654)", () => {
-      signIn("nodata");
+      cy.signIn("nodata");
       cy.visit("/question/4");
 
       // Filter by category and vendor
@@ -190,7 +189,7 @@ describe("scenarios > question > view", () => {
 
     it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
       // Navigate to Q from Dashboard
-      signIn("nodata");
+      cy.signIn("nodata");
       cy.visit("/dashboard/2");
       cy.findByText("Question").click();
 

--- a/frontend/test/metabase/scenarios/reference/databases.cy.spec.js
+++ b/frontend/test/metabase/scenarios/reference/databases.cy.spec.js
@@ -1,9 +1,9 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > reference > databases", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should see the listing", () => {

--- a/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
@@ -1,5 +1,6 @@
 // Migrated from frontend/test/metabase/user/UserSettings.integ.spec.js
-import { restore, signInAsNormalUser, USERS } from "__support__/cypress";
+import { restore, signInAsNormalUser } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
 const { first_name, last_name, email } = USERS.normal;
 
 const requestsCount = alias =>

--- a/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
@@ -1,5 +1,5 @@
 // Migrated from frontend/test/metabase/user/UserSettings.integ.spec.js
-import { restore, signInAsNormalUser } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 const { first_name, last_name, email } = USERS.normal;
 
@@ -8,7 +8,7 @@ const requestsCount = alias =>
 describe("user > settings", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   it("should show user details", () => {

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -6,9 +6,8 @@ import {
   openOrdersTable,
   popover,
   sidebar,
-  USER_GROUPS,
 } from "__support__/cypress";
-
+import { USER_GROUPS } from "__support__/cypress_data";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsNormalUser,
   restore,
   openProductsTable,
   openOrdersTable,
@@ -347,7 +346,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         cy.route("POST", "/api/dataset").as("dataset");
 
         // Switch to the normal user who has restricted SQL access
-        signInAsNormalUser();
+        cy.signInAsNormalUser();
         cy.visit(`/question/${QUESTION_ID}`);
 
         // Initial visualization has rendered and we can now drill-through

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   signInAsNormalUser,
   restore,
   openProductsTable,
@@ -16,7 +15,7 @@ const { DATA_GROUP } = USER_GROUPS;
 describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should allow brush date filter", () => {

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -1,5 +1,5 @@
 // Imported from drillthroughs.e2e.spec.js
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
@@ -14,7 +14,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
   describe("card title click action", () => {
     beforeEach(() => {
       restore();
-      signInAsAdmin();
+      cy.signInAsAdmin();
     });
     describe("from a scalar card", () => {
       const DASHBOARD_NAME = "Scalar Dash";

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  signInAsNormalUser,
-  restore,
-  popover,
-  visitQuestionAdhoc,
-} from "__support__/cypress";
+import { restore, popover, visitQuestionAdhoc } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
@@ -15,7 +10,7 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should display a pin map for a native query", () => {
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
     // create a native query with lng/lat fields
     cy.visit("/question/new");
     cy.contains("Native query").click();

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   signInAsNormalUser,
-  signInAsAdmin,
   restore,
   popover,
   visitQuestionAdhoc,
@@ -12,7 +11,7 @@ const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
 describe("scenarios > visualizations > maps", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should display a pin map for a native query", () => {

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, signInAsNormalUser } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > visualizations > object detail", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   it("should show orders/reviews connected to a product", () => {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signIn,
   signInAsAdmin,
   restore,
   visitQuestionAdhoc,
@@ -692,7 +691,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       display: "pivot",
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
-      signIn("nodata");
+      cy.signIn("nodata");
       cy.visit(`/question/${QUESTION_ID}`);
     });
 

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  signInAsAdmin,
   restore,
   visitQuestionAdhoc,
   getIframeBody,
@@ -29,7 +28,7 @@ const TEST_CASES = [
 describe("scenarios > visualizations > pivot tables", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   it("should be created from an ad-hoc question", () => {

--- a/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 
 describe("scenarios > visualizations > rows", () => {
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
   });
 
   // Until we enable multi-browser support, this repro will be skipped by Cypress in CI

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -1,13 +1,9 @@
-import {
-  openOrdersTable,
-  signInAsNormalUser,
-  restore,
-} from "__support__/cypress";
+import { openOrdersTable, restore } from "__support__/cypress";
 
 describe("scenarios > visualizations > waterfall", () => {
   beforeEach(() => {
     restore();
-    signInAsNormalUser();
+    cy.signInAsNormalUser();
   });
 
   function verifyWaterfallRendering(xLabel = null, yLabel = null) {
@@ -111,7 +107,7 @@ describe("scenarios > visualizations > waterfall", () => {
   describe("scenarios > visualizations > waterfall settings", () => {
     beforeEach(() => {
       restore();
-      signInAsNormalUser();
+      cy.signInAsNormalUser();
       cy.visit("/question/new");
       cy.contains("Native query").click();
       cy.get(".ace_content").type("select 'A' as X, -4.56 as Y");

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -1,10 +1,4 @@
-import {
-  snapshot,
-  restore,
-  withSampleDataset,
-  signInAsAdmin,
-} from "__support__/cypress";
-
+import { snapshot, restore, withSampleDataset } from "__support__/cypress";
 import { USERS, USER_GROUPS } from "__support__/cypress_data";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
@@ -154,7 +148,7 @@ describe("snapshots", () => {
   describe("withSqlite", () => {
     it("withSqlite", () => {
       restore("default");
-      signInAsAdmin();
+      cy.signInAsAdmin();
       cy.request("POST", "/api/database", {
         engine: "sqlite",
         name: "sqlite",

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -1,12 +1,12 @@
 import {
   snapshot,
   restore,
-  USERS,
-  USER_GROUPS,
   withSampleDataset,
   signInAsAdmin,
   createUser,
 } from "__support__/cypress";
+
+import { USERS, USER_GROUPS } from "__support__/cypress_data";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
 const { admin } = USERS;

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -3,7 +3,6 @@ import {
   restore,
   withSampleDataset,
   signInAsAdmin,
-  createUser,
 } from "__support__/cypress";
 
 import { USERS, USER_GROUPS } from "__support__/cypress_data";
@@ -70,10 +69,10 @@ describe("snapshots", () => {
     cy.request("POST", "/api/permissions/group", { name: "data" }); // 5
 
     // additional users
-    createUser("normal");
-    createUser("nodata");
-    createUser("nocollection");
-    createUser("none");
+    cy.createUser("normal");
+    cy.createUser("nodata");
+    cy.createUser("nocollection");
+    cy.createUser("none");
 
     // Make a call to `/api/user` because some things (personal collections) get created there
     cy.request("GET", "/api/user");


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Extracts all user-related data into a separate file
    - That data is needed both for `commands.js` and also for individual tests
    - Since `cypress.js` imports `commands.js`, this data had to be extracted into a separate file
- Converts user-related functions into a set of Cypress custom commands
- Updates all tests with the related changes

### How to verify this works?
- All tests should pass in CI
- Additionally, we need to verify that smoke tests still work:
    - `yarn test-cypress-no-build --folder frontend/test/metabase-smoketest/`

### Additional info:
- I am open for suggestions on what would be the right name for the new file
- I used `cypress_data` because it could possibly contain other shared data, not just user-related stuff (for example, `SAMPLE_DATASET_ID`)