### PR TITLE
Add `cypress-skip-test` library

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -1,4 +1,5 @@
 import "@testing-library/cypress/add-commands";
+import "@cypress/skip-test/support";
 import "./commands";
 
 export const version = require("../../../version.json");

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "devDependencies": {
     "@babel/standalone": "^7.4.5",
+    "@cypress/skip-test": "^2.6.0",
     "@cypress/webpack-preprocessor": "^4.1.0",
     "@slack/client": "^3.5.4",
     "@testing-library/cypress": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,6 +941,11 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+"@cypress/skip-test@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.6.0.tgz#73fc58477b436638cfdfaa212b5378ff81b9b3ee"
+  integrity sha512-H5dnS+o0HaSKPexR5wuwF2YGq5praxRZMVodba/Ar9/SuDEWVlW3qxbn9ar06MFjtQnMsHjo4QHQoZzrUPLrHA==
+
 "@cypress/webpack-preprocessor@^4.1.0":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-4.1.5.tgz#b47d515d2540af977ee8b69d7c4eed64e3027668"


### PR DESCRIPTION
## Conditional Testing
We often have the need to have some conditional testing in order to cover different scenarios for a single test. reasons include:
- We want to run/skip tests depending on some ENV (this is the mechanism that enables EE tests to run, for example)
    - Paul came up with the custom `describeWithToken` function for this very reason
    - But then we needed to run one test for OSS only (that required a separate custom function)
    - This can really be ANY condition - doesn't strictly have to be ENV
- There was also a need to run or skip certain parts of the test
    - This can be achieved with `if-else` or with ternary operators but things can also get ugly real fast

The official Cypress library called [`cypress-skip-test`](https://github.com/cypress-io/cypress-skip-test) covers all those cases with a two simple functions `onlyOn` and `skipOn`. They are also [chainable](https://github.com/cypress-io/cypress-skip-test#notes).
> Simple commands to skip a test based on platform, browser or a url.

As I understood from reading the source code, under the hood it relies on `cy.("state")`. Example:
```javascript
if (boolean) {
  cy.state("runnable")
    .skip();
}
```

Knowing this, we could easily come up with our custom solution, but it felt redundant since this is an official Cypress library.
This library allows the use of "custom commands", as well as custom functions. It may seem irrelevant but we need both.

### [Cypress custom commands](https://github.com/cypress-io/cypress-skip-test#example)
- Can be used inside the test only (`cy` cannot be called outside the test or `before/beforeEach` hook).
- Using only custom commands would result in a lot of _skipped_ tests that we maybe don't want generated in the first place

### [Imports](https://github.com/cypress-io/cypress-skip-test#imports)
- Allow the use of custom functions both within and outside of the test.
- The main difference is that this code behaves as `if-else` block, meaning the test will not even be generated if the condition is false
- Example from the [documentation](https://github.com/cypress-io/cypress-skip-test#imports-with-callback):
> Instead of dynamically skipping a test at run-time, you can hide entire blocks of tests using the callback format.

```javascript
import { onlyOn, skipOn } from '@cypress/skip-test'
onlyOn('mac', () => {
  // this callback will only evaluate on Mac
  // thus the tests will be completely hidden from other platforms
  describe('Mac tests', () => {
    it('works', () => {})
  })
})
skipOn('mac', () => {
  // this test will run on every platform but Mac
  it('hides this test on Mac', () => {})
})
```

### [Boolean flag](https://github.com/cypress-io/cypress-skip-test#boolean-flag)
This is where we can really utilize the library and use it to conditionally skip and also conditionally generate test inside fairly complicated test matrices.
```javascript
// run this test if S is "foo"
cy.onlyOn(S === 'foo')
```

### Warning/Downsides
- I've noticed prolonged time that is needed to calculate/generate tests before Cypress runner even starts running them, but this happens only with O^2 test matrices. My guess is it would be the same even if we used plain `if-else`

### Example of this code in use
https://github.com/metabase/metabase/blob/7a94653a91997cf9f9bde92d221b92b20b44b0c6/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js