### PR TITLE
Enable parallel minification

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -294,7 +294,7 @@ if (NODE_ENV !== "production") {
     }),
   );
 } else {
-  config.plugins.push(new UglifyJSPlugin({ test: /\.jsx?($|\?)/i }));
+  config.plugins.push(new UglifyJSPlugin({ parallel: true, test: /\.jsx?($|\?)/i }));
 
   config.devtool = "source-map";
 }


### PR DESCRIPTION
Use the parallel:true flag in the Uglify plugin to use all cores in a CPU for minification which greatly improves front end build time. You will now be able to take advantage of that watercooler you asked Santa for Christmas