### PR TITLE
Coerced columns click behavior

### DIFF
--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -14,7 +14,9 @@ import type {
 function getFiltersForColumn(column) {
   if (
     isa(column.base_type, TYPE.Number) ||
-    isa(column.base_type, TYPE.Temporal)
+    isa(column.base_type, TYPE.Temporal) ||
+    // change to semantic_type or ideally effective_type if that is known after merging into master
+    isa(column.special_type, TYPE.Temporal)
   ) {
     return [
       { name: "<", operator: "<" },


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/15317

Ensure that the click popovers are aware of the semantic type that coerces these to datetimes. in the future (ie already in master) this should just check the effective type (if that's on columns). 

An example of the small dumb bugs that just go away when we don't have the edge cases spread out everywhere

EDIT:
## Before
Clicking on column item (not header) shows just string comparisons (=, !=) and no comparisons based on a comparable type (<, >, etc).
![image](https://user-images.githubusercontent.com/6377293/112507041-51929280-8d5c-11eb-8266-0d85a7f95c61.png)

## After:
<img width="507" alt="image" src="https://user-images.githubusercontent.com/6377293/112508302-6ae80e80-8d5d-11eb-9e6d-2993a0ce3d85.png">
The context menu when clicking on an item in the column includes the operators available for comparable values (ie, it knows these are temporal values and not just strings now)
