### PR TITLE
Only attempt to sync schemas that have some/any possible permissions

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -251,3 +251,10 @@
                               :filter_values       (field->parameter-value query)})
        " */ "
        (qputil/default-query->remark query)))
+
+(defmethod sql-jdbc.sync/have-any-schema-privileges? :redshift [_ ^Connection conn ^String table-schema]
+  (with-open [stmt ^PreparedStatement (prepare-statement conn "SELECT HAS_SCHEMA_PRIVILEGE(?, 'USAGE');")]
+    (.setString stmt 1 table-schema)
+    (with-open [rs ^ResultSet (.executeQuery stmt)]
+      (when (.next rs)
+        (.getBoolean rs 1)))))

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -12,6 +12,7 @@
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc.execute.legacy-impl :as legacy]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
+            [metabase.driver.sql-jdbc.sync.describe-database :as sync.describe-database]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.mbql.util :as mbql.u]
             [metabase.public-settings :as pubset]
@@ -141,8 +142,9 @@
         (.close ^Connection conn)
         (throw e)))))
 
-(defn- prepare-statement [^Connection conn sql]
-  (.prepareStatement conn sql
+(defn- prepare-statement ^PreparedStatement [^Connection conn sql]
+  (.prepareStatement conn
+                     sql
                      ResultSet/TYPE_FORWARD_ONLY
                      ResultSet/CONCUR_READ_ONLY
                      ResultSet/CLOSE_CURSORS_AT_COMMIT))
@@ -151,11 +153,11 @@
   "Quotes a string literal so that it can be safely inserted into Redshift queries, by returning the result of invoking
   the Redshift QUOTE_LITERAL function on the given string (which is set in a PreparedStatement as a parameter)."
   [^Connection conn ^String s]
-  (with-open [stmt ^PreparedStatement (prepare-statement conn "SELECT QUOTE_LITERAL(?);")]
-    (.setString stmt 1 s)
-    (with-open [rs ^ResultSet (.executeQuery stmt)]
-      (when (.next rs)
-        (.getString rs 1)))))
+  (with-open [stmt (doto (prepare-statement conn "SELECT QUOTE_LITERAL(?);")
+                     (.setString 1 s))
+              rs   (.executeQuery stmt)]
+    (when (.next rs)
+      (.getString rs 1))))
 
 (defn- quote-literal-for-database
   "This function invokes quote-literal-for-connection with a connection for the given database. See its docstring for
@@ -252,9 +254,26 @@
        " */ "
        (qputil/default-query->remark query)))
 
-(defmethod sql-jdbc.sync/have-any-schema-privileges? :redshift [_ ^Connection conn ^String table-schema]
-  (with-open [stmt ^PreparedStatement (prepare-statement conn "SELECT HAS_SCHEMA_PRIVILEGE(?, 'USAGE');")]
-    (.setString stmt 1 table-schema)
-    (with-open [rs ^ResultSet (.executeQuery stmt)]
-      (when (.next rs)
-        (.getBoolean rs 1)))))
+(defn- make-schema-usage-filter-xf [conn]
+  (fn [xf]
+    (let [stmt (prepare-statement conn "SELECT HAS_SCHEMA_PRIVILEGE(?, 'USAGE');")]
+      (fn
+        ([]
+         (xf))
+        ([result]
+         (.close stmt)
+         (xf result))
+        ([result table-schema]
+         (with-open [rs (.executeQuery (doto stmt (.setString 1 table-schema)))]
+           (let [has-perm? (and (.next rs)
+                                (.getBoolean rs 1))]
+             (if has-perm?
+               (xf result table-schema)
+               (do (log/tracef "Ignoring schema %s because no USAGE privilege on it" table-schema)
+                   result)))))))))
+
+(defmethod sql-jdbc.sync/syncable-schemas :redshift
+  [driver conn metadata]
+  (eduction (remove (set (sql-jdbc.sync/excluded-schemas driver)))
+            (make-schema-usage-filter-xf conn)
+            (sync.describe-database/all-schemas metadata)))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -197,11 +197,11 @@
                view-nm))
           (let [table-id (db/select-one-id Table :db_id (u/the-id database), :name view-nm)]
             ;; and its columns' :base_type should have been identified correctly
-            (is (= [{:name "weird_varchar", :database_type "character varying(50)", :base_type :type/Text}
-                    {:name "numeric_col",   :database_type "numeric(10,2)",         :base_type :type/Decimal}]
+            (is (= [{:name "numeric_col",   :database_type "numeric(10,2)",         :base_type :type/Decimal}
+                    {:name "weird_varchar", :database_type "character varying(50)", :base_type :type/Text}]
                    (map
                     (partial into {})
-                    (db/select [Field :name :database_type :base_type] :table_id table-id))))))))))
+                    (db/select [Field :name :database_type :base_type] :table_id table-id {:order-by [:name]}))))))))))
 
 (defn- assert-jdbc-url-fetch-size [db fetch-size]
   (with-open [conn (.getConnection (sql-jdbc.execute/datasource db))]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -1,8 +1,12 @@
 (ns metabase.driver.redshift-test
-  (:require [clojure.string :as str]
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [clojure.test :refer :all]
-            [environ.core :as env]
+            [metabase.driver.redshift :as redshift]
+            [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+            [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
+            [metabase.driver.sql-jdbc.sync.describe-database :as sync.describe-database]
             [metabase.models.database :refer [Database]]
             [metabase.models.field :refer [Field]]
             [metabase.models.setting :as setting]
@@ -17,7 +21,7 @@
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
             [toucan.db :as db])
-  (:import (java.sql ResultSetMetaData ResultSet)
+  (:import [java.sql ResultSet ResultSetMetaData]
            metabase.plugins.jdbc_proxy.ProxyDriver))
 
 (use-fixtures :once (fixtures/initialize :plugins))
@@ -231,3 +235,30 @@
                                    (mt/native-query)
                                    (qp/process-query)
                                    (mt/rows)))))))))))))
