### PR TITLE
#15106 Repro: "Dirty" query fails when sandboxing on linked table column with multiple dimensions and remapping

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -975,7 +975,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.contains("37.65");
     });
 
-    it.skip("(metabase#15106)", () => {
+    it.skip("unsaved/dirty query should work on linked table column with multiple dimensions and remapping (metabase#15106)", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
@@ -1028,6 +1028,8 @@ describeWithToken("formatting > sandboxes", () => {
       cy.wait("@dataset").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
       });
+
+      // Add positive assertion once this issue is fixed
     });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15106 

### How to test this manually?
- `yarn test-cypress-open --folder enterprise/frontend/test/metabase-enterprise/sandboxes/`
- `enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/110868486-f2973d00-82c8-11eb-88ce-d547c99d3413.png)

