### PR TITLE
#15281 Repro: Users with read permissions are offered to save new dashboard in collections they only have read access to

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -1,5 +1,5 @@
 import { onlyOn } from "@cypress/skip-test";
-import { restore } from "__support__/cypress";
+import { restore, popover } from "__support__/cypress";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -118,6 +118,30 @@ describe("collection permissions", () => {
                   ).should("not.exist");
                   cy.get(".Modal").should("not.exist");
                 }
+              });
+            });
+          });
+
+          onlyOn(permission === "view", () => {
+            it.skip("should not be offered to save dashboard in collections they have `read` access to (metabase#15281)", () => {
+              cy.signIn(user);
+              cy.visit("/");
+              cy.icon("add").click();
+              cy.findByText("New dashboard").click();
+              cy.findByLabelText("Name")
+                .click()
+                .type("Foo");
+              cy.get(".AdminSelect").click();
+              popover().within(() => {
+                cy.findByText("My personal collection");
+                // Test will fail on this step first
+                cy.findByText("First collection").should("not.exist");
+                // This is the second step that makes sure not even search returns collections with read-only access
+                cy.icon("search").click();
+                cy.findByPlaceholderText("Search")
+                  .click()
+                  .type("third{Enter}");
+                cy.findByText("Third collection").should("not.exist");
               });
             });
           });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -1,5 +1,6 @@
 import { onlyOn } from "@cypress/skip-test";
 import { restore, popover } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -123,25 +124,34 @@ describe("collection permissions", () => {
           });
 
           onlyOn(permission === "view", () => {
-            it.skip("should not be offered to save dashboard in collections they have `read` access to (metabase#15281)", () => {
+            beforeEach(() => {
               cy.signIn(user);
-              cy.visit("/");
-              cy.icon("add").click();
-              cy.findByText("New dashboard").click();
-              cy.findByLabelText("Name")
-                .click()
-                .type("Foo");
-              cy.get(".AdminSelect").click();
-              popover().within(() => {
-                cy.findByText("My personal collection");
-                // Test will fail on this step first
-                cy.findByText("First collection").should("not.exist");
-                // This is the second step that makes sure not even search returns collections with read-only access
-                cy.icon("search").click();
-                cy.findByPlaceholderText("Search")
+            });
+
+            ["/", "/collection/root"].forEach(route => {
+              it.skip("should not be offered to save dashboard in collections they have `read` access to (metabase#15281)", () => {
+                const { first_name, last_name } = USERS[user];
+                cy.visit(route);
+                cy.icon("add").click();
+                cy.findByText("New dashboard").click();
+                cy.findByLabelText("Name")
                   .click()
-                  .type("third{Enter}");
-                cy.findByText("Third collection").should("not.exist");
+                  .type("Foo");
+                // Coming from the root collection, the initial offered collection will be "Our analytics" (read-only access)
+                cy.findByText(
+                  `${first_name} ${last_name}'s Personal Collection`,
+                ).click();
+                popover().within(() => {
+                  cy.findByText("My personal collection");
+                  // Test will fail on this step first
+                  cy.findByText("First collection").should("not.exist");
+                  // This is the second step that makes sure not even search returns collections with read-only access
+                  cy.icon("search").click();
+                  cy.findByPlaceholderText("Search")
+                    .click()
+                    .type("third{Enter}");
+                  cy.findByText("Third collection").should("not.exist");
+                });
               });
             });
           });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15281

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:

#### Coming from the `/`
The first step this test fails on
![image](https://user-images.githubusercontent.com/31325167/112009045-57069780-8b26-11eb-99aa-722ffe5135b6.png)

Even when that gets fixed, there's another check for search:
![image](https://user-images.githubusercontent.com/31325167/112009203-77ceed00-8b26-11eb-8293-afe6bb533877.png)

#### Coming from the `/collection/root`
The first step this test fails on
![image](https://user-images.githubusercontent.com/31325167/112013949-c1b9d200-8b2a-11eb-9a43-af4a1c6c6f54.png)

The rest of the test behaves exactly like when we visit `/` first