### PR TITLE
Remove flow-typed/, not necessary anymore with no type-checking

### DIFF
--- a/flow-typed/styled-components.js
+++ b/flow-typed/styled-components.js
@@ -1,5 +1,0 @@
-/* For some reason this is needed to suppress flow errros */
-
-declare module 'styled-components' {
-  declare module.exports: any
-}


### PR DESCRIPTION
Everything should just work (`yarn dev`, unit tests, Cypress, etc)