### PR TITLE
#15163 Repro: Cannot view SQL question when accessing via dashboard with filters connected to modified card without SQL permissions

### DIFF
--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -457,6 +457,7 @@ describe("scenarios > question > native", () => {
           cy.wait("@dataset", { timeout: 5000 }).then(xhr => {
             expect(xhr.response.body.error).not.to.exist;
           });
+          cy.get(".ace_content").should("not.exist");
           cy.findByText("Showing 1 row");
         });
       });

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -1,7 +1,7 @@
 import { restore, popover, modal } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
-const { ORDERS } = SAMPLE_DATASET;
+const { ORDERS, PRODUCTS } = SAMPLE_DATASET;
 
 describe("scenarios > question > native", () => {
   beforeEach(() => {
@@ -373,5 +373,79 @@ describe("scenarios > question > native", () => {
     cy.get("@variableField")
       .last()
       .findByText("firstparameter");
+  });
+
+  it.skip("should be able to view SQL question when accessing via dashboard with filters connected to modified card without SQL permissions (metabase#15163)", () => {
+    cy.server();
+    cy.route("POST", "/api/dataset").as("dataset");
+
+    cy.createNativeQuestion({
+      name: "15163",
+      native: {
+        query: 'SELECT COUNT(*) FROM "PRODUCTS" WHERE {{cat}}',
+        "template-tags": {
+          cat: {
+            id: "dd7f3e66-b659-7d1c-87b3-ab627317581c",
+            name: "cat",
+            "display-name": "Cat",
+            type: "dimension",
+            dimension: ["field-id", PRODUCTS.CATEGORY],
+            "widget-type": "category",
+            default: null,
+          },
+        },
+      },
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.createDashboard("15163D").then(({ body: { id: DASHBOARD_ID } }) => {
+        // Add filter to the dashboard
+        cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+          parameters: [
+            {
+              name: "Category",
+              slug: "category",
+              id: "fd723065",
+              type: "category",
+            },
+          ],
+        });
+
+        // Add previously created question to the dashboard
+        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+          cardId: QUESTION_ID,
+        }).then(({ body: { id: DASH_CARD_ID } }) => {
+          // Connect filter to that question
+          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cards: [
+              {
+                id: DASH_CARD_ID,
+                card_id: QUESTION_ID,
+                row: 0,
+                col: 0,
+                sizeX: 10,
+                sizeY: 8,
+                series: [],
+                visualization_settings: {
+                  "card.title": "New Title",
+                },
+                parameter_mappings: [
+                  {
+                    parameter_id: "fd723065",
+                    card_id: QUESTION_ID,
+                    target: ["dimension", ["template-tag", "cat"]],
+                  },
+                ],
+              },
+            ],
+          });
+        });
+
+        cy.signIn("nodata");
+        // Visit dashboard and set the filter through URL
+        cy.visit(`/dashboard/${DASHBOARD_ID}?category=Gizmo`);
+        cy.findByText("New Title").click();
+        cy.wait("@dataset");
+        cy.findByText("Showing 1 row");
+      });
+    });
   });
 });

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -1,7 +1,9 @@
 import { restore, popover, modal } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+import { USER_GROUPS } from "__support__/cypress_data";
 
 const { ORDERS, PRODUCTS } = SAMPLE_DATASET;
