### PR TITLE
Custom expression: constrain the type for boolean nodes/sub-expressions

### DIFF
--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -1,4 +1,5 @@
-import { ngettext, msgid } from "ttag";
+import { getIn } from "icepick";
+import { ngettext, msgid, t } from "ttag";
 import { ExpressionVisitor } from "./visitor";
 import { CLAUSE_TOKENS } from "./lexer";
 
@@ -91,6 +92,24 @@ export function typeCheck(cst, rootType) {
         }
       }
       return super.identifierExpression(ctx);
+    }
+
+    numberLiteral(ctx) {
+      const type = this.typeStack[0];
+      if (type === "boolean") {
+        const literal = getIn(ctx, ["NumberLiteral", 0, "image"]);
+        const message = t`Expecting boolean but found ${literal}`;
+        this.errors.push({ message });
+      }
+    }
+
+    stringLiteral(ctx) {
+      const type = this.typeStack[0];
+      if (type === "boolean") {
+        const literal = getIn(ctx, ["StringLiteral", 0, "image"]);
+        const message = t`Expecting boolean but found ${literal}`;
+        this.errors.push({ message });
+      }
     }
   }
   const checker = new TypeChecker();

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -28,13 +28,6 @@ describe("type-checker", () => {
     return { cst, typeErrors };
   }
 
-  function validate(source) {
-    const { typeErrors } = parseSource(source, "expression");
-    if (typeErrors.length > 0) {
-      throw new Error(typeErrors[0].message);
-    }
-  }
-
   function collect(source, startRule) {
     class Collector extends ExpressionVisitor {
       constructor() {
@@ -70,6 +63,13 @@ describe("type-checker", () => {
     function expr(source) {
       return collect(source, "expression");
     }
+    function validate(source) {
+      const { typeErrors } = parseSource(source, "expression");
+      if (typeErrors.length > 0) {
+        throw new Error(typeErrors[0].message);
+      }
+    }
+
     it("should resolve dimensions correctly", () => {
       expect(expr("[Price]+[Tax]").dimensions).toEqual(["Price", "Tax"]);
       expect(expr("ABS([Discount])").dimensions).toEqual(["Discount"]);

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -104,6 +104,12 @@ describe("type-checker", () => {
     function filter(source) {
       return collect(source, "boolean");
     }
+    function validate(source) {
+      const { typeErrors } = parseSource(source, "boolean");
+      if (typeErrors.length > 0) {
+        throw new Error(typeErrors[0].message);
+      }
+    }
     it("should resolve segments correctly", () => {
       expect(filter("[Clearance]").segments).toEqual(["Clearance"]);
       expect(filter("NOT [Deal]").segments).toEqual(["Deal"]);
@@ -139,6 +145,13 @@ describe("type-checker", () => {
       expect(filter("T OR Between([R],0,9)").dimensions).toEqual(["R"]);
       expect(filter("NOT between(P, 3, 14) OR Q").dimensions).toEqual(["P"]);
       expect(filter("NOT between(P, 3, 14) OR Q").segments).toEqual(["Q"]);
+    });
+
+    it("should reject a number literal", () => {
+      expect(() => validate("3.14159")).toThrow();
+    });
+    it("should reject a string literal", () => {
+      expect(() => validate('"TheAnswer"')).toThrow();
     });
 
     it("should catch mismatched number of function parameters", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -860,4 +860,32 @@ describe("scenarios > question > filter", () => {
     });
     cy.findByText("wilma-muller");
   });
+
+  it("should reject a number literal", () => {
+    openProductsTable();
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+
+    cy.get("[contenteditable='true']")
+      .click()
+      .type("3.14159");
+    cy.findAllByRole("button", { name: "Done" })
+      .should("not.be.disabled")
+      .click();
+    cy.findByText("Expecting boolean but found 3.14159");
+  });
+
+  it("should reject a string literal", () => {
+    openProductsTable();
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+
+    cy.get("[contenteditable='true']")
+      .click()
+      .type('"TheAnswer"');
+    cy.findAllByRole("button", { name: "Done" })
+      .should("not.be.disabled")
+      .click();
+    cy.findByText('Expecting boolean but found "TheAnswer"');
+  });
 });


### PR DESCRIPTION
This is to prevent a regression in error feedback, compared to v38's custom expression.

**Steps to verify**

1. Ask a question, custom question.
2. Sample dataset, Product table.
3. Filter, Add filters to narrow your answer, Custom Expression
4. Type `42` (or any number).
5. Press `Tab` to switch focus.

**Before**:
Nothing happens.

**After**:
An error feedback: 

![image](https://user-images.githubusercontent.com/7288/111010826-7cd4b500-834c-11eb-816f-1befe594656e.png)



Note: This can be verified with a string literal as well.
