### PR TITLE
add throttle to ExplicitSize height/width recalc

### DIFF
--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -89,6 +89,8 @@ export default ({ selector, wrapped } = {}) => ComposedComponent =>
       }
     }
 
+    // if _currentElement's dimensions change too frequently this function
+    // can freeze the application
     _updateSize = _.throttle(() => {
       const element = this._getElement();
       if (element) {

--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom";
 import ResizeObserver from "resize-observer-polyfill";
 
 import cx from "classnames";
+import _ from "underscore";
 
 export default ({ selector, wrapped } = {}) => ComposedComponent =>
   class extends Component {
@@ -88,7 +89,7 @@ export default ({ selector, wrapped } = {}) => ComposedComponent =>
       }
     }
 
-    _updateSize = () => {
+    _updateSize = _.throttle(() => {
       const element = this._getElement();
       if (element) {
         const { width, height } = element.getBoundingClientRect();
@@ -96,7 +97,7 @@ export default ({ selector, wrapped } = {}) => ComposedComponent =>
           this.setState({ width, height });
         }
       }
-    };
+    }, 500);
 
     render() {
       if (wrapped) {


### PR DESCRIPTION
**Description**
I split `SharingSidebar` into a few different components and I think something related to the change in render timing caused the `DashboardGrid` to resize back and forth between two widths until react crashes. We probably shouldn't be auto-resizing a grid next to a variable-sized sidebar, but I think I will address that later. For now, throttling the amount of resizing solves the app freezing problem.