### PR TITLE
Split metric reference page routes

### DIFF
--- a/frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx
+++ b/frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx
@@ -18,7 +18,7 @@ const MetricImportantFieldsDetail = ({
   onChangeLocation,
   formField,
 }) =>
-  isEditing ? (
+  !fields ? null : isEditing ? (
     <div className={cx(D.detail)}>
       <div className={D.detailBody}>
         <div className={D.detailTitle}>
@@ -44,7 +44,7 @@ const MetricImportantFieldsDetail = ({
         </div>
       </div>
     </div>
-  ) : fields ? (
+  ) : (
     <FieldsToGroupBy
       fields={fields}
       databaseId={table.db_id}
@@ -52,7 +52,8 @@ const MetricImportantFieldsDetail = ({
       title={t`Most useful fields to group this metric by`}
       onChangeLocation={onChangeLocation}
     />
-  ) : null;
+  );
+
 MetricImportantFieldsDetail.propTypes = {
   fields: PropTypes.object,
   metric: PropTypes.object.isRequired,

--- a/frontend/src/metabase/reference/metrics/MetricDetail.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetail.jsx
@@ -32,6 +32,8 @@ import {
 import * as metadataActions from "metabase/redux/metadata";
 import * as actions from "metabase/reference/reference";
 
+import _ from "underscore";
+
 const mapStateToProps = (state, props) => {
   const entity = getMetric(state, props) || {};
   const guide = getGuide(state, props);
@@ -65,7 +67,11 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {
   ...metadataActions,
-  ...actions,
+
+  // Metric page doesn't use Redux isEditing state and related callbacks
+  // The state and callbacks are received via props
+  ..._.omit(actions, "startEditing", "endEditing"),
+
   onChangeLocation: push,
 };
 

--- a/frontend/src/metabase/reference/metrics/MetricDetail.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetail.jsx
@@ -5,6 +5,8 @@ import { connect } from "react-redux";
 import { reduxForm } from "redux-form";
 import { push } from "react-router-redux";
 import { t } from "ttag";
+import _ from "underscore";
+
 import List from "metabase/components/List";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
@@ -31,8 +33,6 @@ import {
 
 import * as metadataActions from "metabase/redux/metadata";
 import * as actions from "metabase/reference/reference";
-
-import _ from "underscore";
 
 const mapStateToProps = (state, props) => {
   const entity = getMetric(state, props) || {};

--- a/frontend/src/metabase/reference/metrics/MetricDetail.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetail.jsx
@@ -25,7 +25,6 @@ import {
   getError,
   getLoading,
   getUser,
-  getIsEditing,
   getIsFormulaExpanded,
   getForeignKeys,
 } from "../selectors";
@@ -59,7 +58,6 @@ const mapStateToProps = (state, props) => {
     loadingError: getError(state, props),
     user: getUser(state, props),
     foreignKeys: getForeignKeys(state, props),
-    isEditing: getIsEditing(state, props),
     isFormulaExpanded: getIsFormulaExpanded(state, props),
     initialValues,
   };

--- a/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
@@ -87,7 +87,12 @@ export default class MetricDetailContainer extends Component {
         style={isEditing ? { paddingTop: "43px" } : {}}
         sidebar={<MetricSidebar metric={metric} user={user} />}
       >
-        <MetricDetail {...this.props} isEditing={isEditing} />
+        <MetricDetail
+          {...this.props}
+          isEditing={isEditing}
+          startEditing={this.startEditing}
+          endEditing={this.endEditing}
+        />
       </SidebarLayout>
     );
   }

--- a/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
@@ -10,20 +10,13 @@ import MetricDetail from "metabase/reference/metrics/MetricDetail";
 import * as metadataActions from "metabase/redux/metadata";
 import * as actions from "metabase/reference/reference";
 
-import {
-  getUser,
-  getMetric,
-  getMetricId,
-  getDatabaseId,
-  getIsEditing,
-} from "../selectors";
+import { getUser, getMetric, getMetricId, getDatabaseId } from "../selectors";
 
 const mapStateToProps = (state, props) => ({
   user: getUser(state, props),
   metric: getMetric(state, props),
   metricId: getMetricId(state, props),
   databaseId: getDatabaseId(state, props),
-  isEditing: getIsEditing(state, props),
 });
 
 const mapDispatchToProps = {
@@ -43,7 +36,6 @@ export default class MetricDetailContainer extends Component {
     metric: PropTypes.object.isRequired,
     metricId: PropTypes.number.isRequired,
     databaseId: PropTypes.number.isRequired,
-    isEditing: PropTypes.bool,
   };
 
   async fetchContainerData() {
@@ -63,7 +55,8 @@ export default class MetricDetailContainer extends Component {
   }
 
   render() {
-    const { isEditing, user, metric } = this.props;
+    const { location, user, metric } = this.props;
+    const isEditing = location.pathname.endsWith("/edit");
 
     return (
       <SidebarLayout
@@ -71,7 +64,7 @@ export default class MetricDetailContainer extends Component {
         style={isEditing ? { paddingTop: "43px" } : {}}
         sidebar={<MetricSidebar metric={metric} user={user} />}
       >
-        <MetricDetail {...this.props} />
+        <MetricDetail {...this.props} isEditing={isEditing} />
       </SidebarLayout>
     );
   }

--- a/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
@@ -3,6 +3,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
+import MetabaseAnalytics from "metabase/lib/analytics";
+
 import MetricSidebar from "./MetricSidebar";
 import SidebarLayout from "metabase/components/SidebarLayout";
 import MetricDetail from "metabase/reference/metrics/MetricDetail";
@@ -38,8 +40,26 @@ export default class MetricDetailContainer extends Component {
     databaseId: PropTypes.number.isRequired,
   };
 
+  constructor(props) {
+    super(props);
+    this.startEditing = this.startEditing.bind(this);
+    this.endEditing = this.endEditing.bind(this);
+  }
+
   async fetchContainerData() {
     await actions.wrappedFetchMetricDetail(this.props, this.props.metricId);
+  }
+
+  startEditing() {
+    const { metric, router } = this.props;
+    router.replace(`/reference/metrics/${metric.id}/edit`);
+    MetabaseAnalytics.trackEvent("Data Reference", "Started Editing");
+  }
+
+  endEditing() {
+    const { metric, router } = this.props;
+    router.replace(`/reference/metrics/${metric.id}`);
+    // No need to track end of editing here, as it's done by actions.clearState below
   }
 
   UNSAFE_componentWillMount() {

--- a/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricDetailContainer.jsx
@@ -32,6 +32,9 @@ const mapDispatchToProps = {
 )
 export default class MetricDetailContainer extends Component {
   static propTypes = {
+    router: PropTypes.shape({
+      replace: PropTypes.func.isRequired,
+    }).isRequired,
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -256,6 +256,10 @@ export const getRoutes = store => (
         <Route path="metrics" component={MetricListContainer} />
         <Route path="metrics/:metricId" component={MetricDetailContainer} />
         <Route
+          path="metrics/:metricId/edit"
+          component={MetricDetailContainer}
+        />
+        <Route
           path="metrics/:metricId/questions"
           component={MetricQuestionsContainer}
         />

--- a/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
@@ -25,58 +25,58 @@ describe("scenarios > reference > metrics", () => {
 
   it("should see the listing", () => {
     cy.visit("/reference/metrics");
-    cy.contains(METRIC_NAME);
-    cy.contains(METRIC_DESCRIPTION);
+    cy.findByText(METRIC_NAME);
+    cy.findByText(METRIC_DESCRIPTION);
   });
 
   it("should let the user navigate to details", () => {
     cy.visit("/reference/metrics");
-    cy.contains(METRIC_NAME).click();
-    cy.contains("Why this metric is interesting");
+    cy.findByText(METRIC_NAME).click();
+    cy.findByText("Why this metric is interesting");
   });
 
   it("should let an admin edit details about the metric", () => {
     cy.visit("/reference/metrics");
-    cy.contains(METRIC_NAME).click();
+    cy.findByText(METRIC_NAME).click();
 
-    cy.contains("Edit").click();
-    cy.contains("Description")
+    cy.findByText("Edit").click();
+    cy.findByText("Description")
       .parent()
       .parent()
       .find("textarea")
       .type("Count of orders under $100");
-    cy.contains("button", "Save").click();
-    cy.contains("Reason for changes")
+    cy.findByText("Save").click();
+    cy.findByText("Reason for changes")
       .parent()
       .parent()
       .find("textarea")
       .type("Renaming the description");
-    cy.contains("button", "Save changes").click();
+    cy.findByText("Save changes").click();
 
-    cy.contains("Count of orders under $100");
+    cy.findByText("Count of orders under $100");
   });
 
   it("should let an admin start to edit and cancel without saving", () => {
     cy.visit("/reference/metrics");
-    cy.contains(METRIC_NAME).click();
+    cy.findByText(METRIC_NAME).click();
 
-    cy.contains("Edit").click();
-    cy.contains("Why this metric is interesting")
+    cy.findByText("Edit").click();
+    cy.findByText("Why this metric is interesting")
       .parent()
       .parent()
       .find("textarea")
       .type("Because it's very nice");
-    cy.contains("Cancel").click();
+    cy.findByText("Cancel").click();
 
-    cy.contains("Because it's very nice").should("have.length", 0);
+    cy.findByText("Because it's very nice").should("have.length", 0);
   });
 
   it("should have different URI while editing the metric", () => {
     cy.visit("/reference/metrics");
-    cy.contains(METRIC_NAME).click();
+    cy.findByText(METRIC_NAME).click();
 
     cy.url().should("match", /\/reference\/metrics\/\d+$/);
-    cy.contains("Edit").click();
+    cy.findByText("Edit").click();
     cy.url().should("match", /\/reference\/metrics\/\d+\/edit$/);
   });
 });

--- a/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
@@ -44,6 +44,7 @@ describe("scenarios > reference > metrics", () => {
       .parent()
       .parent()
       .find("textarea")
+      .clear()
       .type("Count of orders under $100");
     cy.findByText("Save").click();
     cy.findByText("Reason for changes")

--- a/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
@@ -1,0 +1,82 @@
+import { signInAsAdmin, restore } from "__support__/cypress";
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+
+describe("scenarios > reference > metrics", () => {
+  const METRIC_NAME = "orders < 100";
+  const METRIC_DESCRIPTION = "Count of orders with a total under $100.";
+
+  beforeEach(() => {
+    restore();
+    signInAsAdmin();
+
+    cy.request("POST", "/api/metric", {
+      definition: {
+        aggregation: ["count"],
+        filter: ["<", ["field", ORDERS.TOTAL, null], 100],
+        "source-table": ORDERS_ID,
+      },
+      name: METRIC_NAME,
+      description: METRIC_DESCRIPTION,
+      table_id: ORDERS_ID,
+    });
+  });
+
+  it("should see the listing", () => {
+    cy.visit("/reference/metrics");
+    cy.contains(METRIC_NAME);
+    cy.contains(METRIC_DESCRIPTION);
+  });
+
+  it("should let the user navigate to details", () => {
+    cy.visit("/reference/metrics");
+    cy.contains(METRIC_NAME).click();
+    cy.contains("Why this metric is interesting");
+  });
+
+  it("should let an admin edit details about the metric", () => {
+    cy.visit("/reference/metrics");
+    cy.contains(METRIC_NAME).click();
+
+    cy.contains("Edit").click();
+    cy.contains("Description")
+      .parent()
+      .parent()
+      .find("textarea")
+      .type("Count of orders under $100");
+    cy.contains("button", "Save").click();
+    cy.contains("Reason for changes")
+      .parent()
+      .parent()
+      .find("textarea")
+      .type("Renaming the description");
+    cy.contains("button", "Save changes").click();
+
+    cy.contains("Count of orders under $100");
+  });
+
+  it("should let an admin start to edit and cancel without saving", () => {
+    cy.visit("/reference/metrics");
+    cy.contains(METRIC_NAME).click();
+
+    cy.contains("Edit").click();
+    cy.contains("Why this metric is interesting")
+      .parent()
+      .parent()
+      .find("textarea")
+      .type("Because it's very nice");
+    cy.contains("Cancel").click();
+
+    cy.contains("Because it's very nice").should("have.length", 0);
+  });
+
+  it("should have different URI while editing the metric", () => {
+    cy.visit("/reference/metrics");
+    cy.contains(METRIC_NAME).click();
+
+    cy.url().should("match", /\/reference\/metrics\/\d+$/);
+    cy.contains("Edit").click();
+    cy.url().should("match", /\/reference\/metrics\/\d+\/edit$/);
+  });
+});

--- a/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/reference/metrics.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin, restore } from "__support__/cypress";
+import { restore } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
@@ -9,7 +9,7 @@ describe("scenarios > reference > metrics", () => {
 
   beforeEach(() => {
     restore();
-    signInAsAdmin();
+    cy.signInAsAdmin();
 
     cy.request("POST", "/api/metric", {
       definition: {


### PR DESCRIPTION
Metrics Data Reference page (available at `reference/metrics/:id`) has viewing and edit states. Currently, the page uses the `isEditing` flag in Redux store to switch between these states (via `startEditing` and `endEditing` actions.

This pull request changes the page, so viewing and editing states correspond to different routes (`metrics/:id` for viewing and `metrics/:id/edit` for editing.