### PR TITLE
Custom expression editor: fix caret position with Firefox

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
@@ -10,7 +10,16 @@ export default class TokenizedExpression extends React.Component {
     if (syntaxTree) {
       return renderSyntaxTree(syntaxTree);
     } else {
-      return <span className="Expression-node">{source}</span>;
+      if (source && source.length > 0) {
+        return <span className="Expression-node">{source}</span>;
+      } else {
+        // <br> is inserted to workaround Firefox caret position issue
+        return (
+          <span className="Expression-node">
+            <br />
+          </span>
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
There is this famous Firefox issue with empty contentEditable: https://bugzilla.mozilla.org/show_bug.cgi?id=1020973

The workaround is to inject `<br>` when there is no expression (it will be wiped out anyway on subsequent typing by the user).

To verify (use Firefox):

1. Ask a question, Simple question
2. Sample Dataset, Products table
3. Filter, Custom Expression

Before:

![image](https://user-images.githubusercontent.com/7288/111914956-5c35ea80-8a31-11eb-929b-6a389cfde381.png)

After:

![image](https://user-images.githubusercontent.com/7288/111914960-60fa9e80-8a31-11eb-9d22-a66808aeb41c.png)
