### PR TITLE
add default param value selector

### DIFF
--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -251,3 +251,15 @@ export const makeGetParameterMappingOptions = () => {
   );
   return getParameterMappingOptions;
 };
+
+export const getDefaultParametersById = createSelector(
+  [getDashboard],
+  dashboard =>
+    ((dashboard && dashboard.parameters) || []).reduce((map, parameter) => {
+      if (parameter.default) {
+        map[parameter.id] = parameter.default;
+      }
+
+      return map;
+    }, {}),
+);


### PR DESCRIPTION
Not in use yet but will be in two incoming sets of changes, to add a default parameter section to dashboard subscription pulses for OSS users, and to add a modifiable parameter value section for enterprise users