### PR TITLE
disable submit button on pristine user settings form

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -40,6 +40,7 @@ export default class SettingsBatchForm extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
+      pristine: true,
       dirty: false,
       formData: {},
       submitting: "default",
@@ -68,7 +69,7 @@ export default class SettingsBatchForm extends Component {
     for (const element of props.elements) {
       formData[element.key] = element.value;
     }
-    this.setState({ formData });
+    this.setState({ formData, pristine: true });
   }
 
   componentDidMount() {
@@ -164,7 +165,12 @@ export default class SettingsBatchForm extends Component {
         );
       }
 
+      const pristine = this.props.elements.every(
+        ({ key, value }) => settingsValues[key] === value,
+      );
+
       return {
+        pristine,
         dirty: true,
         formData: settingsValues,
       };
@@ -221,6 +227,7 @@ export default class SettingsBatchForm extends Component {
       formData,
       formErrors,
       submitting,
+      pristine,
       valid,
       dirty,
       validationErrors,
@@ -255,6 +262,7 @@ export default class SettingsBatchForm extends Component {
           settingValues={settingValues}
           onChangeSetting={(key, value) => this.handleChangeEvent(key, value)}
           errorMessage={errorMessage}
+          fireOnChange
         />
       );
     };
@@ -287,7 +295,7 @@ export default class SettingsBatchForm extends Component {
             mr={1}
             primary={!disabled}
             success={submitting === "success"}
-            disabled={disabled}
+            disabled={disabled || pristine}
             onClick={this.updateSettings}
           >
             {SAVE_SETTINGS_BUTTONS_STATES[submitting]}

--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -41,7 +41,6 @@ export default class SettingsBatchForm extends Component {
     super(props, context);
     this.state = {
       pristine: true,
-      dirty: false,
       formData: {},
       submitting: "default",
       valid: false,
@@ -171,7 +170,6 @@ export default class SettingsBatchForm extends Component {
 
       return {
         pristine,
-        dirty: true,
         formData: settingsValues,
       };
     });
@@ -206,7 +204,7 @@ export default class SettingsBatchForm extends Component {
 
       this.props.updateSettings(formData).then(
         () => {
-          this.setState({ dirty: false, submitting: "success" });
+          this.setState({ pristine: true, submitting: "success" });
 
           // show a confirmation for 3 seconds, then return to normal
           setTimeout(() => this.setState({ submitting: "default" }), 3000);
@@ -229,7 +227,6 @@ export default class SettingsBatchForm extends Component {
       submitting,
       pristine,
       valid,
-      dirty,
       validationErrors,
     } = this.state;
 
@@ -306,7 +303,7 @@ export default class SettingsBatchForm extends Component {
               valid,
               submitting,
               disabled,
-              dirty,
+              pristine,
             })}
         </div>
       </div>

--- a/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
@@ -78,9 +78,9 @@ export default class SettingsEmailForm extends Component {
           {...this.props}
           updateSettings={this.props.updateEmailSettings}
           disable={sendingEmail !== "default"}
-          renderExtraButtons={({ disabled, valid, dirty, submitting }) => {
+          renderExtraButtons={({ disabled, valid, pristine, submitting }) => {
             return [
-              valid && !dirty && submitting === "default" ? (
+              valid && pristine && submitting === "default" ? (
                 <Button
                   mr={1}
                   success={sendingEmail === "success"}

--- a/frontend/src/metabase/components/form/CustomForm.jsx
+++ b/frontend/src/metabase/components/form/CustomForm.jsx
@@ -32,6 +32,7 @@ class CustomForm extends React.Component {
     pristine: PropTypes.bool,
     error: PropTypes.string,
     onChangeField: PropTypes.func,
+    disablePristineSubmit: PropTypes.bool,
   };
 
   getChildContext() {
@@ -50,6 +51,7 @@ class CustomForm extends React.Component {
       style,
       onChangeField,
     } = this.props;
+    const { disablePristineSubmit } = form;
     const formFields = form.fields(values);
     const formFieldsByName = _.indexBy(formFields, "name");
 
@@ -68,6 +70,7 @@ class CustomForm extends React.Component {
       pristine,
       error,
       onChangeField,
+      disablePristineSubmit,
     };
   }
 
@@ -166,18 +169,21 @@ export class CustomFormField extends React.Component {
 export const CustomFormSubmit = (
   { children, ...props },
   {
-    values,
     submitting,
     invalid,
     pristine,
     handleSubmit,
     submitTitle,
     renderSubmit,
+    disablePristineSubmit,
   },
 ) => {
   const title = children || submitTitle || t`Submit`;
-  // NOTE: need a way to configure if "pristine" forms can be submitted
-  const canSubmit = !(submitting || invalid); // || pristine );
+  const canSubmit = !(
+    submitting ||
+    invalid ||
+    (pristine && disablePristineSubmit)
+  );
   if (renderSubmit) {
     return renderSubmit({ canSubmit, title, handleSubmit });
   } else {
@@ -204,6 +210,7 @@ CustomFormSubmit.contextTypes = {
   handleSubmit: PropTypes.func,
   submitTitle: PropTypes.string,
   renderSubmit: PropTypes.func,
+  disablePristineSubmit: PropTypes.bool,
 };
 
 export const CustomFormMessage = (props, { error }) =>

--- a/frontend/src/metabase/containers/Form.jsx
+++ b/frontend/src/metabase/containers/Form.jsx
@@ -67,6 +67,7 @@ type FormObject = {
   initial: () => FormValues,
   normalize: (values: FormValues) => FormValues,
   validate: (values: FormValues, props: FormProps) => FormErrors,
+  disablePristineSubmit?: boolean,
 };
 
 type FormProps = {
@@ -78,7 +79,10 @@ type Props = {
   initialValues?: ?FormValues,
   formName?: string,
   onSubmit: (values: FormValues) => Promise<any>,
+  onSubmitSuccess: (action: any) => Promise<any>,
   formComponent?: React$Component<any, any, any>,
+  dispatch: Function,
+  values: FormValues,
 };
 
 type State = {
@@ -241,7 +245,6 @@ export default class Form extends React.Component {
       Object.keys(prevState.inlineFields),
     );
     if (newFields.length > 0) {
-      // $FlowFixMe: dispatch provided by connect
       this.props.dispatch(
         initialize(this.props.formName, this._getInitialValues(), newFields),
       );
@@ -318,8 +321,14 @@ export default class Form extends React.Component {
     }
   };
 
+  _handleSubmitSuccess = async (action: any) => {
+    await this.props.onSubmitSuccess(action);
+    this.props.dispatch(
+      initialize(this.props.formName, this.props.values, this._getFieldNames()),
+    );
+  };
+
   _handleChangeField = (fieldName: FormFieldName, value: FormValue) => {
-    // $FlowFixMe: dispatch provided by @connect
     return this.props.dispatch(change(this.props.formName, fieldName, value));
   };
 
@@ -340,6 +349,7 @@ export default class Form extends React.Component {
         initialValues={initialValues}
         validate={this._validate}
         onSubmit={this._onSubmit}
+        onSubmitSuccess={this._handleSubmitSuccess}
         onChangeField={this._handleChangeField}
         // HACK: _state is a mutable object so we can pass by reference into the ReduxFormComponent
         submitState={this._state}

--- a/frontend/src/metabase/entities/users/forms.js
+++ b/frontend/src/metabase/entities/users/forms.js
@@ -75,6 +75,7 @@ export default {
   },
   user: {
     fields: [...DETAILS_FORM_FIELDS(), LOCALE_FIELD],
+    disablePristineSubmit: true,
   },
   setup: () => ({
     fields: [

--- a/frontend/src/metabase/user/components/UserSettings.jsx
+++ b/frontend/src/metabase/user/components/UserSettings.jsx
@@ -71,7 +71,7 @@ export default class UserSettings extends Component {
             />
           )}
         </Flex>
-        <Box w={["100%", 540]} ml="auto" mr="auto" px={[1, 2]} pt={[1, 3]}>
+        <Box w={["100%", 540]} ml="auto" mr="auto" px={[1, 2]} py={[1, 3]}>
           {tab === "details" || !showChangePassword ? (
             <User.Form
               {...this.props}

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -367,7 +367,7 @@ describe("scenarios > admin > settings", () => {
       );
     });
 
-    it.skip("should not offer to save email changes when there aren't any (metabase#14749)", () => {
+    it("should not offer to save email changes when there aren't any (metabase#14749)", () => {
       // Make sure some settings are already there
       setupDummySMTP();
 

--- a/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
@@ -11,12 +11,13 @@ describe("user > settings", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should show user details", () => {
+  it("should show user details with disabled submit button", () => {
     cy.visit("/user/edit_current");
     cy.findByText("Account settings");
     cy.findByDisplayValue(first_name);
     cy.findByDisplayValue(last_name);
     cy.findByDisplayValue(email);
+    cy.findByRole("button", { name: "Update" }).should("be.disabled");
   });
 
   it("should update the user without fetching memberships", () => {


### PR DESCRIPTION
### Description

When the "User Settings" form is pristine it makes not much sense to submit it. However, there are other forms like "Save Question" that it should be possible to submit being pristine. Because of that, I added an ability to configure this using a new flag.

Also, I added bottom padding to prevent submit button from being docked to the bottom of the page:

<img width="761" alt="Screen Shot 2021-03-30 at 00 00 08" src="https://user-images.githubusercontent.com/14301985/112901305-3ffb1300-90ed-11eb-9bdd-22824dd2f810.png">


Closes https://github.com/metabase/metabase/issues/14749