### PR TITLE
Custom expression editor: avoid being too wide in a sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.css
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.css
@@ -1,0 +1,3 @@
+.PopoverBody .ExpressionPopover {
+  width: 498px;
+}

--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
@@ -6,6 +6,8 @@ import Button from "metabase/components/Button";
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
 
+import "./ExpressionPopover.css";
+
 // TODO: combine with ExpressionWidget
 export default class ExpressionPopover extends React.Component {
   state = {
@@ -30,7 +32,7 @@ export default class ExpressionPopover extends React.Component {
     const isValid = !error && (!onChangeName || name);
 
     return (
-      <div style={{ width: 498 }}>
+      <div className="ExpressionPopover">
         <div className="text-medium p1 py2 border-bottom flex align-center">
           <a className="cursor-pointer flex align-center" onClick={onBack}>
             <Icon name="chevronleft" size={18} />


### PR DESCRIPTION
The width should be fixed only when the editor is being used in the notebook, and not from the sidebar.

To verify:

1. Ask a question, Simple question
2. Sample Dataset, Products table
3. Filter, Custom Expression

Before:

![image](https://user-images.githubusercontent.com/7288/111915092-debeaa00-8a31-11eb-907b-f1aa572c0c4f.png)

After:

![image](https://user-images.githubusercontent.com/7288/111915097-e2eac780-8a31-11eb-8e91-0334c7e9004e.png)
