### PR TITLE
#8406 Repro: It shouldn't be possible to change permission levels on sub-collections inside personal collection

### DIFF
--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -28,15 +28,30 @@ describe("personal collections", () => {
       });
     });
 
-    it("shouldn't be able to change permission levels on or edit personal collections", () => {
+    it("shouldn't be able to change permission levels or edit personal collections", () => {
       cy.visit("/collection/root");
       cy.findByText("Your personal collection").click();
+      cy.icon("new_folder");
       cy.icon("lock").should("not.exist");
       cy.icon("pencil").should("not.exist");
       // Visit random user's personal collection
       cy.visit("/collection/5");
+      cy.icon("new_folder");
       cy.icon("lock").should("not.exist");
       cy.icon("pencil").should("not.exist");
+    });
+
+    it.skip("shouldn't be able to change permission levels for sub-collections in personal collections (metabase#8406)", () => {
+      cy.visit("/collection/root");
+      cy.findByText("Your personal collection").click();
+      // Create new collection inside admin's personal collection and navigate to it
+      addNewCollection("Foo");
+      cy.get("[class*=CollectionSidebar]")
+        .findByText("Foo")
+        .click();
+      cy.icon("new_folder");
+      cy.icon("pencil");
+      cy.icon("lock").should("not.exist");
     });
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #8406

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/112548576-ba115c00-8dbc-11eb-85de-7cd57f18bed5.png)

