### PR TITLE
Custom expression editor: avoid squiggly red lines (spellchecking)

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -166,6 +166,7 @@ export default class TokenizedInput extends Component {
         className={className}
         style={{ ...style }}
         contentEditable
+        spellCheck={false}
         onKeyDown={
           this.props.tokenizedEditing
             ? this.onKeyDownTokenized


### PR DESCRIPTION
It does not make sense anyway for the web browser to suggest corrections for function names etc.

Steps:
1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Custom column, type `CASEE` (intentionally misspelled)

Before:

![image](https://user-images.githubusercontent.com/7288/111714614-3af5b400-880f-11eb-8509-cb86aa6d2272.png)

After:

![image](https://user-images.githubusercontent.com/7288/111714627-421cc200-880f-11eb-9e78-f36ea39378a6.png)
