### PR TITLE
Custom expression: feedback on CASE arguments

### DIFF
--- a/frontend/src/metabase/lib/expressions/parser.js
+++ b/frontend/src/metabase/lib/expressions/parser.js
@@ -278,18 +278,10 @@ export class ExpressionParser extends CstParser {
     $.RULE("caseExpression", returnType => {
       $.CONSUME(Case, { LABEL: "functionName" });
       $.CONSUME(LParen);
-      $.SUBRULE($.boolean, { LABEL: "arguments" });
-      $.CONSUME(Comma);
-      $.SUBRULE($.expression, { LABEL: "arguments", ARGS: [returnType] });
+      $.SUBRULE($.expression, { LABEL: "arguments" });
       $.MANY(() => {
-        $.CONSUME2(Comma);
-        $.SUBRULE2($.boolean, { LABEL: "arguments" });
-        $.CONSUME3(Comma);
-        $.SUBRULE3($.expression, { LABEL: "arguments", ARGS: [returnType] });
-      });
-      $.OPTION(() => {
-        $.CONSUME4(Comma);
-        $.SUBRULE4($.expression, { LABEL: "arguments", ARGS: [returnType] });
+        $.CONSUME(Comma);
+        $.SUBRULE1($.expression, { LABEL: "arguments", ARGS: [returnType] });
       });
       $.CONSUME(RParen);
     });

--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -39,6 +39,10 @@ export function typeCheck(cst, rootType) {
     caseExpression(ctx) {
       const type = this.typeStack[0];
       const args = ctx.arguments || [];
+      if (args.length < 2) {
+        this.errors.push({ message: t`CASE expects 2 arguments or more` });
+        return [];
+      }
       return args.map((arg, index) => {
         // argument 0, 2, 4, ...(even) is always a boolean, ...
         const argType = index & 1 ? type : "boolean";

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -98,6 +98,18 @@ describe("type-checker", () => {
       expect(() => validate("CONCAT('1','2')")).not.toThrow();
       expect(() => validate("CONCAT('1','2','3')")).not.toThrow();
     });
+
+    it("should reject a CASE expression with only one argument", () => {
+      expect(() => validate("CASE([Deal])")).toThrow();
+    });
+
+    it("should reject a CASE expression with incorrect argument type", () => {
+      expect(() => validate("CASE(X, 1, 2, 3)")).toThrow();
+    });
+
+    it("should accept a CASE expression with complex arguments", () => {
+      expect(() => validate("CASE(Deal, 0.5*X, Y-Z)")).not.toThrow();
+    });
   });
 
   describe("for a filter", () => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -106,6 +106,18 @@ describe("scenarios > question > notebook", () => {
     cy.contains(/^Function contains expects 2 arguments/i);
   });
 
+  it("should show the correct number of CASE arguments in a custom expression", () => {
+    openProductsTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']").type("CASE([Price]>0)");
+      cy.findByPlaceholderText("Something nice and descriptive")
+        .click()
+        .type("Sum Divide");
+      cy.contains(/^CASE expects 2 arguments or more/i);
+    });
+  });
+
   describe("joins", () => {
     it("should allow joins", () => {
       // start a custom question with orders


### PR DESCRIPTION
This is basically a revival of PR #14800 now that I know how to make it work properly.

How to verify:

1. Ask a question, Custom question.
2. Pick Sample Dataset, Products table
3. Custom column, type `case([Price]>100)`

Before this PR:

![image](https://user-images.githubusercontent.com/7288/107835274-c6ca7b00-6d4d-11eb-9f72-801c09bc6b69.png)

After this PR:

![image](https://user-images.githubusercontent.com/7288/107835294-d21da680-6d4d-11eb-9c03-581b9cea53fe.png)

The feedback message is more useful, and also it supports i18n.