### PR TITLE
Fixing translations that defaults to ES

### DIFF
--- a/bin/i18n/src/i18n/common.clj
+++ b/bin/i18n/src/i18n/common.clj
@@ -21,7 +21,7 @@
 
 (defn- catalog ^Catalog [locale]
   (let [parser (PoParser.)]
-    (.parseCatalog parser (io/file (locale-source-po-filename "es")))))
+    (.parseCatalog parser (io/file (locale-source-po-filename locale)))))
 
 (defn po-headers [locale]
   (when-let [^Message message (.locateHeader (catalog locale))]


### PR DESCRIPTION
Just built a jar with the change you proposed @flamber and you were absolutely right

fixes https://github.com/metabase/metabase/issues/15302