### PR TITLE
Move code from meta/Dashboard to meta/Parameter

### DIFF
--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -11,7 +11,7 @@ import { isa, TYPE } from "metabase/lib/types";
 import {
   dimensionFilterForParameter,
   variableFilterForParameter,
-} from "metabase/meta/Dashboard";
+} from "metabase/meta/Parameter";
 
 export function getDataFromClicked({
   extraData: { dashboard, parameterValuesBySlug, userAttributes } = {},

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -1,86 +1,23 @@
 import Question from "metabase-lib/lib/Question";
 
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
-import type Field from "metabase-lib/lib/metadata/Field";
-import type { TemplateTag } from "metabase-types/types/Query";
 import type { Card } from "metabase-types/types/Card";
 import type {
   ParameterOption,
   Parameter,
-  ParameterType,
   ParameterMappingUIOption,
 } from "metabase-types/types/Parameter";
 
-import Dimension from "metabase-lib/lib/Dimension";
-import Variable, { TemplateTagVariable } from "metabase-lib/lib/Variable";
+import {
+  dimensionFilterForParameter,
+  variableFilterForParameter,
+  PARAMETER_OPTIONS,
+} from "metabase/meta/Parameter";
 
 import { t } from "ttag";
 import _ from "underscore";
 
 import { slugify } from "metabase/lib/formatting";
-
-type DimensionFilter = (dimension: Dimension) => boolean;
-type TemplateTagFilter = (tag: TemplateTag) => boolean;
-type FieldFilter = (field: Field) => boolean;
-type VariableFilter = (variable: Variable) => boolean;
-
-export const PARAMETER_OPTIONS: ParameterOption[] = [
-  {
-    type: "date/month-year",
-    name: t`Month and Year`,
-    description: t`Like January, 2016`,
-  },
-  {
-    type: "date/quarter-year",
-    name: t`Quarter and Year`,
-    description: t`Like Q1, 2016`,
-  },
-  {
-    type: "date/single",
-    name: t`Single Date`,
-    description: t`Like January 31, 2016`,
-  },
-  {
-    type: "date/range",
-    name: t`Date Range`,
-    description: t`Like December 25, 2015 - February 14, 2016`,
-  },
-  {
-    type: "date/relative",
-    name: t`Relative Date`,
-    description: t`Like "the last 7 days" or "this month"`,
-  },
-  {
-    type: "date/all-options",
-    name: t`Date Filter`,
-    menuName: t`All Options`,
-    description: t`Contains all of the above`,
-  },
-  {
-    type: "location/city",
-    name: t`City`,
-  },
-  {
-    type: "location/state",
-    name: t`State`,
-  },
-  {
-    type: "location/zip_code",
-    name: t`ZIP or Postal Code`,
-  },
-  {
-    type: "location/country",
-    name: t`Country`,
-  },
-  {
-    type: "id",
-    name: t`ID`,
-  },
-  {
-    type: "category",
-    name: t`Category`,
-  },
-];
 
 export type ParameterSection = {
   id: string,
@@ -126,77 +63,6 @@ for (const option of PARAMETER_OPTIONS) {
     section.options = section.options || [];
     section.options.push(option);
   }
-}
-
-function fieldFilterForParameter(parameter: Parameter) {
-  return fieldFilterForParameterType(parameter.type);
-}
-
-function fieldFilterForParameterType(
-  parameterType: ParameterType,
-): FieldFilter {
-  const [type] = parameterType.split("/");
-  switch (type) {
-    case "date":
-      return (field: Field) => field.isDate();
-    case "id":
-      return (field: Field) => field.isID();
-    case "category":
-      return (field: Field) => field.isCategory();
-  }
-
-  switch (parameterType) {
-    case "location/city":
-      return (field: Field) => field.isCity();
-    case "location/state":
-      return (field: Field) => field.isState();
-    case "location/zip_code":
-      return (field: Field) => field.isZipCode();
-    case "location/country":
-      return (field: Field) => field.isCountry();
-  }
-  return (field: Field) => false;
-}
-
-export function parameterOptionsForField(field: Field): ParameterOption[] {
-  return PARAMETER_OPTIONS.filter(option =>
-    fieldFilterForParameterType(option.type)(field),
-  );
-}
-
-export function dimensionFilterForParameter(
-  parameter: Parameter,
-): DimensionFilter {
-  const fieldFilter = fieldFilterForParameter(parameter);
-  return dimension => fieldFilter(dimension.field());
-}
-
-export function variableFilterForParameter(
-  parameter: Parameter,
-): VariableFilter {
-  const tagFilter = tagFilterForParameter(parameter);
-  return variable => {
-    if (variable instanceof TemplateTagVariable) {
-      const tag = variable.tag();
-      return tag ? tagFilter(tag) : false;
-    }
-    return false;
-  };
-}
-
-function tagFilterForParameter(parameter: Parameter): TemplateTagFilter {
-  const [type, subtype] = parameter.type.split("/");
-  switch (type) {
-    case "date":
-      return (tag: TemplateTag) => subtype === "single" && tag.type === "date";
-    case "location":
-      return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
-    case "id":
-      return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
-    case "category":
-      return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
-  }
-  return (tag: TemplateTag) => false;
 }
 
 export function getParameterMappingOptions(

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -7,6 +7,7 @@ import type {
 } from "metabase-types/types/Query";
 import type {
   Parameter,
+  ParameterOption,
   ParameterInstance,
   ParameterTarget,
   ParameterValue,
@@ -16,13 +17,147 @@ import type {
 } from "metabase-types/types/Parameter";
 import type { FieldId } from "metabase-types/types/Field";
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
-import { FieldDimension } from "metabase-lib/lib/Dimension";
-
+import type Field from "metabase-lib/lib/metadata/Field";
+import Dimension, { FieldDimension } from "metabase-lib/lib/Dimension";
 import moment from "moment";
-
+import { t } from "ttag";
 import * as FIELD_REF from "metabase/lib/query/field_ref";
-
 import { isNumericBaseType } from "metabase/lib/schema_metadata";
+import Variable, { TemplateTagVariable } from "metabase-lib/lib/Variable";
+
+type DimensionFilter = (dimension: Dimension) => boolean;
+type TemplateTagFilter = (tag: TemplateTag) => boolean;
+type FieldPredicate = (field: Field) => boolean;
+type VariableFilter = (variable: Variable) => boolean;
+
+export const PARAMETER_OPTIONS: ParameterOption[] = [
+  {
+    type: "date/month-year",
+    name: t`Month and Year`,
+    description: t`Like January, 2016`,
+  },
+  {
+    type: "date/quarter-year",
+    name: t`Quarter and Year`,
+    description: t`Like Q1, 2016`,
+  },
+  {
+    type: "date/single",
+    name: t`Single Date`,
+    description: t`Like January 31, 2016`,
+  },
+  {
+    type: "date/range",
+    name: t`Date Range`,
+    description: t`Like December 25, 2015 - February 14, 2016`,
+  },
+  {
+    type: "date/relative",
+    name: t`Relative Date`,
+    description: t`Like "the last 7 days" or "this month"`,
+  },
+  {
+    type: "date/all-options",
+    name: t`Date Filter`,
+    menuName: t`All Options`,
+    description: t`Contains all of the above`,
+  },
+  {
+    type: "location/city",
+    name: t`City`,
+  },
+  {
+    type: "location/state",
+    name: t`State`,
+  },
+  {
+    type: "location/zip_code",
+    name: t`ZIP or Postal Code`,
+  },
+  {
+    type: "location/country",
+    name: t`Country`,
+  },
+  {
+    type: "id",
+    name: t`ID`,
+  },
+  {
+    type: "category",
+    name: t`Category`,
+  },
+];
+
+function fieldFilterForParameter(parameter: Parameter) {
+  return fieldFilterForParameterType(parameter.type);
+}
+
+function fieldFilterForParameterType(
+  parameterType: ParameterType,
+): FieldPredicate {
+  const [type] = parameterType.split("/");
+  switch (type) {
+    case "date":
+      return (field: Field) => field.isDate();
+    case "id":
+      return (field: Field) => field.isID();
+    case "category":
+      return (field: Field) => field.isCategory();
+  }
+
+  switch (parameterType) {
+    case "location/city":
+      return (field: Field) => field.isCity();
+    case "location/state":
+      return (field: Field) => field.isState();
+    case "location/zip_code":
+      return (field: Field) => field.isZipCode();
+    case "location/country":
+      return (field: Field) => field.isCountry();
+  }
+  return (field: Field) => false;
+}
+
+export function parameterOptionsForField(field: Field): ParameterOption[] {
+  return PARAMETER_OPTIONS.filter(option =>
+    fieldFilterForParameterType(option.type)(field),
+  );
+}
+
+export function dimensionFilterForParameter(
+  parameter: Parameter,
+): DimensionFilter {
+  const fieldFilter = fieldFilterForParameter(parameter);
+  return dimension => fieldFilter(dimension.field());
+}
+
+export function variableFilterForParameter(
+  parameter: Parameter,
+): VariableFilter {
+  const tagFilter = tagFilterForParameter(parameter);
+  return variable => {
+    if (variable instanceof TemplateTagVariable) {
+      const tag = variable.tag();
+      return tag ? tagFilter(tag) : false;
+    }
+    return false;
+  };
+}
+
+function tagFilterForParameter(parameter: Parameter): TemplateTagFilter {
+  const [type, subtype] = parameter.type.split("/");
+  switch (type) {
+    case "date":
+      return (tag: TemplateTag) => subtype === "single" && tag.type === "date";
+    case "location":
+      return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
+    case "id":
+      return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
+    case "category":
+      return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
+  }
+  return (tag: TemplateTag) => false;
+}
 
 // NOTE: this should mirror `template-tag-parameters` in src/metabase/api/embed.clj
 export function getTemplateTagParameters(tags: TemplateTag[]): Parameter[] {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -9,7 +9,7 @@ import InputBlurChange from "metabase/components/InputBlurChange";
 import Select, { Option } from "metabase/components/Select";
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget";
 
-import { parameterOptionsForField } from "metabase/meta/Dashboard";
+import { parameterOptionsForField } from "metabase/meta/Parameter";
 import type { TemplateTag } from "metabase-types/types/Query";
 import type { Database } from "metabase-types/types/Database";
 


### PR DESCRIPTION
**Description**
This code makes more sense in `meta/Parameter.js` as it doesn't have any dependencies on things related to dashboards. I'm doing this refactor before I add some additional parameter-specific code that'll be depended on by `TagEditorParam`, which is used in native questions and not dashboards.

**Verification**
The build passing should suffice here since I'm just shifting a little code around.