### PR TITLE
Fix typo in semantic migration

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8054,6 +8054,23 @@ databaseChangeLog:
                 WHERE semantic_type IN ('type/UNIXTimestampSeconds',
                                         'type/UNIXTimestampMilliSeconds',
                                         'type/UNIXTimestampMicroSeconds')
+
+  - changeSet:
+      id: 296
+      author: dpsutton
+      comment: Added 0.39 - Semantic type system - migrate unix timestamps (corrects typo- seconds was migrated correctly, not millis and micros)
+      changes:
+        - sql:
+              sql: >-
+                UPDATE metabase_field
+                set semantic_type     = null,
+                    effective_type    = 'type/DateTime',
+                    coercion_strategy = (case semantic_type
+                                          WHEN 'type/UNIXTimestampMilliseconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
+                                          WHEN 'type/UNIXTimestampMicroseconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
+                                         END)
+                WHERE semantic_type IN ('type/UNIXTimestampMilliseconds',
+                                        'type/UNIXTimestampMicroseconds')
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8018,12 +8018,14 @@ databaseChangeLog:
       id: 287
       author: dpsutton
       comment: Added 0.39 - Semantic type system - migrate ISO8601 strings
+      validCheckSum:
+        - 8:ed47b08ec425a34cf66bd1e96c7b2446
+        - 8:0679eedae767a8648383aac2f923e413
       changes:
         - sql:
             sql: >-
               UPDATE metabase_field
