### PR TITLE
Consolidate collection permissions tests

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -162,33 +162,6 @@ describe("scenarios > collection_defaults", () => {
     });
 
     describe("managing items", () => {
-      it("should let a user move a collection item via modal", () => {
-        cy.visit("/collection/root");
-
-        // 1. Click on the ... menu
-        openEllipsisMenuFor("Orders");
-
-        // 2. Select "move this" from the popover
-        cy.findByText("Move this item").click();
-        modal().within(() => {
-          cy.findByText(`Move "Orders"?`);
-          // 3. Select a collection that has child collections and hit the right chevron to navigate there
-          cy.findByText("First collection")
-            .next() // right chevron icon
-            .click();
-          cy.findByText("Second collection").click();
-          // 4. Move that item
-          cy.findByText("Move").click();
-        });
-        // Assert that the item no longer exists in "Our collection"...
-        cy.findByText("Orders").should("not.exist");
-
-        openDropdownFor("First collection");
-        // ...and that it is indeed moved inside "Second collection"
-        cy.findByText("Second collection").click();
-        cy.findByText("Orders");
-      });
-
 
       it.skip("should let a user select all items using checkbox (metabase#14705)", () => {
         cy.visit("/collection/root");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -189,33 +189,6 @@ describe("scenarios > collection_defaults", () => {
         cy.findByText("Orders");
       });
 
-      it("pinning an item workflow should work", () => {
-        cy.visit("/collection/root");
-        // Assert that we're starting from a scenario with no pins
-        cy.findByText("Pinned items").should("not.exist");
-
-        pinItem("Orders in a dashboard"); // dashboard
-        pinItem("Orders, Count"); // question
-
-        // Should see "pinned items" and items should be in that section
-        cy.findByText("Pinned items")
-          .parent()
-          .within(() => {
-            cy.findByText("Orders in a dashboard");
-            cy.findByText("Orders, Count");
-          });
-        // Consequently, "Everything else" should now also be visible
-        cy.findByText("Everything else");
-        // Only pinned dashboards should show up on the home page...
-        cy.visit("/");
-        cy.findByText("Orders in a dashboard");
-        cy.findByText("Orders, Count").should("not.exist");
-        // ...but not for the user without permissions to see the root collection
-        cy.signOut();
-        cy.signIn("none");
-        cy.visit("/");
-        cy.findByText("Orders in a dashboard").should("not.exist");
-      });
 
       it.skip("should let a user select all items using checkbox (metabase#14705)", () => {
         cy.visit("/collection/root");
@@ -584,9 +557,4 @@ function openEllipsisMenuFor(item) {
     .closest("a")
     .find(".Icon-ellipsis")
     .click({ force: true });
-}
-
-function pinItem(item) {
-  openEllipsisMenuFor(item);
-  cy.findByText("Pin this item").click();
 }

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -161,26 +161,6 @@ describe("scenarios > collection_defaults", () => {
       });
     });
 
-    describe("managing items", () => {
-
-      it.skip("should let a user select all items using checkbox (metabase#14705)", () => {
-        cy.visit("/collection/root");
-        cy.findByText("Orders")
-          .closest("a")
-          .within(() => {
-            cy.icon("table").trigger("mouseover");
-            cy.findByRole("checkbox")
-              .should("be.visible")
-              .click();
-          });
-
-        cy.findByText("1 item selected").should("be.visible");
-        cy.icon("dash").click();
-        cy.icon("dash").should("not.exist");
-        cy.findByText("4 items selected");
-      });
-    });
-
     // [quarantine]: cannot run tests that rely on email setup in CI (yet)
     describe.skip("a new pulse", () => {
       it("should be in the root collection", () => {
@@ -495,6 +475,23 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("Everything Else");
       cy.findByText("Second Collection").should("not.exist");
       cy.findByText("First Collection");
+    });
+
+    it.skip("should let a user select all items using checkbox (metabase#14705)", () => {
+      cy.visit("/collection/root");
+      cy.findByText("Orders")
+        .closest("a")
+        .within(() => {
+          cy.icon("table").trigger("mouseover");
+          cy.findByRole("checkbox")
+            .should("be.visible")
+            .click();
+        });
+
+      cy.findByText("1 item selected").should("be.visible");
+      cy.icon("dash").click();
+      cy.icon("dash").should("not.exist");
+      cy.findByText("4 items selected");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -322,6 +322,23 @@ describe("collection permissions", () => {
                   cy.location("pathname").should("eq", "/dashboard/2");
                   cy.findByText(`Orders in a dashboard - Duplicate`);
                 });
+
+                describe("move", () => {
+                  beforeEach(() => {
+                    cy.findByText("Move").click();
+                    cy.location("pathname").should("eq", "/dashboard/1/move");
+                    cy.findByText("First collection").click();
+                    clickButton("Move");
+                  });
+
+                  it("should be able to move/undo move a dashboard", () => {
+                    assertOnRequest("updateDashboard");
+                    // Why do we use "Dashboard moved to" here (without its location, btw) vs. "Moved dashboard" for the same action?
+                    cy.findByText("Dashboard moved to");
+                    cy.findByText("Undo").click();
+                    assertOnRequest("updateDashboard");
+                  });
+                });
               });
             });
           });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -24,6 +24,36 @@ describe("collection permissions", () => {
                 cy.signIn(user);
               });
 
+              describe("pin", () => {
+                it("pinning should work properly for both questions and dashboards", () => {
+                  cy.visit("/collection/root");
+                  // Assert that we're starting from a scenario with no pins
+                  cy.findByText("Pinned items").should("not.exist");
+
+                  pinItem("Orders in a dashboard"); // dashboard
+                  pinItem("Orders, Count"); // question
+
+                  // Should see "pinned items" and items should be in that section
+                  cy.findByText("Pinned items")
+                    .parent()
+                    .within(() => {
+                      cy.findByText("Orders in a dashboard");
+                      cy.findByText("Orders, Count");
+                    });
+                  // Consequently, "Everything else" should now also be visible
+                  cy.findByText("Everything else");
+                  // Only pinned dashboards should show up on the home page...
+                  cy.visit("/");
+                  cy.findByText("Orders in a dashboard");
+                  cy.findByText("Orders, Count").should("not.exist");
+                  // ...but not for the user without permissions to see the root collection
+                  cy.signOut();
+                  cy.signIn("none");
+                  cy.visit("/");
+                  cy.findByText("Orders in a dashboard").should("not.exist");
+                });
+              });
+
               describe("duplicate", () => {
                 it.skip("should be able to duplicate the dashboard without obstructions from the modal (metabase#15255)", () => {
                   duplicate("Orders in a dashboard");
@@ -365,4 +395,9 @@ function clickButton(name) {
   cy.findByRole("button", { name })
     .should("not.be.disabled")
     .click();
+}
+
+function pinItem(item) {
+  openEllipsisMenuFor(item);
+  cy.findByText("Pin this item").click();
 }

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -338,6 +338,11 @@ describe("collection permissions", () => {
                     cy.findByText("Undo").click();
                     assertOnRequest("updateDashboard");
                   });
+
+                  it.skip("should update dashboard's collection after the move without page reload (metabase#13059)", () => {
+                    cy.contains("37.65");
+                    cy.get(".DashboardHeader a").contains("First collection");
+                  });
                 });
               });
             });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -287,6 +287,25 @@ describe("collection permissions", () => {
                 });
               });
 
