### PR TITLE
#15250 Repro: Click Behavior not parsing measure value for first row on Pie chart

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -9,7 +9,14 @@ import {
 import { USER_GROUPS } from "__support__/cypress_data";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
+const {
+  ORDERS,
+  ORDERS_ID,
+  PRODUCTS,
+  PRODUCTS_ID,
+  PEOPLE,
+  PEOPLE_ID,
+} = SAMPLE_DATASET;
 const { DATA_GROUP } = USER_GROUPS;
 
 describe("scenarios > visualizations > drillthroughs > chart drill", () => {
@@ -390,6 +397,61 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("View these Orders").click();
     cy.findByText("Quantity between 10 20");
     cy.findByText("Showing 85 rows");
+  });
+
+  it.skip("should parse value on click through on the first row of pie chart (metabase#15250)", () => {
+    cy.createQuestion({
+      name: "15250",
+      query: {
+        "source-table": PRODUCTS_ID,
+        aggregation: [["count"]],
+        breakout: [["field-id", PRODUCTS.CATEGORY]],
+      },
+      display: "pie",
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.createDashboard("15250D").then(({ body: { id: DASHBOARD_ID } }) => {
+        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+          cardId: QUESTION_ID,
+        }).then(({ body: { id: DASH_CARD_ID } }) => {
+          // Add click through to the custom destination on a card
+          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cards: [
+              {
+                id: DASH_CARD_ID,
+                card_id: QUESTION_ID,
+                row: 0,
+                col: 0,
+                sizeX: 16,
+                sizeY: 10,
+                series: [],
+                visualization_settings: {
+                  click_behavior: {
+                    type: "link",
+                    linkType: "url",
+                    linkTemplate: "question/{{count}}",
+                  },
+                },
+                parameter_mappings: [],
+              },
+            ],
+          });
+        });
+
+        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+      });
+    });
+
+    cy.get("[class*=PieChart__Donut]")
+      .find("path")
+      .first()
+      .as("doohickeyChart")
+      .trigger("mousemove");
+    popover().within(() => {
+      cy.findByText("Doohickey");
+      cy.findByText("42");
+    });
+    cy.get("@doohickeyChart").click();
+    cy.location("pathname").should("eq", "/question/42");
   });
 
   describe("for an unsaved question", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15250 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/113019008-6e2a3280-9181-11eb-8dca-192474bb0063.png)


Sanity check: let's try this same test on the last value (`category: Widget, count: 54`)
![image](https://user-images.githubusercontent.com/31325167/113019249-ad588380-9181-11eb-8fde-5034283f795a.png)

