### PR TITLE
#15324 Repro: Count of rows from drill-down on binned results doesn't match the number of records

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -4,6 +4,7 @@ import {
   openOrdersTable,
   popover,
   sidebar,
+  visitQuestionAdhoc,
 } from "__support__/cypress";
 import { USER_GROUPS } from "__support__/cypress_data";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -363,6 +364,32 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         cy.findByText("Macy Olson");
       });
     });
+  });
+
+  it.skip("count of rows from drill-down on binned results should match the number of records (metabase#15324)", () => {
+    visitQuestionAdhoc({
+      name: "15324",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["binning-strategy", ["field-id", ORDERS.QUANTITY], "num-bins", 10],
+          ],
+        },
+        type: "query",
+      },
+      display: "table",
+    });
+    cy.findByText(/^10 –/)
+      .closest(".TableInteractive-cellWrapper")
+      .next()
+      .contains("85")
+      .click();
+    cy.findByText("View these Orders").click();
+    cy.findByText("Quantity between 10 20");
+    cy.findByText("Showing 85 rows");
   });
 
   describe("for an unsaved question", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15324

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/112887697-c6a2f680-90d3-11eb-8614-7a30c96c2982.png)

