### PR TITLE
Only display schema in search results if there is more than one schema

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -185,20 +185,16 @@ function InfoText({ result }) {
                   {({ list }) =>
                     list && list.length > 1 ? (
                       <span>
-                        {list.length > 1 && (
-                          <span>
-                            <Icon name="chevronright" mx="4px" size={10} />
-                            {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
-                            <Link
-                              to={Urls.browseSchema({
-                                db: { id: result.database_id },
-                                schema_name: result.table_schema,
-                              })}
-                            >
-                              {result.table_schema}
-                            </Link>
-                          </span>
-                        )}
+                        <Icon name="chevronright" mx="4px" size={10} />
+                        {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
+                        <Link
+                          to={Urls.browseSchema({
+                            db: { id: result.database_id },
+                            schema_name: result.table_schema,
+                          })}
+                        >
+                          {result.table_schema}
+                        </Link>
                       </span>
                     ) : null
                   }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -210,13 +210,18 @@ function InfoText({ result }) {
       );
     case "segment":
     case "metric":
-      return jt`${result.model === "segment" ? "Segment of " : "Metric for "}${(
-        <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
-          <Table.Loader id={result.table_id} loadingAndErrorWrapper={false}>
-            {({ table }) => (table ? <span>{table.display_name}</span> : null)}
-          </Table.Loader>
-        </Link>
-      )}`;
+      return (
+        <span>
+          {result.model === "segment" ? t`Segment of ` : t`Metric for `}
+          <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
+            <Table.Loader id={result.table_id} loadingAndErrorWrapper={false}>
+              {({ table }) =>
+                table ? <span>{table.display_name}</span> : null
+              }
+            </Table.Loader>
+          </Link>
+        </span>
+      );
     default:
       return jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
   }

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -11,6 +11,7 @@ import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import Text from "metabase/components/type/Text";
 
+import Schema from "metabase/entities/schemas";
 import Database from "metabase/entities/databases";
 import Table from "metabase/entities/tables";
 
@@ -177,18 +178,28 @@ function InfoText({ result }) {
                 <Database.Name id={result.database_id} />{" "}
               </Link>
               {result.table_schema && (
-                <span>
-                  <Icon name="chevronright" mx="4px" size={10} />
-                  {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
-                  <Link
-                    to={Urls.browseSchema({
-                      db: { id: result.database_id },
-                      schema_name: result.table_schema,
-                    })}
-                  >
-                    {result.table_schema}
-                  </Link>
-                </span>
+                <Schema.ListLoader query={{ dbId: result.database_id }}>
+                  {({ list }) => {
+                    return (
+                      <span>
+                        {list.length > 1 && (
+                          <span>
+                            <Icon name="chevronright" mx="4px" size={10} />
+                            {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
+                            <Link
+                              to={Urls.browseSchema({
+                                db: { id: result.database_id },
+                                schema_name: result.table_schema,
+                              })}
+                            >
+                              {result.table_schema}
+                            </Link>
+                          </span>
+                        )}
+                      </span>
+                    );
+                  }}
+                </Schema.ListLoader>
               )}
             </span>
           )}`}
@@ -196,9 +207,7 @@ function InfoText({ result }) {
       );
     case "segment":
     case "metric":
-      return jt`${
-        result.model === "segment" ? "Segment of" : "Metric for"
-      } of ${(
+      return jt`${result.model === "segment" ? "Segment of" : "Metric for"} ${(
         <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
           <Table.Loader id={result.table_id}>
             {({ table }) => <span>{table.display_name}</span>}

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -178,9 +178,12 @@ function InfoText({ result }) {
                 <Database.Name id={result.database_id} />{" "}
               </Link>
               {result.table_schema && (
-                <Schema.ListLoader query={{ dbId: result.database_id }}>
-                  {({ list }) => {
-                    return (
+                <Schema.ListLoader
+                  query={{ dbId: result.database_id }}
+                  loadingAndErrorWrapper={false}
+                >
+                  {({ list }) =>
+                    list && list.length > 1 ? (
                       <span>
                         {list.length > 1 && (
                           <span>
@@ -197,8 +200,8 @@ function InfoText({ result }) {
                           </span>
                         )}
                       </span>
-                    );
-                  }}
+                    ) : null
+                  }
                 </Schema.ListLoader>
               )}
             </span>
@@ -207,10 +210,10 @@ function InfoText({ result }) {
       );
     case "segment":
     case "metric":
-      return jt`${result.model === "segment" ? "Segment of" : "Metric for"} ${(
+      return jt`${result.model === "segment" ? "Segment of " : "Metric for "}${(
         <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
-          <Table.Loader id={result.table_id}>
-            {({ table }) => <span>{table.display_name}</span>}
+          <Table.Loader id={result.table_id} loadingAndErrorWrapper={false}>
+            {({ table }) => (table ? <span>{table.display_name}</span> : null)}
           </Table.Loader>
         </Link>
       )}`;


### PR DESCRIPTION
Fixes #15216 

Uses `Schema.ListLoader` to look at the number of schemas for a database and only shows the schema for a table if there are multiple that we need to display. This keeps things consistent with how we show schemas elsewhere in the app.

One unfortunate side effect of this is that there can be a brief "loading" spinner on individual items. I'm going to investigate setting `loadingAndErrorWrapper` to false on the loader to prevent the UI flash.

Todo

- [x] Try removing `loadingAndErrorWrapper` from `Schema.ListLoader` to prevent UI flash