+              describe("managing dashboard from the dashboard's edit menu", () => {
+                beforeEach(() => {
+                  cy.route("PUT", "/api/dashboard/1").as("updateDashboard");
+                  cy.visit("/dashboard/1");
+                  cy.icon("ellipsis").click();
+                });
+
+                it("should be able to change title and description", () => {
+                  cy.findByText("Change title and description").click();
+                  cy.location("pathname").should("eq", "/dashboard/1/details");
+                  cy.findByLabelText("Name")
+                    .click()
+                    .type("1");
+                  cy.findByLabelText("Description")
+                    .click()
+                    .type("Foo");
+                  clickButton("Update");
+                  assertOnRequest("updateDashboard");
+                });
               });
             });
           });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -305,6 +305,9 @@ describe("collection permissions", () => {
                     .type("Foo");
                   clickButton("Update");
                   assertOnRequest("updateDashboard");
+                  cy.findByText("Orders in a dashboard1");
+                  cy.icon("info").click();
+                  cy.findByText("Foo");
                 });
 
                 it("should be able to duplicate a dashboard", () => {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -306,6 +306,19 @@ describe("collection permissions", () => {
                   clickButton("Update");
                   assertOnRequest("updateDashboard");
                 });
+
+                it("should be able to duplicate a dashboard", () => {
+                  cy.route("POST", "/api/dashboard/1/copy").as("copyDashboard");
+                  cy.findByText("Duplicate").click();
+                  cy.location("pathname").should("eq", "/dashboard/1/copy");
+                  cy.get(".Modal").within(() => {
+                    clickButton("Duplicate");
+                    cy.findByText("Failed").should("not.exist");
+                  });
+                  assertOnRequest("copyDashboard");
+                  cy.location("pathname").should("eq", "/dashboard/2");
+                  cy.findByText(`Orders in a dashboard - Duplicate`);
+                });
               });
             });
           });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -375,7 +375,8 @@ describe("collection permissions", () => {
               });
 
               it("should be able to revert the question", () => {
-                // It's possible that the mechanics of who should be able to revert the question will change, but for now that's not possible for user without data access
+                // It's possible that the mechanics of who should be able to revert the question will change (see https://github.com/metabase/metabase/issues/15131)
+                // For now that's not possible for user without data access (likely it will be again when #11719 is fixed)
                 cy.skipOn(user === "nodata");
                 cy.visit("/question/1");
                 cy.icon("pencil").click();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -384,6 +384,12 @@ describe("collection permissions", () => {
                 cy.signIn(user);
               });
 
+              it("should be able to get to the dashboard revision modal directly via url", () => {
+                cy.visit("/dashboard/1/history");
+                cy.findByText("First revision.");
+                cy.findAllByRole("button", { name: "Revert" });
+              });
+
               it.skip("should be able to revert the dashboard (metabase#15237)", () => {
                 cy.visit("/dashboard/1");
                 cy.icon("ellipsis").click();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -344,6 +344,19 @@ describe("collection permissions", () => {
                     cy.get(".DashboardHeader a").contains("First collection");
                   });
                 });
+
+                it("should be able to archive/unarchive a dashboard", () => {
+                  cy.findByText("Archive").click();
+                  cy.location("pathname").should("eq", "/dashboard/1/archive");
+                  cy.findByText("Archive this dashboard?"); //Without this, there is some race condition and the button click fails
+                  clickButton("Archive");
+                  assertOnRequest("updateDashboard");
+                  cy.location("pathname").should("eq", "/collection/root");
+                  cy.findByText("Orders in a dashboard").should("not.exist");
+                  cy.findByText("Archived dashboard");
+                  cy.findByText("Undo").click();
+                  assertOnRequest("updateDashboard");
+                });
               });
             });
           });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -265,7 +265,7 @@ describe("collection permissions", () => {
                     .click()
                     .type("1");
                   clickButton("Save");
-                  assertOnQuestionUpdate();
+                  assertOnRequest("updateQuestion");
                   cy.findByText("Orders1");
                 });
 
