### PR TITLE
GitHub Action CI: No need to check for msgfmt anymore

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -44,7 +44,6 @@ jobs:
         java -version
         echo "Clojure `clojure -e "(println (clojure-version))"`"
         lein --version
-        msgfmt --version
 
     - name: Get yarn cache
       uses: actions/cache@v2


### PR DESCRIPTION
Just a clean-up following PR #15189.