### PR TITLE
12489 Repro: Archiving sub-collection should redirect to its parent

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -68,7 +68,7 @@ describe("collection permissions", () => {
 
                   it("archiving sub-collection should redirect to its parent (metabase#12489)", () => {
                     cy.request("GET", "/api/collection").then(xhr => {
-                      // We need its ID to continue nesting below it
+                      // We need to obtain the ID programatically
                       const { id: THIRD_COLLECTION_ID } = xhr.body.find(
                         collection => collection.slug === "third_collection",
                       );


### PR DESCRIPTION
Closing in favor of the new PR after Flamber found out that the issue can still be reproduced but using the different set of steps.