### PR TITLE
#15289 Repro: Abandoning archive collection process should let you stay in the same collection

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -58,6 +58,52 @@ describe("collection permissions", () => {
                   archiveUnarchive("Orders in a dashboard");
                 });
 
+                describe("collections", () => {
+                  it("shouldn't be able to arhive root or personal collection", () => {
+                    cy.visit("/collection/root");
+                    cy.icon("edit").should("not.exist");
+                    cy.findByText("Your personal collection").click();
+                    cy.icon("edit").should("not.exist");
+                  });
+
+                  it("archiving sub-collection should redirect to its parent (metabase#12489)", () => {
+                    cy.request("GET", "/api/collection").then(xhr => {
+                      // We need to obtain the ID programatically
+                      const { id: THIRD_COLLECTION_ID } = xhr.body.find(
+                        collection => collection.slug === "third_collection",
+                      );
+                      cy.visit(`/collection/${THIRD_COLLECTION_ID}`);
+                    });
+                    cy.icon("pencil").click();
+                    cy.findByText("Archive this collection").click();
+                    cy.get(".Modal")
+                      .findByText("Archive")
+                      .click();
+                    cy.get("[class*=PageHeading]")
+                      .as("title")
+                      .contains("Second collection");
+                    cy.get("[class*=CollectionSidebar]")
+                      .as("sidebar")
+                      .within(() => {
+                        cy.findByText("First collection");
+                        cy.findByText("Second collection");
+                        cy.findByText("Third collection").should("not.exist");
+                      });
+                    // Although this was not the part of the original issue, it is a good place to test unarchiving collection without duplicating tests
+                    cy.findByText("Archived collection");
+                    cy.findByText("Undo").click();
+                    cy.findByText(
+                      "Sorry, you don’t have permission to see that.",
+                    ).should("not.exist");
+                    // We're still in the parent collection
+                    cy.get("@title").contains("Second collection");
+                    // But unarchived collection is now visible in the sidebar
+                    cy.get("@sidebar").within(() => {
+                      cy.findByText("Third collection");
+                    });
+                  });
+                });
+
                 function archiveUnarchive(item) {
                   cy.visit("/collection/root");
                   openEllipsisMenuFor(item);

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -59,7 +59,7 @@ describe("collection permissions", () => {
                 });
 
                 describe("collections", () => {
-                  it("shouldn't be able to arhive root or personal collection", () => {
+                  it("shouldn't be able to archive/edit root or personal collection", () => {
                     cy.visit("/collection/root");
                     cy.icon("edit").should("not.exist");
                     cy.findByText("Your personal collection").click();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -66,7 +66,7 @@ describe("collection permissions", () => {
                     cy.icon("edit").should("not.exist");
                   });
 
-                  it("archiving sub-collection should redirect to its parent (metabase#12489)", () => {
+                  it("archiving sub-collection should redirect to its parent", () => {
                     cy.request("GET", "/api/collection").then(xhr => {
                       // We need to obtain the ID programatically
                       const { id: THIRD_COLLECTION_ID } = xhr.body.find(
@@ -89,7 +89,7 @@ describe("collection permissions", () => {
                         cy.findByText("Second collection");
                         cy.findByText("Third collection").should("not.exist");
                       });
-                    // Although this was not the part of the original issue, it is a good place to test unarchiving collection without duplicating tests
+                    // While we're here, we can test unarchiving the collection as well
                     cy.findByText("Archived collection");
                     cy.findByText("Undo").click();
                     cy.findByText(
@@ -100,6 +100,27 @@ describe("collection permissions", () => {
                     // But unarchived collection is now visible in the sidebar
                     cy.get("@sidebar").within(() => {
                       cy.findByText("Third collection");
+                    });
+                  });
+
+                  it.skip("abandoning archive process should keep you in the same collection (metabase#15289)", () => {
+                    cy.request("GET", "/api/collection").then(xhr => {
+                      const { id: THIRD_COLLECTION_ID } = xhr.body.find(
+                        collection => collection.slug === "third_collection",
+                      );
+                      cy.visit(`/collection/${THIRD_COLLECTION_ID}`);
+                      cy.icon("pencil").click();
+                      cy.findByText("Archive this collection").click();
+                      cy.get(".Modal")
+                        .findByText("Cancel")
+                        .click();
+                      cy.location("pathname").should(
+                        "eq",
+                        `/collection/${THIRD_COLLECTION_ID}`,
+                      );
+                      cy.get("[class*=PageHeading]")
+                        .as("title")
+                        .contains("Third collection");
                     });
                   });
                 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15289

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/112144653-cab5ac80-8bd9-11eb-94f8-5665101aa318.png)

