### PR TITLE
CI: Run clj-kondo linter

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -23,8 +23,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Run clj-kondo on src/ and enterprise/backend/src/
-      run: docker run -v $PWD:/work --rm cljkondo/clj-kondo clj-kondo --config /work/lint-config.edn --lint /work/src /work/enterprise/backend/src
+    - name: Run clj-kondo
+      run: docker run -v $PWD:/work --rm cljkondo/clj-kondo clj-kondo --config /work/lint-config.edn --lint /work/src /work/enterprise/backend/src /work/backend/mbql/src /work/shared/src
 
   be-linter-bikeshed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,6 +18,14 @@ on:
 
 jobs:
 
+  be-linter-clj-kondo:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clj-kondo on src/ and enterprise/backend/src/
+      run: docker run -v $PWD:/work --rm cljkondo/clj-kondo clj-kondo --config /work/lint-config.edn --lint /work/src /work/enterprise/backend/src
+
   be-linter-bikeshed:
     runs-on: ubuntu-20.04
     timeout-minutes: 10

--- a/lint-config.edn
+++ b/lint-config.edn
@@ -1,0 +1,9 @@
+^:replace
+{:linters {:missing-else-branch         {:level :warn}
+           :misplaced-docstring         {:level :warn}
+           :missing-body-in-when        {:level :warn}
+           :missing-docstring           {:level :warn}
+           :refer-all                   {:level   :warn
+                                         :exclude [clojure.test]}
+           :unsorted-required-namespace {:level :warn}
+           :use                         {:level :warn}}}


### PR DESCRIPTION
This implements issue #14808. Running time is really fast, < 1 minute.

It will appear as an additional line item in the (GitHub) Actions panel:

![image](https://user-images.githubusercontent.com/7288/110963229-aec32880-8306-11eb-8140-643ff41cf057.png)