-              SET semantic_type     = NULL, -- special type was overriden to provide coercion so no semantic type
-                  effective_type    = (CASE semantic_type
+              SET effective_type    = (CASE semantic_type
                                          WHEN 'type/ISO8601DateTimeString' THEN 'type/DateTime'
                                          WHEN 'type/ISO8601TimeString'     THEN 'type/Time'
                                          WHEN 'type/ISO8601DateString'     THEN 'type/Date'
@@ -8040,12 +8042,14 @@ databaseChangeLog:
       id: 288
       author: dpsutton
       comment: Added 0.39 - Semantic type system - migrate unix timestamps
+      validCheckSum:
+        - 8:4fa37c8edede4a10c39bf5aca13bd1b5
+        - 8:96af0fae84744857640d029cf4cd4bb6
       changes:
         - sql:
               sql: >-
                 UPDATE metabase_field
-                set semantic_type     = null,
-                    effective_type    = 'type/DateTime',
+                set effective_type    = 'type/DateTime',
                     coercion_strategy = (case semantic_type
                                           WHEN 'type/UNIXTimestampSeconds'      THEN 'Coercion/UNIXSeconds->DateTime'
                                           WHEN 'type/UNIXTimestampMilliSeconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
@@ -8053,24 +8057,32 @@ databaseChangeLog:
                                          END)
                 WHERE semantic_type IN ('type/UNIXTimestampSeconds',
                                         'type/UNIXTimestampMilliSeconds',
-                                        'type/UNIXTimestampMicroSeconds')
+                                        'type/UNIXTimestampMicroSeconds');
 
   - changeSet:
-      id: 296
+      id: 289
       author: dpsutton
       comment: Added 0.39 - Semantic type system - migrate unix timestamps (corrects typo- seconds was migrated correctly, not millis and micros)
       changes:
         - sql:
               sql: >-
                 UPDATE metabase_field
-                set semantic_type     = null,
-                    effective_type    = 'type/DateTime',
+                set effective_type    = 'type/DateTime',
                     coercion_strategy = (case semantic_type
                                           WHEN 'type/UNIXTimestampMilliseconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
                                           WHEN 'type/UNIXTimestampMicroseconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
                                          END)
                 WHERE semantic_type IN ('type/UNIXTimestampMilliseconds',
                                         'type/UNIXTimestampMicroseconds')
+
+  - changeSet:
+      id: 290
+      author: dpsutton
+      comment: Added 0.39 - Semantic type system - Clobber semantic_type where there was a coercion
+      changes:
+        - sql:
+              sql: UPDATE metabase_field set semantic_type = null where coercion_strategy is not null
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -62,72 +62,86 @@
 
 (deftest semantic-type-migration-tests
   (testing "updates each of the coercion types"
-    (impl/test-migrations [283 296] [migrate!]
-      (db/simple-insert! Database {:name "DB", :engine "h2", :created_at :%now, :updated_at :%now})
-      (db/simple-insert! Table {:name "Table", :db_id 1, :created_at :%now, :updated_at :%now, :active true})
-      (db/insert-many! Field
-                       [{:base_type :type/Text
-                         :semantic_type :type/ISO8601DateTimeString
-                         :name "iso-datetime"
-                         :table_id 1
-                         :database_type "VARCHAR"}
-                        {:base_type :type/Text
-                         :semantic_type :type/ISO8601DateString
-                         :name "iso-date"
-                         :table_id 1
-                         :database_type "VARCHAR"}
-                        {:base_type :type/Text
-                         :semantic_type :type/ISO8601TimeString
-                         :name "iso-time"
-                         :table_id 1
-                         :database_type "VARCHAR"}
-                        {:base_type :type/Integer
-                         :semantic_type :type/UNIXTimestampSeconds
-                         :name "unix-seconds"
-                         :table_id 1
-                         :database_type "INT"}
-                        {:base_type :type/Integer
-                         :semantic_type :type/UNIXTimestampMilliseconds
-                         :name "unix-millis"
-                         :table_id 1
-                         :database_type "INT"}
-                        {:base_type :type/Integer
-                         :semantic_type :type/UNIXTimestampMicroseconds
-                         :name "unix-micros"
-                         :table_id 1
-                         :database_type "INT"}])
-      (migrate!)
-      (is (= #{{:base_type :type/Text
-                :effective_type :type/DateTime
-                :coercion_strategy :Coercion/ISO8601->DateTime
-                :semantic_type nil
-                :name "iso-datetime"}
-               {:base_type :type/Text
-                :effective_type :type/Date
-                :coercion_strategy :Coercion/ISO8601->Date
-                :semantic_type nil
-                :name "iso-date"}
-               {:base_type :type/Text
-                :effective_type :type/Time
-                :coercion_strategy :Coercion/ISO8601->Time
-                :semantic_type nil
-                :name "iso-time"}
-               {:base_type :type/Integer
-                :effective_type :type/DateTime
-                :coercion_strategy :Coercion/UNIXSeconds->DateTime
-                :semantic_type nil
-                :name "unix-seconds"}
-               {:base_type :type/Integer
-                :effective_type :type/DateTime
-                :coercion_strategy :Coercion/UNIXMilliSeconds->DateTime
-                :semantic_type nil
-                :name "unix-millis"}
-               {:base_type :type/Integer
-                :effective_type :type/DateTime
-                :coercion_strategy :Coercion/UNIXMicroSeconds->DateTime
-                :semantic_type nil
-                :name "unix-micros"}}
-             (into #{}
-                   (map #(select-keys % [:base_type :effective_type :coercion_strategy
-                                         :semantic_type :name]))
-                   (db/select Field)))))))
+    ;; by name hoists results into a map by name so diffs are easier to read than sets.
+    (let [by-name #(into {} (map (juxt :name identity)) %)]
+      (impl/test-migrations [283 296] [migrate!]
+        (db/simple-insert! Database {:name "DB", :engine "h2", :created_at :%now, :updated_at :%now})
+        (db/simple-insert! Table {:name "Table", :db_id 1, :created_at :%now, :updated_at :%now, :active true})
+        (db/insert-many! Field
+                         [{:base_type     :type/Text
+                           :semantic_type :type/Address
+                           :name          "address"
+                           :table_id      1
+                           :database_type "VARCHAR"}
+                          {:base_type     :type/Text
+                           :semantic_type :type/ISO8601DateTimeString
+                           :name          "iso-datetime"
+                           :table_id      1
+                           :database_type "VARCHAR"}
+                          {:base_type     :type/Text
+                           :semantic_type :type/ISO8601DateString
+                           :name          "iso-date"
+                           :table_id      1
+                           :database_type "VARCHAR"}
+                          {:base_type     :type/Text
+                           :semantic_type :type/ISO8601TimeString
+                           :name          "iso-time"
+                           :table_id      1
+                           :database_type "VARCHAR"}
+                          {:base_type     :type/Integer
+                           :semantic_type :type/UNIXTimestampSeconds
+                           :name          "unix-seconds"
+                           :table_id      1
+                           :database_type "INT"}
+                          {:base_type     :type/Integer
+                           :semantic_type :type/UNIXTimestampMilliseconds
+                           :name          "unix-millis"
+                           :table_id      1
+                           :database_type "INT"}
+                          {:base_type     :type/Integer
+                           :semantic_type :type/UNIXTimestampMicroseconds
+                           :name          "unix-micros"
+                           :table_id      1
+                           :database_type "INT"}])
+        (migrate!)
+        (is (= (by-name
+                [{:base_type         :type/Text
+                  :effective_type    :type/Text
+                  :coercion_strategy nil
+                  :semantic_type     :type/Address
+                  :name              "address"}
+                 {:base_type         :type/Text
+                  :effective_type    :type/DateTime
+                  :coercion_strategy :Coercion/ISO8601->DateTime
+                  :semantic_type     nil
+                  :name              "iso-datetime"}
+                 {:base_type         :type/Text
+                  :effective_type    :type/Date
+                  :coercion_strategy :Coercion/ISO8601->Date
+                  :semantic_type     nil
+                  :name              "iso-date"}
+                 {:base_type         :type/Text
+                  :effective_type    :type/Time
+                  :coercion_strategy :Coercion/ISO8601->Time
+                  :semantic_type     nil
+                  :name              "iso-time"}
+                 {:base_type         :type/Integer
+                  :effective_type    :type/DateTime
+                  :coercion_strategy :Coercion/UNIXSeconds->DateTime
+                  :semantic_type     nil
+                  :name              "unix-seconds"}
+                 {:base_type         :type/Integer
+                  :effective_type    :type/DateTime
+                  :coercion_strategy :Coercion/UNIXMilliSeconds->DateTime
+                  :semantic_type     nil
+                  :name              "unix-millis"}
+                 {:base_type         :type/Integer
+                  :effective_type    :type/DateTime
+                  :coercion_strategy :Coercion/UNIXMicroSeconds->DateTime
+                  :semantic_type     nil
+                  :name              "unix-micros"}])
+               (by-name
+                (into #{}
+                      (map #(select-keys % [:base_type :effective_type :coercion_strategy
+                                            :semantic_type :name]))
+                      (db/select Field)))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -59,3 +59,75 @@
         (doseq [e [e1 e2]]
           (is (= true
                  (db/exists? User :email (u/lower-case-en e1)))))))))
