### PR TITLE
Add space btwn colon and next word in CaveatMessage

### DIFF
--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -306,7 +306,7 @@ AddEditSlackSidebar.propTypes = {
 function CaveatMessage() {
   return (
     <Text className="mx4 my2 p2 bg-light text-dark rounded">
-      <span className="text-bold">{t`Note`}:</span>
+      <span className="text-bold">{t`Note`}:&nbsp;</span>
       {t`charts in your subscription won't look the same as in your dashboard.`}
       &nbsp;
       <ExternalLink


### PR DESCRIPTION
from
<img width="328" alt="Screen Shot 2021-03-27 at 11 36 53 AM" src="https://user-images.githubusercontent.com/13057258/112731002-f0042c80-8ef1-11eb-8bb9-d4e4593291cf.png">

to
<img width="334" alt="Screen Shot 2021-03-27 at 11 39 49 AM" src="https://user-images.githubusercontent.com/13057258/112731004-f2668680-8ef1-11eb-94d7-983d08fd7812.png">
