### PR TITLE
#13229 Repro: User without permissions can see "Revert" buttons

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -44,6 +44,20 @@ describe("collection permissions", () => {
               });
             });
           });
+
+          onlyOn(permission === "view", () => {
+            describe(`${user} user`, () => {
+              it.skip("should not see revert buttons (metabase#13229)", () => {
+                cy.signIn(user);
+                cy.visit("/dashboard/1");
+                cy.icon("ellipsis").click();
+                cy.findByText("Revision history").click();
+                cy.findAllByRole("button", { name: "Revert" }).should(
+                  "not.exist",
+                );
+              });
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13229

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/111567910-0c8cc000-87a0-11eb-963a-0583b52a9208.png)