@@ -274,30 +274,19 @@ describe("collection permissions", () => {
                   cy.findByText("Move").click();
                   cy.findByText("My personal collection").click();
                   clickButton("Move");
-                  assertOnQuestionUpdate();
+                  assertOnRequest("updateQuestion");
                   cy.contains("37.65");
                 });
 
                 it("should be able to archive the question (metabase#11719-3)", () => {
                   cy.findByText("Archive").click();
                   clickButton("Archive");
-                  assertOnQuestionUpdate();
+                  assertOnRequest("updateQuestion");
                   cy.location("pathname").should("eq", "/collection/root");
                   cy.findByText("Orders").should("not.exist");
                 });
+              });
 
-                /**
-                 * Custom function related to this describe block only
-                 */
-                function assertOnQuestionUpdate() {
-                  cy.wait("@updateQuestion").then(xhr => {
-                    expect(xhr.status).not.to.eq(403);
-                  });
-                  cy.findByText(
-                    "Sorry, you don’t have permission to see that.",
-                  ).should("not.exist");
-                  cy.get(".Modal").should("not.exist");
-                }
               });
             });
           });
@@ -445,4 +434,14 @@ function exposeChildrenFor(collectionName) {
     .find(".Icon-chevronright")
     .eq(0) // there may be more nested icons, but we need the top level one
     .click();
+}
+
+function assertOnRequest(xhr_alias) {
+  cy.wait("@" + xhr_alias).then(xhr => {
+    expect(xhr.status).not.to.eq(403);
+  });
+  cy.findByText("Sorry, you don’t have permission to see that.").should(
+    "not.exist",
+  );
+  cy.get(".Modal").should("not.exist");
 }

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -515,35 +515,6 @@ describe("scenarios > dashboard", () => {
     });
   });
 
