### PR TITLE
Drop maxIdleTimeExcessConnections

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -75,8 +75,8 @@
    ;; Connections acquired are no longer needed. If maxIdleTime is set, maxIdleTimeExcessConnections should be smaller
    ;; if the parameter is to have any effect.
    ;;
-   ;; Kill idle connections above the minPoolSize after 15 minutes.
-   "maxIdleTimeExcessConnections" (* 15 60)})
+   ;; Kill idle connections above the minPoolSize after 5 minutes.
+   "maxIdleTimeExcessConnections" (* 5 60)})
 
 (defn- create-pool!
   "Create a new C3P0 `ComboPooledDataSource` for connecting to the given `database`."


### PR DESCRIPTION
To address connection pools that go beyond the maxPoolSize of 15, reduce
the maxIdleTimeExcessConnections so it'll start to pare back the pool
towards minPoolSize sooner.

See swaldman/c3p0#65 for an explanation.

Resolves metabase/metabase#8679