+
+(deftest semantic-type-migration-tests
+  (testing "updates each of the coercion types"
+    (impl/test-migrations [283 296] [migrate!]
+      (db/simple-insert! Database {:name "DB", :engine "h2", :created_at :%now, :updated_at :%now})
+      (db/simple-insert! Table {:name "Table", :db_id 1, :created_at :%now, :updated_at :%now, :active true})
+      (db/insert-many! Field
+                       [{:base_type :type/Text
+                         :semantic_type :type/ISO8601DateTimeString
+                         :name "iso-datetime"
+                         :table_id 1
+                         :database_type "VARCHAR"}
+                        {:base_type :type/Text
+                         :semantic_type :type/ISO8601DateString
+                         :name "iso-date"
+                         :table_id 1
+                         :database_type "VARCHAR"}
+                        {:base_type :type/Text
+                         :semantic_type :type/ISO8601TimeString
+                         :name "iso-time"
+                         :table_id 1
+                         :database_type "VARCHAR"}
+                        {:base_type :type/Integer
+                         :semantic_type :type/UNIXTimestampSeconds
+                         :name "unix-seconds"
+                         :table_id 1
+                         :database_type "INT"}
+                        {:base_type :type/Integer
+                         :semantic_type :type/UNIXTimestampMilliseconds
+                         :name "unix-millis"
+                         :table_id 1
+                         :database_type "INT"}
+                        {:base_type :type/Integer
+                         :semantic_type :type/UNIXTimestampMicroseconds
+                         :name "unix-micros"
+                         :table_id 1
+                         :database_type "INT"}])
+      (migrate!)
+      (is (= #{{:base_type :type/Text
+                :effective_type :type/DateTime
+                :coercion_strategy :Coercion/ISO8601->DateTime
+                :semantic_type nil
+                :name "iso-datetime"}
+               {:base_type :type/Text
+                :effective_type :type/Date
+                :coercion_strategy :Coercion/ISO8601->Date
+                :semantic_type nil
+                :name "iso-date"}
+               {:base_type :type/Text
+                :effective_type :type/Time
+                :coercion_strategy :Coercion/ISO8601->Time
+                :semantic_type nil
+                :name "iso-time"}
+               {:base_type :type/Integer
+                :effective_type :type/DateTime
+                :coercion_strategy :Coercion/UNIXSeconds->DateTime
+                :semantic_type nil
+                :name "unix-seconds"}
+               {:base_type :type/Integer
+                :effective_type :type/DateTime
+                :coercion_strategy :Coercion/UNIXMilliSeconds->DateTime
+                :semantic_type nil
+                :name "unix-millis"}
+               {:base_type :type/Integer
+                :effective_type :type/DateTime
+                :coercion_strategy :Coercion/UNIXMicroSeconds->DateTime
+                :semantic_type nil
+                :name "unix-micros"}}
+             (into #{}
+                   (map #(select-keys % [:base_type :effective_type :coercion_strategy
+                                         :semantic_type :name]))
+                   (db/select Field)))))))


### PR DESCRIPTION
correct a typo in the migration and add some tests:

`'type/UNIXTimestampMilliseconds'` and `'type/UNIXTimestampMicroseconds'` are the correct types. Had used `MilliSeconds` and `MicroSeconds`. As a result the unix seconds had successfully migrated but not the micro- or milliseconds. This corrects those and adds some tests