+
+(deftest syncable-schemas-test
+  (mt/test-driver :redshift
+    (testing "Should filter out schemas for which the DB has no perms"
+      ;; Don't know how to create a schema with no perms for testing, so instead we'll just test a schema that doesn't
+      ;; exist, since you can't have perms for something that doesn't exist.
+      (let [fake-schema-name (u/qualified-name ::fake-schema)]
+        ;; override `all-schemas` so it returns our fake schema in addition to the real ones.
+        (with-redefs [sync.describe-database/all-schemas (let [orig sync.describe-database/all-schemas]
+                                                           (fn [metadata]
+                                                             (eduction
+                                                              cat
+                                                              [(orig metadata) [fake-schema-name]])))]
+          (let [jdbc-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
+            (with-open [conn (jdbc/get-connection jdbc-spec)]
+              (letfn [(schemas []
+                        (reduce
+                         conj
+                         #{}
+                         (sql-jdbc.sync/syncable-schemas :redshift conn (.getMetaData conn))))]
+                (testing "if schemas-with-usage-permissions is disabled, the ::fake-schema should come back"
+                  (with-redefs [redshift/reducible-schemas-with-usage-permissions (fn [_ reducible]
+                                                                                    reducible)]
+                    (is (contains? (schemas) fake-schema-name))))
+                ;; TODO -- not sure if there's a way to actually test a REAL schema without permissions as well.
+                (testing "normally, ::fake-schema should be filtered out (because it does not exist)"
+                  (is (not (contains? (schemas) fake-schema-name))))))))))))

--- a/src/metabase/driver/sql_jdbc/sync.clj
+++ b/src/metabase/driver/sql_jdbc/sync.clj
@@ -16,7 +16,7 @@
   excluded-schemas
   fallback-metadata-query
   have-select-privilege?
-  have-any-schema-privileges?]
+  syncable-schemas]
 
  [sync.describe-table
   add-table-pks

--- a/src/metabase/driver/sql_jdbc/sync.clj
+++ b/src/metabase/driver/sql_jdbc/sync.clj
@@ -15,7 +15,8 @@
   db-default-timezone
   excluded-schemas
   fallback-metadata-query
-  have-select-privilege?]
+  have-select-privilege?
+  have-any-schema-privileges?]
 
  [sync.describe-table
   add-table-pks

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -14,7 +14,7 @@
 (defmethod i/excluded-schemas :sql-jdbc [_] nil)
 
 (defn all-schemas
-  "Gets all schemas from the given database metadata."
+  "Get a *reducible* sequence of all string schema names for the current database from its JDBC database metadata."
   [^DatabaseMetaData metadata]
   {:added "0.39.0", :pre [(instance? DatabaseMetaData metadata)]}
   (common/reducible-results

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -28,8 +28,9 @@
   :hierarchy #'driver/hierarchy)
 
 (defmulti syncable-schemas
-  "Returns a sequence of all schemas that can be synced for the given database. The default implementation will check
-  the database metadata for a list of all schemas, and filter that to exclude the excluded-schemas."
+  "Return a reducible sequence of string names of schemas that should be synced for the given database. Schemas for
+  which the current DB user has no `SELECT` permissions should be filtered out. The default implementation will fetch
+  a sequence of all schema names from the JDBC database metadata and filter out any schemas in `excluded-schemas`."
   {:added "0.39.0", :arglists '([driver ^java.sql.Connection connection ^java.sql.DatabaseMetaData metadata])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -27,10 +27,10 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
-(defmulti have-any-schema-privileges?
-  "Check if we have any sort of privileges for the given `schema`. If this method is defined for some driver, and it
-  returns false for the given schema, then we won't attempt to check for any tables within."
-  {:arglists '([driver ^java.sql.Connection connection ^String table-schema])}
+(defmulti syncable-schemas
+  "Returns a sequence of all schemas that can be synced for the given database. The default implementation will check
+  the database metadata for a list of all schemas, and filter that to exclude the excluded-schemas."
+  {:added "0.39.0", :arglists '([driver ^java.sql.Connection connection ^java.sql.DatabaseMetaData metadata])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -27,6 +27,13 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
+(defmulti have-any-schema-privileges?
+  "Check if we have any sort of privileges for the given `schema`. If this method is defined for some driver, and it
+  returns false for the given schema, then we won't attempt to check for any tables within."
+  {:arglists '([driver ^java.sql.Connection connection ^String table-schema])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
 (defmulti database-type->base-type
   "Given a native DB column type (as a keyword), return the corresponding `Field` `base-type`, which should derive from
   `:type/*`. You can use `pattern-based-database-type->base-type` in this namespace to implement this using regex


### PR DESCRIPTION
Add new multimethod `have-any-schema-privileges?`, to the sync interface, that a driver can implement if it has a way to check for "any" schema-level permissions

Update `syncable-schemas` to call that method, if defined, in order to filter the output of `all-schemas`

Update Redshift driver to define implementation for `have-any-schema-privileges?` by calling the Redshift `HAS_SCHEMA_PRIVILEGE` function
