### PR TITLE
Expand user roles for testing

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -1,9 +1,9 @@
 import { restore, describeWithToken } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
-import _ from "underscore";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 const { normal } = USERS;
 const { PRODUCTS } = SAMPLE_DATASET;
+const TOTAL_USERS = Object.entries(USERS).length;
 
 const year = new Date().getFullYear();
 
@@ -84,24 +84,23 @@ describeWithToken("audit > auditing", () => {
         .as("charts")
         .should("have.length", 2);
 
-      // For queries viewed, we have 2 users that haven't viewed anything
+      // For queries viewed, only 3 viewed something
       cy.get("@charts")
         .first()
         .find("[width='0']")
-        .should("have.length", 2);
+        .should("have.length", TOTAL_USERS - 3);
 
-      // For queries created, we have 3 users that haven't created anything
+      // For queries created, only 2 users created something
       cy.get("@charts")
         .last()
         .find("[width='0']")
-        .should("have.length", 3);
+        .should("have.length", TOTAL_USERS - 2);
     });
 
     it("should load the All Members tab", () => {
       cy.visit("/admin/audit/members/all");
 
-      const CREATED_USERS = _.omit(USERS, "sandboxed");
-      Object.values(CREATED_USERS).forEach(({ first_name, last_name }) => {
+      Object.values(USERS).forEach(({ first_name, last_name }) => {
         cy.findByText(`${first_name} ${last_name}`);
       });
 

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -9,7 +9,7 @@ import {
   remapDisplayValueToFK,
   sidebar,
 } from "__support__/cypress";
-import { USERS, USER_GROUPS } from "__support__/cypress_data";
+import { USER_GROUPS } from "__support__/cypress_data";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
@@ -25,7 +25,6 @@ const {
 } = SAMPLE_DATASET;
 
 const { DATA_GROUP } = USER_GROUPS;
-const { sandboxed } = USERS;
 
 describeWithToken("formatting > sandboxes", () => {
   describe("admin", () => {
@@ -48,10 +47,10 @@ describeWithToken("formatting > sandboxes", () => {
 
     it("should add key attributes to a new user", () => {
       cy.findByText("Add someone").click();
-      cy.findByPlaceholderText("Johnny").type(sandboxed.first_name);
-      cy.findByPlaceholderText("Appleseed").type(sandboxed.last_name);
+      cy.findByPlaceholderText("Johnny").type("John");
+      cy.findByPlaceholderText("Appleseed").type("Smith");
       cy.findByPlaceholderText("youlooknicetoday@email.com").type(
-        sandboxed.email,
+        "john@smith.test",
       );
       cy.findByText("Add an attribute").click();
       cy.findByPlaceholderText("Key").type("User ID");

--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -173,7 +173,6 @@ describeWithToken("formatting > sandboxes", () => {
     beforeEach(() => {
       restore();
       cy.signInAsAdmin();
-      cy.createUser("sandboxed");
     });
 
     it("should allow joins to the sandboxed table (metabase-enterprise#154)", () => {

--- a/frontend/test/__support__/cypress_data.js
+++ b/frontend/test/__support__/cypress_data.js
@@ -3,11 +3,20 @@ export const USER_GROUPS = {
   ADMIN_GROUP: 2,
   COLLECTION_GROUP: 4,
   DATA_GROUP: 5,
+  READONLY_GROUP: 6,
+  NOSQL_GROUP: 7,
 };
 
-const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
+const {
+  ALL_USERS_GROUP,
+  COLLECTION_GROUP,
+  DATA_GROUP,
+  READONLY_GROUP,
+  NOSQL_GROUP,
+} = USER_GROUPS;
 
 export const USERS = {
+  // All around access
   admin: {
     first_name: "Bobby",
     last_name: "Tables",
@@ -21,26 +30,13 @@ export const USERS = {
     password: "12341234",
     group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP],
   },
+  // Collection-related users that don't have access to data at all
   nodata: {
     first_name: "No Data",
     last_name: "Tableton",
     email: "nodata@metabase.com",
     password: "12341234",
     group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
-  },
-  nocollection: {
-    first_name: "No Collection",
-    last_name: "Tableton",
-    email: "nocollection@metabase.com",
-    password: "12341234",
-    group_ids: [ALL_USERS_GROUP, DATA_GROUP],
-  },
-  none: {
-    first_name: "None",
-    last_name: "Tableton",
-    email: "none@metabase.com",
-    password: "12341234",
-    group_ids: [ALL_USERS_GROUP],
   },
   sandboxed: {
     first_name: "User",
@@ -52,5 +48,35 @@ export const USERS = {
       attr_cat: "Widget",
     },
     group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
+  },
+  readonly: {
+    first_name: "Read Only",
+    last_name: "Tableton",
+    email: "readonly@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP, READONLY_GROUP],
+  },
+  // Users with access to data, but no access to collections
+  nocollection: {
+    first_name: "No Collection",
+    last_name: "Tableton",
+    email: "nocollection@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP, DATA_GROUP],
+  },
+  nosql: {
+    first_name: "No SQL",
+    last_name: "Tableton",
+    email: "nosqln@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP, NOSQL_GROUP],
+  },
+  // No access at all
+  none: {
+    first_name: "None",
+    last_name: "Tableton",
+    email: "none@metabase.com",
+    password: "12341234",
+    group_ids: [ALL_USERS_GROUP],
   },
 };

--- a/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/sandboxes.cy.spec.js
@@ -16,7 +16,6 @@ describeWithToken("postgres > user > query", () => {
     restore();
     cy.signInAsAdmin();
     addPostgresDatabase(PG_DB_NAME);
-    cy.createUser("sandboxed");
     // Update basic permissions (the same starting "state" as we have for the "Sample Dataset")
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -5,6 +5,8 @@ import { restore, popover, setupDummySMTP } from "__support__/cypress";
 import { USERS, USER_GROUPS } from "__support__/cypress_data";
 const { normal, admin } = USERS;
 const { DATA_GROUP } = USER_GROUPS;
+const TOTAL_USERS = Object.entries(USERS).length;
+const TOTAL_GROUPS = Object.entries(USER_GROUPS).length;
 
 describe("scenarios > admin > people", () => {
   beforeEach(() => {
@@ -29,7 +31,7 @@ describe("scenarios > admin > people", () => {
       cy.get(".ContentTable tbody tr")
         .as("result-rows")
         // Bobby Tables, No Collection Tableton, No Data Tableton, None Tableton, Robert Tableton
-        .should("have.length", 5);
+        .should("have.length", TOTAL_USERS);
 
       // A small sidebar selector
       cy.get(".AdminList-items").within(() => {
@@ -41,7 +43,7 @@ describe("scenarios > admin > people", () => {
       cy.get(".PageTitle").contains("Groups");
 
       // Administrators, All Users, collection, data
-      cy.get("@result-rows").should("have.length", 4);
+      cy.get("@result-rows").should("have.length", TOTAL_GROUPS);
 
       cy.get(".AdminList-items").within(() => {
         cy.findByText("Groups").should("have.class", "selected");
@@ -54,7 +56,7 @@ describe("scenarios > admin > people", () => {
       cy.get(".PageTitle").contains("All Users");
 
       // The same list as for "People"
-      cy.get("@result-rows").should("have.length", 5);
+      cy.get("@result-rows").should("have.length", TOTAL_USERS);
     });
 
     it("should load the members when navigating to the group directly", () => {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -132,13 +132,9 @@ describe("scenarios > collection_defaults", () => {
       describe("deeply nested collection navigation", () => {
         it("should correctly display deep nested collections", () => {
           cy.request("GET", "/api/collection").then(xhr => {
-            // "Third collection" is the last nested collection in the snapshot (data set)
-            // we need its ID to continue nesting below it
-            const THIRD_COLLECTION_ID = xhr.body.length - 1;
-
-            // sanity check and early alarm if the initial data set changes in the future
-            expect(xhr.body[THIRD_COLLECTION_ID].name).to.eq(
-              "Third collection",
+            // We need its ID to continue nesting below it
+            const { id: THIRD_COLLECTION_ID } = xhr.body.find(
+              collection => collection.slug === "third_collection",
             );
 
             cy.log("Create two more nested collections");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds new users and new user groups to the default testing "snapshot", making them available for all tests
    - readonly group: has no data access and only "view" collection access
    - nosql group: has data access, but cannot write SQL and has no collection access

![image](https://user-images.githubusercontent.com/31325167/111719713-bc276800-885c-11eb-9c5c-0c5aee4b0deb.png)

![image](https://user-images.githubusercontent.com/31325167/111719726-c21d4900-885c-11eb-91e8-49233137b0ba.png)

### Additional notes:
- sandboxed user is now also created initially, instead of only in files related to sandboxing tests
- All related tests have been updated