### PR TITLE
Bump Lein versions and replace images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
   clojure-and-node:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
 
   # CircleCI base (Lein 2.9.5) + Node + Headless browsers + Clojure CLI - big one
   clojure-and-node-and-browsers:
@@ -23,14 +23,14 @@ executors:
   java-11:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -46,7 +46,7 @@ executors:
   postgres-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -63,7 +63,7 @@ executors:
   mysql-5-7:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -76,7 +76,7 @@ executors:
   mysql-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -89,7 +89,7 @@ executors:
   mariadb-10-2:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -102,7 +102,7 @@ executors:
   mariadb-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -119,13 +119,13 @@ executors:
   mongo:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: metabase/ci:latest
+       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
        - image: circleci/mongo:4.0
 
   presto:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
       - image: metabase/presto-mb-ci
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx1g"
@@ -133,19 +133,19 @@ executors:
   sparksql:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
       - image: metabase/spark:2.1.1
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
       - image: sumitchawla/vertica
 
   sqlserver:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:latest
+      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_SQLSERVER_TEST_HOST: localhost
           MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,37 +5,17 @@ version: 2.1
 ########################################################################################################################
 
 executors:
-  # Basic executor with git and bash and not much else.
-  basic:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      # CircleCI base image
-      - image: cimg/base:2020.01
-
-  clojure:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      - image: circleci/clojure:lein-2.8.1
-
-  node:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      # - image: circleci/node:7-browsers
-      - image: circleci/clojure:lein-2.8.1-node-browsers
-
+  # Our brand new builder
   clojure-and-node:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: metabase/ci:latest
 
-  # This is a special image that is based on clojure-and-node but includes extras like gettext and the Clojure CLI
-  # tools. See https://github.com/metabase/metabase-docker-ci for more information. You shouldn't use this image
-  # unless you need the extra stuff -- because it's not an official Circle image, the extra layers won't get cached
-  # and it might take longer to spin this up.
-  metabase-ci:
+  # CircleCI base (Lein 2.9.5) + Node + Headless browsers + Clojure CLI - big one
+  clojure-and-node-and-browsers:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:2020-11-30
+      - image: circleci/clojure:lein-2.9.5-node-browsers
 
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
@@ -43,14 +23,14 @@ executors:
   java-11:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -66,7 +46,7 @@ executors:
   postgres-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -74,7 +54,7 @@ executors:
           MB_DB_DBNAME: metabase_test
           MB_DB_USER: metabase_test
           MB_POSTGRESQL_TEST_USER: metabase_test
-      - image: postgres:latest
+      - image: circleci/postgres:latest
         environment:
           POSTGRES_USER: metabase_test
           POSTGRES_DB: metabase_test
@@ -83,7 +63,7 @@ executors:
   mysql-5-7:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -96,7 +76,7 @@ executors:
   mysql-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -109,7 +89,7 @@ executors:
   mariadb-10-2:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -122,30 +102,30 @@ executors:
   mariadb-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
           MB_DB_PORT: 3306
-          MB_DB_DBNAME: metabase_test
+          MB_DB_DBNAME: circle_test
           MB_DB_USER: root
           MB_MYSQL_TEST_USER: root
-      - image: mariadb:latest
+      - image: circleci/mariadb:latest
         environment:
-          MYSQL_DATABASE: metabase_test
-          MYSQL_USER: root
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          # MYSQL_DATABASE: metabase_test
+          # MYSQL_USER: root
+          # MYSQL_ALLOW_EMPTY_PASSWORD: yes
 
   mongo:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: circleci/clojure:lein-2.8.1
+       - image: metabase/ci:latest
        - image: circleci/mongo:4.0
 
   presto:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
       - image: metabase/presto-mb-ci
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx1g"
@@ -153,19 +133,19 @@ executors:
   sparksql:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
       - image: metabase/spark:2.1.1
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
       - image: sumitchawla/vertica
 
   sqlserver:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1
+      - image: metabase/ci:latest
         environment:
           MB_SQLSERVER_TEST_HOST: localhost
           MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
@@ -179,19 +159,19 @@ executors:
   fe-mongo-4:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:mongo-sample-4.0
 
   fe-postgres-12:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:postgres-sample-12
 
   fe-mysql-8:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+      - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:mysql-sample-8
 
 ########################################################################################################################
@@ -486,7 +466,7 @@ jobs:
 ########################################################################################################################
 
   checkout:
-    executor: basic
+    executor: clojure-and-node
     steps:
       - checkout
       # .BACKEND-CHECKSUMS is every Clojure source file as well as dependency files like deps.edn and plugin manifests
@@ -527,7 +507,7 @@ jobs:
 
   check-migrations:
     executor:
