### PR TITLE
#13347 Repro: Cannot select "Saved Questions", which belongs to database user doesn't have Data-permissions for

### DIFF
--- a/frontend/test/metabase-db/postgres/permissions.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/permissions.cy.spec.js
@@ -1,0 +1,61 @@
+import {
+  restore,
+  addPostgresDatabase,
+  withDatabase,
+} from "__support__/cypress";
+import { USER_GROUPS } from "__support__/cypress_data";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+const PG_DB_NAME = "QA Postgres12";
+const PG_DB_ID = 2;
+
+describe("postgres > permissions", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    addPostgresDatabase(PG_DB_NAME);
+    cy.server();
+  });
+
+  // NOTE: This issue wasn't specifically related to PostgreSQL. We simply needed to add another DB to reproduce it.
+  ["QB", "Native"].forEach(test => {
+    it.skip(`${test.toUpperCase()} version:\n should be able to select question (from "Saved Questions") which belongs to the database user doesn't have data-permissions for (metabase#13347)`, () => {
+      cy.route("POST", "/api/dataset").as("dataset");
+
+      cy.updatePermissionsGraph({
+        [ALL_USERS_GROUP]: {
+          1: { schemas: "all", native: "write" },
+          [PG_DB_ID]: { schemas: "none", native: "none" },
+        },
+      });
+
+      cy.updateCollectionGraph({
+        [ALL_USERS_GROUP]: { root: "read" },
+      });
+
+      withDatabase(
+        PG_DB_ID,
+        ({ ORDERS_ID }) =>
+          cy.createQuestion({
+            name: "Q1",
+            query: { "source-table": ORDERS_ID },
+            database: PG_DB_ID,
+          }),
+
+        cy.createNativeQuestion({
+          name: "Q2",
+          native: { query: "SELECT * FROM ORDERS" },
+          database: PG_DB_ID,
+        }),
+      );
+
+      cy.signIn("none");
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      test === "QB" ? cy.findByText("Q1").click() : cy.findByText("Q2").click();
+      cy.wait("@dataset", { timeout: 5000 });
+      cy.contains("37.65");
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13347

### How to test this manually?
- `yarn test-cypress-open --folder frontend/test/metabase-db/`
- `frontend/test/metabase-db/postgres/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- Both versions of this tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Test fails for BOTH version at the same point - `dataset` request never happens because one cannot actually click on question Q1/Q2
![image](https://user-images.githubusercontent.com/31325167/111221861-58dad300-85db-11eb-8153-5ce426c25337.png)

Sanity check - same test for admin (both versions are passing)
![image](https://user-images.githubusercontent.com/31325167/111221971-7c058280-85db-11eb-8146-852d8a08fe54.png)
