### PR TITLE
#15237 Repro: User with sufficient permissions can't revert the dashboard

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -1,0 +1,58 @@
+import { onlyOn } from "@cypress/skip-test";
+import { restore } from "__support__/cypress";
+
+const PERMISSIONS = {
+  curate: ["admin", "normal", "nodata"],
+  view: ["readonly"],
+  no: ["nocollection", "nosql", "none"],
+};
+
+describe("collection permissions", () => {
+  beforeEach(() => {
+    restore();
+    cy.server();
+  });
+
+  describe("revision history", () => {
+    beforeEach(() => {
+      cy.route("POST", "/api/revision/revert").as("revert");
+    });
+
+    Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
+      context(`${permission} access`, () => {
+        userGroup.forEach(user => {
+          // This function `onlyOn` will not generate tests for any other condition.
+          // It helps to make both our tests and Cypress runner sidebar clean
+          onlyOn(permission === "curate", () => {
+            describe(`${user} user`, () => {
+              beforeEach(() => {
+                cy.signIn(user);
+              });
+
+              it.skip("should be able to revert the dashboard (metabase#15237)", () => {
+                cy.visit("/dashboard/1");
+                cy.icon("ellipsis").click();
+                cy.findByText("Revision history").click();
+                clickRevert("First revision.");
+                cy.wait("@revert").then(xhr => {
+                  expect(xhr.status).to.eq(200);
+                  expect(xhr.cause).not.to.exist;
+                });
+                cy.findAllByText(/Revert/).should("not.exist");
+                // We reverted the dashboard to the state prior to adding any cards to it
+                cy.findByText("This dashboard is looking empty.");
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});
+
+function clickRevert(event_name) {
+  cy.findByText(event_name)
+    .closest("tr")
+    .findByText(/Revert/i)
+    .click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15237 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/111725223-fe55a700-8866-11eb-9652-3f3b8b982030.png)

![image](https://user-images.githubusercontent.com/31325167/111725313-2218ed00-8867-11eb-8308-506ba9828133.png)


