### PR TITLE
safeguard email/slack configured checks

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/sandboxes/sandboxes.cy.spec.js
@@ -904,7 +904,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("Row totals");
     });
 
-    it.skip("should show dashboard subscriptions for sandboxed user (metabase#14990)", () => {
+    it("should show dashboard subscriptions for sandboxed user (metabase#14990)", () => {
       cy.sandboxTable({
         table_id: ORDERS_ID,
         attribute_remappings: {

--- a/frontend/src/metabase/lib/pulse.js
+++ b/frontend/src/metabase/lib/pulse.js
@@ -85,7 +85,7 @@ export function cleanPulse(pulse, channelSpecs) {
 
 export function getDefaultChannel(channelSpecs) {
   // email is the first choice
-  if (channelSpecs.email.configured) {
+  if (channelSpecs.email && channelSpecs.email.configured) {
     return channelSpecs.email;
   }
   // otherwise just pick the first configured

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -748,8 +748,8 @@ class SharingSidebar extends React.Component {
     }
 
     if (editingMode === "new-pulse" || pulses.length === 0) {
-      const emailSpec = formInput.channels.email;
-      const slackSpec = formInput.channels.slack;
+      const emailSpec = formInput.channels.email || {};
+      const slackSpec = formInput.channels.slack || {};
 
       return (
         <Sidebar onCancel={this.onCancel}>


### PR DESCRIPTION
Looks like the "form_input" endpoint can return an empty object `channels` property, resulting in an error when we check `formInput.channels.email.configured`, so I added some additional safeguards and the cypress test passes.

Fixes #14990 