### PR TITLE
#15339 Repro: Admin can't see other users' personal sub-collections

### DIFF
--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -53,6 +53,15 @@ describe("personal collections", () => {
       cy.icon("pencil");
       cy.icon("lock").should("not.exist");
     });
+
+    it.skip("should be able view other users' personal sub-collections (metabase#15339)", () => {
+      cy.visit("/collection/5");
+      cy.icon("new_folder").click();
+      cy.findByLabelText("Name").type("Foo");
+      cy.findByText("Create").click();
+      // This repro could possibly change depending on the design decision for this feature implementation
+      cy.get("[class*=CollectionSidebar]").findByText("Foo");
+    });
   });
 
   describe("all users", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15339 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/112550194-458bec80-8dbf-11eb-8f0b-759214fa14cc.png)

