### PR TITLE
Nontrivial prefix trim for operators in custom expressions

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -388,7 +388,7 @@ function operatorSuggestion(clause) {
     type: "operators",
     name: name,
     text: " " + name + " ",
-    prefixTrim: new RegExp("\\s*" + name.replace(/(.{1})/g, "$1?") + "$", "i"),
+    prefixTrim: new RegExp("\\s*" + escape(name).replace(/(.{1})/g, "$1?") + "$", "i"),
     postfixTrim: new RegExp("/^s*" + escape(name) + "?s*/"),
   };
 }

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -388,7 +388,10 @@ function operatorSuggestion(clause) {
     type: "operators",
     name: name,
     text: " " + name + " ",
-    prefixTrim: new RegExp("\\s*" + escape(name).replace(/(.{1})/g, "$1?") + "$", "i"),
+    prefixTrim: new RegExp(
+      "\\s*" + escape(name).replace(/(.{1})/g, "$1?") + "$",
+      "i",
+    ),
     postfixTrim: new RegExp("/^s*" + escape(name) + "?s*/"),
   };
 }

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -388,7 +388,7 @@ function operatorSuggestion(clause) {
     type: "operators",
     name: name,
     text: " " + name + " ",
-    prefixTrim: /\s*$/,
+    prefixTrim: new RegExp("\\s*" + name.replace(/(.{1})/g, "$1?") + "$", "i"),
     postfixTrim: new RegExp("/^s*" + escape(name) + "?s*/"),
   };
 }

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -148,6 +148,10 @@ describe("metabase/lib/expression/suggest", () => {
       return cleanSuggestions(suggest_(...args).suggestions);
     }
 
+    function uncleanSuggest(...args) {
+      return suggest_(...args).suggestions;
+    }
+
     function helpText(...args) {
       return suggest_(...args).helpText;
     }
@@ -364,6 +368,19 @@ describe("metabase/lib/expression/suggest", () => {
         });
         expect(name).toEqual("sum");
         expect(example).toEqual("Sum([Subtotal])");
+      });
+
+      it("should give us the prefix trim regex in expressions that actually trims", () => {
+        expect(
+          "no".replace(
+            uncleanSuggest({
+              source: "no",
+              query: ORDERS.query(),
+              startRule: "boolean",
+            })[0].prefixTrim,
+            "",
+          ),
+        ).toEqual("");
       });
     });
 


### PR DESCRIPTION
Pursuant to #15247

Root cause is the prefix trim for operators assuming that operators are like, ">" or "+" or what-have-you, just one-character dealies only. obviously "AND" and "NOT" are still operators but not one-character dealios.