### PR TITLE
Use GitHub Actions to run i18n checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,34 +525,6 @@ jobs:
           paths:
             - metabase/metabase
 
-  verify-i18n-files:
-    executor: metabase-ci
-    steps:
-      - attach-workspace
-      - create-checksum-file:
-          filename: .I18N-CHECKSUMS
-          find-args: "locales -type f -name '*.po'"
-      # In case the i18n scripts themselves change
-      - create-checksum-file:
-          filename: .I18N-SCRIPT-CHECKSUMS
-          find-args: "bin/i18n -type f"
-      - run-on-change:
-          checksum: '{{ checksum ".I18N-CHECKSUMS" }}-{{ checksum ".I18N-SCRIPT-CHECKSUMS" }}'
-          steps:
-            - restore-fe-deps-cache
-            - run:
-                name: Check i18n tags/make sure template can be built
-                # fix OOM when running -- see https://stackoverflow.com/a/59572966/1198455
-                # without this option, sometimes this step will fail with an OOM error.
-                environment:
-                  NODE_OPTIONS: '--max-old-space-size=2048'
-                command: ./bin/i18n/update-translation-template
-                no_output_timeout: 2m
-            - run:
-                name: Verify i18n translations (.po files)
-                command: ./bin/i18n/build-translation-resources
-                no_output_timeout: 2m
-
   check-migrations:
     executor:
       metabase-ci
@@ -976,10 +948,6 @@ workflows:
   build:
     jobs:
       - checkout
-
-      - verify-i18n-files:
-          requires:
-            - fe-deps
 
       - check-migrations:
           requires:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,42 @@
+name: i18n
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'release**'
+      - 'feature**'
+    tags:
+      - '**'
+    paths:
+    - '**.clj'
+    - '**.js'
+    - '**.jsx'
+    - '.github/workflows/**'
+    - 'bin/**'
+
+jobs:
+
+  verify-i18n-files:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-i18n-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+
+    - run: sudo apt install gettext
+
+    - run: ./bin/i18n/update-translation-template
+      name: Check i18n tags/make sure template can be built
+    - run: ./bin/i18n/build-translation-resources
+      name: Verify i18n translations (.po files)


### PR DESCRIPTION
Same spirit as PR #14701, #14050, etc: frees a Circle CI container to run other priority tasks (e.g. Cypress tests).