### PR TITLE
expand fieldset wrapper div to width of container

### DIFF
--- a/frontend/src/metabase/components/FieldSet.jsx
+++ b/frontend/src/metabase/components/FieldSet.jsx
@@ -24,7 +24,7 @@ export default function FieldSet({
           {legend}
         </legend>
       )}
-      <div>{children}</div>
+      <div className="w-full">{children}</div>
     </fieldset>
   );
 }

--- a/frontend/src/metabase/css/core/index.css
+++ b/frontend/src/metabase/css/core/index.css
@@ -23,3 +23,4 @@
 @import "./spacing.css";
 @import "./text.css";
 @import "./transitions.css";
+@import "./width.css";

--- a/frontend/src/metabase/css/core/width.css
+++ b/frontend/src/metabase/css/core/width.css
@@ -1,0 +1,4 @@
+.w-full,
+:local(.w-full) {
+  width: 100%;
+}


### PR DESCRIPTION
**Description**
the `Fieldset` component wraps its `children` in a `div`, so the children can't expand to the full width of the `Fieldset` (the `div` takes on the width of the child elements).

Here's the fix, to add a `width: 100%` to the wrapping div
![Screen Shot 2021-03-22 at 5 00 59 PM](https://user-images.githubusercontent.com/13057258/112073223-e153f900-8b30-11eb-9c8f-6718d052161b.png)
