### PR TITLE
Add a way to see which in-app hosting CTAs are being clicked

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink.jsx
@@ -4,7 +4,9 @@ import ExternalLink from "metabase/components/ExternalLink";
 const HostingInfoLink = ({ text }) => (
   <ExternalLink
     className="bordered rounded border-brand bg-brand-hover text-white-hover px2 py1 text-bold text-center"
-    href={"https://www.metabase.com/migrate/from/selfhosted"}
+    href={
+      "https://www.metabase.com/migrate/from/selfhosted?utm_source=admin-panel&utm_medium=in-app"
+    }
     target="_blank"
   >
     {text}


### PR DESCRIPTION
We want to know which of the in-app info links we added are bringing any traffic to https://www.metabase.com/migrate/

Where I need an assist is — because we made the CTA link DRY by having it be an include, we're going to have to probably append a custom UTM tag to the URL based on the location of the CTA (email page, admin settings/setup, or the Updates page). I don't know how to do that. :b