### PR TITLE
Improve search result comprehension

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import styled from "styled-components";
-import { jt } from "ttag";
+import { t, jt } from "ttag";
 
 import * as Urls from "metabase/lib/urls";
 import { color, lighten } from "metabase/lib/colors";
@@ -94,61 +94,6 @@ function ItemIcon({ item, type }) {
   );
 }
 
-export default function SearchResult(props) {
-  const { result } = props;
-  switch (result.model) {
-    case "card":
-      return <QuestionResult question={result} options={props} />;
-    case "collection":
-      return <CollectionResult collection={result} options={props} />;
-    case "dashboard":
-      return <DashboardResult dashboard={result} options={props} />;
-    case "table":
-      return <TableResult table={result} options={props} />;
-    case "segment":
-      return <SegmentResult segment={result} options={props} />;
-    case "metric":
-      return <MetricResult metric={result} options={props} />;
-    default:
-      return <DefaultResult result={result} options={props} />;
-  }
-}
-
-function TableResult({ table, options }) {
-  return (
-    <ResultLink to={table.getUrl()} compact={options.compact}>
-      <Flex align="start">
-        <ItemIcon item={table} type="table" />
-        <Box>
-          <Title>{table.name}</Title>
-          <Text>
-            Table in &nbsp;
-            <span>
-              <Link to={Urls.browseDatabase({ id: table.database_id })}>
-                <Database.Name id={table.database_id} />&nbsp;
-              </Link>
-              {table.table_schema && (
-                <span>
-                  <Icon name="chevronright" mx="4px" size={10} />
-                  {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
-                  <Link
-                    to={Urls.browseSchema({
-                      db: { id: table.database_id },
-                      schema_name: table.table_schema,
-                    })}
-                  >
-                    {table.table_schema}
-                  </Link>
-                </span>
-              )}
-            </span>
-          </Text>
-        </Box>
-      </Flex>
-    </ResultLink>
-  );
-}
-
 const CollectionLink = styled(Link)`
   text-decoration: dashed;
   &:hover {
@@ -173,35 +118,6 @@ function Score({ scores }) {
     <pre className="hide search-score">{JSON.stringify(scores, null, 2)}</pre>
   );
 }
-
-// Generally these should be at the bottom of the list I'd hope
-function CollectionResult({ collection, options }) {
-  return (
-    <ResultLink to={Urls.collection(collection.id)} compact={options.compact}>
-      <Flex align="start">
-        <ItemIcon item={collection} type="collection" />
-        <Box>
-          <Title>{collection.name}</Title>
-          <Text>{jt`Collection in ${formatCollection(
-            collection.getCollection(),
-          )}`}</Text>
-        </Box>
-        <Score scores={collection.scores} />
-      </Flex>
-    </ResultLink>
-  );
-}
-
-function contextText(context) {
-  return context.map(function({ is_match, text }) {
-    if (is_match) {
-      return <strong style={{ color: color("brand") }}> {text}</strong>;
-    } else {
-      return <span> {text}</span>;
-    }
-  });
-}
-
 const Context = styled("p")`
   line-height: 1.4em;
   color: ${color("text-medium")};
@@ -229,111 +145,83 @@ const Description = styled(Text)`
   border-left: 2px solid ${lighten("brand", 0.45)};
 `;
 
-function DashboardResult({ dashboard, options }) {
-  return (
-    <ResultLink to={dashboard.getUrl()} compact={options.compact}>
-      <Flex align="start">
-        <ItemIcon item={dashboard} type="dashboard" />
-        <Box>
-          <Title>{dashboard.name}</Title>
-          <Text>{jt`Dashboard in ${formatCollection(
-            dashboard.getCollection(),
-          )}`}</Text>
-          {dashboard.description && (
-            <Description>{dashboard.description}</Description>
-          )}
-          <Score scores={dashboard.scores} />
-        </Box>
-      </Flex>
-      {formatContext(dashboard.context, options.compact)}
-    </ResultLink>
-  );
+function contextText(context) {
+  return context.map(function ({ is_match, text }) {
+    if (is_match) {
+      return <strong style={{ color: color("brand") }}> {text}</strong>;
+    } else {
+      return <span> {text}</span>;
+    }
+  });
 }
 
-function QuestionResult({ question, options }) {
+export default function SearchResult({ result, compact }) {
+  let info;
+  const collection = result.getCollection();
+  switch (result.model) {
+    case "card":
+      info = jt`Saved question in ${formatCollection(collection)}`;
+      break;
+    case "collection":
+      info = t`Collection`;
+      break;
+    case "table":
+      info = (
+        <span>
+          {jt`Table in ${(
+            <span>
+              <Link to={Urls.browseDatabase({ id: result.database_id })}>
+                <Database.Name id={result.database_id} />{" "}
+              </Link>
+              {result.table_schema && (
+                <span>
+                  <Icon name="chevronright" mx="4px" size={10} />
+                  {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
+                  <Link
+                    to={Urls.browseSchema({
+                      db: { id: result.database_id },
+                      schema_name: result.table_schema,
+                    })}
+                  >
+                    {result.table_schema}
+                  </Link>
+                </span>
+              )}
+            </span>
+          )}`}
+        </span>
+      );
+      break;
+    case "segment":
+    case "metric":
+      info = jt`${result.model === "segment" ? "Segment of" : "Metric for"
+        } of ${(
+          <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
+            <Table.Loader id={result.table_id}>
+              {({ table }) => <span>{table.display_name}</span>}
+            </Table.Loader>
+          </Link>
+        )}`;
+      break;
+    default:
+      info = jt`${result.model.charAt(0).toUpperCase() +
+        result.model.slice(1)} in ${formatCollection(collection)}`;
+      break;
+  }
   return (
-    <ResultLink to={question.getUrl()} compact={options.compact}>
+    <ResultLink to={result.getUrl()} compact={compact}>
       <Flex align="start">
-        <ItemIcon item={question} type="question" />
-        <Box>
-          <Title>{question.name}</Title>
-          <Text>{jt`Saved question in ${formatCollection(
-            question.getCollection(),
-          )}`}</Text>
-          {question.description && (
-            <Description>{question.description}</Description>
-          )}
-          <Score scores={question.scores} />
-        </Box>
-      </Flex>
-      {formatContext(question.context, options.compact)}
-    </ResultLink>
-  );
-}
-
-function SegmentResult({ segment, options }) {
-  return (
-    <ResultLink to={segment.getUrl()} compact={options.compact}>
-      <Flex align="start">
-        <ItemIcon item={segment} />
-        <Box>
-          <Title>{segment.name}</Title>
-          <Text>{jt`Segment of ${(
-            <Link
-              to={Urls.tableRowsQuery(segment.database_id, segment.table_id)}
-            >
-              <Table.Name id={segment.table_id} />
-            </Link>
-          )}`}</Text>
-          {segment.description && (
-            <Description>{segment.description}</Description>
-          )}
-          <Score scores={segment.scores} />
-        </Box>
-      </Flex>
-    </ResultLink>
-  );
-}
-
-function MetricResult({ metric, options }) {
-  return (
-    <ResultLink to={metric.getUrl()} compact={options.compact}>
-      <Flex align="start">
-        <ItemIcon item={metric} />
-        <Box>
-          <Title>{metric.name}</Title>
-          <Text>{jt`Metric for ${(
-            <Link to={Urls.tableRowsQuery(metric.database_id, metric.table_id)}>
-              <Table.Name id={metric.table_id} />
-            </Link>
-          )}`}</Text>
-          {metric.description && (
-            <Description>{metric.description}</Description>
-          )}
-          <Score scores={metric.scores} />
-        </Box>
-      </Flex>
-    </ResultLink>
-  );
-}
-
-function DefaultResult({ result, options }) {
-  return (
-    <ResultLink to={result.getUrl()} compact={options.compact}>
-      <Flex align="start">
-        <ItemIcon item={result} />
+        <ItemIcon item={result} type={result.model} />
         <Box>
           <Title>{result.name}</Title>
-          <Text>{jt`${result.model} in ${formatCollection(
-            result.getCollection(),
-          )}`}</Text>
+          <Text>{info}</Text>
           {result.description && (
             <Description>{result.description}</Description>
           )}
           <Score scores={result.scores} />
         </Box>
       </Flex>
-      {formatContext(result.context, options.compact)}
+      {formatContext(result.context, compact)}
     </ResultLink>
   );
 }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -5,6 +5,7 @@ import { t, jt } from "ttag";
 
 import * as Urls from "metabase/lib/urls";
 import { color, lighten } from "metabase/lib/colors";
+import { capitalize } from "metabase/lib/formatting";
 
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
@@ -205,8 +206,7 @@ export default function SearchResult({ result, compact }) {
       )}`;
       break;
     default:
-      info = jt`${result.model.charAt(0).toUpperCase() +
-        result.model.slice(1)} in ${formatCollection(collection)}`;
+      info = jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
       break;
   }
   return (

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -146,7 +146,7 @@ const Description = styled(Text)`
 `;
 
 function contextText(context) {
-  return context.map(function ({ is_match, text }) {
+  return context.map(function({ is_match, text }) {
     if (is_match) {
       return <strong style={{ color: color("brand") }}> {text}</strong>;
     } else {
@@ -194,14 +194,15 @@ export default function SearchResult({ result, compact }) {
       break;
     case "segment":
     case "metric":
-      info = jt`${result.model === "segment" ? "Segment of" : "Metric for"
-        } of ${(
-          <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
-            <Table.Loader id={result.table_id}>
-              {({ table }) => <span>{table.display_name}</span>}
-            </Table.Loader>
-          </Link>
-        )}`;
+      info = jt`${
+        result.model === "segment" ? "Segment of" : "Metric for"
+      } of ${(
+        <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
+          <Table.Loader id={result.table_id}>
+            {({ table }) => <span>{table.display_name}</span>}
+          </Table.Loader>
+        </Link>
+      )}`;
       break;
     default:
       info = jt`${result.model.charAt(0).toUpperCase() +

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -104,6 +104,8 @@ export default function SearchResult(props) {
       return <DashboardResult dashboard={result} options={props} />;
     case "table":
       return <TableResult table={result} options={props} />;
+    case "segment":
+      return <SegmentResult segment={result} options={props} />;
     default:
       // metric, segment, and table deliberately included here
       return <DefaultResult result={result} options={props} />;
@@ -263,6 +265,23 @@ function QuestionResult({ question, options }) {
         </Box>
       </Flex>
       {formatContext(question.context, options.compact)}
+    </ResultLink>
+  );
+}
+
+function SegmentResult({ segment, options }) {
+  return (
+    <ResultLink to={segment.getUrl()} compact={options.compact}>
+      <Flex align="start">
+        <ItemIcon item={segment} />
+        <Box>
+          <Title>{segment.name}</Title>
+          {segment.description && (
+            <Description>{segment.description}</Description>
+          )}
+          <Score scores={segment.scores} />
+        </Box>
+      </Flex>
     </ResultLink>
   );
 }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -125,7 +125,7 @@ function TableResult({ table, options }) {
             Table in &nbsp;
             <span>
               <Link to={Urls.browseDatabase({ id: table.database_id })}>
-                <Database.Name id={table.database_id} />{" "}
+                <Database.Name id={table.database_id} />&nbsp;
               </Link>
               {table.table_schema && (
                 <span>

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -110,7 +110,6 @@ export default function SearchResult(props) {
     case "metric":
       return <MetricResult metric={result} options={props} />;
     default:
-      // metric, segment, and table deliberately included here
       return <DefaultResult result={result} options={props} />;
   }
 }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -113,11 +113,21 @@ function TableResult({ table, options }) {
           <Text>
             Table in &nbsp;
             <span>
-              <Database.Name id={table.database_id} />{" "}
+              <Link to={Urls.browseDatabase({ id: table.database_id })}>
+                <Database.Name id={table.database_id} />{" "}
+              </Link>
               {table.table_schema && (
                 <span>
                   <Icon name="chevronright" mx="4px" size={10} />
-                  {table.table_schema}
+                  {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
+                  <Link
+                    to={Urls.browseSchema({
+                      db: { id: table.database_id },
+                      schema_name: table.table_schema,
+                    })}
+                  >
+                    {table.table_schema}
+                  </Link>
                 </span>
               )}
             </span>

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -56,6 +56,16 @@ const ResultLink = styled(Link)`
     }
   }
 
+  ${Link} {
+    text-underline-position: under;
+    text-decoration: underline ${color("text-light")};
+    text-decoration-style: dashed;
+    &:hover {
+      color: ${color("brand")};
+      text-decoration-color: ${color("brand")};
+    }
+  }
+
   ${Text} {
     margin-top: 0;
     margin-bottom: 0;

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -37,11 +37,8 @@ const IconWrapper = styled.div`
 `;
 
 const ResultLink = styled(Link)`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  display: block;
   background-color: transparent;
-  border-radius: 6px;
   min-height: ${props => (props.compact ? "36px" : "54px")};
   padding-top: 8px;
   padding-bottom: 8px;
@@ -49,7 +46,7 @@ const ResultLink = styled(Link)`
   padding-right: ${props => (props.compact ? "20px" : "32px")};
 
   &:hover {
-    background-color: #fafafa;
+    background-color: ${lighten("brand", 0.63)};
 
     h3 {
       color: ${color("brand")};
@@ -90,7 +87,7 @@ function ItemIcon({ item, type }) {
       {type === "table" ? (
         <Icon name="database" />
       ) : (
-        <Icon name={item.getIcon()} />
+        <Icon name={item.getIcon()} size={20} />
       )}
     </IconWrapper>
   );
@@ -116,7 +113,7 @@ export default function SearchResult(props) {
 function TableResult({ table, options }) {
   return (
     <ResultLink to={table.getUrl()} compact={options.compact}>
-      <Flex align="center">
+      <Flex align="start">
         <ItemIcon item={table} type="table" />
         <Box>
           <Title>{table.name}</Title>
@@ -177,7 +174,7 @@ function Score({ scores }) {
 function CollectionResult({ collection, options }) {
   return (
     <ResultLink to={Urls.collection(collection.id)} compact={options.compact}>
-      <Flex align="center">
+      <Flex align="start">
         <ItemIcon item={collection} type="collection" />
         <Box>
           <Title>{collection.name}</Title>
@@ -222,16 +219,25 @@ function formatCollection(collection) {
   return collection.id && <CollectionBadge collection={collection} />;
 }
 
+const Description = styled(Text)`
+  padding-left: 8px;
+  margin-top: 6px !important;
+  border-left: 2px solid ${lighten("brand", 0.45)};
+`;
+
 function DashboardResult({ dashboard, options }) {
   return (
     <ResultLink to={dashboard.getUrl()} compact={options.compact}>
-      <Flex align="center">
+      <Flex align="start">
         <ItemIcon item={dashboard} type="dashboard" />
         <Box>
           <Title>{dashboard.name}</Title>
           <Text>{jt`Dashboard in ${formatCollection(
             dashboard.getCollection(),
           )}`}</Text>
+          {dashboard.description && (
+            <Description>{dashboard.description}</Description>
+          )}
           <Score scores={dashboard.scores} />
         </Box>
       </Flex>
@@ -243,22 +249,18 @@ function DashboardResult({ dashboard, options }) {
 function QuestionResult({ question, options }) {
   return (
     <ResultLink to={question.getUrl()} compact={options.compact}>
-      <Flex align="center">
+      <Flex align="start">
         <ItemIcon item={question} type="question" />
         <Box>
           <Title>{question.name}</Title>
           <Text>{jt`Saved question in ${formatCollection(
             question.getCollection(),
           )}`}</Text>
+          {question.description && (
+            <Description>{question.description}</Description>
+          )}
           <Score scores={question.scores} />
         </Box>
-        {question.description && (
-          <Box ml="auto">
-            <Tooltip tooltip={question.description}>
-              <Icon name="info" />
-            </Tooltip>
-          </Box>
-        )}
       </Flex>
       {formatContext(question.context, options.compact)}
     </ResultLink>
@@ -268,7 +270,7 @@ function QuestionResult({ question, options }) {
 function DefaultResult({ result, options }) {
   return (
     <ResultLink to={result.getUrl()} compact={options.compact}>
-      <Flex align="center">
+      <Flex align="start">
         <ItemIcon item={result} />
         <Box>
           <Title>{result.name}</Title>

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -161,18 +161,15 @@ function contextText(context) {
   });
 }
 
-export default function SearchResult({ result, compact }) {
-  let info;
+function InfoText({ result }) {
   const collection = result.getCollection();
   switch (result.model) {
     case "card":
-      info = jt`Saved question in ${formatCollection(collection)}`;
-      break;
+      return jt`Saved question in ${formatCollection(collection)}`;
     case "collection":
-      info = t`Collection`;
-      break;
+      return t`Collection`;
     case "table":
-      info = (
+      return (
         <span>
           {jt`Table in ${(
             <span>
@@ -197,10 +194,9 @@ export default function SearchResult({ result, compact }) {
           )}`}
         </span>
       );
-      break;
     case "segment":
     case "metric":
-      info = jt`${
+      return jt`${
         result.model === "segment" ? "Segment of" : "Metric for"
       } of ${(
         <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
@@ -209,18 +205,21 @@ export default function SearchResult({ result, compact }) {
           </Table.Loader>
         </Link>
       )}`;
-      break;
     default:
-      info = jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
-      break;
+      return jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
   }
+}
+
+export default function SearchResult({ result, compact }) {
   return (
     <ResultLink to={result.getUrl()} compact={compact}>
       <Flex align="start">
         <ItemIcon item={result} type={result.model} />
         <Box>
           <Title>{result.name}</Title>
-          <Text>{info}</Text>
+          <Text>
+            <InfoText result={result} />
+          </Text>
           {result.description && (
             <Description>{result.description}</Description>
           )}

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import styled from "styled-components";
-import { t, jt } from "ttag";
+import { jt } from "ttag";
 
 import * as Urls from "metabase/lib/urls";
 import { color, lighten } from "metabase/lib/colors";
@@ -171,7 +171,9 @@ function CollectionResult({ collection, options }) {
         <ItemIcon item={collection} type="collection" />
         <Box>
           <Title>{collection.name}</Title>
-          <Text>{t`Collection in COLLECTION_NAME`}</Text>
+          <Text>{jt`Collection in ${formatCollection(
+            collection.getCollection(),
+          )}`}</Text>
         </Box>
         <Score scores={collection.scores} />
       </Flex>
@@ -235,7 +237,7 @@ function QuestionResult({ question, options }) {
         <ItemIcon item={question} type="question" />
         <Box>
           <Title>{question.name}</Title>
-          <Text>{jt`Question in ${formatCollection(
+          <Text>{jt`Saved question in ${formatCollection(
             question.getCollection(),
           )}`}</Text>
           <Score scores={question.scores} />

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -14,7 +14,7 @@ import Text from "metabase/components/type/Text";
 import Database from "metabase/entities/databases";
 import Table from "metabase/entities/tables";
 
-function colorForType(props) {
+function getColorForIconWrapper(props) {
   if (props.item.collection_position) {
     return color("warning");
   }
@@ -32,7 +32,7 @@ const IconWrapper = styled.div`
   justify-content: center;
   width: 32px;
   height: 32px;
-  color: ${colorForType};
+  color: ${getColorForIconWrapper};
   margin-right: 10px;
   flex-shrink: 0;
 `;
@@ -147,7 +147,7 @@ const Description = styled(Text)`
 `;
 
 function contextText(context) {
-  return context.map(function({ is_match, text }, i) {
+  return context.map(function ({ is_match, text }, i) {
     if (is_match) {
       return (
         <strong key={i} style={{ color: color("brand") }}>
@@ -196,15 +196,14 @@ function InfoText({ result }) {
       );
     case "segment":
     case "metric":
-      return jt`${
-        result.model === "segment" ? "Segment of" : "Metric for"
-      } of ${(
-        <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
-          <Table.Loader id={result.table_id}>
-            {({ table }) => <span>{table.display_name}</span>}
-          </Table.Loader>
-        </Link>
-      )}`;
+      return jt`${result.model === "segment" ? "Segment of" : "Metric for"
+        } of ${(
+          <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
+            <Table.Loader id={result.table_id}>
+              {({ table }) => <span>{table.display_name}</span>}
+            </Table.Loader>
+          </Link>
+        )}`;
     default:
       return jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
   }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -15,7 +15,8 @@ const IconWrapper = styled.div`
   justify-content: center;
   width: 32px;
   height: 32px;
-  color: ${color("brand")};
+  color: ${props =>
+    props.item.collection_position ? color("warning") : color("brand")};
   margin-right: 10px;
   flex-shrink: 0;
 `;

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -9,9 +9,9 @@ import { color, lighten } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import Text from "metabase/components/type/Text";
-import Tooltip from "metabase/components/Tooltip";
 
 import Database from "metabase/entities/databases";
+import Table from "metabase/entities/tables";
 
 function colorForType(props) {
   if (props.item.collection_position) {
@@ -67,6 +67,7 @@ const ResultLink = styled(Link)`
     margin-top: 0;
     margin-bottom: 0;
     font-size: 13px;
+    line-height: 19px;
   }
 
   h3 {
@@ -106,6 +107,8 @@ export default function SearchResult(props) {
       return <TableResult table={result} options={props} />;
     case "segment":
       return <SegmentResult segment={result} options={props} />;
+    case "metric":
+      return <MetricResult metric={result} options={props} />;
     default:
       // metric, segment, and table deliberately included here
       return <DefaultResult result={result} options={props} />;
@@ -276,10 +279,39 @@ function SegmentResult({ segment, options }) {
         <ItemIcon item={segment} />
         <Box>
           <Title>{segment.name}</Title>
+          <Text>{jt`Segment of ${(
+            <Link
+              to={Urls.tableRowsQuery(segment.database_id, segment.table_id)}
+            >
+              <Table.Name id={segment.table_id} />
+            </Link>
+          )}`}</Text>
           {segment.description && (
             <Description>{segment.description}</Description>
           )}
           <Score scores={segment.scores} />
+        </Box>
+      </Flex>
+    </ResultLink>
+  );
+}
+
+function MetricResult({ metric, options }) {
+  return (
+    <ResultLink to={metric.getUrl()} compact={options.compact}>
+      <Flex align="start">
+        <ItemIcon item={metric} />
+        <Box>
+          <Title>{metric.name}</Title>
+          <Text>{jt`Metric for ${(
+            <Link to={Urls.tableRowsQuery(metric.database_id, metric.table_id)}>
+              <Table.Name id={metric.table_id} />
+            </Link>
+          )}`}</Text>
+          {metric.description && (
+            <Description>{metric.description}</Description>
+          )}
+          <Score scores={metric.scores} />
         </Box>
       </Flex>
     </ResultLink>
@@ -293,6 +325,9 @@ function DefaultResult({ result, options }) {
         <ItemIcon item={result} />
         <Box>
           <Title>{result.name}</Title>
+          {result.description && (
+            <Description>{result.description}</Description>
+          )}
           {formatCollection(result.getCollection())}
           <Score scores={result.scores} />
         </Box>

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -15,8 +15,6 @@ const IconWrapper = styled.div`
   justify-content: center;
   width: 32px;
   height: 32px;
-  border-radius: 99px;
-  background-color: #ddecfa;
   color: ${color("brand")};
   margin-right: 10px;
   flex-shrink: 0;

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -147,11 +147,16 @@ const Description = styled(Text)`
 `;
 
 function contextText(context) {
-  return context.map(function({ is_match, text }) {
+  return context.map(function({ is_match, text }, i) {
     if (is_match) {
-      return <strong style={{ color: color("brand") }}> {text}</strong>;
+      return (
+        <strong key={i} style={{ color: color("brand") }}>
+          {" "}
+          {text}
+        </strong>
+      );
     } else {
-      return <span> {text}</span>;
+      return <span key={i}> {text}</span>;
     }
   });
 }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -147,7 +147,7 @@ const Description = styled(Text)`
 `;
 
 function contextText(context) {
-  return context.map(function ({ is_match, text }, i) {
+  return context.map(function({ is_match, text }, i) {
     if (is_match) {
       return (
         <strong key={i} style={{ color: color("brand") }}>
@@ -196,14 +196,15 @@ function InfoText({ result }) {
       );
     case "segment":
     case "metric":
-      return jt`${result.model === "segment" ? "Segment of" : "Metric for"
-        } of ${(
-          <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
-            <Table.Loader id={result.table_id}>
-              {({ table }) => <span>{table.display_name}</span>}
-            </Table.Loader>
-          </Link>
-        )}`;
+      return jt`${
+        result.model === "segment" ? "Segment of" : "Metric for"
+      } of ${(
+        <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
+          <Table.Loader id={result.table_id}>
+            {({ table }) => <span>{table.display_name}</span>}
+          </Table.Loader>
+        </Link>
+      )}`;
     default:
       return jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
   }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -325,10 +325,12 @@ function DefaultResult({ result, options }) {
         <ItemIcon item={result} />
         <Box>
           <Title>{result.name}</Title>
+          <Text>{jt`${result.model} in ${formatCollection(
+            result.getCollection(),
+          )}`}</Text>
           {result.description && (
             <Description>{result.description}</Description>
           )}
-          {formatCollection(result.getCollection())}
           <Score scores={result.scores} />
         </Box>
       </Flex>


### PR DESCRIPTION
A set of changes to make it easier to understand what you're looking at in search results.
- Highlights pinned items to make them easier to see
- Removes the icon surround on items to make parsing the icons easier
- Faded blue on collection icons to help differentiate collections
- Adds what type something is as part of the location description (e.x. Dashboard in Our Analytics)
- Adds a new icon, and the database name (and schema if applicable) to database tables

![image](https://user-images.githubusercontent.com/5248953/110838533-943e7000-8270-11eb-8cba-469aed6e4cbe.png)



ToDo
- [x] Collection items show themselves as the parent collection due to the API response object (need a BE assist, maybe @tsmacdonald or we can punt on this and remove that info). - Removing for now
- [x] Segments and Metrics show the original "name" of the source table, not the humanized `displayName`
- [x] If a description exists show it inline
- [x] Handle segment and metric types
- [x] Add "pulse" to location description on pulse items
- [x] Add links to table and schema names for tables
- [x] Spacing tweaks