### PR TITLE
#15256 Repro: "Duplicate" dashboard modal says it "failed", when it actually did duplicate successfully

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -13,6 +13,38 @@ describe("collection permissions", () => {
     cy.server();
   });
 
+  describe("item management", () => {
+    Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
+      context(`${permission} access`, () => {
+        userGroup.forEach(user => {
+          onlyOn(permission === "curate", () => {
+            describe(`${user} user`, () => {
+              beforeEach(() => {
+                cy.signIn(user);
+              });
+
+              it.skip("should be able to duplicate the dashboard without obstructions from the modal (metabase#15256)", () => {
+                cy.visit("/collection/root");
+                openEllipsisMenuFor("Orders in a dashboard");
+                cy.findByText("Duplicate this item").click();
+                cy.get(".Modal")
+                  .as("modal")
+                  .within(() => {
+                    cy.findByRole("button", { name: "Duplicate" })
+                      .should("not.be.disabled")
+                      .click();
+                    cy.findByText("Failed").should("not.exist");
+                  });
+                cy.get("@modal").should("not.exist");
+                cy.findByText("Orders in a dashboard - Duplicate");
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe("revision history", () => {
     beforeEach(() => {
       cy.route("POST", "/api/revision/revert").as("revert");
@@ -55,4 +87,12 @@ function clickRevert(event_name) {
     .closest("tr")
     .findByText(/Revert/i)
     .click();
+}
+
+function openEllipsisMenuFor(item, index = 0) {
+  cy.findAllByText(item)
+    .eq(index)
+    .closest("a")
+    .find(".Icon-ellipsis")
+    .click({ force: true });
 }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15256

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/111824426-7dd68b00-88e6-11eb-8269-07241da5bd2e.png)

