### PR TITLE
Handle renaming column casing

### DIFF
--- a/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
@@ -22,11 +22,13 @@
          old-base-type         :base-type
          old-field-comment     :field-comment
          old-special-type      :special-type
-         old-database-position :database-position}  metabase-field
+         old-database-position :database-position
+         old-database-name     :name}  metabase-field
         {new-database-type     :database-type
          new-base-type         :base-type
          new-field-comment     :field-comment
-         new-database-position :database-position} field-metadata
+         new-database-position :database-position
+         new-database-name     :name} field-metadata
         new-database-type                          (or new-database-type "NULL")
         new-special-type                           (common/special-type field-metadata)
 
@@ -47,6 +49,8 @@
 
         new-database-position?
         (not= old-database-position new-database-position)
+
+        new-name? (not= old-database-name new-database-name)
 
         ;; calculate combined updates
         updates
@@ -78,7 +82,13 @@
                           (common/field-metadata-name-for-logging table metabase-field)
                           old-database-position
                           new-database-position))
-           {:database_position new-database-position}))]
+           {:database_position new-database-position})
+         (when new-name?
+           (log/info (trs "Name of {0} has changed from ''{1}'' to ''{2}''."
+                          (common/field-metadata-name-for-logging table metabase-field)
+                          old-database-name
+                          new-database-name))
+           {:name new-database-name}))]
     ;; if any updates need to be done, do them and return 1 (because 1 Field was updated), otherwise return 0
     (if (and (seq updates)
              (db/update! Field (u/get-id metabase-field) updates))

--- a/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
@@ -50,6 +50,8 @@
         new-database-position?
         (not= old-database-position new-database-position)
 
+        ;; these fields are paired by by metabase.sync.sync-metadata.fields.common/canonical-name, so if they are
+        ;; different they have the same canonical representation (lower-casing at the moment).
         new-name? (not= old-database-name new-database-name)
 
         ;; calculate combined updates

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -2,7 +2,9 @@
   "Tests for the logic that syncs Field models with the Metadata fetched from a DB. (There are more tests for this
   behavior in the namespace `metabase.sync-database.sync-dynamic-test`, which is sort of a misnomer.)"
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.test :refer :all]
             [expectations :refer [expect]]
+            [medley.core :as m]
             [metabase.models.field :refer [Field]]
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
@@ -18,7 +20,7 @@
 ;;; |                                         Dropping & Undropping Columns                                          |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- with-test-db-before-and-after-dropping-a-column
