### PR TITLE
add minWidth to Sidebar

### DIFF
--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -8,7 +8,7 @@ const WIDTH = 384;
 function Sidebar({ onClose, onCancel, closeIsDisabled, children }) {
   return (
     <div
-      style={{ width: WIDTH }}
+      style={{ width: WIDTH, minWidth: WIDTH }}
       className="flex flex-column border-left bg-white"
     >
       <div className="flex flex-column flex-auto overflow-y-auto">


### PR DESCRIPTION
**Description**
Seems like the intention was to give `Sidebar` a static width. Unfortunately, that won't work when the component is the child of a flex container. You can see this is a problem with the `SharingSidebar`. It's also the source of a flapping width problem when creating a slack dashboard subscription.

Before
<img width="285" alt="Screen Shot 2021-03-18 at 10 02 27 PM" src="https://user-images.githubusercontent.com/13057258/111733748-d6018480-8835-11eb-823c-86746ed1e23d.png">

After
<img width="413" alt="Screen Shot 2021-03-18 at 10 03 38 PM" src="https://user-images.githubusercontent.com/13057258/111733750-d7cb4800-8835-11eb-9e35-fbe21096f37a.png">
