### PR TITLE
Add lsp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ dev/src/dev/nocommit/
 **/cypress_sample_dataset.json
 /frontend/src/cljs
 .shadow-cljs
+
+# lsp: ignore all but the config file
+.lsp/*
+!.lsp/config.edn

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,2 +1,4 @@
 {:keep-require-at-start?        true
- :show-docs-arity-on-same-line? true}
+ :show-docs-arity-on-same-line? true
+ :project-specs                 [{:project-path "project.clj"
+                                  :classpath-cmd ["lein" "with-profile" "+ee" "classpath"]}]}

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,0 +1,2 @@
+{:keep-require-at-start?        true
+ :show-docs-arity-on-same-line? true}

--- a/project.clj
+++ b/project.clj
@@ -191,6 +191,12 @@
    {:source-paths ["enterprise/backend/src"]
     :test-paths   ["enterprise/backend/test"]}
 
+   :socket
+   {:dependencies
+    [[vlaaad/reveal "1.3.196"]]
+    :jvm-opts
+    ["-Dclojure.server.repl={:port 5555 :accept clojure.core.server/repl}"]}
+
    :dev
    {:source-paths ["dev/src" "local/src"]
     :test-paths   ["test" "backend/mbql/test" "shared/test"]


### PR DESCRIPTION
## LSP

<img width="1691" alt="image" src="https://user-images.githubusercontent.com/6377293/111234825-6719f680-85bd-11eb-952f-3958bab3a09b.png">

Enables refactorings, navigation, and some other goodies. Configured with 

```emacs-lisp
(use-package lsp-mode
  :ensure t
  :hook ((clojure-mode . lsp)
         (clojurec-mode . lsp)
         (clojurescript-mode . lsp))
  :config
  (setq lsp-enable-indentation nil)
  (setq lsp-enable-file-watchers nil) ;; annoying and i can't specify paths
  ;; add paths to your local installation of project mgmt tools, like lein
  (dolist (m '(clojure-mode
               clojurec-mode
               clojurescript-mode
               clojurex-mode))
     (add-to-list 'lsp-language-id-configuration `(,m . "clojure"))))

(use-package lsp-ui
  :ensure t
  :commands lsp-ui-mode)
```

## Inf-clojure

This is very useful if you want to try out using `inf-clojure` and a bare socket repl.

```emacs-lisp
(use-package inf-clojure
  :demand t
  :load-path "~/projects/dev/inf-clojure/"
  :bind (:map
         inf-clojure-mode-map
         ("RET" . newline)
         ("C-j" . comint-send-input)))
```

`lein with-profile +socket repl`.

I added [reveal](https://vlaaad.github.io/reveal/) to the socket profile so you can have nice things like:

`(add-tap (reveal/ui))`

<img width="957" alt="image" src="https://user-images.githubusercontent.com/6377293/111235408-911fe880-85be-11eb-8e58-e0de18d36613.png">

I'm hoping that this kind of workflow might make it easier to transition into docker or fully remote setups.

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/6377293/111236130-27a0d980-85c0-11eb-833e-d421669974ca.png">

Two pane view. I don't use a ton of CIDER's more esoteric features that often (occasionally the debugger and test runner, never enlighten mode, inspector, etc) so this much lighter footprint interaction feels a bit better for some reason.