### PR TITLE
Throw an error if a setting already exists

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -442,11 +442,11 @@
 (defn register-setting!
   "Register a new Setting with a map of `SettingDefinition` attributes. Returns the map it was passed. This is used
   internally be `defsetting`; you shouldn't need to use it yourself."
-  [{setting-name :name, setting-type :type, default :default, :as setting} namespace-sym]
+  [{setting-name :name, setting-ns :namespace, setting-type :type, default :default, :as setting}]
   (u/prog1 (let [setting-type         (s/validate Type (or setting-type :string))]
              (merge
               {:name        setting-name
-               :namespace   namespace-sym
+               :namespace   setting-ns
                :description nil
                :type        setting-type
                :default     default
@@ -461,7 +461,7 @@
     (s/validate SettingDefinition <>)
     ;; eastwood complains about (setting-name @registered-settings) for shadowing the function `setting-name`
     (when-let [registered-setting (clojure.core/get @registered-settings setting-name)]
-      (when (not= namespace-sym (:namespace registered-setting))
+      (when (not= setting-ns (:namespace registered-setting))
         (throw (ex-info (tru "Setting {0} already registered in {1}" setting-name (:namespace registered-setting))
                         {:existing-setting (dissoc registered-setting :on-change :getter :setter)}))))
     (swap! registered-settings assoc setting-name <>)))
@@ -588,8 +588,8 @@
                   (validate-description description))
          setting# (register-setting! (assoc ~options
                                             :name ~(keyword setting-symb)
-                                            :description desc#)
-                                     (ns-name *ns*))]
+                                            :description desc#
+                                            :namespace (ns-name *ns*)))]
      (-> (def ~setting-symb (setting-fn setting#))
          (alter-meta! merge (metadata-for-setting-fn setting#)))))
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -459,7 +459,8 @@
                :cache?      true}
               (dissoc setting :name :type :default)))
     (s/validate SettingDefinition <>)
-    (when-let [registered-setting (setting-name @registered-settings)]
+    ;; eastwood complains about (setting-name @registered-settings) for shadowing the function `setting-name`
+    (when-let [registered-setting (clojure.core/get @registered-settings setting-name)]
       (when (not= namespace-sym (:namespace registered-setting))
         (throw (ex-info (tru "Setting {0} already registered in {1}" setting-name (:namespace registered-setting))
                         {:existing-setting (dissoc registered-setting :on-change :getter :setter)}))))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -513,3 +513,31 @@
     ;; ok, make sure the setting was set
     (is (= "Banana Beak"
            (toucan-name)))))
+
+
+(deftest duplicated-setting-name
+  (testing "can re-register a setting in the same ns (redefining or reloading ns)"
+    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public))
+    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public)))
+  (testing "if attempt to register in a different ns throws an error"
+    (let [current-ns (ns-name *ns*)]
+      (try
+        (ns nested-setting-test
+          (:require [metabase.models.setting :refer [defsetting]]
+                    [metabase.util.i18n :as i18n :refer [deferred-tru]]))
+        (defsetting foo (deferred-tru "A testing setting") :visibility :public)
+        (catch Exception e
+          (is (= {:existing-setting
+                  {:description (deferred-tru "A testing setting"),
+                   :cache? true,
+                   :default nil,
+                   :name :foo,
+                   :type :string,
+                   :sensitive? false,
+                   :tag 'java.lang.String,
+                   :namespace current-ns
+                   :visibility :public}}
+                 (ex-data e)))
+          (is (= "Setting :foo already registered in metabase.models.setting-test"
+                 (ex-message e))))
+        (finally (in-ns current-ns))))))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -538,6 +538,6 @@
                    :namespace current-ns
                    :visibility :public}}
                  (ex-data e)))
-          (is (= "Setting :foo already registered in metabase.models.setting-test"
+          (is (= (str "Setting :foo already registered in " current-ns)
                  (ex-message e))))
         (finally (in-ns current-ns))))))


### PR DESCRIPTION
Fixes #15000

```clojure
setting-test=> (defsetting site-name (deferred-tru "A testing setting") :visibility :public)
Execution error (ExceptionInfo) at metabase.models.setting/register-setting! (setting.clj:464).
Setting :site-name already registered in metabase.public-settings
setting-test=> (pprint (ex-data *e))
{:existing-setting
 {:description "The name used for this instance of Metabase.",
  :cache? true,
  :default "Metabase",
  :name :site-name,
  :type :string,
  :sensitive? false,
  :tag java.lang.String,
  :namespace metabase.public-settings,
  :visibility :admin}}
nil
```
