### PR TITLE
#15119 Repro: User without data access should be able to use dashboard filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -656,8 +656,14 @@ describe("scenarios > dashboard", () => {
         cy.get("fieldset")
           .contains("Category")
           .click();
-        cy.findByPlaceholderText("Search the list");
-        popover().findByText("Gizmo");
+
+        cy.findByPlaceholderText("Enter some text")
+          .click()
+          .type("Gizmo", { delay: 10 });
+        cy.findByRole("button", { name: "Add filter" })
+          .should("not.be.disabled")
+          .click();
+        cy.contains("Rustic Paper Wallet");
       });
     });
   });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15119 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Add filter button is disabled for "nodata" user
![image](https://user-images.githubusercontent.com/31325167/111005390-0014fb80-838b-11eb-8ec9-dbb6c62b706b.png)