### PR TITLE
#15352 Repro: Different time filter query used in saved and nested question

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -422,30 +422,61 @@ describe("scenarios > question > nested", () => {
     }
   });
 
-  it.skip("should use the same query for date filter in both base and nested questions (metabase#15352)", () => {
-    cy.createQuestion({
-      name: "15352",
-      query: {
-        "source-table": ORDERS_ID,
+  describe.skip("should use the same query for date filter in both base and nested questions (metabase#15352)", () => {
+    it("should work with 'between' date filter (metabase#15352-1)", () => {
+      assertOnFilter({
+        name: "15352-1",
         filter: [
           "between",
           ["field-id", ORDERS.CREATED_AT],
           "2020-02-01",
           "2020-02-29",
         ],
-        aggregation: [["count"]],
-      },
-      display: "scalar",
-    }).then(({ body }) => {
-      cy.visit(`/question/${body.id}`);
-      cy.get(".ScalarValue").findByText("543");
+        value: "543",
+      });
     });
-    // Start new question based on the saved one
-    cy.visit("/question/new");
-    cy.findByText("Simple question").click();
-    cy.findByText("Saved Questions").click();
-    cy.findByText("15352").click();
-    cy.get(".ScalarValue").findByText("543");
+
+    it("should work with 'after/before' date filter (metabase#15352-2)", () => {
+      assertOnFilter({
+        name: "15352-2",
+        filter: [
+          "and",
+          [">", ["field-id", ORDERS.CREATED_AT], "2020-01-31"],
+          ["<", ["field-id", ORDERS.CREATED_AT], "2020-03-01"],
+        ],
+        value: "543",
+      });
+    });
+
+    it("should work with 'on' date filter (metabase#15352-3)", () => {
+      assertOnFilter({
+        name: "15352-3",
+        filter: ["=", ["field-id", ORDERS.CREATED_AT], "2020-02-01"],
+        value: "17",
+      });
+    });
+
+    function assertOnFilter({ name, filter, value } = {}) {
+      cy.createQuestion({
+        name,
+        query: {
+          "source-table": ORDERS_ID,
+          filter,
+          aggregation: [["count"]],
+        },
+        type: "query",
+        display: "scalar",
+      }).then(({ body }) => {
+        cy.visit(`/question/${body.id}`);
+        cy.get(".ScalarValue").findByText(value);
+      });
+      // Start new question based on the saved one
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText(name).click();
+      cy.get(".ScalarValue").findByText(value);
+    }
   });
 });
 

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -421,6 +421,32 @@ describe("scenarios > question > nested", () => {
         });
     }
   });
+
+  it.skip("should use the same query for date filter in both base and nested questions (metabase#15352)", () => {
+    cy.createQuestion({
+      name: "15352",
+      query: {
+        "source-table": ORDERS_ID,
+        filter: [
+          "between",
+          ["field-id", ORDERS.CREATED_AT],
+          "2020-02-01",
+          "2020-02-29",
+        ],
+        aggregation: [["count"]],
+      },
+      display: "scalar",
+    }).then(({ body }) => {
+      cy.visit(`/question/${body.id}`);
+      cy.get(".ScalarValue").findByText("543");
+    });
+    // Start new question based on the saved one
+    cy.visit("/question/new");
+    cy.findByText("Simple question").click();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("15352").click();
+    cy.get(".ScalarValue").findByText("543");
+  });
 });
 
 function ordersJoinProducts(name) {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15352 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/nested.cy.spec.js`
- Replace `describe.skip()` with `describe.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Case 1 (`between` filter)
![image](https://user-images.githubusercontent.com/31325167/112869884-edeec900-90bd-11eb-9f55-5b265957b20b.png)

Case 2 (`before/after` filter)
![image](https://user-images.githubusercontent.com/31325167/112869986-052db680-90be-11eb-82ed-407783a83bea.png)

Case 3 (`on` filter)
![image](https://user-images.githubusercontent.com/31325167/112870067-1971b380-90be-11eb-8827-bfdbe87a5a3f.png)

