### PR TITLE
#6884 Repro: Dashboard revert fails for users with revert permissions

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -1,4 +1,5 @@
 import "@testing-library/cypress/add-commands";
+import "@cypress/skip-test/support";
 import "./commands";
 
 export const version = require("../../../version.json");

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -1,0 +1,56 @@
+import { onlyOn } from "@cypress/skip-test";
+import { restore } from "__support__/cypress";
+
+const PERMISSIONS = {
+  curate: ["admin", "normal", "nodata"],
+  view: ["nodata"],
+  no: ["nocollection", "none"],
+};
+
+describe("collection permissions", () => {
+  beforeEach(() => {
+    restore();
+    cy.server();
+  });
+
+  describe("revision history", () => {
+    beforeEach(() => {
+      cy.route("POST", "/api/revision/revert").as("revert");
+    });
+
+    Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
+      context(`${permission} access`, () => {
+        // This function `onlyOn` will not generate tests for any other condition.
+        // It helps to make both our tests and Cypress runner sidebar clean
+        onlyOn(permission === "curate", () => {
+          userGroup.forEach(user => {
+            beforeEach(() => {
+              cy.signIn(user);
+            });
+
+            it.skip(`${user} user should be able to revert the dashboard (metabase#6884)`, () => {
+              cy.visit("/dashboard/1");
+              cy.icon("ellipsis").click();
+              cy.findByText("Revision history").click();
+              clickRevert("First revision.");
+              cy.wait("@revert").then(xhr => {
+                expect(xhr.status).to.eq(200);
+                expect(xhr.cause).not.to.exist;
+              });
+              cy.findAllByText(/Revert/).should("not.exist");
+              // We reverted the dashboard to the state prior to adding any cards to it
+              cy.findByText("This dashboard is looking empty.");
+            });
+          });
+        });
+      });
+    });
+  });
+});
+
+function clickRevert(event_name) {
+  cy.findByText(event_name)
+    .closest("tr")
+    .findByText(/Revert/i)
+    .click();
+}

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "devDependencies": {
     "@babel/standalone": "^7.4.5",
+    "@cypress/skip-test": "^2.6.0",
     "@cypress/webpack-preprocessor": "^4.1.0",
     "@slack/client": "^3.5.4",
     "@testing-library/cypress": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,6 +941,11 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+"@cypress/skip-test@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.6.0.tgz#73fc58477b436638cfdfaa212b5378ff81b9b3ee"
+  integrity sha512-H5dnS+o0HaSKPexR5wuwF2YGq5praxRZMVodba/Ar9/SuDEWVlW3qxbn9ar06MFjtQnMsHjo4QHQoZzrUPLrHA==
+
 "@cypress/webpack-preprocessor@^4.1.0":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-4.1.5.tgz#b47d515d2540af977ee8b69d7c4eed64e3027668"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #6884

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/111546486-0b479d00-8778-11eb-9917-6dada6be48fb.png)

With the help of `onlyOn` function from `cypress-skip-test` library, we can now generate describe/context blocks, and tests conditionally while keeping everything neat and clean at the same time :)
- Please note that test wasn't even created for "view" and "no" access contexts":

![image](https://user-images.githubusercontent.com/31325167/111567434-43aea180-879f-11eb-921f-b6dc71337202.png)
