### PR TITLE
#15105 Repro: When Sandbox is granted to linked table column, but no access to the linked table, then "dirty" queries fail

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -948,7 +948,7 @@ describeWithToken("formatting > sandboxes", () => {
         });
     });
 
-    it.skip("(metabase#15105)", () => {
+    it.skip("should be able to visit ad-hoc/dirty question when permission is granted to the linked table column, but not to the linked table itself (metabase#15105)", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
@@ -969,6 +969,8 @@ describeWithToken("formatting > sandboxes", () => {
       cy.wait("@dataset").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
       });
+
+      cy.contains("37.65");
     });
   });
 });

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -947,6 +947,29 @@ describeWithToken("formatting > sandboxes", () => {
           cy.findByText("Slack");
         });
     });
+
+    it.skip("(metabase#15105)", () => {
+      cy.server();
+      cy.route("POST", "/api/dataset").as("dataset");
+
+      cy.sandboxTable({
+        table_id: ORDERS_ID,
+        attribute_remappings: {
+          attr_uid: [
+            "dimension",
+            ["fk->", ["field-id", ORDERS.USER_ID], ["field-id", PEOPLE.ID]],
+          ],
+        },
+      });
+
+      cy.signOut();
+      cy.signInAsSandboxedUser();
+      openOrdersTable();
+
+      cy.wait("@dataset").then(xhr => {
+        expect(xhr.response.body.error).not.to.exist;
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15105

### How to test this manually?
- `yarn test-cypress-open --folder enterprise/frontend/test/metabase-enterprise/sandboxes/`
- `enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/110863488-0b035980-82c1-11eb-8433-a950fbf4b46a.png)

