### PR TITLE
More search relevance tweaking

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -61,6 +61,11 @@
   [:name
    :dataset_query])
 
+(defmethod searchable-columns-for-model (class Dashboard)
+  [_]
+  [:name
+   :description])
+
 (defmethod searchable-columns-for-model (class Table)
   [_]
   [:name

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -99,11 +99,13 @@
                      :let   [matched-text (-> search-result
                                               (get column)
                                               (search-config/column->string (:model search-result) column))
-                             match-tokens (-> matched-text normalize tokenize)
-                             score        (reduce + (score-ratios query-tokens
-                                                                  match-tokens
-                                                                  scoring-fns))]
-                     :when  (> score 0)]
+                             match-tokens (some-> matched-text normalize tokenize)
+                             score        (and matched-text
+                                               (reduce + (score-ratios query-tokens
+                                                                       match-tokens
+                                                                       scoring-fns)))]
+                     :when  (and matched-text
+                                 (> score 0))]
                  {:text-score          (/ score text-score-max)
                   :match               matched-text
                   :match-context-thunk #(match-context query-tokens match-tokens)

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -79,7 +79,7 @@
 
 (def ^:const text-score-max
   "The maximum text score that could be achieved without normalization. This value is then used to normalize it down to the interval [0, 1]"
-  4)
+  9/2)
 
 (defn- text-score-with
   [scoring-fns query-tokens search-result]
@@ -151,7 +151,7 @@
   ;; If the below is modified, be sure to update `text-score-max`!
   [consecutivity-scorer
    total-occurrences-scorer
-   fullness-scorer
+   (weigh-by 1/2 fullness-scorer)
    (weigh-by 2 exact-match-scorer)])
 
 (def ^:private model->sort-position

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -50,12 +50,6 @@
   [search-token match-tokens]
   (some #(matches? search-token %) match-tokens))
 
-(defn- score-ratios
-  [search-tokens result-tokens fs]
-  (map (fn [f]
-         (f search-tokens result-tokens))
-       fs))
-
 (defn- tokens->string
   [tokens abbreviate?]
   (let [->string (partial str/join " ")
@@ -95,9 +89,11 @@
                                               (search-config/column->string (:model search-result) column))
                              match-tokens (some-> matched-text normalize tokenize)
                              score        (and matched-text
-                                               (reduce + (score-ratios query-tokens
-                                                                       match-tokens
-                                                                       scoring-fns)))]
+                                               (reduce (fn [tally f]
+                                                         (+ tally
+                                                            (f query-tokens match-tokens)))
+                                                       0
+                                                       scoring-fns))]
                      :when  (and matched-text
                                  (> score 0))]
                  {:text-score          (/ score text-score-max)

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -163,12 +163,13 @@
                      result)))
 
 (defn- pinned-score
-  [{:keys [:collection_position]}]
+  [{:keys [model collection_position]}]
   ;; We experimented with favoring lower collection positions, but it wasn't good
   ;; So instead, just give a bonus for items that are pinned at all
-  (if ((fnil pos? 0) collection_position)
-    1
-    0))
+  (when (#{"card" "dashboard" "pulse"} model)
+    (if ((fnil pos? 0) collection_position)
+      1
+      0)))
 
 (defn- dashboard-count-score
   [{:keys [model dashboardcard_count]}]

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -90,6 +90,24 @@
            (score ["rasta" "the" "toucan"]
                   (result-row "")))))))
 
+(deftest fullness-scorer-test
+  (let [score (scorer->score #'search/fullness-scorer)]
+    (testing "partial matches"
+      (is (= 1/8
+             (score ["rasta" "el" "tucan"]
+                    (result-row "Here is Rasta the hero of many lands")))))
+    (testing "full matches"
+      (is (= 1
+             (score ["rasta" "the" "toucan"]
+                    (result-row "Rasta the Toucan")))))
+    (testing "misses"
+      (is (nil?
+           (score ["rasta"]
+                  (result-row "just a straight-up imposter"))))
+      (is (nil?
+           (score ["rasta" "the" "toucan"]
+                  (result-row "")))))))
+
 (deftest exact-match-scorer-test
   (let [score (scorer->score #'search/exact-match-scorer)]
     (is (nil?
@@ -182,7 +200,8 @@
 
 (deftest pinned-score-test
   (let [score #'search/pinned-score
-        item (fn [collection-position] {:collection_position collection-position})]
+        item (fn [collection-position] {:collection_position collection-position
+                                        :model "card"})]
     (testing "it provides a sortable score, but doesn't favor magnitude"
       (let [result (->> [(item 0)
                          (item nil)

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -26,9 +26,8 @@
 
 (defn scorer->score
   [scorer]
-  (comp (fn [s] (when s (* s search/text-score-max)))
-        :text-score
-        (partial #'search/text-score-with [scorer])))
+  (comp :text-score
+        (partial #'search/text-score-with [{:weight 1 :scorer scorer}])))
 
 (deftest consecutivity-scorer-test
   (let [score (scorer->score #'search/consecutivity-scorer)]


### PR DESCRIPTION
- [x] search dashboard descriptions
- [x] Don't penalize non-questions for having a null dashboard-count score
- [x] Don't penalize un-pinnable items for having a null pinned score
- [x] Don't give full text-score credit to results that are a superset of the query (when searching for "rasta the toucan", the result "Toucan stats for Rasta the toucan and Crowberto the crow" should have a high but imperfect score. Currently it's 1.0)
