### PR TITLE
Expand "pin collection items" test

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -194,18 +194,22 @@ describe("scenarios > collection_defaults", () => {
         // Assert that we're starting from a scenario with no pins
         cy.findByText("Pinned items").should("not.exist");
 
-        // 1. Click on the ... menu
-        openEllipsisMenuFor("Orders in a dashboard");
+        pinItem("Orders in a dashboard"); // dashboard
+        pinItem("Orders, Count"); // question
 
-        // 2. Select "pin this" from the popover
-        cy.findByText("Pin this item").click();
-
-        // 3. Should see "pinned items" and the item should be in that section
+        // Should see "pinned items" and items should be in that section
         cy.findByText("Pinned items")
           .parent()
-          .contains("Orders in a dashboard");
-        // 4. Consequently, "Everything else" should now also be visible
+          .within(() => {
+            cy.findByText("Orders in a dashboard");
+            cy.findByText("Orders, Count");
+          });
+        // Consequently, "Everything else" should now also be visible
         cy.findByText("Everything else");
+        // Only pinned dashboards should show up on the home page
+        cy.visit("/");
+        cy.findByText("Orders in a dashboard");
+        cy.findByText("Orders, Count").should("not.exist");
       });
 
       it.skip("should let a user select all items using checkbox (metabase#14705)", () => {
@@ -575,4 +579,9 @@ function openEllipsisMenuFor(item) {
     .closest("a")
     .find(".Icon-ellipsis")
     .click({ force: true });
+}
+
+function pinItem(item) {
+  openEllipsisMenuFor(item);
+  cy.findByText("Pin this item").click();
 }

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -189,7 +189,7 @@ describe("scenarios > collection_defaults", () => {
         cy.findByText("Orders");
       });
 
-      it("should allow a user to pin an item", () => {
+      it("pinning an item workflow should work", () => {
         cy.visit("/collection/root");
         // Assert that we're starting from a scenario with no pins
         cy.findByText("Pinned items").should("not.exist");
@@ -206,10 +206,15 @@ describe("scenarios > collection_defaults", () => {
           });
         // Consequently, "Everything else" should now also be visible
         cy.findByText("Everything else");
-        // Only pinned dashboards should show up on the home page
+        // Only pinned dashboards should show up on the home page...
         cy.visit("/");
         cy.findByText("Orders in a dashboard");
         cy.findByText("Orders, Count").should("not.exist");
+        // ...but not for the user without permissions to see the root collection
+        cy.signOut();
+        cy.signIn("none");
+        cy.visit("/");
+        cy.findByText("Orders in a dashboard").should("not.exist");
       });
 
       it.skip("should let a user select all items using checkbox (metabase#14705)", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
Expands "pin collection item" workflow to include in a following manner:
1. Pins both dashboard and a question
2. Asserts that only the dashboard is visible on the home page (according to the documentation in https://www.metabase.com/docs/latest/users-guide/06-sharing-answers.html)