### PR TITLE
Replace 😢 error screen with a closable error card

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -6,6 +6,7 @@ import Navbar from "metabase/nav/containers/Navbar";
 import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
 
 import UndoListing from "metabase/containers/UndoListing";
+import ErrorCard from "metabase/components/ErrorCard";
 
 import {
   Archived,
@@ -44,15 +45,21 @@ const getErrorComponent = ({ status, data, context }) => {
 @connect(mapStateToProps)
 export default class App extends Component {
   state = {
-    hasError: false,
+    errorInfo: undefined,
   };
 
-  UNSAFE_componentWillMount() {
+  constructor(props) {
+    super(props);
     initializeIframeResizer();
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ errorInfo });
   }
 
   render() {
     const { children, currentUser, location, errorPage } = this.props;
+    const { errorInfo } = this.state;
 
     return (
       <ScrollToTop>
@@ -61,6 +68,7 @@ export default class App extends Component {
           {errorPage ? getErrorComponent(errorPage) : children}
           <UndoListing />
         </div>
+        <ErrorCard errorInfo={errorInfo} />
       </ScrollToTop>
     );
   }

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -51,17 +51,8 @@ export default class App extends Component {
     initializeIframeResizer();
   }
 
-  componentDidCatch(error, info) {
-    console.error("Error caught in <App>", error, info);
-    this.setState({ hasError: true });
-  }
-
   render() {
     const { children, currentUser, location, errorPage } = this.props;
-
-    if (this.state.hasError) {
-      return <div>😢</div>;
-    }
 
     return (
       <ScrollToTop>

--- a/frontend/src/metabase/components/ErrorCard.jsx
+++ b/frontend/src/metabase/components/ErrorCard.jsx
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import BodyComponent from "metabase/components/BodyComponent";
+import Card from "metabase/components/Card";
+import Icon from "metabase/components/Icon";
+
+function ErrorCard({ errorInfo }) {
+  const [showError, setShowError] = useState(false);
+
+  useEffect(() => {
+    if (errorInfo) {
+      setShowError(true);
+    }
+  }, [errorInfo]);
+
+  return showError ? (
+    <Card className="fixed right bottom zF" p={2} m={2} width={350}>
+      <div className="flex justify-between align-center mb1">
+        <div className="text-error flex align-center">
+          <Icon name="info_outline" mr={1} size="20" />
+          <h2>Something went wrong</h2>
+        </div>
+        <Icon
+          name="close"
+          className="pl1 cursor-pointer text-dark"
+          onClick={() => setShowError(false)}
+        />
+      </div>
+      <pre style={{ height: "20vh" }} className="overflow-auto">
+        {errorInfo.componentStack}
+      </pre>
+    </Card>
+  ) : (
+    showError
+  );
+}
+
+ErrorCard.propTypes = {
+  errorInfo: PropTypes.object,
+};
+
+export default BodyComponent(ErrorCard);

--- a/frontend/src/metabase/components/ErrorCard.jsx
+++ b/frontend/src/metabase/components/ErrorCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import BodyComponent from "metabase/components/BodyComponent";
 import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
+import { t } from "ttag";
 
 function ErrorCard({ errorInfo }) {
   const [showError, setShowError] = useState(false);
@@ -18,7 +19,7 @@ function ErrorCard({ errorInfo }) {
       <div className="flex justify-between align-center mb1">
         <div className="text-error flex align-center">
           <Icon name="info_outline" mr={1} size="20" />
-          <h2>Something went wrong</h2>
+          <h2>{t`Something went wrong`}</h2>
         </div>
         <Icon
           name="close"


### PR DESCRIPTION
**Description**
I'm replacing the 😢 error screen with a card that appears in the bottom right corner of the app when an error is caught by React. Errors are hard to catch in the browser console since we have so many prop errors from React so I figured it'd be wise to replace the 😢 screen with something that is still very visible.

The card will appear whenever a new error is caught by React in the `<App>` component. The card won't disappear until manually closed and will reappear if an error is caught again. Here's the current appearance--I figure @kdoh can tweak if desired 🙂:

<img width="391" alt="Screen Shot 2021-03-12 at 11 01 17 AM" src="https://user-images.githubusercontent.com/13057258/110986986-4afb2880-8323-11eb-9aab-af2772b384e6.png">

We don't have access to the error message of the thrown error, but React will point us to where the error occurred.

Per the React docs https://reactjs.org/docs/react-component.html#componentdidcatch this card ought to appear in **development** builds of the app (unless the `App` component itself throws an error, but that is unlikely) but not production builds, mimicking behavior of the 😢 screen (I think).

**Verification**
I put a `this.foo()` in a random react component event callback to trigger an error. The app no longer goes away -- instead, the above card appears. Tested closing of the card, tested the card's reappearance.