-  describe("revisions screen", () => {
-    it("should open and close", () => {
-      cy.visit("/dashboard/1");
-      cy.icon("ellipsis").click();
-      cy.findByText("Revision history").click();
-
-      cy.get(".Modal").within(() => {
-        cy.get(".LoadingSpinner").should("not.exist");
-      });
-
-      cy.findAllByText("Bobby Tables");
-      cy.contains(/revert/i);
-
-      cy.get(".Modal .Icon-close").click();
-      cy.findAllByText("Bobby Tables").should("not.exist");
-    });
-
-    it("should open with url", () => {
-      cy.visit("/dashboard/1/history");
-      cy.get(".Modal").within(() => {
-        cy.get(".LoadingSpinner").should("not.exist");
-        cy.findByText("Revision history");
-      });
-
-      cy.findAllByText("Bobby Tables");
-      cy.contains(/revert/i);
-    });
-  });
-
   it("should show sub-day resolutions in relative date filter (metabase#6660)", () => {
     cy.visit("/dashboard/1");
     cy.icon("pencil").click();

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -99,23 +99,6 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Orders, Count");
   });
 
-  it("should duplicate a dashboard", () => {
-    cy.visit("/dashboard/1");
-    cy.findByText("Orders in a dashboard");
-    cy.icon("ellipsis").click();
-    cy.findByText("Duplicate").click();
-    cy.findByLabelText("Name")
-      .click()
-      .clear()
-      .type("Doppleganger");
-    cy.get(".Button--primary")
-      .contains("Duplicate")
-      .click();
-
-    cy.findByText("Orders in a dashboard").should("not.exist");
-    cy.findByText("Doppleganger");
-  });
-
   it("should link filters to custom question with filtered aggregate data (metabase#11007)", () => {
     // programatically create and save a question as per repro instructions in #11007
     cy.request("POST", "/api/card", {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -45,25 +45,6 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Test Dash");
   });
 
-  it("should update title and description", () => {
-    cy.visit("/dashboard/1");
-    cy.icon("ellipsis").click();
-    cy.findByText("Change title and description").click();
-    cy.findByLabelText("Name")
-      .click()
-      .clear()
-      .type("Test Title");
-    cy.findByLabelText("Description")
-      .click()
-      .clear()
-      .type("Test description");
-
-    cy.findByText("Update").click();
-    cy.findByText("Test Title");
-    cy.icon("info").click();
-    cy.findByText("Test description");
-  });
-
   it("should add a filter", () => {
     cy.visit("/dashboard/1");
     cy.icon("pencil").click();


### PR DESCRIPTION
### Status
PENGING REVIEW

### What does this PR accomplish?
- Removes duplicate tests from different files
- Adds a set of tests for managing dashboard from its edit menu (when one visits `/dashboard/:id`)
- Adds a repro for #13059

### Additional notes
- Although this is a huge PR, I tried to keep everything separated into logical commits so that's probably the easiest way to review it.
- `frontend/test/metabase/scenarios/collections/permissions.cy.spec.js` now takes around 150s to finish (with many skipped tests)
    - We'll probably need to divide it later into smaller test files