### PR TITLE
Fix sandboxes test flake (in repro #14612)

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -892,7 +892,8 @@ describeWithToken("formatting > sandboxes", () => {
         visualization_settings: {},
       });
 
-      cy.visit("/admin/permissions/databases/1/schemas/PUBLIC/tables");
+      cy.visit("/admin/permissions/databases/1/schemas");
+      cy.findByText("View tables").click();
       // |                | All users | collection |
       // |--------------- |:---------:|:----------:|
       // | Orders         |   X (0)   |    X (1)   |

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -875,6 +875,7 @@ describeWithToken("formatting > sandboxes", () => {
 
       cy.server();
       cy.route("POST", "/api/mt/gtap").as("sandboxTable");
+      cy.route("GET", "/api/permissions/group").as("tablePermissions");
 
       cy.log(
         "Create question that will have differently-typed columns than the sandboxed table",
@@ -895,6 +896,8 @@ describeWithToken("formatting > sandboxes", () => {
       // |                | All users | collection |
       // |--------------- |:---------:|:----------:|
       // | Orders         |   X (0)   |    X (1)   |
+
+      cy.wait("@tablePermissions");
       cy.icon("close")
         .eq(1) // No better way of doing this, undfortunately (see table above)
         .click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Attempts to fix a CI flake for a Cypress test that reproduces #14612
- Test now waits for the request after which the table should be fully loaded (when we had similar incidents in the past, it was _usually_ some sort of race condition)

### Additional info:
- We've had numerous test failures in CircleCI only because the page doesn't render at all
- I couldn't reproduce this behavior locally, no matter how many times I re-run this test

Example of this failure:
https://app.circleci.com/pipelines/github/metabase/metabase/13825/workflows/11d88955-5a3e-4ccf-9220-1f1991bbb421/jobs/525850
```
formatting > sandboxes Sandboxing reproductions attempt to sandbox based on question with differently-typed columns than a sandboxed table should provide meaningful UI error (metabase#14612) - attempt to sandbox based on question with differently-typed columns than a sandboxed table should provide meaningful UI error (metabase#14612)
AssertionError: Timed out retrying: Expected to find element: `.Icon-close`, but never found it.
```