### PR TITLE
Add pointer cursor on voronoi map of the line charts

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -179,6 +179,7 @@
 }
 
 .LineAreaBarChart .dc-chart .voronoi {
+  cursor: pointer;
   fill: transparent;
 }
 


### PR DESCRIPTION
### Description
Make cursor to be `pointer` on voronoi map of the line charts when there are less than 500 dots.