### PR TITLE
Look at effective-type in the UI

### DIFF
--- a/frontend/src/metabase-types/types/Field.js
+++ b/frontend/src/metabase-types/types/Field.js
@@ -20,7 +20,7 @@ export type Field = {
   display_name: string,
   description: string,
   base_type: BaseType,
-  effective_type: BaseType,
+  effective_type?: BaseType,
   semantic_type: SemanticType,
   active: boolean,
   visibility_type: FieldVisibilityType,

--- a/frontend/src/metabase-types/types/Field.js
+++ b/frontend/src/metabase-types/types/Field.js
@@ -20,6 +20,7 @@ export type Field = {
   display_name: string,
   description: string,
   base_type: BaseType,
+  effective_type: BaseType,
   semantic_type: SemanticType,
   active: boolean,
   visibility_type: FieldVisibilityType,

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -92,7 +92,7 @@ export function isFieldType(type, field) {
   // check to see if it belongs to any of the field types:
   const props = field.effective_type
     ? ["effective", "semantic"]
-    : ["base", "effective"];
+    : ["base", "semantic"];
   for (const prop of props) {
     const allowedTypes = typeDefinition[prop];
     if (!allowedTypes) {

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -169,7 +169,7 @@ export const isNumericBaseType = field => {
   if (field.effective_type) {
     return isa(field.effective_type, TYPE.Number);
   } else {
-    return isa(field.effective_type, TYPE.Number);
+    return isa(field.base_type, TYPE.Number);
   }
 };
 

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -31,21 +31,26 @@ export const UNKNOWN = "UNKNOWN";
 const TYPES = {
   [TEMPORAL]: {
     base: [TYPE.Temporal],
+    effective: [TYPE.Temporal],
     semantic: [TYPE.Temporal],
   },
   [NUMBER]: {
     base: [TYPE.Number],
+    effective: [TYPE.Number],
     semantic: [TYPE.Number],
   },
   [STRING]: {
     base: [TYPE.Text],
+    effective: [TYPE.Text],
     semantic: [TYPE.Text],
   },
   [STRING_LIKE]: {
     base: [TYPE.TextLike],
+    effective: [TYPE.TextLike],
   },
   [BOOLEAN]: {
     base: [TYPE.Boolean],
+    effective: [TYPE.Boolean],
   },
   [COORDINATE]: {
     semantic: [TYPE.Coordinate],
@@ -68,6 +73,7 @@ const TYPES = {
   },
   [CATEGORY]: {
     base: [TYPE.Boolean],
+    effective: [TYPE.Boolean],
     semantic: [TYPE.Category],
     include: [LOCATION],
   },
@@ -84,7 +90,10 @@ export function isFieldType(type, field) {
 
   const typeDefinition = TYPES[type];
   // check to see if it belongs to any of the field types:
-  for (const prop of ["base", "semantic"]) {
+  const props = field.effective_type
+    ? ["effective", "semantic"]
+    : ["base", "effective"];
+  for (const prop of props) {
     const allowedTypes = typeDefinition[prop];
     if (!allowedTypes) {
       continue;
@@ -153,8 +162,16 @@ export const isEntityName = field =>
 
 export const isAny = col => true;
 
-export const isNumericBaseType = field =>
-  field && isa(field.base_type, TYPE.Number);
+export const isNumericBaseType = field => {
+  if (!field) {
+    return false;
+  }
+  if (field.effective_type) {
+    return isa(field.effective_type, TYPE.Number);
+  } else {
+    return isa(field.effective_type, TYPE.Number);
+  }
+};
 
 // ZipCode, ID, etc derive from Number but should not be formatted as numbers
 export const isNumber = field =>
@@ -164,7 +181,16 @@ export const isNumber = field =>
 
 export const isBinnedNumber = field => isNumber(field) && !!field.binning_info;
 
-export const isTime = field => field && isa(field.base_type, TYPE.Time);
+export const isTime = field => {
+  if (!field) {
+    return false;
+  }
+  if (field.effective_type) {
+    return isa(field.effective_type, TYPE.Time);
+  } else {
+    return isa(field.base_type, TYPE.Time);
+  }
+};
 
 export const isAddress = field =>
   field && isa(field.semantic_type, TYPE.Address);


### PR DESCRIPTION
still want to fall back to base_type if effective_type is not
present. Our inference doesn't set effective_type at the moment as
this change was super invasive and led to conflicts to other refactors
at the time. In the future almost nothing except for query processors
should care about base_type and only look at the (required)
effective_type.

## Issue

The frontend was still only checking base_type for what type something was. Thus coerced columns which had a different effective_type were not correctly recognized as datetimes.

### On stats
<img width="638" alt="image" src="https://user-images.githubusercontent.com/6377293/111662509-faca0d80-87dd-11eb-90bc-7abd475f378e.png">
(Here the timestamp column is recognized as a numeric type (its base type) rather than as a datetime (its effective type)

### With this change
<img width="365" alt="image" src="https://user-images.githubusercontent.com/6377293/111662658-1df4bd00-87de-11eb-9e2f-07497ca273b2.png">

## Solution

In the type system, check base_type only if effective_type does not exist. The reason it can't go to just effective_type yet is that when we infer this information from computed columns, we still use the tag base_type everywhere in the backend. I attempted to change this but it led to too many conflicts with other refactors and was a bit invasive with an already large diff.
