### PR TITLE
split SharingSidebar into a few separate components

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -79,6 +79,8 @@ export function formatHourAMPM(hour) {
     return t`${newHour}:00 PM`;
   } else if (hour === 0) {
     return t`12:00 AM`;
+  } else if (hour === 12) {
+    return t`12:00 PM`;
   } else {
     return t`${hour}:00 AM`;
   }

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -1,4 +1,5 @@
 import moment from "moment-timezone";
+import { t } from "ttag";
 
 const NUMERIC_UNIT_FORMATS = {
   // workaround for https://github.com/metabase/metabase/issues/1992
@@ -69,5 +70,50 @@ export function parseTime(value) {
     ]);
   } else {
     return moment.utc(value);
+  }
+}
+
+export function formatHourAMPM(hour) {
+  if (hour > 12) {
+    const newHour = hour - 12;
+    return t`${newHour}:00 PM`;
+  } else if (hour === 0) {
+    return t`12:00 AM`;
+  } else {
+    return t`${hour}:00 AM`;
+  }
+}
+
+export function formatDay(day) {
+  switch (day) {
+    case "mon":
+      return t`Monday`;
+    case "tue":
+      return t`Tuesday`;
+    case "wed":
+      return t`Wednesday`;
+    case "thu":
+      return t`Thursday`;
+    case "fri":
+      return t`Friday`;
+    case "sat":
+      return t`Saturday`;
+    case "sun":
+      return t`Sunday`;
+    default:
+      return day;
+  }
+}
+
+export function formatFrame(frame) {
+  switch (frame) {
+    case "first":
+      return t`first`;
+    case "last":
+      return t`last`;
+    case "mid":
+      return t`15th (Midpoint)`;
+    default:
+      return frame;
   }
 }

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -34,7 +34,8 @@ export function AddEditEmailSidebar({
   formInput,
   channel,
   channelSpec,
-  index,
+  users,
+
   handleSave,
   onCancel,
   onChannelPropertyChange,
@@ -42,7 +43,6 @@ export function AddEditEmailSidebar({
   testPulse,
   toggleSkipIfEmpty,
   setPulse,
-  users,
   handleArchive,
 }) {
   return (
@@ -67,7 +67,7 @@ export function AddEditEmailSidebar({
             recipientTypes={channelSpec.recipients}
             users={users}
             onRecipientsChange={recipients =>
-              onChannelPropertyChange(index, "recipients", recipients)
+              onChannelPropertyChange("recipients", recipients)
             }
           />
         </div>
@@ -75,7 +75,6 @@ export function AddEditEmailSidebar({
           <ChannelFields
             channel={channel}
             channelSpec={channelSpec}
-            index={index}
             onChannelPropertyChange={onChannelPropertyChange}
           />
         )}
@@ -93,7 +92,7 @@ export function AddEditEmailSidebar({
             channelSpec && channelSpec.type
           ] || t`Messages`} will be sent at`}
           onScheduleChange={(newSchedule, changedProp) =>
-            onChannelScheduleChange(index, newSchedule, changedProp)
+            onChannelScheduleChange(newSchedule, changedProp)
           }
         />
         <div className="pt2 pb1">
@@ -199,7 +198,6 @@ export function AddEditSlackSidebar({
   formInput,
   channel,
   channelSpec,
-  index,
   handleSave,
   onCancel,
   onChannelPropertyChange,
@@ -224,7 +222,6 @@ export function AddEditSlackSidebar({
           <ChannelFields
             channel={channel}
             channelSpec={channelSpec}
-            index={index}
             onChannelPropertyChange={onChannelPropertyChange}
           />
         )}
@@ -242,7 +239,7 @@ export function AddEditSlackSidebar({
             channelSpec && channelSpec.type
           ] || t`Messages`} will be sent at`}
           onScheduleChange={(newSchedule, changedProp) =>
-            onChannelScheduleChange(index, newSchedule, changedProp)
+            onChannelScheduleChange(newSchedule, changedProp)
           }
         />
         <div className="text-bold py2 mt2 flex justify-between align-center border-top">
@@ -279,12 +276,7 @@ function CaveatMessage() {
   );
 }
 
-function ChannelFields({
-  channel,
-  channelSpec,
-  index,
-  onChannelPropertyChange,
-}) {
+function ChannelFields({ channel, channelSpec, onChannelPropertyChange }) {
   const valueForField = field => {
     const value = channel.details && channel.details[field.name];
     return value != null ? value : null; // convert undefined to null so Uncontrollable doesn't ignore changes
@@ -302,7 +294,7 @@ function ChannelFields({
               searchProp="name"
               // Address #5799 where `details` object is missing for some reason
               onChange={o =>
-                onChannelPropertyChange(index, "details", {
+                onChannelPropertyChange("details", {
                   ...channel.details,
                   [field.name]: o.target.value,
                 })

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -35,7 +35,6 @@ export function AddEditEmailSidebar({
   channel,
   channelSpec,
   index,
-  emailRecipientText,
   handleSave,
   onCancel,
   onChannelPropertyChange,
@@ -61,7 +60,7 @@ export function AddEditEmailSidebar({
       <CaveatMessage />
       <div className="my2 px4">
         <div>
-          <div className="text-bold mb1">{emailRecipientText || t`To:`}</div>
+          <div className="text-bold mb1">{t`To:`}</div>
           <RecipientPicker
             isNewPulse={pulseId === undefined}
             autoFocus={false}

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -42,7 +42,6 @@ export function AddEditEmailSidebar({
   testPulse,
   toggleSkipIfEmpty,
   setPulse,
-  pulseId,
   users,
   handleArchive,
 }) {
@@ -62,7 +61,7 @@ export function AddEditEmailSidebar({
         <div>
           <div className="text-bold mb1">{t`To:`}</div>
           <RecipientPicker
-            isNewPulse={pulseId === undefined}
+            isNewPulse={pulse.id == null}
             autoFocus={false}
             recipients={channel.recipients}
             recipientTypes={channelSpec.recipients}

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -36,6 +36,7 @@ export function AddEditEmailSidebar({
   channelSpec,
   users,
 
+  // form callbacks
   handleSave,
   onCancel,
   onChannelPropertyChange,
@@ -198,6 +199,8 @@ export function AddEditSlackSidebar({
   formInput,
   channel,
   channelSpec,
+
+  // form callbacks
   handleSave,
   onCancel,
   onChannelPropertyChange,

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -1,0 +1,324 @@
+import React from "react";
+import _ from "underscore";
+import { t, jt, ngettext, msgid } from "ttag";
+
+import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
+import EmailAttachmentPicker from "metabase/sharing/components/EmailAttachmentPicker";
+import ExternalLink from "metabase/components/ExternalLink";
+import Icon from "metabase/components/Icon";
+import Text from "metabase/components/type/Text";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+import RecipientPicker from "metabase/pulse/components/RecipientPicker";
+import SchedulePicker from "metabase/components/SchedulePicker";
+import SendTestEmail from "metabase/components/SendTestEmail";
+import Sidebar from "metabase/dashboard/components/Sidebar";
+import Toggle from "metabase/components/Toggle";
+import Select, { Option } from "metabase/components/Select";
+
+import { dashboardPulseIsValid } from "metabase/lib/pulse";
+import MetabaseSettings from "metabase/lib/settings";
+
+const Heading = ({ children }) => <h4>{children}</h4>;
+export const CHANNEL_ICONS = {
+  email: "mail",
+  slack: "slack",
+};
+
+const CHANNEL_NOUN_PLURAL = {
+  email: t`Emails`,
+  slack: t`Slack messages`,
+};
+
+export function AddEditEmailSidebar({
+  pulse,
+  formInput,
+  channel,
+  channelSpec,
+  index,
+  emailRecipientText,
+  handleSave,
+  onCancel,
+  onChannelPropertyChange,
+  onChannelScheduleChange,
+  testPulse,
+  toggleSkipIfEmpty,
+  setPulse,
+  pulseId,
+  users,
+  handleArchive,
+}) {
+  return (
+    <Sidebar
+      onClose={handleSave}
+      onCancel={onCancel}
+      className="text-dark"
+      closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
+    >
+      <div className="pt4 px4 flex align-center">
+        <Icon name="mail" className="mr1" size={21} />
+        <Heading>{t`Email this dashboard`}</Heading>
+      </div>
+      <CaveatMessage />
+      <div className="my2 px4">
+        <div>
+          <div className="text-bold mb1">{emailRecipientText || t`To:`}</div>
+          <RecipientPicker
+            isNewPulse={pulseId === undefined}
+            autoFocus={false}
+            recipients={channel.recipients}
+            recipientTypes={channelSpec.recipients}
+            users={users}
+            onRecipientsChange={recipients =>
+              onChannelPropertyChange(index, "recipients", recipients)
+            }
+          />
+        </div>
+        {channelSpec.fields && (
+          <ChannelFields
+            channel={channel}
+            channelSpec={channelSpec}
+            index={index}
+            onChannelPropertyChange={onChannelPropertyChange}
+          />
+        )}
+        <SchedulePicker
+          schedule={_.pick(
+            channel,
+            "schedule_day",
+            "schedule_frame",
+            "schedule_hour",
+            "schedule_type",
+          )}
+          scheduleOptions={channelSpec.schedules}
+          textBeforeInterval={t`Sent`}
+          textBeforeSendTime={t`${CHANNEL_NOUN_PLURAL[
+            channelSpec && channelSpec.type
+          ] || t`Messages`} will be sent at`}
+          onScheduleChange={(newSchedule, changedProp) =>
+            onChannelScheduleChange(index, newSchedule, changedProp)
+          }
+        />
+        <div className="pt2 pb1">
+          <SendTestEmail
+            channel={channel}
+            pulse={pulse}
+            testPulse={testPulse}
+          />
+        </div>
+        <div className="text-bold py3 mt2 flex justify-between align-center border-top">
+          <Heading>{t`Don't send if there aren't results`}</Heading>
+          <Toggle
+            value={pulse.skip_if_empty || false}
+            onChange={toggleSkipIfEmpty}
+          />
+        </div>
+        <div className="text-bold py2 flex justify-between align-center border-top">
+          <div className="flex align-center">
+            <Heading>{t`Attach results`}</Heading>
+            <Icon
+              name="info"
+              className="text-medium ml1"
+              size={12}
+              tooltip={t`Attachments can contain up to 2,000 rows of data.`}
+            />
+          </div>
+        </div>
+        <EmailAttachmentPicker
+          cards={pulse.cards}
+          pulse={pulse}
+          setPulse={setPulse}
+        />
+        {pulse.id != null && (
+          <DeleteSubscriptionAction
+            pulse={pulse}
+            handleArchive={handleArchive}
+          />
+        )}
+      </div>
+    </Sidebar>
+  );
+}
+
+function DeleteSubscriptionAction({ pulse, handleArchive }) {
+  return pulse.id != null && !pulse.archived ? (
+    <div className="border-top pt1 pb3 flex justify-end">
+      <ModalWithTrigger
+        triggerClasses="Button Button--borderless text-light text-error-hover flex-align-right flex-no-shrink"
+        triggerElement={t`Delete this subscription`}
+      >
+        {({ onClose }) => (
+          <DeleteModalWithConfirm
+            objectType="pulse"
+            title={t`Delete this subscription to ${pulse.name}?`}
+            buttonText={t`Delete`}
+            confirmItems={getConfirmItems(pulse)}
+            onClose={onClose}
+            onDelete={handleArchive}
+          />
+        )}
+      </ModalWithTrigger>
+    </div>
+  ) : null;
+}
+
+function getConfirmItems(pulse) {
+  return pulse.channels.map((c, index) =>
+    c.channel_type === "email" ? (
+      <span key={index}>
+        {jt`This dashboard will no longer be emailed to ${(
+          <strong>
+            {(n => ngettext(msgid`${n} address`, `${n} addresses`, n))(
+              c.recipients.length,
+            )}
+          </strong>
+        )} ${<strong>{c.schedule_type}</strong>}`}
+        .
+      </span>
+    ) : c.channel_type === "slack" ? (
+      <span key={index}>
+        {jt`Slack channel ${(
+          <strong>{c.details && c.details.channel}</strong>
+        )} will no longer get this dashboard ${(
+          <strong>{c.schedule_type}</strong>
+        )}`}
+        .
+      </span>
+    ) : (
+      <span key={index}>
+        {jt`Channel ${(
+          <strong>{c.channel_type}</strong>
+        )} will no longer receive this dashboard ${(
+          <strong>{c.schedule_type}</strong>
+        )}`}
+        .
+      </span>
+    ),
+  );
+}
+
+export function AddEditSlackSidebar({
+  pulse,
+  formInput,
+  channel,
+  channelSpec,
+  index,
+  handleSave,
+  onCancel,
+  onChannelPropertyChange,
+  onChannelScheduleChange,
+  toggleSkipIfEmpty,
+  handleArchive,
+}) {
+  return (
+    <Sidebar
+      onClose={handleSave}
+      onCancel={onCancel}
+      className="text-dark"
+      closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
+    >
+      <div className="pt4 flex align-center px4 mb3">
+        <Icon name="slack" className="mr1" size={21} />
+        <Heading>{t`Send this dashboard to Slack`}</Heading>
+      </div>
+      <CaveatMessage />
+      <div className="pb2 px4">
+        {channelSpec.fields && (
+          <ChannelFields
+            channel={channel}
+            channelSpec={channelSpec}
+            index={index}
+            onChannelPropertyChange={onChannelPropertyChange}
+          />
+        )}
+        <SchedulePicker
+          schedule={_.pick(
+            channel,
+            "schedule_day",
+            "schedule_frame",
+            "schedule_hour",
+            "schedule_type",
+          )}
+          scheduleOptions={channelSpec.schedules}
+          textBeforeInterval={t`Sent`}
+          textBeforeSendTime={t`${CHANNEL_NOUN_PLURAL[
+            channelSpec && channelSpec.type
+          ] || t`Messages`} will be sent at`}
+          onScheduleChange={(newSchedule, changedProp) =>
+            onChannelScheduleChange(index, newSchedule, changedProp)
+          }
+        />
+        <div className="text-bold py2 mt2 flex justify-between align-center border-top">
+          <Heading>{t`Don't send if there aren't results`}</Heading>
+          <Toggle
+            value={pulse.skip_if_empty || false}
+            onChange={toggleSkipIfEmpty}
+          />
+        </div>
+        {pulse.id != null && (
+          <DeleteSubscriptionAction
+            pulse={pulse}
+            handleArchive={handleArchive}
+          />
+        )}
+      </div>
+    </Sidebar>
+  );
+}
+
+function CaveatMessage() {
+  return (
+    <Text className="mx4 my2 p2 bg-light text-dark rounded">{jt`${(
+      <span className="text-bold">Note:</span>
+    )} charts in your subscription won't look the same as in your dashboard. ${(
+      <ExternalLink
+        className="link"
+        target="_blank"
+        href={MetabaseSettings.docsUrl("users-guide/dashboard-subscriptions")}
+      >
+        Learn more
+      </ExternalLink>
+    )}.`}</Text>
+  );
+}
+
+function ChannelFields({
+  channel,
+  channelSpec,
+  index,
+  onChannelPropertyChange,
+}) {
+  const valueForField = field => {
+    const value = channel.details && channel.details[field.name];
+    return value != null ? value : null; // convert undefined to null so Uncontrollable doesn't ignore changes
+  };
+  return (
+    <div>
+      {channelSpec.fields.map(field => (
+        <div key={field.name} className={field.name}>
+          <span className="text-bold mr1">{field.displayName}</span>
+          {field.type === "select" ? (
+            <Select
+              className="text-bold bg-white inline-block"
+              value={valueForField(field)}
+              placeholder={t`Pick a user or channel...`}
+              searchProp="name"
+              // Address #5799 where `details` object is missing for some reason
+              onChange={o =>
+                onChannelPropertyChange(index, "details", {
+                  ...channel.details,
+                  [field.name]: o.target.value,
+                })
+              }
+            >
+              {field.options.map(option => (
+                <Option name={option} value={option}>
+                  {option}
+                </Option>
+              ))}
+            </Select>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -1,4 +1,7 @@
+/* eslint "react/prop-types": "error" */
+
 import React from "react";
+import PropTypes from "prop-types";
 import _ from "underscore";
 import { t, jt, ngettext, msgid } from "ttag";
 
@@ -19,6 +22,8 @@ import { dashboardPulseIsValid } from "metabase/lib/pulse";
 import MetabaseSettings from "metabase/lib/settings";
 
 const Heading = ({ children }) => <h4>{children}</h4>;
+Heading.propTypes = { children: PropTypes.any };
+
 export const CHANNEL_ICONS = {
   email: "mail",
   slack: "slack",
@@ -137,6 +142,22 @@ export function AddEditEmailSidebar({
   );
 }
 
+AddEditEmailSidebar.propTypes = {
+  pulse: PropTypes.object.isRequired,
+  formInput: PropTypes.object.isRequired,
+  channel: PropTypes.object.isRequired,
+  channelSpec: PropTypes.object.isRequired,
+  users: PropTypes.array,
+  handleSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onChannelPropertyChange: PropTypes.func.isRequired,
+  onChannelScheduleChange: PropTypes.func.isRequired,
+  testPulse: PropTypes.func.isRequired,
+  toggleSkipIfEmpty: PropTypes.func.isRequired,
+  setPulse: PropTypes.func.isRequired,
+  handleArchive: PropTypes.func.isRequired,
+};
+
 function DeleteSubscriptionAction({ pulse, handleArchive }) {
   return pulse.id != null && !pulse.archived ? (
     <div className="border-top pt1 pb3 flex justify-end">
@@ -159,34 +180,39 @@ function DeleteSubscriptionAction({ pulse, handleArchive }) {
   ) : null;
 }
 
+DeleteSubscriptionAction.propTypes = {
+  pulse: PropTypes.object.isRequired,
+  handleArchive: PropTypes.func.isRequired,
+};
+
 function getConfirmItems(pulse) {
   return pulse.channels.map((c, index) =>
     c.channel_type === "email" ? (
       <span key={index}>
         {jt`This dashboard will no longer be emailed to ${(
-          <strong>
+          <strong key="msg">
             {(n => ngettext(msgid`${n} address`, `${n} addresses`, n))(
               c.recipients.length,
             )}
           </strong>
-        )} ${<strong>{c.schedule_type}</strong>}`}
+        )} ${<strong key="type">{c.schedule_type}</strong>}`}
         .
       </span>
     ) : c.channel_type === "slack" ? (
       <span key={index}>
         {jt`Slack channel ${(
-          <strong>{c.details && c.details.channel}</strong>
+          <strong key="msg">{c.details && c.details.channel}</strong>
         )} will no longer get this dashboard ${(
-          <strong>{c.schedule_type}</strong>
+          <strong key="type">{c.schedule_type}</strong>
         )}`}
         .
       </span>
     ) : (
       <span key={index}>
         {jt`Channel ${(
-          <strong>{c.channel_type}</strong>
+          <strong key="msg">{c.channel_type}</strong>
         )} will no longer receive this dashboard ${(
-          <strong>{c.schedule_type}</strong>
+          <strong key="type">{c.schedule_type}</strong>
         )}`}
         .
       </span>
@@ -263,19 +289,35 @@ export function AddEditSlackSidebar({
   );
 }
 
+AddEditSlackSidebar.propTypes = {
+  pulse: PropTypes.object.isRequired,
+  formInput: PropTypes.object.isRequired,
+  channel: PropTypes.object.isRequired,
+  channelSpec: PropTypes.object.isRequired,
+  users: PropTypes.array,
+  handleSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onChannelPropertyChange: PropTypes.func.isRequired,
+  onChannelScheduleChange: PropTypes.func.isRequired,
+  toggleSkipIfEmpty: PropTypes.func.isRequired,
+  handleArchive: PropTypes.func.isRequired,
+};
+
 function CaveatMessage() {
   return (
-    <Text className="mx4 my2 p2 bg-light text-dark rounded">{jt`${(
-      <span className="text-bold">Note:</span>
-    )} charts in your subscription won't look the same as in your dashboard. ${(
+    <Text className="mx4 my2 p2 bg-light text-dark rounded">
+      <span className="text-bold">{t`Note`}:</span>
+      {t`charts in your subscription won't look the same as in your dashboard.`}
+      &nbsp;
       <ExternalLink
         className="link"
         target="_blank"
         href={MetabaseSettings.docsUrl("users-guide/dashboard-subscriptions")}
       >
-        Learn more
+        {t`Learn more`}
       </ExternalLink>
-    )}.`}</Text>
+      .
+    </Text>
   );
 }
 
@@ -304,7 +346,7 @@ function ChannelFields({ channel, channelSpec, onChannelPropertyChange }) {
               }
             >
               {field.options.map(option => (
-                <Option name={option} value={option}>
+                <Option key={option} name={option} value={option}>
                   {option}
                 </Option>
               ))}
@@ -315,3 +357,9 @@ function ChannelFields({ channel, channelSpec, onChannelPropertyChange }) {
     </div>
   );
 }
+
+ChannelFields.propTypes = {
+  channel: PropTypes.object.isRequired,
+  channelSpec: PropTypes.object.isRequired,
+  onChannelPropertyChange: PropTypes.func.isRequired,
+};

--- a/frontend/src/metabase/sharing/components/NewPulseSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/NewPulseSidebar.jsx
@@ -1,4 +1,7 @@
+/* eslint "react/prop-types": "error" */
+
 import React from "react";
+import PropTypes from "prop-types";
 import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
 import Text from "metabase/components/type/Text";
@@ -51,7 +54,7 @@ function NewPulseSidebar({
             >
               {!emailConfigured &&
                 jt`You'll need to ${(
-                  <Link to="/admin/settings/email" className="link">
+                  <Link key="link" to="/admin/settings/email" className="link">
                     set up email
                   </Link>
                 )} first.`}
@@ -89,7 +92,7 @@ function NewPulseSidebar({
             >
               {!slackConfigured &&
                 jt`First, you'll have to ${(
-                  <Link to="/admin/settings/slack" className="link">
+                  <Link key="link" to="/admin/settings/slack" className="link">
                     configure Slack
                   </Link>
                 )}.`}
@@ -102,5 +105,13 @@ function NewPulseSidebar({
     </Sidebar>
   );
 }
+
+NewPulseSidebar.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  emailConfigured: PropTypes.bool.isRequired,
+  slackConfigured: PropTypes.bool.isRequired,
+  onNewEmailPulse: PropTypes.func.isRequired,
+  onNewSlackPulse: PropTypes.func.isRequired,
+};
 
 export default NewPulseSidebar;

--- a/frontend/src/metabase/sharing/components/NewPulseSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/NewPulseSidebar.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import Card from "metabase/components/Card";
+import Icon from "metabase/components/Icon";
+import Text from "metabase/components/type/Text";
+import Link from "metabase/components/Link";
+import Sidebar from "metabase/dashboard/components/Sidebar";
+import cx from "classnames";
+import { t, jt } from "ttag";
+
+function NewPulseSidebar({
+  onCancel,
+  emailConfigured,
+  slackConfigured,
+  onNewEmailPulse,
+  onNewSlackPulse,
+}) {
+  return (
+    <Sidebar onCancel={onCancel}>
+      <div className="mt2 pt2 px4">
+        <h4>{t`Create a dashboard subscription`}</h4>
+      </div>
+      <div className="my1 mx4">
+        <Card
+          flat
+          className={cx("mt1 mb3", {
+            "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit": emailConfigured,
+          })}
+          onClick={onNewEmailPulse}
+        >
+          <div className="px3 pt3 pb2">
+            <div className="flex align-center">
+              <Icon
+                name="mail"
+                className={cx(
+                  "mr1",
+                  {
+                    "text-brand hover-child hover--inherit": emailConfigured,
+                  },
+                  { "text-light": !emailConfigured },
+                )}
+              />
+              <h3
+                className={cx({ "text-light": !emailConfigured })}
+              >{t`Email it`}</h3>
+            </div>
+            <Text
+              lineHeight={1.5}
+              className={cx("text-medium", {
+                "hover-child hover--inherit": emailConfigured,
+              })}
+            >
+              {!emailConfigured &&
+                jt`You'll need to ${(
+                  <Link to="/admin/settings/email" className="link">
+                    set up email
+                  </Link>
+                )} first.`}
+              {emailConfigured &&
+                t`You can send this dashboard regularly to users or email addresses.`}
+            </Text>
+          </div>
+        </Card>
+        <Card
+          flat
+          className={cx({
+            "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit": slackConfigured,
+          })}
+          onClick={onNewSlackPulse}
+        >
+          <div className="px3 pt3 pb2">
+            <div className="flex align-center mb1">
+              <Icon
+                name={slackConfigured ? "slack_colorized" : "slack"}
+                size={24}
+                className={cx("mr1", {
+                  "text-light": !slackConfigured,
+                  "hover-child hover--inherit": slackConfigured,
+                })}
+              />
+              <h3
+                className={cx({ "text-light": !slackConfigured })}
+              >{t`Send it to Slack`}</h3>
+            </div>
+            <Text
+              lineHeight={1.5}
+              className={cx("text-medium", {
+                "hover-child hover--inherit": slackConfigured,
+              })}
+            >
+              {!slackConfigured &&
+                jt`First, you'll have to ${(
+                  <Link to="/admin/settings/slack" className="link">
+                    configure Slack
+                  </Link>
+                )}.`}
+              {slackConfigured &&
+                t`Pick a channel and a schedule, and Metabase will do the rest.`}
+            </Text>
+          </div>
+        </Card>
+      </div>
+    </Sidebar>
+  );
+}
+
+export default NewPulseSidebar;

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -1,0 +1,200 @@
+import React from "react";
+import { t, ngettext, msgid } from "ttag";
+import { Flex } from "grid-styled";
+
+import Card from "metabase/components/Card";
+import Icon from "metabase/components/Icon";
+import Label from "metabase/components/type/Label";
+import Subhead from "metabase/components/type/Subhead";
+import Sidebar from "metabase/dashboard/components/Sidebar";
+import Tooltip from "metabase/components/Tooltip";
+
+function PulsesListSidebar({
+  pulses,
+  createSubscription,
+  onCancel,
+  editPulse,
+}) {
+  return (
+    <Sidebar>
+      <div className="px4 pt3   flex justify-between align-center">
+        <Subhead>{t`Subscriptions`}</Subhead>
+
+        <Flex align="center">
+          <Tooltip tooltip={t`Set up a new schedule`}>
+            <Icon
+              name="add"
+              className="text-brand bg-light-hover rounded p1 cursor-pointer mr1"
+              size={18}
+              onClick={createSubscription}
+            />
+          </Tooltip>
+          <Tooltip tooltip={t`Close`}>
+            <Icon
+              name="close"
+              className="text-light bg-light-hover rounded p1 cursor-pointer"
+              size={22}
+              onClick={onCancel}
+            />
+          </Tooltip>
+        </Flex>
+      </div>
+      <div className="my2 mx4">
+        {pulses.map(pulse => (
+          <Card
+            key={pulse.id}
+            flat
+            className="mb3 cursor-pointer bg-brand-hover"
+            onClick={() => editPulse(pulse, pulse.channels[0].channel_type)}
+          >
+            <div className="px3 py2 hover-parent hover--inherit text-white-hover">
+              <div className="flex align-center hover-child hover--inherit">
+                <Icon
+                  name={
+                    pulse.channels[0].channel_type === "email"
+                      ? "mail"
+                      : "slack"
+                  }
+                  className="mr1"
+                  style={{ paddingBottom: "5px" }}
+                  size={16}
+                />
+                <Label className="hover-child hover--inherit">
+                  {friendlySchedule(pulse.channels[0])}
+                </Label>
+              </div>
+              {pulse.channels[0].channel_type === "email" && (
+                <EmailRecipients pulse={pulse} />
+              )}
+            </div>
+          </Card>
+        ))}
+      </div>
+    </Sidebar>
+  );
+}
+
+function EmailRecipients({ pulse }) {
+  const recipients = pulse.channels[0].recipients;
+  const [first, ...rest] = recipients;
+
+  let text = "";
+
+  if (rest != null && rest.length > 0) {
+    text += ngettext(
+      msgid` and ${rest.length} other`,
+      ` and ${rest.length} others`,
+      rest.length,
+    );
+  }
+
+  return (
+    <div className="text-medium hover-child">
+      <ul
+        className="flex flex-wrap scroll-x scroll-y"
+        style={{ maxHeight: 130 }}
+      >
+        <li className="flex align-center mr1 text-bold text-medium hover-child hover--inherit">
+          <Icon
+            name="group"
+            className="text-medium hover-child hover--inherit"
+            size={12}
+          />
+          <span
+            className="ml1 text-medium hover-child hover--inherit"
+            style={{ fontSize: "12px" }}
+          >
+            {first.common_name || first.email}
+            {text !== "" && text}
+          </span>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+function friendlySchedule(channel) {
+  let scheduleString = "";
+  if (channel.channel_type === "email") {
+    scheduleString += t`Emailed `;
+  } else if (channel.channel_type === "slack") {
+    scheduleString += t`Sent to ` + channel.details.channel + " ";
+  } else {
+    scheduleString += t`Sent `;
+  }
+
+  switch (channel.schedule_type) {
+    case "hourly":
+      scheduleString += t`hourly`;
+      break;
+    case "daily": {
+      const ampm = formatHourAMPM(channel.schedule_hour);
+      scheduleString += t`daily at ${ampm}`;
+      break;
+    }
+    case "weekly": {
+      const ampm = formatHourAMPM(channel.schedule_hour);
+      const day = formatDay(channel.schedule_day);
+      scheduleString += t`${day} at ${ampm}`;
+      break;
+    }
+    case "monthly": {
+      const ampm = formatHourAMPM(channel.schedule_hour);
+      const day = formatDay(channel.schedule_day);
+      const frame = formatFrame(channel.schedule_frame);
+      scheduleString += t`monthly on the ${frame} ${day} at ${ampm}`;
+      break;
+    }
+    default:
+      scheduleString += channel.schedule_type;
+  }
+
+  return scheduleString;
+}
+
+function formatHourAMPM(hour) {
+  if (hour > 12) {
+    const newHour = hour - 12;
+    return t`${newHour}:00 PM`;
+  } else if (hour === 0) {
+    return t`12:00 AM`;
+  } else {
+    return t`${hour}:00 AM`;
+  }
+}
+
+function formatDay(day) {
+  switch (day) {
+    case "mon":
+      return t`Monday`;
+    case "tue":
+      return t`Tuesday`;
+    case "wed":
+      return t`Wednesday`;
+    case "thu":
+      return t`Thursday`;
+    case "fri":
+      return t`Friday`;
+    case "sat":
+      return t`Saturday`;
+    case "sun":
+      return t`Sunday`;
+    default:
+      return day;
+  }
+}
+
+function formatFrame(frame) {
+  switch (frame) {
+    case "first":
+      return t`first`;
+    case "last":
+      return t`last`;
+    case "mid":
+      return t`15th (Midpoint)`;
+    default:
+      return frame;
+  }
+}
+
+export default PulsesListSidebar;

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -1,4 +1,7 @@
+/* eslint "react/prop-types": "error" */
+
 import React from "react";
+import PropTypes from "prop-types";
 import { t, ngettext, msgid } from "ttag";
 import { Flex } from "grid-styled";
 
@@ -74,6 +77,13 @@ function PulsesListSidebar({
   );
 }
 
+PulsesListSidebar.propTypes = {
+  pulses: PropTypes.array.isRequired,
+  createSubscription: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  editPulse: PropTypes.func.isRequired,
+};
+
 function EmailRecipients({ pulse }) {
   const recipients = pulse.channels[0].recipients;
   const [first, ...rest] = recipients;
@@ -112,6 +122,10 @@ function EmailRecipients({ pulse }) {
     </div>
   );
 }
+
+EmailRecipients.propTypes = {
+  pulse: PropTypes.object.isRequired,
+};
 
 function friendlySchedule(channel) {
   let scheduleString = "";

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -12,6 +12,8 @@ import Subhead from "metabase/components/type/Subhead";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import Tooltip from "metabase/components/Tooltip";
 
+import { formatHourAMPM, formatDay, formatFrame } from "metabase/lib/time";
+
 function PulsesListSidebar({
   pulses,
   createSubscription,
@@ -164,51 +166,6 @@ function friendlySchedule(channel) {
   }
 
   return scheduleString;
-}
-
-function formatHourAMPM(hour) {
-  if (hour > 12) {
-    const newHour = hour - 12;
-    return t`${newHour}:00 PM`;
-  } else if (hour === 0) {
-    return t`12:00 AM`;
-  } else {
-    return t`${hour}:00 AM`;
-  }
-}
-
-function formatDay(day) {
-  switch (day) {
-    case "mon":
-      return t`Monday`;
-    case "tue":
-      return t`Tuesday`;
-    case "wed":
-      return t`Wednesday`;
-    case "thu":
-      return t`Thursday`;
-    case "fri":
-      return t`Friday`;
-    case "sat":
-      return t`Saturday`;
-    case "sun":
-      return t`Sunday`;
-    default:
-      return day;
-  }
-}
-
-function formatFrame(frame) {
-  switch (frame) {
-    case "first":
-      return t`first`;
-    case "last":
-      return t`last`;
-    case "mid":
-      return t`15th (Midpoint)`;
-    default:
-      return frame;
-  }
 }
 
 export default PulsesListSidebar;

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -248,7 +248,7 @@ class SharingSidebar extends React.Component {
 
   render() {
     const { editingMode } = this.state;
-    const { pulse, pulses, formInput, testPulse, pulseId, users } = this.props;
+    const { pulse, pulses, formInput, testPulse, users } = this.props;
 
     // protect from empty values that will mess this up
     if (!formInput.channels || !pulse) {
@@ -296,7 +296,6 @@ class SharingSidebar extends React.Component {
           testPulse={testPulse}
           toggleSkipIfEmpty={this.toggleSkipIfEmpty}
           setPulse={this.setPulse}
-          pulseId={pulseId}
           users={users}
           handleArchive={this.handleArchive}
         />

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -1,3 +1,5 @@
+/* eslint "react/prop-types": "error" */
+
 import React from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
@@ -136,6 +138,10 @@ class SharingSidebar extends React.Component {
     setEditingPulse: PropTypes.func.isRequired,
     testPulse: PropTypes.func.isRequired,
     updateEditingPulse: PropTypes.func.isRequired,
+    pulses: PropTypes.array.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    setPulseArchived: PropTypes.func.isRequired,
+    users: PropTypes.array,
   };
 
   setPulse = pulse => {

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import _ from "underscore";
 
 import NewPulseSidebar from "metabase/sharing/components/NewPulseSidebar";
 import PulsesListSidebar from "metabase/sharing/components/PulsesListSidebar";
@@ -285,14 +286,19 @@ class SharingSidebar extends React.Component {
       return (
         <AddEditEmailSidebar
           pulse={pulse}
-          index={index}
           formInput={formInput}
           channel={channel}
           channelSpec={channelSpec}
           handleSave={this.handleSave}
           onCancel={this.onCancel}
-          onChannelPropertyChange={this.onChannelPropertyChange}
-          onChannelScheduleChange={this.onChannelScheduleChange}
+          onChannelPropertyChange={_.partial(
+            this.onChannelPropertyChange,
+            index,
+          )}
+          onChannelScheduleChange={_.partial(
+            this.onChannelScheduleChange,
+            index,
+          )}
           testPulse={testPulse}
           toggleSkipIfEmpty={this.toggleSkipIfEmpty}
           setPulse={this.setPulse}
@@ -324,14 +330,19 @@ class SharingSidebar extends React.Component {
       return (
         <AddEditSlackSidebar
           pulse={pulse}
-          index={index}
           formInput={formInput}
           channel={channel}
           channelSpec={channelSpec}
           handleSave={this.handleSave}
           onCancel={this.onCancel}
-          onChannelPropertyChange={this.onChannelPropertyChange}
-          onChannelScheduleChange={this.onChannelScheduleChange}
+          onChannelPropertyChange={_.partial(
+            this.onChannelPropertyChange,
+            index,
+          )}
+          onChannelScheduleChange={_.partial(
+            this.onChannelScheduleChange,
+            index,
+          )}
           toggleSkipIfEmpty={this.toggleSkipIfEmpty}
           handleArchive={this.handleArchive}
         />

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -279,8 +279,7 @@ class SharingSidebar extends React.Component {
         return <Sidebar />;
       }
 
-      const channel = channelDetails[0][0];
-      const index = channelDetails[0][1];
+      const [channel, index] = channelDetails[0];
       const channelSpec = formInput.channels.email;
 
       return (
@@ -312,20 +311,16 @@ class SharingSidebar extends React.Component {
       editingMode === "add-edit-slack" &&
       (pulse.channels && pulse.channels.length > 0)
     ) {
-      const channelType = "slack";
-
       const channelDetails = pulse.channels
         .map((c, i) => [c, i])
-        .filter(([c, i]) => c.enabled && c.channel_type === channelType);
+        .filter(([c, i]) => c.enabled && c.channel_type === "slack");
 
       // protection from a failure where the channels aren't loaded yet
       if (channelDetails.length === 0) {
         return <Sidebar />;
       }
 
-      const channel = channelDetails[0][0];
-      const index = channelDetails[0][1];
-
+      const [channel, index] = channelDetails[0];
       const channelSpec = formInput.channels.slack;
       return (
         <AddEditSlackSidebar

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -248,15 +248,7 @@ class SharingSidebar extends React.Component {
 
   render() {
     const { editingMode } = this.state;
-    const {
-      pulse,
-      pulses,
-      formInput,
-      emailRecipientText,
-      testPulse,
-      pulseId,
-      users,
-    } = this.props;
+    const { pulse, pulses, formInput, testPulse, pulseId, users } = this.props;
 
     // protect from empty values that will mess this up
     if (!formInput.channels || !pulse) {
@@ -297,7 +289,6 @@ class SharingSidebar extends React.Component {
           formInput={formInput}
           channel={channel}
           channelSpec={channelSpec}
-          emailRecipientText={emailRecipientText}
           handleSave={this.handleSave}
           onCancel={this.onCancel}
           onChannelPropertyChange={this.onChannelPropertyChange}

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -1,39 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
-import _ from "underscore";
-import { t, jt, ngettext, msgid } from "ttag";
-import { Flex } from "grid-styled";
 
-import Card from "metabase/components/Card";
-import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
-import EmailAttachmentPicker from "metabase/sharing/components/EmailAttachmentPicker";
-import ExternalLink from "metabase/components/ExternalLink";
-import Icon from "metabase/components/Icon";
-import Label from "metabase/components/type/Label";
-import Subhead from "metabase/components/type/Subhead";
-import Text from "metabase/components/type/Text";
-import Link from "metabase/components/Link";
-import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import RecipientPicker from "metabase/pulse/components/RecipientPicker";
-import SchedulePicker from "metabase/components/SchedulePicker";
-import Select, { Option } from "metabase/components/Select";
-import SendTestEmail from "metabase/components/SendTestEmail";
+import NewPulseSidebar from "metabase/sharing/components/NewPulseSidebar";
+import PulsesListSidebar from "metabase/sharing/components/PulsesListSidebar";
+import {
+  AddEditSlackSidebar,
+  AddEditEmailSidebar,
+} from "metabase/sharing/components/AddEditSidebar";
 import Sidebar from "metabase/dashboard/components/Sidebar";
-import Toggle from "metabase/components/Toggle";
-import Tooltip from "metabase/components/Tooltip";
-
 import Collections from "metabase/entities/collections";
 import Pulses from "metabase/entities/pulses";
 import User from "metabase/entities/users";
 
 import { connect } from "react-redux";
 
-import {
-  cleanPulse,
-  createChannel,
-  dashboardPulseIsValid,
-} from "metabase/lib/pulse";
-import MetabaseSettings from "metabase/lib/settings";
+import { cleanPulse, createChannel } from "metabase/lib/pulse";
 
 import {
   getPulseId,
@@ -51,19 +32,10 @@ import {
   testPulse,
 } from "metabase/pulse/actions";
 
-import cx from "classnames";
-
 export const CHANNEL_ICONS = {
   email: "mail",
   slack: "slack",
 };
-
-const CHANNEL_NOUN_PLURAL = {
-  email: t`Emails`,
-  slack: t`Slack messages`,
-};
-
-const Heading = ({ children }) => <h4>{children}</h4>;
 
 const cardsFromDashboard = dashboard => {
   if (dashboard === undefined) {
@@ -169,7 +141,7 @@ class SharingSidebar extends React.Component {
     this.props.updateEditingPulse(pulse);
   };
 
-  addChannel(type) {
+  addChannel = type => {
     const { dashboard, pulse, formInput } = this.props;
 
     const channelSpec = formInput.channels[type];
@@ -185,7 +157,7 @@ class SharingSidebar extends React.Component {
       cards: nonTextCardsFromDashboard(dashboard),
     };
     this.setPulse(newPulse);
-  }
+  };
 
   componentDidMount = async () => {
     await this.props.fetchPulseFormInput();
@@ -196,61 +168,24 @@ class SharingSidebar extends React.Component {
     );
   };
 
-  onChannelPropertyChange(index, name, value) {
+  onChannelPropertyChange = (index, name, value) => {
     const { pulse } = this.props;
     const channels = [...pulse.channels];
 
     channels[index] = { ...channels[index], [name]: value };
 
     this.setPulse({ ...pulse, channels });
-  }
+  };
 
   // changedProp contains the schedule property that user just changed
   // newSchedule may contain also other changed properties as some property changes reset other properties
-  onChannelScheduleChange(index, newSchedule, changedProp) {
+  onChannelScheduleChange = (index, newSchedule, changedProp) => {
     const { pulse } = this.props;
     const channels = [...pulse.channels];
 
     channels[index] = { ...channels[index], ...newSchedule };
     this.setPulse({ ...pulse, channels });
-  }
-
-  renderFields(channel, index, channelSpec) {
-    const valueForField = field => {
-      const value = channel.details && channel.details[field.name];
-      return value != null ? value : null; // convert undefined to null so Uncontrollable doesn't ignore changes
-    };
-    return (
-      <div>
-        {channelSpec.fields.map(field => (
-          <div key={field.name} className={field.name}>
-            <span className="text-bold mr1">{field.displayName}</span>
-            {field.type === "select" ? (
-              <Select
-                className="text-bold bg-white inline-block"
-                value={valueForField(field)}
-                placeholder={t`Pick a user or channel...`}
-                searchProp="name"
-                // Address #5799 where `details` object is missing for some reason
-                onChange={o =>
-                  this.onChannelPropertyChange(index, "details", {
-                    ...channel.details,
-                    [field.name]: o.target.value,
-                  })
-                }
-              >
-                {field.options.map(option => (
-                  <Option name={option} value={option}>
-                    {option}
-                  </Option>
-                ))}
-              </Select>
-            ) : null}
-          </div>
-        ))}
-      </div>
-    );
-  }
+  };
 
   toggleSkipIfEmpty = () => {
     const { pulse } = this.props;
@@ -290,197 +225,6 @@ class SharingSidebar extends React.Component {
     });
   };
 
-  formatHourAMPM(hour) {
-    if (hour > 12) {
-      const newHour = hour - 12;
-      return t`${newHour}:00 PM`;
-    } else if (hour === 0) {
-      return t`12:00 AM`;
-    } else {
-      return t`${hour}:00 AM`;
-    }
-  }
-
-  formatDay(day) {
-    switch (day) {
-      case "mon":
-        return t`Monday`;
-      case "tue":
-        return t`Tuesday`;
-      case "wed":
-        return t`Wednesday`;
-      case "thu":
-        return t`Thursday`;
-      case "fri":
-        return t`Friday`;
-      case "sat":
-        return t`Saturday`;
-      case "sun":
-        return t`Sunday`;
-      default:
-        return day;
-    }
-  }
-
-  formatFrame(frame) {
-    switch (frame) {
-      case "first":
-        return t`first`;
-      case "last":
-        return t`last`;
-      case "mid":
-        return t`15th (Midpoint)`;
-      default:
-        return frame;
-    }
-  }
-
-  friendlySchedule(channel) {
-    let scheduleString = "";
-    if (channel.channel_type === "email") {
-      scheduleString += t`Emailed `;
-    } else if (channel.channel_type === "slack") {
-      scheduleString += t`Sent to ` + channel.details.channel + " ";
-    } else {
-      scheduleString += t`Sent `;
-    }
-
-    switch (channel.schedule_type) {
-      case "hourly":
-        scheduleString += t`hourly`;
-        break;
-      case "daily": {
-        const ampm = this.formatHourAMPM(channel.schedule_hour);
-        scheduleString += t`daily at ${ampm}`;
-        break;
-      }
-      case "weekly": {
-        const ampm = this.formatHourAMPM(channel.schedule_hour);
-        const day = this.formatDay(channel.schedule_day);
-        scheduleString += t`${day} at ${ampm}`;
-        break;
-      }
-      case "monthly": {
-        const ampm = this.formatHourAMPM(channel.schedule_hour);
-        const day = this.formatDay(channel.schedule_day);
-        const frame = this.formatFrame(channel.schedule_frame);
-        scheduleString += t`monthly on the ${frame} ${day} at ${ampm}`;
-        break;
-      }
-      default:
-        scheduleString += channel.schedule_type;
-    }
-
-    return scheduleString;
-  }
-
-  renderEmailRecipients(recipients) {
-    const [first, ...rest] = recipients;
-
-    let text = "";
-
-    if (rest != null && rest.length > 0) {
-      text += ngettext(
-        msgid` and ${rest.length} other`,
-        ` and ${rest.length} others`,
-        rest.length,
-      );
-    }
-
-    return (
-      <li className="flex align-center mr1 text-bold text-medium hover-child hover--inherit">
-        <Icon
-          name="group"
-          className="text-medium hover-child hover--inherit"
-          size={12}
-        />
-        <span
-          className="ml1 text-medium hover-child hover--inherit"
-          style={{ fontSize: "12px" }}
-        >
-          {first.common_name || first.email}
-          {text !== "" && text}
-        </span>
-      </li>
-    );
-  }
-
-  renderRecipients(pulse) {
-    return (
-      <div className="text-medium hover-child">
-        <ul
-          className="flex flex-wrap scroll-x scroll-y"
-          style={{ maxHeight: 130 }}
-        >
-          {this.renderEmailRecipients(pulse.channels[0].recipients)}
-        </ul>
-      </div>
-    );
-  }
-
-  getConfirmItems() {
-    return this.props.pulse.channels.map((c, index) =>
-      c.channel_type === "email" ? (
-        <span key={index}>
-          {jt`This dashboard will no longer be emailed to ${(
-            <strong>
-              {(n => ngettext(msgid`${n} address`, `${n} addresses`, n))(
-                c.recipients.length,
-              )}
-            </strong>
-          )} ${<strong>{c.schedule_type}</strong>}`}
-          .
-        </span>
-      ) : c.channel_type === "slack" ? (
-        <span key={index}>
-          {jt`Slack channel ${(
-            <strong>{c.details && c.details.channel}</strong>
-          )} will no longer get this dashboard ${(
-            <strong>{c.schedule_type}</strong>
-          )}`}
-          .
-        </span>
-      ) : (
-        <span key={index}>
-          {jt`Channel ${(
-            <strong>{c.channel_type}</strong>
-          )} will no longer receive this dashboard ${(
-            <strong>{c.schedule_type}</strong>
-          )}`}
-          .
-        </span>
-      ),
-    );
-  }
-
-  renderDeleteSubscription() {
-    const { pulse } = this.props;
-
-    if (pulse.id != null && !pulse.archived) {
-      return (
-        <div className="border-top pt1 pb3 flex justify-end">
-          <ModalWithTrigger
-            triggerClasses="Button Button--borderless text-light text-error-hover flex-align-right flex-no-shrink"
-            triggerElement={t`Delete this subscription`}
-          >
-            {({ onClose }) => (
-              <DeleteModalWithConfirm
-                objectType="pulse"
-                title={t`Delete this subscription to ${pulse.name}?`}
-                buttonText={t`Delete`}
-                confirmItems={this.getConfirmItems()}
-                onClose={onClose}
-                onDelete={this.handleArchive}
-              />
-            )}
-          </ModalWithTrigger>
-        </div>
-      );
-    }
-
-    return null;
-  }
-
   handleArchive = async () => {
     await this.props.setPulseArchived(this.props.pulse, true);
     this.setState({ editingMode: "list-pulses", returnMode: [] });
@@ -504,21 +248,15 @@ class SharingSidebar extends React.Component {
 
   render() {
     const { editingMode } = this.state;
-    const { pulse, pulses, formInput } = this.props;
-
-    const caveatMessage = (
-      <Text className="mx4 my2 p2 bg-light text-dark rounded">{jt`${(
-        <span className="text-bold">Note:</span>
-      )} charts in your subscription won't look the same as in your dashboard. ${(
-        <ExternalLink
-          className="link"
-          target="_blank"
-          href={MetabaseSettings.docsUrl("users-guide/dashboard-subscriptions")}
-        >
-          Learn more
-        </ExternalLink>
-      )}.`}</Text>
-    );
+    const {
+      pulse,
+      pulses,
+      formInput,
+      emailRecipientText,
+      testPulse,
+      pulseId,
+      users,
+    } = this.props;
 
     // protect from empty values that will mess this up
     if (!formInput.channels || !pulse) {
@@ -527,72 +265,22 @@ class SharingSidebar extends React.Component {
 
     if (editingMode === "list-pulses" && pulses.length > 0) {
       return (
-        <Sidebar>
-          <div className="px4 pt3 flex justify-between align-center">
-            <Subhead>{t`Subscriptions`}</Subhead>
-
-            <Flex align="center">
-              <Tooltip tooltip={t`Set up a new schedule`}>
-                <Icon
-                  name="add"
-                  className="text-brand bg-light-hover rounded p1 cursor-pointer mr1"
-                  size={18}
-                  onClick={() => this.createSubscription()}
-                />
-              </Tooltip>
-              <Tooltip tooltip={t`Close`}>
-                <Icon
-                  name="close"
-                  className="text-light bg-light-hover rounded p1 cursor-pointer"
-                  size={22}
-                  onClick={this.onCancel}
-                />
-              </Tooltip>
-            </Flex>
-          </div>
-          <div className="my2 mx4">
-            {pulses.map(pulse => (
-              <Card
-                flat
-                className="mb3 cursor-pointer bg-brand-hover"
-                onClick={() =>
-                  this.editPulse(pulse, pulse.channels[0].channel_type)
-                }
-              >
-                <div className="px3 py2 hover-parent hover--inherit text-white-hover">
-                  <div className="flex align-center hover-child hover--inherit">
-                    <Icon
-                      name={
-                        pulse.channels[0].channel_type === "email"
-                          ? "mail"
-                          : "slack"
-                      }
-                      className="mr1"
-                      style={{ paddingBottom: "5px" }}
-                      size={16}
-                    />
-                    <Label className="hover-child hover--inherit">
-                      {this.friendlySchedule(pulse.channels[0])}
-                    </Label>
-                  </div>
-                  {pulse.channels[0].channel_type === "email" &&
-                    this.renderRecipients(pulse)}
-                </div>
-              </Card>
-            ))}
-          </div>
-        </Sidebar>
+        <PulsesListSidebar
+          pulses={pulses}
+          createSubscription={this.createSubscription}
+          onCancel={this.onCancel}
+          editPulse={this.editPulse}
+        />
       );
     }
+
     if (
       editingMode === "add-edit-email" &&
       (pulse.channels && pulse.channels.length > 0)
     ) {
-      const channelType = "email";
-
       const channelDetails = pulse.channels
         .map((c, i) => [c, i])
-        .filter(([c, i]) => c.enabled && c.channel_type === channelType);
+        .filter(([c, i]) => c.enabled && c.channel_type === "email");
       // protection from a failure where the channels aren't loaded yet
       if (channelDetails.length === 0) {
         return <Sidebar />;
@@ -600,88 +288,27 @@ class SharingSidebar extends React.Component {
 
       const channel = channelDetails[0][0];
       const index = channelDetails[0][1];
-
       const channelSpec = formInput.channels.email;
 
       return (
-        <Sidebar
-          onClose={this.handleSave}
+        <AddEditEmailSidebar
+          pulse={pulse}
+          index={index}
+          formInput={formInput}
+          channel={channel}
+          channelSpec={channelSpec}
+          emailRecipientText={emailRecipientText}
+          handleSave={this.handleSave}
           onCancel={this.onCancel}
-          className="text-dark"
-          closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
-        >
-          <div className="pt4 px4 flex align-center">
-            <Icon name="mail" className="mr1" size={21} />
-            <Heading>{t`Email this dashboard`}</Heading>
-          </div>
-          {caveatMessage}
-          <div className="my2 px4">
-            <div>
-              <div className="text-bold mb1">
-                {this.props.emailRecipientText || t`To:`}
-              </div>
-              <RecipientPicker
-                isNewPulse={this.props.pulseId === undefined}
-                autoFocus={false}
-                recipients={channel.recipients}
-                recipientTypes={channelSpec.recipients}
-                users={this.props.users}
-                onRecipientsChange={recipients =>
-                  this.onChannelPropertyChange(index, "recipients", recipients)
-                }
-              />
-            </div>
-            {channelSpec.fields &&
-              this.renderFields(channel, index, channelSpec)}
-            <SchedulePicker
-              schedule={_.pick(
-                channel,
-                "schedule_day",
-                "schedule_frame",
-                "schedule_hour",
-                "schedule_type",
-              )}
-              scheduleOptions={channelSpec.schedules}
-              textBeforeInterval={t`Sent`}
-              textBeforeSendTime={t`${CHANNEL_NOUN_PLURAL[
-                channelSpec && channelSpec.type
-              ] || t`Messages`} will be sent at`}
-              onScheduleChange={this.onChannelScheduleChange.bind(this, index)}
-            />
-            <div className="pt2 pb1">
-              <SendTestEmail
-                channel={channel}
-                pulse={pulse}
-                testPulse={this.props.testPulse}
-              />
-            </div>
-
-            <div className="text-bold py3 mt2 flex justify-between align-center border-top">
-              <Heading>{t`Don't send if there aren't results`}</Heading>
-              <Toggle
-                value={pulse.skip_if_empty || false}
-                onChange={this.toggleSkipIfEmpty}
-              />
-            </div>
-            <div className="text-bold py2 flex justify-between align-center border-top">
-              <div className="flex align-center">
-                <Heading>{t`Attach results`}</Heading>
-                <Icon
-                  name="info"
-                  className="text-medium ml1"
-                  size={12}
-                  tooltip={t`Attachments can contain up to 2,000 rows of data.`}
-                />
-              </div>
-            </div>
-            <EmailAttachmentPicker
-              cards={pulse.cards}
-              pulse={pulse}
-              setPulse={this.setPulse.bind(this)}
-            />
-            {pulse.id != null && this.renderDeleteSubscription()}
-          </div>
-        </Sidebar>
+          onChannelPropertyChange={this.onChannelPropertyChange}
+          onChannelScheduleChange={this.onChannelScheduleChange}
+          testPulse={testPulse}
+          toggleSkipIfEmpty={this.toggleSkipIfEmpty}
+          setPulse={this.setPulse}
+          pulseId={pulseId}
+          users={users}
+          handleArchive={this.handleArchive}
+        />
       );
     }
 
@@ -694,6 +321,7 @@ class SharingSidebar extends React.Component {
       const channelDetails = pulse.channels
         .map((c, i) => [c, i])
         .filter(([c, i]) => c.enabled && c.channel_type === channelType);
+
       // protection from a failure where the channels aren't loaded yet
       if (channelDetails.length === 0) {
         return <Sidebar />;
@@ -703,163 +331,55 @@ class SharingSidebar extends React.Component {
       const index = channelDetails[0][1];
 
       const channelSpec = formInput.channels.slack;
-
       return (
-        <Sidebar
-          onClose={this.handleSave}
+        <AddEditSlackSidebar
+          pulse={pulse}
+          index={index}
+          formInput={formInput}
+          channel={channel}
+          channelSpec={channelSpec}
+          handleSave={this.handleSave}
           onCancel={this.onCancel}
-          className="text-dark"
-          closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
-        >
-          <div className="pt4 flex align-center px4 mb3">
-            <Icon name="slack" className="mr1" size={21} />
-            <Heading>{t`Send this dashboard to Slack`}</Heading>
-          </div>
-          {caveatMessage}
-          <div className="pb2 px4">
-            {channelSpec.fields &&
-              this.renderFields(channel, index, channelSpec)}
-            <SchedulePicker
-              schedule={_.pick(
-                channel,
-                "schedule_day",
-                "schedule_frame",
-                "schedule_hour",
-                "schedule_type",
-              )}
-              scheduleOptions={channelSpec.schedules}
-              textBeforeInterval={t`Sent`}
-              textBeforeSendTime={t`${CHANNEL_NOUN_PLURAL[
-                channelSpec && channelSpec.type
-              ] || t`Messages`} will be sent at`}
-              onScheduleChange={this.onChannelScheduleChange.bind(this, index)}
-            />
-            <div className="text-bold py2 mt2 flex justify-between align-center border-top">
-              <Heading>{t`Don't send if there aren't results`}</Heading>
-              <Toggle
-                value={pulse.skip_if_empty || false}
-                onChange={this.toggleSkipIfEmpty}
-              />
-            </div>
-            {pulse.id != null && this.renderDeleteSubscription()}
-          </div>
-        </Sidebar>
+          onChannelPropertyChange={this.onChannelPropertyChange}
+          onChannelScheduleChange={this.onChannelScheduleChange}
+          toggleSkipIfEmpty={this.toggleSkipIfEmpty}
+          handleArchive={this.handleArchive}
+        />
       );
     }
 
     if (editingMode === "new-pulse" || pulses.length === 0) {
-      const emailSpec = formInput.channels.email;
-      const slackSpec = formInput.channels.slack;
+      const emailConfigured = formInput.channels.email.configured;
+      const slackConfigured = formInput.channels.slack.configured;
 
       return (
-        <Sidebar onCancel={this.onCancel}>
-          <div className="mt2 pt2 px4">
-            <Heading>{t`Create a dashboard subscription`}</Heading>
-          </div>
-          <div className="my1 mx4">
-            <Card
-              flat
-              className={cx("mt1 mb3", {
-                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
-                  emailSpec.configured,
-              })}
-              onClick={() => {
-                if (emailSpec.configured) {
-                  this.setState(({ returnMode }) => {
-                    return {
-                      editingMode: "add-edit-email",
-                      returnMode: returnMode.concat([editingMode]),
-                    };
-                  });
-                  this.addChannel("email");
-                }
-              }}
-            >
-              <div className="px3 pt3 pb2">
-                <div className="flex align-center">
-                  <Icon
-                    name="mail"
-                    className={cx(
-                      "mr1",
-                      {
-                        "text-brand hover-child hover--inherit":
-                          emailSpec.configured,
-                      },
-                      { "text-light": !emailSpec.configured },
-                    )}
-                  />
-                  <h3
-                    className={cx({ "text-light": !emailSpec.configured })}
-                  >{t`Email it`}</h3>
-                </div>
-                <Text
-                  lineHeight={1.5}
-                  className={cx("text-medium", {
-                    "hover-child hover--inherit": emailSpec.configured,
-                  })}
-                >
-                  {!emailSpec.configured &&
-                    jt`You'll need to ${(
-                      <Link to="/admin/settings/email" className="link">
-                        set up email
-                      </Link>
-                    )} first.`}
-                  {emailSpec.configured &&
-                    t`You can send this dashboard regularly to users or email addresses.`}
-                </Text>
-              </div>
-            </Card>
-            <Card
-              flat
-              className={cx({
-                "cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit":
-                  slackSpec.configured,
-              })}
-              onClick={() => {
-                if (slackSpec.configured) {
-                  this.setState(({ returnMode }) => {
-                    return {
-                      editingMode: "add-edit-slack",
-                      returnMode: returnMode.concat([editingMode]),
-                    };
-                  });
-                  this.addChannel("slack");
-                }
-              }}
-            >
-              <div className="px3 pt3 pb2">
-                <div className="flex align-center mb1">
-                  <Icon
-                    name={slackSpec.configured ? "slack_colorized" : "slack"}
-                    size={24}
-                    className={cx("mr1", {
-                      "text-light": !slackSpec.configured,
-                      "hover-child hover--inherit": slackSpec.configured,
-                    })}
-                  />
-                  <h3
-                    className={cx({ "text-light": !slackSpec.configured })}
-                  >{t`Send it to Slack`}</h3>
-                </div>
-                <Text
-                  lineHeight={1.5}
-                  className={cx("text-medium", {
-                    "hover-child hover--inherit": slackSpec.configured,
-                  })}
-                >
-                  {!slackSpec.configured &&
-                    jt`First, you'll have to ${(
-                      <Link to="/admin/settings/slack" className="link">
-                        configure Slack
-                      </Link>
-                    )}.`}
-                  {slackSpec.configured &&
-                    t`Pick a channel and a schedule, and Metabase will do the rest.`}
-                </Text>
-              </div>
-            </Card>
-          </div>
-        </Sidebar>
+        <NewPulseSidebar
+          onCancel={this.onCancel}
+          emailConfigured={emailConfigured}
+          slackConfigured={slackConfigured}
+          onNewEmailPulse={() => {
+            if (emailConfigured) {
+              this.setState(({ returnMode }) => {
+                return {
+                  editingMode: "add-edit-email",
+                  returnMode: returnMode.concat([editingMode]),
+                };
+              });
+              this.addChannel("email");
+            }
+          }}
+          onNewSlackPulse={() => {
+            if (slackConfigured) {
+              this.setState(({ returnMode }) => {
+                return {
+                  editingMode: "add-edit-slack",
+                  returnMode: returnMode.concat([editingMode]),
+                };
+              });
+              this.addChannel("slack");
+            }
+          }}
+        />
       );
     }
 


### PR DESCRIPTION
**Description**
1. split the different branches of `SharingSidebar`'s `render` function into several different components
2. converted any `renderFoo`-like functions into components
3. minor tweak to a few props to avoid having to pass them down
4. fixed a few react errors -- missing/incorrect props & missing `key` errors 

I'm turning on propType lint rules in these new files I've created to avoid any propType regressions as they're hard to catch. Hopefully, we can turn on these linting rules everywhere soon (after we fix the many errs).

**Verification**
tested the following, comparing request bodies made to endpoints, as well.
- shows "new pulse" screen when no subscriptions exist
- shows a link to configure either email/slack if not previously configured
- can add a new email subscription 
- can add a new slack subscription
- can edit existing subscriptions
- can delete existing subscriptions