### PR TITLE
#15368 Repro: Click behavior leading to the dashboard without permissions causes a permission error

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -604,9 +604,6 @@ describe("scenarios > dashboard", () => {
   });
 
   it.skip("should be possible to visit a dashboard with click-behavior linked to the dashboard without permissions (metabase#15368)", () => {
-    cy.server();
-    cy.route("GET", "/api/dashboard/2").as("loadDashboard");
-
     cy.request("GET", "/api/user/current").then(
       ({ body: { personal_collection_id } }) => {
         // Save new dashboard in admin's personal collection
@@ -642,6 +639,11 @@ describe("scenarios > dashboard", () => {
               },
             ],
           });
+
+          cy.server();
+          cy.route("GET", `/api/dashboard/${NEW_DASHBOARD_ID}`).as(
+            "loadDashboard",
+          );
         });
       },
     );

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -648,10 +648,7 @@ describe("scenarios > dashboard", () => {
     cy.signInAsNormalUser();
     cy.visit("/dashboard/1");
 
-    cy.wait("@loadDashboard").then(xhr => {
-      expect(xhr.status).not.to.eq(403);
-      expect(xhr.response.body).not.to.contain("You don't have permissions");
-    });
+    cy.wait("@loadDashboard");
     cy.findByText("Orders in a dashboard");
     cy.contains("37.65");
   });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15368

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/112849291-3485f880-90a9-11eb-9e3a-9e09ddead1d3.png)

