### PR TITLE
#15253 Repro: User with curate access can't unarchive question

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -39,6 +39,30 @@ describe("collection permissions", () => {
                 cy.findByText("Orders in a dashboard - Duplicate");
               });
 
+              describe("archive", () => {
+                it("should be able to archive/unarchive question (metabase#15253)", () => {
+                  cy.skipOn(user === "nodata");
+                  archiveUnarchive("Orders");
+                });
+
+                it("should be able to archive/unarchive dashboard", () => {
+                  archiveUnarchive("Orders in a dashboard");
+                });
+
+                function archiveUnarchive(item) {
+                  cy.visit("/collection/root");
+                  openEllipsisMenuFor(item);
+                  cy.findByText("Archive this item").click();
+                  cy.findByText(item).should("not.exist");
+                  cy.findByText(/Archived (question|dashboard)/);
+                  cy.findByText("Undo").click();
+                  cy.findByText(
+                    "Sorry, you don’t have permission to see that.",
+                  ).should("not.exist");
+                  cy.findByText(item);
+                }
+              });
+
               describe("managing question from the question's edit dropdown (metabase#11719)", () => {
                 beforeEach(() => {
                   cy.route("PUT", "/api/card/1").as("updateQuestion");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15253 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `skipOn()` with `onlyOn()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skipOn` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Unskipped test for "nodata" 
![image](https://user-images.githubusercontent.com/31325167/111842651-14637600-8900-11eb-9777-d03454286247.png)

Current state for all users
![image](https://user-images.githubusercontent.com/31325167/111842776-44127e00-8900-11eb-8377-654de9cfcea3.png)