-      metabase-ci
+      clojure-and-node
     steps:
       - attach-workspace
       - create-checksum-file:
@@ -550,7 +530,7 @@ jobs:
 ########################################################################################################################
 
   be-deps:
-    executor: clojure
+    executor: clojure-and-node
     parameters:
       <<: *Params
     steps:
@@ -572,7 +552,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: clojure
+        default: clojure-and-node
       before-steps:
         type: steps
         default: []
@@ -609,7 +589,7 @@ jobs:
                 edition: << parameters.edition >>
 
   be-linter-reflection-warnings:
-    executor: clojure
+    executor: clojure-and-node
     steps:
       - attach-workspace
       - run-on-change:
@@ -625,7 +605,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: clojure
+        default: clojure-and-node
       driver:
         type: string
       timeout:
@@ -659,7 +639,7 @@ jobs:
                 path: /home/circleci/metabase/metabase/target/junit
 
   test-build-scripts:
-    executor: metabase-ci
+    executor: clojure-and-node
     steps:
       - attach-workspace
       - run-on-change:
@@ -703,7 +683,7 @@ jobs:
 ########################################################################################################################
 
   fe-deps:
-    executor: node
+    executor: clojure-and-node
     steps:
       - attach-workspace
       # This step is *really* slow, so we can skip it if yarn.lock hasn't changed since last time we ran it
@@ -725,7 +705,7 @@ jobs:
                   - /home/circleci/.cache/Cypress
 
   fe-tests-unit:
-    executor: node
+    executor: clojure-and-node
     steps:
       - run-yarn-command:
           command-name: Run frontend unit tests
@@ -733,7 +713,7 @@ jobs:
           skip-when-no-change: true
 
   shared-tests-cljs:
-    executor: node
+    executor: clojure-and-node
     steps:
       - run-yarn-command:
           command-name: Run Cljs tests for shared/ code
@@ -741,7 +721,7 @@ jobs:
           skip-when-no-change: true
 
   fe-tests-timezones:
-    executor: node
+    executor: clojure-and-node
     steps:
       - run-yarn-command:
           command-name: Run frontend timezone tests
@@ -751,7 +731,7 @@ jobs:
   # Unlike the other build-uberjar steps, this step should be run once overall and the results can be shared between
   # OSS and EE uberjars.
   build-uberjar-drivers:
-    executor: metabase-ci
+    executor: clojure-and-node
     parameters:
       <<: *Params
     steps:
@@ -803,7 +783,7 @@ jobs:
   build-uberjar-frontend:
     parameters:
       <<: *Params
-    executor: metabase-ci
+    executor: clojure-and-node
     steps:
       - attach-workspace
       - run-on-change:
@@ -826,7 +806,7 @@ jobs:
   build-uberjar:
     parameters:
       <<: *Params
-    executor: metabase-ci
+    executor: clojure-and-node
     steps:
       - attach-workspace
       - run-on-change:
@@ -871,7 +851,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: clojure-and-node
+        default: clojure-and-node-and-browsers
       cypress-group:
         type: string
       only-single-database:
@@ -917,7 +897,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: clojure-and-node
+        default: clojure-and-node-and-browsers
       cypress-group:
         type: string
       <<: *Params
@@ -943,7 +923,7 @@ jobs:
 ########################################################################################################################
 
   deploy-master:
-    executor: clojure
+    executor: clojure-and-node
     steps:
       - attach-workspace
       - run: ./bin/deploy-webhook $DEPLOY_WEBHOOK

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -50,7 +50,7 @@ export const BackendResource = createSharedResource("BackendResource", {
         [
           "-XX:+IgnoreUnrecognizedVMOptions", // ignore options not recognized by this Java version (e.g. Java 8 should ignore Java 9 options)
           "-Dh2.bindAddress=localhost", // fix H2 randomly not working (?)
-          "-Xmx2g", // Hard limit of 2GB size for the heap since Circle is dumb and the JVM tends to go over the limit
+          // "-Xmx2g", // Hard limit of 2GB size for the heap since Circle is dumb and the JVM tends to go over the limit
           "-Djava.awt.headless=true", // when running on macOS prevent little Java icon from popping up in Dock
           "-Duser.timezone=US/Pacific",
           `-Dlog4j.configurationFile=file:${__dirname}/log4j2.xml`,

--- a/project.clj
+++ b/project.clj
@@ -256,7 +256,7 @@
      :format-result metabase.junit/format-result}}
 
    :ci
-   {:jvm-opts ["-Xmx2000m"]}
+   {}
 
    :install
    {}


### PR DESCRIPTION
Bumped Lein 2.8 with 2.9.5
Change the build image from CircleCI to OpenJDK:alpine to build and test