### PR TITLE
Add it.only error linting rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
     "react/no-did-update-set-state": 0,
     "react/no-find-dom-node": 0,
     "prefer-const": [1, { "destructuring": "all" }],
-    "no-useless-escape": 0
+    "no-useless-escape": 0,
+    "no-only-tests/no-only-tests": "error"
   },
   "globals": {
     "pending": false,
@@ -32,7 +33,7 @@
     "jest": true
   },
   "parser": "babel-eslint",
-  "plugins": ["react"],
+  "plugins": ["react", "no-only-tests"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -72,6 +72,8 @@ describe("scenarios > admin > databases > add", () => {
   });
 
   it("should show validation error if you enable scheduling toggle and enter invalid db connection info", () => {
+    cy.route("POST", "/api/database").as("createDatabase");
+
     cy.visit("/admin/databases/create");
 
     typeField("Name", "Test db name");
@@ -81,6 +83,8 @@ describe("scenarios > admin > databases > add", () => {
     cy.findByRole("button", { name: "Save" })
       .should("not.be.disabled")
       .click();
+
+    cy.wait("@createDatabase");
 
     toggleFieldWithDisplayName("let me choose when Metabase syncs and scans");
 

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -221,7 +221,7 @@ describe("scenarios > admin > databases > add", () => {
   });
 
   describe("Google Analytics ", () => {
-    it.only("should generate well-formed external auth URLs", () => {
+    it("should generate well-formed external auth URLs", () => {
       cy.visit("/admin/databases/create");
       cy.contains("Database type")
         .parents(".Form-field")

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "d3-scale": "^2.1.0",
     "dc": "2.1.9",
     "diff": "^3.2.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "grid-styled": "4.1.0",
     "history": "3",
     "humanize-plus": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5226,6 +5226,11 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-no-only-tests@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
+  integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
+
 eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"


### PR DESCRIPTION
**Description**
I screwed up and merged code with an `it.only` in it a while back. Added a new linting rule to prevent this from happening going forward.

Shouldn't be too much of a hassle as it still works correctly when you intend to run single cypress test.

![Screen Shot 2021-03-23 at 4 08 58 PM](https://user-images.githubusercontent.com/13057258/112231057-36f0da00-8bf3-11eb-9f36-064c9143801b.png)
