### PR TITLE
#15316 Repro: Custom Expression name containing brackets ([ or ]) can break the UI

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -448,4 +448,29 @@ describe("scenarios > question > custom columns", () => {
     cy.findByText(CC_NAME);
     cy.contains("37.65");
   });
+
+  it.skip("should handle brackets in the name of the custom column (metabase#15316)", () => {
+    cy.createQuestion({
+      name: "15316",
+      query: {
+        "source-table": ORDERS_ID,
+        expressions: { "MyCC [2021]": ["+", 1, 1] },
+      },
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.visit(`/question/${QUESTION_ID}/notebook`);
+    });
+    cy.findByText("Summarize").click();
+    cy.findByText("Sum of ...").click();
+    popover()
+      .findByText("MyCC [2021]")
+      .click();
+    cy.get("[class*=NotebookCellItem]")
+      .contains("Sum of MyCC [2021]")
+      .click();
+    popover().within(() => {
+      cy.icon("chevronleft").click();
+      cy.findByText("Custom Expression").click();
+    });
+    cy.get("[contenteditable='true']").contains("Sum([MyCC [2021]])");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15316 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/113002628-467f9e00-9172-11eb-89a3-9a50b50efdd0.png)

Sanity check: the same test without brackets in the name
![image](https://user-images.githubusercontent.com/31325167/113002778-69aa4d80-9172-11eb-969d-baaaa227ef69.png)

