### PR TITLE
Put schema forms in meta for schemas

### DIFF
--- a/shared/src/metabase/mbql/schema/macros.clj
+++ b/shared/src/metabase/mbql/schema/macros.clj
@@ -30,6 +30,10 @@
                                   [clause-name (or (:clause-name (meta clause-name)) clause-name)])]
     `(def ~(vary-meta symb-name assoc
                       :clause-name (keyword clause-name)
+                      :clause-form (into [(keyword clause-name)]
+                                         (mapcat (fn [[arg schema]]
+                                                   [(keyword arg) `'~schema])
+                                                 (partition 2 arg-names-and-schemas)))
                       :doc         (format "Schema for a valid %s clause." clause-name))
        (metabase.mbql.schema.helpers/clause ~(keyword clause-name) ~@(stringify-names arg-names-and-schemas)))))
 


### PR DESCRIPTION
If you want a nice way to see schemas its useful to have them queryable from the repl and viewable in some capacity.

```clojure
schema=> (->> (ns-publics 'metabase.mbql.schema)
              (keep (fn [[s v]] (:clause-form (meta v))))
              (run! pprint))

[:not-null :field Field]
[:interval :n s/Int :unit RelativeDatetimeUnit]
[:regex-match-first :s StringExpressionArg :pattern s/Str]
[:var :field-or-expression FieldOrExpressionDef]
[:does-not-contain
 :field
 StringExpressionArg
 :string-or-field
 StringExpressionArg
 :options
 (optional StringFilterOptions)]
[:= :field EqualityComparable :value-or-field EqualityComparable :more-values-or-fields (rest EqualityComparable)]
[:log :x NumericExpressionArg]
[:< :field OrderComparable :value-or-field OrderComparable]
[:floor :x NumericExpressionArg]
[:metric :metric-id (s/cond-pre helpers/IntGreaterThanZero helpers/NonBlankString)]
[:ends-with :field StringExpressionArg :string-or-field StringExpressionArg :options (optional StringFilterOptions)]
[:relative-datetime :n (s/cond-pre (s/eq :current) s/Int) :unit (optional RelativeDatetimeUnit)]
[:sum :field-or-expression FieldOrExpressionDef]
[:time-interval
 :field
 field
 :n
 (s/cond-pre s/Int (s/enum :current :last :next))
 :unit
 RelativeDatetimeUnit
 :options
 (optional TimeIntervalOptions)]
[:rtrim :s StringExpressionArg]
[:ceil :x NumericExpressionArg]
[:starts-with :field StringExpressionArg :string-or-field StringExpressionArg :options (optional StringFilterOptions)]
[:<= :field OrderComparable :value-or-field OrderComparable]
[:upper :s StringExpressionArg]
[:* :x NumericExpressionArg :y NumericExpressionArg :more (rest NumericExpressionArg)]
[:min :field-or-expression FieldOrExpressionDef]
[:inside
 :lat-field
 OrderComparable
 :lon-field
 OrderComparable
 :lat-max
 OrderComparable
 :lon-min
 OrderComparable
 :lat-min
 OrderComparable
 :lon-max
 OrderComparable]
[:ltrim :s StringExpressionArg]
[:desc :field FieldOrAggregationReference]
[:contains :field StringExpressionArg :string-or-field StringExpressionArg :options (optional StringFilterOptions)]
[:expression :expression-name helpers/NonBlankString]
[:is-empty :field Field]
[:substring :s StringExpressionArg :start NumericExpressionArg :length (optional NumericExpressionArg)]
[:stddev :field-or-expression FieldOrExpressionDef]
[:> :field OrderComparable :value-or-field OrderComparable]
[:replace :s StringExpressionArg :match s/Str :replacement s/Str]
[:sqrt :x NumericExpressionArg]
[:concat :a StringExpressionArg :b StringExpressionArg :more (rest StringExpressionArg)]
[:count-where :pred Filter]
[:- :x NumericExpressionArg :y NumericExpressionArgOrInterval :more (rest NumericExpressionArgOrInterval)]
[:asc :field FieldOrAggregationReference]
[:cum-count :field (optional Field)]
[:value :value s/Any :type-info (s/maybe ValueTypeInfo)]
[:or
 :first-clause
 (s/recursive #'Filter)
 :second-clause
 (s/recursive #'Filter)
 :other-clauses
 (rest (s/recursive #'Filter))]
[:exp :x NumericExpressionArg]
[:time :time (s/cond-pre java.time.LocalTime java.time.OffsetTime) :unit TimeUnit]
[:between :field OrderComparable :min OrderComparable :max OrderComparable]
[:sum-where :field-or-expression FieldOrExpressionDef :pred Filter]
[:not :clause (s/recursive #'Filter)]
[:cum-sum :field-or-expression FieldOrExpressionDef]
[:coalesce :a ExpressionArg :b ExpressionArg :more (rest ExpressionArg)]
[:is-null :field Field]
[:/ :x NumericExpressionArg :y NumericExpressionArg :more (rest NumericExpressionArg)]
[:>= :field OrderComparable :value-or-field OrderComparable]
[:not-empty :field Field]
[:distinct :field-or-expression FieldOrExpressionDef]
[:percentile :field-or-expression FieldOrExpressionDef :percentile NumericExpressionArg]
[:round :x NumericExpressionArg]
[:power :x NumericExpressionArg :y NumericExpressionArg]
[:aggregation-options :aggregation UnnamedAggregation :options AggregationOptions]
[:+ :x NumericExpressionArg :y NumericExpressionArgOrInterval :more (rest NumericExpressionArgOrInterval)]
[:abs :x NumericExpressionArg]
[:median :field-or-expression FieldOrExpressionDef]
[:share :pred Filter]
[:case :clauses CaseClauses :options (optional CaseOptions)]
[:segment :segment-id (s/cond-pre helpers/IntGreaterThanZero helpers/NonBlankString)]
[:max :field-or-expression FieldOrExpressionDef]
[:!= :field EqualityComparable :value-or-field EqualityComparable :more-values-or-fields (rest EqualityComparable)]
[:count :field (optional Field)]
[:lower :s StringExpressionArg]
[:length :s StringExpressionArg]
[:trim :s StringExpressionArg]
[:and
 :first-clause
 (s/recursive #'Filter)
 :second-clause
 (s/recursive #'Filter)
 :other-clauses
 (rest (s/recursive #'Filter))]
[:avg :field-or-expression FieldOrExpressionDef]
[:aggregation :aggregation-clause-index s/Int]
nil
schema=>
```

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
