### PR TITLE
Unify start scripts in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,73 +2,42 @@
 # STAGE 1.1: builder frontend
 ###################
 
-FROM node:12.20.1-alpine as frontend
+FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as frontend
 
 WORKDIR /app/source
-
-ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # frontend dependencies
 COPY yarn.lock package.json .yarnrc ./
 RUN yarn install --frozen-lockfile
+# TODO: we should build the frontend here while the backend is getting deps, should be way faster than what we do today
 
 ###################
 # STAGE 1.2: builder backend
 ###################
 
-FROM adoptopenjdk/openjdk11:alpine as backend
+FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as backend
 
 WORKDIR /app/source
 
-ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
-
-# bash:    various shell scripts
-# curl:    needed by script that installs Clojure CLI
-
-RUN apk add --no-cache curl bash
-
-# lein:    backend dependencies and building
-RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
-  chmod +x /usr/local/bin/lein && \
-  /usr/local/bin/lein upgrade
-
 # backend dependencies
 COPY project.clj .
-RUN lein deps
+RUN lein deps :tree
 
 ###################
 # STAGE 1.3: main builder
 ###################
 
-FROM adoptopenjdk/openjdk11:alpine as builder
+FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as builder
 
 ARG MB_EDITION=oss
 
 WORKDIR /app/source
 
-ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
-
-# bash:    various shell scripts
-# curl:    needed by script that installs Clojure CLI
-# git:     ./bin/version
-# yarn:    frontend building
-# java-cacerts: installs updated cacerts to /etc/ssl/certs/java/cacerts
-
-RUN apk add --no-cache coreutils bash yarn git curl java-cacerts
-
-# lein:    backend dependencies and building
-RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
-  chmod +x /usr/local/bin/lein && \
-  /usr/local/bin/lein upgrade
-
-# Clojure CLI (needed for some build scripts)
-RUN curl https://download.clojure.org/install/linux-install-1.10.1.708.sh -o /tmp/linux-install-1.10.1.708.sh && \
-  chmod +x /tmp/linux-install-1.10.1.708.sh && \
-  sh /tmp/linux-install-1.10.1.708.sh
-
+# try to reuse caching as much as possible
+COPY --from=frontend /usr/local/share/.cache/yarn/. /usr/local/share/.cache/yarn/.
 COPY --from=frontend /app/source/. .
+COPY --from=backend /root/.m2/repository/. /root/.m2/repository/.
 COPY --from=backend /app/source/. .
-COPY --from=backend /root/. /root/
 
 # add the rest of the source
 COPY . .
@@ -80,15 +49,15 @@ RUN INTERACTIVE=false MB_EDITION=$MB_EDITION bin/build
 # # STAGE 2: runner
 # ###################
 
-FROM adoptopenjdk/openjdk11:alpine-jre as runner
+## Remember that this runner image needs to be the same as bin/docker/Dockerfile with the exception that this one grabs the 
+## jar from the previous stage rather than the local build
 
-WORKDIR /app
+FROM adoptopenjdk/openjdk11:alpine-jre as runner
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk -U upgrade &&  \
-    apk add --update --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk upgrade && apk add --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
@@ -96,16 +65,12 @@ RUN apk -U upgrade &&  \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
     mkdir -p /plugins && chmod a+rwx /plugins
 
-# add fixed cacerts
-COPY --from=builder /etc/ssl/certs/java/cacerts /opt/java/openjdk/lib/security/cacerts
-
 # add Metabase script and uberjar
-RUN mkdir -p bin target/uberjar
-COPY --from=builder /app/source/target/uberjar/metabase.jar /app/target/uberjar/
-COPY --from=builder /app/source/bin/start /app/bin/
+COPY --from=builder /app/source/target/uberjar/metabase.jar /app/
+COPY bin/docker/run_metabase.sh /app/
 
 # expose our default runtime port
 EXPOSE 3000
 
 # run it
-ENTRYPOINT ["/app/bin/start"]
+CMD ["/app/run_metabase.sh"]

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,10 +1,12 @@
+## Remember that this runner image needs to be the same as the Dockerfile in the root with the exception that this one grabs the 
+## jar from the local folder rather than the jar from the previous step in a multi-stage build
+
 FROM adoptopenjdk/openjdk11:alpine-jre
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk -U upgrade &&  \
-    apk add --update --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk upgrade & apk add --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
@@ -18,10 +20,4 @@ COPY ./metabase.jar ./run_metabase.sh /app/
 # expose our default runtime port
 EXPOSE 3000
 
-# if you have an H2 database that you want to initialize the new Metabase
-# instance with, mount it in the container as a volume that will match the
-# pattern /app/initial*.db:
-# $ docker run ... -v $PWD/metabase.db.mv.db:/app/initial.db.mv.db ...
-
-# run it
-ENTRYPOINT ["/app/run_metabase.sh"]
+CMD ["/app/run_metabase.sh"]


### PR DESCRIPTION
- Unifying the run_metabase.sh start script to both containers (build and release)
- Use newer builder images