### PR TITLE
Add CollapseSection UI component

### DIFF
--- a/frontend/src/metabase/components/CollapseSection.info.js
+++ b/frontend/src/metabase/components/CollapseSection.info.js
@@ -9,13 +9,13 @@ A collapsible section with a clickable header.
 `;
 
 export const examples = {
-  "Closed by default": (
+  "Collapsed by default": (
     <CollapseSection header="Section header">
       foo foo foo foo foo foo foo foo
     </CollapseSection>
   ),
-  "Settable initial state": (
-    <CollapseSection initialState="open" header="Foo">
+  "Settable collpased/expanded initial state": (
+    <CollapseSection initialState="expanded" header="Foo">
       foo foo foo foo foo
     </CollapseSection>
   ),
@@ -33,7 +33,7 @@ export const examples = {
   ),
   "Header and body classes": (
     <CollapseSection
-      initialState="open"
+      initialState="expanded"
       header="Section header"
       headerClass="text-brand flex-reverse justify-between p1 border-bottom"
       bodyClass="p2"

--- a/frontend/src/metabase/components/CollapseSection.info.js
+++ b/frontend/src/metabase/components/CollapseSection.info.js
@@ -1,0 +1,55 @@
+import React from "react";
+import CollapseSection from "metabase/components/CollapseSection";
+
+export const component = CollapseSection;
+export const category = "layout";
+export const description = `
+A collapsible section with a clickable header.
+`;
+
+export const examples = {
+  "Closed by default": (
+    <CollapseSection headerText="Section header">
+      foo foo foo foo foo foo foo foo
+    </CollapseSection>
+  ),
+  "Settable initial state": (
+    <CollapseSection initialState="open" headerText="Foo">
+      foo foo foo foo foo
+    </CollapseSection>
+  ),
+  "Header Icon": (
+    <CollapseSection headerIconName="folder" headerText="<-- folder icon">
+      foo foo foo foo foo
+    </CollapseSection>
+  ),
+  "Header and body classes": (
+    <CollapseSection
+      initialState="open"
+      headerText="Section header"
+      headerClass="text-brand flex-reverse justify-between p1 border-bottom"
+      bodyClass="p2"
+    >
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus neque
+        tellus, mattis ut felis non, tempus mollis lacus. Vivamus nulla massa,
+        accumsan non ligula eu, dapibus volutpat libero. Mauris sollicitudin
+        dolor et ipsum fringilla auctor. Praesent et diam non nisi consequat
+        ornare. Aenean et risus vel dolor maximus dapibus a id massa. Nam
+        finibus quis libero eu finibus. Sed vehicula ac enim pellentesque
+        luctus. Phasellus vehicula et ipsum porttitor mollis. Fusce blandit
+        lacus a elit pretium, vestibulum porta nisi vehicula. Aliquam vel ligula
+        enim. Orci varius natoque penatibus et magnis dis parturient montes,
+        nascetur ridiculus mus. Pellentesque eget porta mi. Duis et lectus eget
+        dolor convallis mollis. Sed commodo nec urna eget egestas.
+        <br />
+        <br />
+        Mauris in ante sit amet ipsum tempus consequat. Curabitur auctor massa
+        vitae dui auctor scelerisque. Donec in leo a libero commodo sodales.
+        Integer egestas lacinia elit, vitae cursus sem mollis ut. Proin ut
+        dapibus metus, vel accumsan justo. Pellentesque eget finibus elit, ut
+        commodo felis. Ut non lacinia metus. Maecenas eget bibendum nisl.
+      </div>
+    </CollapseSection>
+  ),
+};

--- a/frontend/src/metabase/components/CollapseSection.info.js
+++ b/frontend/src/metabase/components/CollapseSection.info.js
@@ -1,5 +1,6 @@
 import React from "react";
 import CollapseSection from "metabase/components/CollapseSection";
+import Icon from "metabase/components/Icon";
 
 export const component = CollapseSection;
 export const category = "layout";
@@ -9,24 +10,31 @@ A collapsible section with a clickable header.
 
 export const examples = {
   "Closed by default": (
-    <CollapseSection headerText="Section header">
+    <CollapseSection header="Section header">
       foo foo foo foo foo foo foo foo
     </CollapseSection>
   ),
   "Settable initial state": (
-    <CollapseSection initialState="open" headerText="Foo">
+    <CollapseSection initialState="open" header="Foo">
       foo foo foo foo foo
     </CollapseSection>
   ),
-  "Header Icon": (
-    <CollapseSection headerIconName="folder" headerText="<-- folder icon">
+  "Components in header": (
+    <CollapseSection
+      header={
+        <div>
+          <Icon className="mr1" name="folder" size={12} />
+          Component header
+        </div>
+      }
+    >
       foo foo foo foo foo
     </CollapseSection>
   ),
   "Header and body classes": (
     <CollapseSection
       initialState="open"
-      headerText="Section header"
+      header="Section header"
       headerClass="text-brand flex-reverse justify-between p1 border-bottom"
       bodyClass="p2"
     >

--- a/frontend/src/metabase/components/CollapseSection.jsx
+++ b/frontend/src/metabase/components/CollapseSection.jsx
@@ -11,15 +11,18 @@ function CollapseSection({
   header,
   headerClass,
   bodyClass,
-  initialState = "closed",
+  initialState = "collapsed",
 }) {
-  const [isOpen, setIsOpen] = useState(initialState === "open");
+  const [isExpanded, setIsExpanded] = useState(initialState === "expanded");
 
   return (
     <div
-      className={cx("collapse-section", isOpen && "collapse-section--open")}
+      className={cx(
+        "collapse-section",
+        isExpanded && "collapse-section--expanded",
+      )}
       role="tab"
-      aria-expanded={isOpen}
+      aria-expanded={isExpanded}
     >
       <div
         role="button"
@@ -28,12 +31,14 @@ function CollapseSection({
           "collapse-section__header cursor-pointer flex align-center",
           headerClass,
         )}
-        onClick={() => setIsOpen(isOpen => !isOpen)}
-        onKeyDown={e => e.key === "Enter" && setIsOpen(isOpen => !isOpen)}
+        onClick={() => setIsExpanded(isExpanded => !isExpanded)}
+        onKeyDown={e =>
+          e.key === "Enter" && setIsExpanded(isExpanded => !isExpanded)
+        }
       >
         <Icon
           className="mr1"
-          name={isOpen ? "chevrondown" : "chevronright"}
+          name={isExpanded ? "chevrondown" : "chevronright"}
           size={12}
         />
         <span className="collapse-section__header-text flex align-center">
@@ -41,7 +46,7 @@ function CollapseSection({
         </span>
       </div>
       <div role="tabpanel" className="collapse-section__body-container">
-        {isOpen && (
+        {isExpanded && (
           <div className={cx("collapse-section__body-container", bodyClass)}>
             {children}
           </div>
@@ -56,7 +61,7 @@ CollapseSection.propTypes = {
   header: PropTypes.node,
   headerClass: PropTypes.string,
   bodyClass: PropTypes.string,
-  initialState: PropTypes.oneOf(["open", "closed"]),
+  initialState: PropTypes.oneOf(["expanded", "collapsed"]),
 };
 
 export default CollapseSection;

--- a/frontend/src/metabase/components/CollapseSection.jsx
+++ b/frontend/src/metabase/components/CollapseSection.jsx
@@ -1,0 +1,67 @@
+/* eslint "react/prop-types": 2 */
+
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+
+import Icon from "metabase/components/Icon";
+
+function CollapseSection({
+  children,
+  headerIconName,
+  headerText,
+  headerClass,
+  bodyClass,
+  initialState = "closed",
+}) {
+  const [isOpen, setIsOpen] = useState(initialState === "open");
+
+  return (
+    <div
+      className={cx("collapse-section", isOpen && "collapse-section--open")}
+      role="tab"
+      aria-expanded={isOpen}
+    >
+      <div
+        role="button"
+        tabIndex="0"
+        className={cx(
+          "collapse-section__header cursor-pointer flex align-center",
+          headerClass,
+        )}
+        onClick={() => setIsOpen(isOpen => !isOpen)}
+        onKeyDown={e => e.key === "Enter" && setIsOpen(isOpen => !isOpen)}
+      >
+        <Icon
+          className="mr1"
+          name={isOpen ? "chevrondown" : "chevronright"}
+          size={12}
+        />
+        <span className="collapse-section__header-text flex align-center">
+          {headerIconName && (
+            <Icon className="mr1" name={headerIconName} size={12} />
+          )}
+          {headerText}
+        </span>
+      </div>
+      <div role="tabpanel" className="collapse-section__body-container">
+        {isOpen && (
+          <div className={cx("collapse-section__body-container", bodyClass)}>
+            {children}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+CollapseSection.propTypes = {
+  children: PropTypes.node,
+  headerIconName: PropTypes.string,
+  headerText: PropTypes.string,
+  headerClass: PropTypes.string,
+  bodyClass: PropTypes.string,
+  initialState: PropTypes.oneOf(["open", "closed"]),
+};
+
+export default CollapseSection;

--- a/frontend/src/metabase/components/CollapseSection.jsx
+++ b/frontend/src/metabase/components/CollapseSection.jsx
@@ -8,6 +8,7 @@ import Icon from "metabase/components/Icon";
 
 function CollapseSection({
   children,
+  className,
   header,
   headerClass,
   bodyClass,
@@ -20,6 +21,7 @@ function CollapseSection({
       className={cx(
         "collapse-section",
         isExpanded && "collapse-section--expanded",
+        className,
       )}
       role="tab"
       aria-expanded={isExpanded}
@@ -58,6 +60,7 @@ function CollapseSection({
 
 CollapseSection.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   header: PropTypes.node,
   headerClass: PropTypes.string,
   bodyClass: PropTypes.string,

--- a/frontend/src/metabase/components/CollapseSection.jsx
+++ b/frontend/src/metabase/components/CollapseSection.jsx
@@ -8,8 +8,7 @@ import Icon from "metabase/components/Icon";
 
 function CollapseSection({
   children,
-  headerIconName,
-  headerText,
+  header,
   headerClass,
   bodyClass,
   initialState = "closed",
@@ -38,10 +37,7 @@ function CollapseSection({
           size={12}
         />
         <span className="collapse-section__header-text flex align-center">
-          {headerIconName && (
-            <Icon className="mr1" name={headerIconName} size={12} />
-          )}
-          {headerText}
+          {header}
         </span>
       </div>
       <div role="tabpanel" className="collapse-section__body-container">
@@ -57,8 +53,7 @@ function CollapseSection({
 
 CollapseSection.propTypes = {
   children: PropTypes.node,
-  headerIconName: PropTypes.string,
-  headerText: PropTypes.string,
+  header: PropTypes.node,
   headerClass: PropTypes.string,
   bodyClass: PropTypes.string,
   initialState: PropTypes.oneOf(["open", "closed"]),


### PR DESCRIPTION
Adding a simple collapsible section component for use in the dashboard subscription sidebar. Didn't see anything else similar besides what is in `CollectionsList.jsx`, which may be replaceable with this with a few tweaks.

I've tried to keep things simple so that we can revisit later after a bit of usage. A few things I've intentionally left out: animations/toggle transitions, full control of opening/closing via parent component, super opinionated styling.

Not sure how people feel about BEM, but I've appreciated BEM inside of UI components in the past as it helps with style extensibility. Added a few unused classes for that purpose.

Tried to make it reasonably accessible via keyboard + added some some role attributes and `aria-expanded`

https://user-images.githubusercontent.com/13057258/112701934-305e9e80-8e4f-11eb-9a94-c52430cdd5c7.mov


