### PR TITLE
#15279 Repro: Dashboard filters not working if one of them is corrupted

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -654,6 +654,101 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Orders in a dashboard");
     cy.contains("37.65");
   });
+
+  ["normal", "corrupted"].forEach(test => {
+    it(`${test.toUpperCase()} version:\n filters should work even if one of them is corrupted (metabase #15279)`, () => {
+      cy.skipOn(test === "corrupted"); // Remove this line when the issue is fixed
+      cy.createQuestion({
+        name: "15279",
+        query: { "source-table": PEOPLE_ID },
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.createDashboard("15279D").then(({ body: { id: DASHBOARD_ID } }) => {
+          const parameters = [
+            {
+              name: "List",
+              slug: "list",
+              id: "6fe14171",
+              type: "category",
+            },
+            {
+              name: "Search",
+              slug: "search",
+              id: "4db4913a",
+              type: "category",
+            },
+          ];
+
+          if (test === "corrupted") {
+            // This filter is corrupted because it's missing `name` and the `slug`
+            parameters.push({
+              name: "",
+              slug: "",
+              id: "af72ce9c",
+              type: "category",
+            });
+          }
+          // Add filters to the dashboard
+          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+            parameters,
+          });
+
+          // Add previously created question to the dashboard
+          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cardId: QUESTION_ID,
+          }).then(({ body: { id: DASH_CARD_ID } }) => {
+            // Connect filters to that question
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cards: [
+                {
+                  id: DASH_CARD_ID,
+                  card_id: QUESTION_ID,
+                  row: 0,
+                  col: 0,
+                  sizeX: 18,
+                  sizeY: 8,
+                  series: [],
+                  visualization_settings: {},
+                  parameter_mappings: [
+                    {
+                      parameter_id: "6fe14171",
+                      card_id: QUESTION_ID,
+                      target: ["dimension", ["field-id", PEOPLE.SOURCE]],
+                    },
+                    {
+                      parameter_id: "4db4913a",
+                      card_id: QUESTION_ID,
+                      target: ["dimension", ["field-id", PEOPLE.NAME]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+
+          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        });
+      });
+      // Check that dropdown list works
+      cy.get("fieldset")
+        .contains("List")
+        .click();
+      popover()
+        .findByText("Organic")
+        .click();
+      cy.findByRole("button", { name: "Add filter" }).click();
+      // Check that the search works
+      cy.get("fieldset")
+        .contains("Search")
+        .click();
+      cy.findByPlaceholderText("Search by Name")
+        .click()
+        .type("Lor", { delay: 50 });
+      popover().within(() => {
+        cy.get(".LoadingSpinner").should("not.exist");
+        cy.findByText("Lora Cronin");
+      });
+    });
+  });
 });
 
 function checkOptionsForFilter(filter) {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15279 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- Replace `cy.skipOn` with `cy.onlyOn` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `cy.skipOn(test === "corrupted")` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Normal version of the test
![image](https://user-images.githubusercontent.com/31325167/113012913-813a0400-917b-11eb-8717-85e0b16e32b8.png)

Version with corrupted filter
![image](https://user-images.githubusercontent.com/31325167/113013088-b21a3900-917b-11eb-9d72-d3b6e3cfee5d.png)

