### PR TITLE
Wipe stacktrace to users during SAML/JWT login

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/error_page.mustache
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/error_page.mustache
@@ -13,18 +13,10 @@
         <h2><tt>{{errorMessage}}</tt></h2>
 
         <p style="margin-top: 20px;">
-          Stuck? Need help? Contact us at <a href="{{mailto}}">support@metabase.com</a>.
+          Stuck? Need help? Contact the administrator of your Metabase instance about this error.
         </p>
 
         <div align="left" style="border:1px dashed gray; padding: 5px; margin-top:100px;">
-          <h3>Additonal Info</h3>
-
-          <h4>Exception Class</h4>
-          <pre>{{exceptionClass}}</pre>
-
-          <h4>Stacktrace</h4>
-          <pre>{{stacktrace}}</pre>
-
           <h4>Additional Info</h4>
           <pre>{{additionalData}}</pre>
         </div>

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -70,18 +70,9 @@
    :headers {"Content-Type" "text/html"}
    :body    (stencil/render-file "metabase_enterprise/sandbox/api/error_page"
               (let [message    (.getMessage e)
-                    stacktrace (u/pprint-to-str (vec (.getStackTrace e)))
                     data       (u/pprint-to-str (ex-data e))]
-                {:mailto         (str "mailto:support@metabase.com"
-                                      (str "?subject=" (codec/url-encode (str "[Login Error] " message)))
-                                      (str "&body=" (codec/url-encode
-                                                     (str/join "\n" ["Stacktrace:"
-                                                                     stacktrace
-                                                                     "Additional Info:"
-                                                                     data]))))
-                 :errorMessage   message
+                {:errorMessage   message
                  :exceptionClass (.getName Exception)
-                 :stacktrace     stacktrace
                  :additionalData data}))})
 
 (api/defendpoint POST "/"


### PR DESCRIPTION
Simplify the messages and point to the instance administrator

Should fix https://github.com/metabase/metabase/issues/14820