+const { COLLECTION_GROUP } = USER_GROUPS;
 
 describe("scenarios > question > native", () => {
   beforeEach(() => {
@@ -375,76 +377,88 @@ describe("scenarios > question > native", () => {
       .findByText("firstparameter");
   });
 
-  it.skip("should be able to view SQL question when accessing via dashboard with filters connected to modified card without SQL permissions (metabase#15163)", () => {
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
+  ["nodata+nosql", "nosql"].forEach(test => {
+    it.skip(`${test.toUpperCase()} version:\n should be able to view SQL question when accessing via dashboard with filters connected to modified card without SQL permissions (metabase#15163)`, () => {
+      cy.server();
+      cy.route("POST", "/api/dataset").as("dataset");
 
-    cy.createNativeQuestion({
-      name: "15163",
-      native: {
-        query: 'SELECT COUNT(*) FROM "PRODUCTS" WHERE {{cat}}',
-        "template-tags": {
-          cat: {
-            id: "dd7f3e66-b659-7d1c-87b3-ab627317581c",
-            name: "cat",
-            "display-name": "Cat",
-            type: "dimension",
-            dimension: ["field-id", PRODUCTS.CATEGORY],
-            "widget-type": "category",
-            default: null,
+      cy.signInAsAdmin();
+      cy.createNativeQuestion({
+        name: "15163",
+        native: {
+          query: 'SELECT COUNT(*) FROM "PRODUCTS" WHERE {{cat}}',
+          "template-tags": {
+            cat: {
+              id: "dd7f3e66-b659-7d1c-87b3-ab627317581c",
+              name: "cat",
+              "display-name": "Cat",
+              type: "dimension",
+              dimension: ["field-id", PRODUCTS.CATEGORY],
+              "widget-type": "category",
+              default: null,
+            },
           },
         },
-      },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("15163D").then(({ body: { id: DASHBOARD_ID } }) => {
-        // Add filter to the dashboard
-        cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-          parameters: [
-            {
-              name: "Category",
-              slug: "category",
-              id: "fd723065",
-              type: "category",
-            },
-          ],
-        });
-
-        // Add previously created question to the dashboard
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-        }).then(({ body: { id: DASH_CARD_ID } }) => {
-          // Connect filter to that question
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cards: [
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.createDashboard("15163D").then(({ body: { id: DASHBOARD_ID } }) => {
+          // Add filter to the dashboard
+          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+            parameters: [
               {
-                id: DASH_CARD_ID,
-                card_id: QUESTION_ID,
-                row: 0,
-                col: 0,
-                sizeX: 10,
-                sizeY: 8,
-                series: [],
-                visualization_settings: {
-                  "card.title": "New Title",
-                },
-                parameter_mappings: [
-                  {
-                    parameter_id: "fd723065",
-                    card_id: QUESTION_ID,
-                    target: ["dimension", ["template-tag", "cat"]],
-                  },
-                ],
+                name: "Category",
+                slug: "category",
+                id: "fd723065",
+                type: "category",
               },
             ],
           });
-        });
 
-        cy.signIn("nodata");
-        // Visit dashboard and set the filter through URL
-        cy.visit(`/dashboard/${DASHBOARD_ID}?category=Gizmo`);
-        cy.findByText("New Title").click();
-        cy.wait("@dataset");
-        cy.findByText("Showing 1 row");
+          // Add previously created question to the dashboard
+          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cardId: QUESTION_ID,
+          }).then(({ body: { id: DASH_CARD_ID } }) => {
+            // Connect filter to that question
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cards: [
+                {
+                  id: DASH_CARD_ID,
+                  card_id: QUESTION_ID,
+                  row: 0,
+                  col: 0,
+                  sizeX: 10,
+                  sizeY: 8,
+                  series: [],
+                  visualization_settings: {
+                    "card.title": "New Title",
+                  },
+                  parameter_mappings: [
+                    {
+                      parameter_id: "fd723065",
+                      card_id: QUESTION_ID,
+                      target: ["dimension", ["template-tag", "cat"]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+
+          if (test === "nosql") {
+            cy.updatePermissionsGraph({
+              [COLLECTION_GROUP]: { "1": { schemas: "all", native: "none" } },
+            });
+          }
+
+          cy.signIn("nodata");
+
+          // Visit dashboard and set the filter through URL
+          cy.visit(`/dashboard/${DASHBOARD_ID}?category=Gizmo`);
+          cy.findByText("New Title").click();
+          cy.wait("@dataset", { timeout: 5000 }).then(xhr => {
+            expect(xhr.response.body.error).not.to.exist;
+          });
+          cy.findByText("Showing 1 row");
+        });
       });
     });
   });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15163 in two versions (as per the repro steps)

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/native.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
This test will fail on waiting for `@dataset` request because it never occurs (due to the bug). I tried to assert on the error message on the screen, but test always gives false positives.
![image](https://user-images.githubusercontent.com/31325167/111180730-9aed2000-85ad-11eb-86c8-633b7fff3875.png)

`NOSQL` version of the test
![image](https://user-images.githubusercontent.com/31325167/111210107-1f9b6680-85cd-11eb-9320-5c56691f1804.png)


Sanity check - the same test for admin
![image](https://user-images.githubusercontent.com/31325167/111180996-d4259000-85ad-11eb-9c4a-9e076587ef55.png)

