### PR TITLE
Custom expression editor: fix Enter not committing the change

### DIFF
--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
@@ -52,7 +52,6 @@ export default class ExpressionPopover extends React.Component {
             }}
             onCommit={expression => {
               if (!onChangeName) {
-                onChange(expression);
                 onUpdateAndCommit(expression);
               }
             }}

--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
@@ -19,6 +19,7 @@ export default class ExpressionPopover extends React.Component {
       query,
       expression,
       onChange,
+      onUpdateAndCommit,
       onBack,
       onDone,
       name,
@@ -52,7 +53,7 @@ export default class ExpressionPopover extends React.Component {
             onCommit={expression => {
               if (!onChangeName) {
                 onChange(expression);
-                onDone();
+                onUpdateAndCommit(expression);
               }
             }}
           />

--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
@@ -19,9 +19,8 @@ export default class ExpressionPopover extends React.Component {
       query,
       expression,
       onChange,
-      onUpdateAndCommit,
-      onBack,
       onDone,
+      onBack,
       name,
       onChangeName,
     } = this.props;
@@ -52,7 +51,7 @@ export default class ExpressionPopover extends React.Component {
             }}
             onCommit={expression => {
               if (!onChangeName) {
-                onUpdateAndCommit(expression);
+                onDone(expression);
               }
             }}
           />
@@ -63,13 +62,18 @@ export default class ExpressionPopover extends React.Component {
               onChange={e => onChangeName(e.target.value)}
               onKeyPress={e => {
                 if (e.key === "Enter" && isValid) {
-                  onDone();
+                  onDone(expression);
                 }
               }}
               placeholder={t`Name (required)`}
             />
           )}
-          <Button className="full" primary disabled={!isValid} onClick={onDone}>
+          <Button
+            className="full"
+            primary
+            disabled={!isValid}
+            onClick={() => onDone(expression)}
+          >
             {t`Done`}
           </Button>
         </div>

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -155,9 +155,8 @@ export default class ViewFilterPopover extends Component {
           startRule="boolean"
           isValid={filter && filter.isValid()}
           onChange={this.handleFilterChange}
-          onUpdateAndCommit={this.handleUpdateAndCommit}
+          onDone={this.handleUpdateAndCommit}
           onBack={() => this.setState({ editingFilter: false })}
-          onDone={this.handleCommit}
         />
       );
     }

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -88,6 +88,14 @@ export default class ViewFilterPopover extends Component {
     }
   }
 
+  handleUpdateAndCommit = (newFilter: ?Filter) => {
+    const base = this.state.filter || new Filter([], null, this.props.query);
+    const filter = base.set(newFilter);
+    this.setState({ filter }, () => {
+      this.handleCommitFilter(filter, this.props.query);
+    });
+  };
+
   handleCommit = () => {
     this.handleCommitFilter(this.state.filter, this.props.query);
   };
@@ -147,6 +155,7 @@ export default class ViewFilterPopover extends Component {
           startRule="boolean"
           isValid={filter && filter.isValid()}
           onChange={this.handleFilterChange}
+          onUpdateAndCommit={this.handleUpdateAndCommit}
           onBack={() => this.setState({ editingFilter: false })}
           onDone={this.handleCommit}
         />

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -117,6 +117,27 @@ describe("scenarios > question > notebook", () => {
     });
   });
 
+  it("should process the updated expression when pressing Enter", () => {
+    openProductsTable({ mode: "notebook" });
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+    cy.get("[contenteditable='true']")
+      .click()
+      .clear()
+      .type("[Price] > 1");
+    cy.findAllByRole("button", { name: "Done" }).click();
+
+    // change the corresponding custom expression
+    cy.findByText("Price is greater than 1").click();
+    cy.get(".Icon-chevronleft").click();
+    cy.findByText("Custom Expression").click();
+    cy.get("[contenteditable='true']")
+      .click()
+      .clear()
+      .type("[Price] > 1 AND [Price] < 5{enter}");
+    cy.contains(/^Price is less than 5/i);
+  });
+
   describe("joins", () => {
     it("should allow joins", () => {
       // start a custom question with orders


### PR DESCRIPTION
This fixes issue #15241. The solution is to ensure that the state change is synchronized with the commit event propagation.

To verify:

1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Add filters to narrow your search
4. Choose Price, Greater than 1, click Add Filter
5. Click on the new "Price is greater than 1" filter
6. Click on the left chevron arrow, Custom Expression
7. Complete the expression to `[Price] > 1 AND [Price] < 5`
8. Press Enter

Before:

![image](https://user-images.githubusercontent.com/7288/111913091-c6e32800-8a29-11eb-80df-47f9be3d73bb.png)


After:

![image](https://user-images.githubusercontent.com/7288/111913084-bd59c000-8a29-11eb-87c3-d6ca7f1c4c9b.png)