+(defn- with-test-db-before-and-after-altering
   "Testing function that performs the following steps:
 
    1.  Create a temporary test database & syncs it
@@ -26,7 +28,7 @@
    3.  Drops one of the columns from the test DB & syncs it again
    4.  Executes `(f database)` a second time
    5.  Returns a map containing results from both calls to `f` for comparison."
-  [f]
+  [alter-sql f]
   ;; first, create a new in-memory test DB and add some data to it
   (one-off-dbs/with-blank-db
     (doseq [statement [ ;; H2 needs that 'guest' user for QP purposes. Set that up
@@ -47,127 +49,146 @@
     ;; ok, let's see what (f) gives us
     (let [f-before (f (data/db))]
       ;; ok cool! now delete one of those columns...
-      (jdbc/execute! one-off-dbs/*conn* ["ALTER TABLE \"birds\" DROP COLUMN \"example_name\";"])
+      (jdbc/execute! one-off-dbs/*conn* [alter-sql])
       ;; ...and re-sync...
       (sync/sync-database! (data/db))
       ;; ...now let's see how (f) may have changed! Compare to original.
       {:before-drop f-before
        :after-drop  (f (data/db))})))
 
+(deftest renaming-fields-test
+  (testing "make sure we can identify case changes on a field"
+    (let [db-state (with-test-db-before-and-after-altering
+                     "ALTER TABLE \"birds\" RENAME COLUMN \"example_name\" to \"Example_Name\";"
+                     (fn [database]
+                       (set
+                        (map (partial into {})
+                             (db/select [Field :id :name :active]
+                                        :table_id [:in (db/select-ids Table :db_id (u/get-id database))])))))]
+      (is (= {:before-drop #{{:name "species",      :active true}
+                             {:name "example_name", :active true}}
+              :after-drop #{{:name "species",      :active true}
+                            {:name "Example_Name", :active true}}}
+             (m/map-vals (fn [results] (into (empty results)
+                                             (map #(dissoc % :id))
+                                             results))
+                         db-state)))
+      (testing "It sees this as the same field and not a new field"
+        (let [ids-of (fn [k] (->> db-state k (into #{} (map :id))))]
+          (is (= (ids-of :before-drop) (ids-of :after-drop))))))))
 
-;; make sure sync correctly marks a Field as active = false when it gets dropped from the DB
-(expect
-  {:before-drop #{{:name "species",      :active true}
-                  {:name "example_name", :active true}}
-   :after-drop  #{{:name "species",      :active true}
-                  {:name "example_name", :active false}}}
-  (with-test-db-before-and-after-dropping-a-column
-    (fn [database]
-      (set
-       (map (partial into {})
-            (db/select [Field :name :active]
-              :table_id [:in (db/select-ids Table :db_id (u/get-id database))]))))))
 
-;; make sure deleted fields doesn't show up in `:fields` of a table
-(expect
-  {:before-drop #{"species" "example_name"}
-   :after-drop  #{"species"}}
-  (with-test-db-before-and-after-dropping-a-column
-    (fn [database]
-      (let [table (hydrate (db/select-one Table :db_id (u/get-id database)) :fields)]
-        (set
-         (map :name (:fields table)))))))
+(deftest dropping-fields-test
+  (testing "make sure sync correctly marks a Field as active = false when it gets dropped from the DB"
+    (is (= {:before-drop #{{:name "species",      :active true}
+                           {:name "example_name", :active true}}
+            :after-drop  #{{:name "species",      :active true}
+                           {:name "example_name", :active false}}}
+           (with-test-db-before-and-after-altering
+             "ALTER TABLE \"birds\" DROP COLUMN \"example_name\";"
+             (fn [database]
+               (set
+                (map (partial into {})
+                     (db/select [Field :name :active]
+                                :table_id [:in (db/select-ids Table :db_id (u/get-id database))]))))))))
+  (testing "make sure deleted fields doesn't show up in `:fields` of a table"
+    (is (= {:before-drop #{"species" "example_name"}
+            :after-drop  #{"species"}}
+           (with-test-db-before-and-after-altering
+             "ALTER TABLE \"birds\" DROP COLUMN \"example_name\";"
+             (fn [database]
+               (let [table (hydrate (db/select-one Table :db_id (u/get-id database)) :fields)]
+                 (set
+                  (map :name (:fields table)))))))))
+  (testing "make sure that inactive columns don't end up getting spliced into queries!"
 
-;; make sure that inactive columns don't end up getting spliced into queries! This test arguably belongs in the query
-;; processor tests since it's ultimately checking to make sure columns marked as `:active` = `false` aren't getting
-;; put in queries with implicit `:fields` clauses, but since this could be seen as covering both QP and sync (my and
-;; others' assumption when first coming across bug #6146 was that this was a sync issue), this test can stay here for
-;; now along with the other test we have testing sync after dropping a column.
-(expect
-  {:before-drop (str "SELECT \"PUBLIC\".\"birds\".\"species\" AS \"species\", "
-                     "\"PUBLIC\".\"birds\".\"example_name\" AS \"example_name\" "
-                     "FROM \"PUBLIC\".\"birds\" "
-                     "LIMIT 1048576")
-   :after-drop  (str "SELECT \"PUBLIC\".\"birds\".\"species\" AS \"species\" "
-                     "FROM \"PUBLIC\".\"birds\" "
-                     "LIMIT 1048576")}
-  (with-test-db-before-and-after-dropping-a-column
-    (fn [database]
-      (-> (qp/process-query {:database (u/get-id database)
-                             :type     :query
-                             :query    {:source-table (db/select-one-id Table
-                                                        :db_id (u/get-id database), :name "birds")}})
-          :data
-          :native_form
-          :query))))
+    ;; make sure that inactive columns don't end up getting spliced into queries! This test arguably belongs in the query
+    ;; processor tests since it's ultimately checking to make sure columns marked as `:active` = `false` aren't getting
+    ;; put in queries with implicit `:fields` clauses, but since this could be seen as covering both QP and sync (my and
+    ;; others' assumption when first coming across bug #6146 was that this was a sync issue), this test can stay here for
+    ;; now along with the other test we have testing sync after dropping a column.
+    (is (= {:before-drop (str "SELECT \"PUBLIC\".\"birds\".\"species\" AS \"species\", "
+                              "\"PUBLIC\".\"birds\".\"example_name\" AS \"example_name\" "
+                              "FROM \"PUBLIC\".\"birds\" "
+                              "LIMIT 1048576")
+            :after-drop  (str "SELECT \"PUBLIC\".\"birds\".\"species\" AS \"species\" "
+                              "FROM \"PUBLIC\".\"birds\" "
+                              "LIMIT 1048576")}
+           (with-test-db-before-and-after-altering
+             "ALTER TABLE \"birds\" DROP COLUMN \"example_name\";"
+             (fn [database]
+               (-> (qp/process-query {:database (u/get-id database)
+                                      :type     :query
+                                      :query    {:source-table (db/select-one-id Table
+                                                                                 :db_id (u/get-id database), :name "birds")}})
+                   :data
+                   :native_form
+                   :query)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                PK & FK Syncing                                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; Test PK Syncing
-(expect
-  [:type/PK
-   nil
-   :type/PK
-   :type/Latitude
-   :type/PK]
-  (data/with-temp-copy-of-db
-    (let [get-special-type (fn [] (db/select-one-field :special_type Field, :id (data/id :venues :id)))]
-      [ ;; Special type should be :id to begin with
-       (get-special-type)
-       ;; Clear out the special type
-       (do (db/update! Field (data/id :venues :id), :special_type nil)
-           (get-special-type))
-       ;; Calling sync-table! should set the special type again
-       (do (sync/sync-table! (Table (data/id :venues)))
-           (get-special-type))
-       ;; sync-table! should *not* change the special type of fields that are marked with a different type
-       (do (db/update! Field (data/id :venues :id), :special_type :type/Latitude)
-           (get-special-type))
-       ;; Make sure that sync-table runs set-table-pks-if-needed!
-       (do (db/update! Field (data/id :venues :id), :special_type nil)
-           (sync/sync-table! (Table (data/id :venues)))
-           (get-special-type))])))
+(deftest relation-tests
+  (testing "Test PK Syncing"
+    (is (= [:type/PK
+            nil
+            :type/PK
+            :type/Latitude
+            :type/PK]
+           (data/with-temp-copy-of-db
+             (let [get-special-type (fn [] (db/select-one-field :special_type Field, :id (data/id :venues :id)))]
+               [ ;; Special type should be :id to begin with
+                (get-special-type)
+                ;; Clear out the special type
+                (do (db/update! Field (data/id :venues :id), :special_type nil)
+                    (get-special-type))
+                ;; Calling sync-table! should set the special type again
+                (do (sync/sync-table! (Table (data/id :venues)))
+                    (get-special-type))
+                ;; sync-table! should *not* change the special type of fields that are marked with a different type
+                (do (db/update! Field (data/id :venues :id), :special_type :type/Latitude)
+                    (get-special-type))
+                ;; Make sure that sync-table runs set-table-pks-if-needed!
+                (do (db/update! Field (data/id :venues :id), :special_type nil)
+                    (sync/sync-table! (Table (data/id :venues)))
+                    (get-special-type))]))))
+    (testing "Check that Foreign Key relationships were created on sync as we expect"
+      (is (= (data/id :venues :id)
+             (db/select-one-field :fk_target_field_id Field, :id (data/id :checkins :venue_id))))
+      (is (= (data/id :users :id)
+             (db/select-one-field :fk_target_field_id Field, :id (data/id :checkins :user_id))))
+      (is (= (data/id :categories :id)
+             (db/select-one-field :fk_target_field_id Field, :id (data/id :venues :category_id))))))
+  (testing "Check that sync-table! causes FKs to be set like we'd expect"
+    (is (= {:before
+            {:step-info         {:total-fks 3, :updated-fks 0, :total-failed 0}
+             :task-details      {:total-fks 3, :updated-fks 0, :total-failed 0}
+             :special-type      :type/FK
+             :fk-target-exists? true}
+
+            :after
+            {:step-info         {:total-fks 3, :updated-fks 1, :total-failed 0}
+             :task-details      {:total-fks 3, :updated-fks 1, :total-failed 0}
+             :special-type      :type/FK
+             :fk-target-exists? true}}
+           (data/with-temp-copy-of-db
+             (let [state (fn []
+                           (let [{:keys                  [step-info]
+                                  {:keys [task_details]} :task-history}    (sync.util-test/sync-database! "sync-fks" (data/db))
+                                 {:keys [special_type fk_target_field_id]} (db/select-one [Field :special_type :fk_target_field_id]
+                                                                                          :id (data/id :checkins :user_id))]
+                             {:step-info         (sync.util-test/only-step-keys step-info)
+                              :task-details      task_details
+                              :special-type      special_type
+                              :fk-target-exists? (db/exists? Field :id fk_target_field_id)}))]
+               (array-map
+                :before (state)
+                :after  (do (db/update! Field (data/id :checkins :user_id), :special_type nil, :fk_target_field_id nil)
+                            (state)))))))))
 
 
-;; Check that Foreign Key relationships were created on sync as we expect
-(expect
-  (data/id :venues :id)
-  (db/select-one-field :fk_target_field_id Field, :id (data/id :checkins :venue_id)))
 
-(expect
-  (data/id :users :id)
-  (db/select-one-field :fk_target_field_id Field, :id (data/id :checkins :user_id)))
 
-(expect
-  (data/id :categories :id)
-  (db/select-one-field :fk_target_field_id Field, :id (data/id :venues :category_id)))
 
 ;; Check that sync-table! causes FKs to be set like we'd expect
-(expect
-  {:before
-   {:step-info         {:total-fks 3, :updated-fks 0, :total-failed 0}
-    :task-details      {:total-fks 3, :updated-fks 0, :total-failed 0}
-    :special-type      :type/FK
-    :fk-target-exists? true}
-
-   :after
-   {:step-info         {:total-fks 3, :updated-fks 1, :total-failed 0}
-    :task-details      {:total-fks 3, :updated-fks 1, :total-failed 0}
-    :special-type      :type/FK
-    :fk-target-exists? true}}
-  (data/with-temp-copy-of-db
-    (let [state (fn []
-                  (let [{:keys                  [step-info]
-                         {:keys [task_details]} :task-history}    (sync.util-test/sync-database! "sync-fks" (data/db))
-                        {:keys [special_type fk_target_field_id]} (db/select-one [Field :special_type :fk_target_field_id]
-                                                                    :id (data/id :checkins :user_id))]
-                    {:step-info         (sync.util-test/only-step-keys step-info)
-                     :task-details      task_details
-                     :special-type      special_type
-                     :fk-target-exists? (db/exists? Field :id fk_target_field_id)}))]
-      (array-map
-       :before (state)
-       :after  (do (db/update! Field (data/id :checkins :user_id), :special_type nil, :fk_target_field_id nil)
-                   (state))))))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -57,7 +57,7 @@
        :after-drop  (f (data/db))})))
 
 (deftest renaming-fields-test
-  (testing "make sure we can identify case changes on a field"
+  (testing "make sure we can identify case changes on a field (#7923)"
     (let [db-state (with-test-db-before-and-after-altering
                      "ALTER TABLE \"birds\" RENAME COLUMN \"example_name\" to \"Example_Name\";"
                      (fn [database]

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -71,7 +71,8 @@
             (log/debug (format "SET VISIBILITY TYPE %s.%s -> %s" table-name field-name visibility-type))
             (db/update! Field (:id @field) :visibility_type (name visibility-type)))
           (when special-type
-            (log/debug (format "SET SPECIAL TYPE %s.%s -> %s" table-name field-name special-type))
+            (log/debug (format "SET SPECIAL TYPE %s.%s -> %s" table-name field-name
+                               special-type))
             (db/update! Field (:id @field) :special_type (u/qualified-name special-type))))))))
 
 (def ^:private create-database-timeout-ms


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/7923

products -> Products and the like

need to worry about one issue though:
what if they _add_ a new column that has a name that is the same but
for casing:
products and Products. We would probably identify arbitrarily one of
these with the existing products column and probably bad things will
happen. Need to extend this check that identifies the casing
indifference only in the case that there is no ambiguity
