### PR TITLE
add default param values section

### DIFF
--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -421,9 +421,9 @@ function DefaultParametersSection({
         />
       </Heading>
       <div className="pt1 text-small text-normal text-medium">{t`If a dashboard filter has a default value, it’ll be applied when your subscription is sent.`}</div>
-      {formattedParameterValues.map(formattedValue => {
+      {formattedParameterValues.map((formattedValue, index) => {
         return (
-          <div className="pt1 text-medium" key={formattedValue}>
+          <div className="pt1 text-medium" key={index}>
             {formattedValue}
           </div>
         );


### PR DESCRIPTION
Adds a readonly section to dashboard subscriptions so that users can see more explicitly that default params affect the data of a given subscription. In the below image, I have two parameters with values but only one of them is a "default" value. See on the right side of the image where I'm only listing the default value.

<img width="1260" alt="Screen Shot 2021-03-29 at 4 08 18 PM" src="https://user-images.githubusercontent.com/13057258/112910761-effa5d00-90a8-11eb-99b2-f47768f4afb5.png">

Not adding an additional cypress test for this section in this PR (unless someone feels strongly otherwise) but will once I'm done with the EE part of this work.
