### PR TITLE
normalize MetabaseApi.field_search data structure

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -256,6 +256,8 @@ export class FieldValuesWidget extends Component {
           ),
         ),
       );
+
+      results = results.map(result => [].concat(result));
     }
 
     if (this.showRemapping()) {


### PR DESCRIPTION
**Description**
I recently changed how searching values worked in the `FieldValueWidget` to be a `contains` search. The FE search function operates on what is typed as an array -- `type Option = [Value, ?string][]`, and the code I added included the use of `.some` instead of what was originally a `foo[0]` property reference. Unfortunately, one of the search endpoints comes back with a different data structure than the rest, and I missed that. The previous code failed to filter correctly but didn't throw an error since in the `foo[0]` example `foo` would've been a string. The fix is simple: normalized the response from that endpoint like we do to the rest by wrapping everything in an additional array.

**Verification**
I was unable to repro the exact behavior on localhost (stats responds with a 204 + empty body), so I used the Requestly extension to match that behavior as best I could by changing the response status code to 204 and the response body to a "" or an `\n` character (Unfortunately, Requestly doesn't let you return an empty body, but maybe "" is sufficient?). No errors results from morphing the response.