### PR TITLE
Add Bitcoin and Ethereum to currency list

### DIFF
--- a/frontend/src/metabase/lib/currency.js
+++ b/frontend/src/metabase/lib/currency.js
@@ -161,6 +161,15 @@ export default {
     code: "BRL",
     name_plural: "Brazilian reals",
   },
+  BTC: {
+    symbol: "BTC",
+    name: "Bitcoin",
+    symbol_native: "BTC",
+    decimal_digits: 8,
+    rounding: 0,
+    code: "BTC",
+    name_plural: "Bitcoins",
+  },
   BWP: {
     symbol: "BWP",
     name: "Botswanan Pula",
@@ -296,15 +305,6 @@ export default {
     code: "DZD",
     name_plural: "Algerian dinars",
   },
-  EEK: {
-    symbol: "Ekr",
-    name: "Estonian Kroon",
-    symbol_native: "kr",
-    decimal_digits: 2,
-    rounding: 0,
-    code: "EEK",
-    name_plural: "Estonian kroons",
-  },
   EGP: {
     symbol: "EGP",
     name: "Egyptian Pound",
@@ -331,6 +331,15 @@ export default {
     rounding: 0,
     code: "ETB",
     name_plural: "Ethiopian birrs",
+  },
+  ETH: {
+    symbol: "ETH",
+    name: "Ethereum",
+    symbol_native: "ETH",
+    decimal_digits: 8,
+    rounding: 0,
+    code: "ETH",
+    name_plural: "Ethereum",
   },
   GBP: {
     symbol: "£",


### PR DESCRIPTION
Added Bitcoin and Ethereum to the currency list, because if we are going to the moon, we will need Metabase there

Fixes https://github.com/metabase/metabase/issues/11406