### PR TITLE
Improve card permissions errors

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d %p %c{2} :: %m%n">
+      <PatternLayout pattern="%date %level %logger{2} :: %message%n%throwable">
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>
     </Console>

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -10,6 +10,7 @@
             [metabase.async.util :as async.u]
             [metabase.email.messages :as messages]
             [metabase.events :as events]
+            [metabase.mbql.normalize :as mbql.normalize]
             [metabase.models.card :as card :refer [Card]]
             [metabase.models.card-favorite :refer [CardFavorite]]
             [metabase.models.collection :as collection :refer [Collection]]
@@ -272,8 +273,9 @@
 (defn- check-allowed-to-modify-query
   "If the query is being modified, check that we have data permissions to run the query."
   [card-before-updates card-updates]
-  (when (api/column-will-change? :dataset_query card-before-updates card-updates)
-    (check-data-permissions-for-query (:dataset_query card-updates))))
+  (let [card-updates (m/update-existing card-updates :dataset_query mbql.normalize/normalize)]
+    (when (api/column-will-change? :dataset_query card-before-updates card-updates)
+      (check-data-permissions-for-query (:dataset_query card-updates)))))
 
 (defn- check-allowed-to-unarchive
   "When unarchiving a Card, make sure we have data permissions for the Card query before doing so."

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -198,7 +198,7 @@
                            (query-perms/perms-set query :throw-exceptions? true)
                            (catch Throwable e
                              e))]
-      (throw (ex-info (tru "You cannot save this Question because you do not permissions to run its query.")
+      (throw (ex-info (tru "You cannot save this Question because you do not have permissions to run its query.")
                       {:status-code    403
                        :query          query
                        :required-perms (if (instance? Throwable required-perms)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -3,7 +3,6 @@
   is a historical name, but is the same thing; both terms are used interchangeably in the backend codebase."
   (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
-            [metabase.api.common :as api :refer [*current-user-id*]]
             [metabase.mbql.normalize :as normalize]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.collection :as collection]
@@ -13,7 +12,6 @@
             [metabase.models.params :as params]
             [metabase.models.permissions :as perms]
             [metabase.models.query :as query]
-            [metabase.models.query.permissions :as query-perms]
             [metabase.models.revision :as revision]
             [metabase.plugins.classloader :as classloader]
             [metabase.public-settings :as public-settings]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -149,28 +149,7 @@
     (seq (:dataset_query card)) (update :dataset_query normalize/normalize)))
 
 (defn- pre-insert [{query :dataset_query, :as card}]
-  ;; TODO - we usually check permissions to save/update stuff in the API layer rather than here in the Toucan
-  ;; model-layer functions... Not saying one pattern is better than the other (although this one does make it harder
-  ;; to do the wrong thing) but we should try to be consistent
   (u/prog1 card
-    ;; Make sure the User saving the Card has the appropriate permissions to run its query. We don't want Users saving
-    ;; Cards with queries they wouldn't be allowed to run!
-    (when *current-user-id*
-      (when-not (query-perms/can-run-query? query)
-        (let [required-perms (try
-                               (query-perms/perms-set query :throw-exceptions? true)
-                               (catch Throwable e
-                                 e))]
-          (throw (ex-info (tru "You do not have permissions to run ad-hoc native queries against Database {0}."
-                               (:database query))
-                          {:status-code    403
-                           :query          query
-                           :required-perms (if (instance? Throwable required-perms)
-                                             :error
-                                             required-perms)
-                           :actual-perms   @api/*current-user-permissions-set*}
-                          (when (instance? Throwable required-perms)
-                            required-perms))))))
     ;; make sure this Card doesn't have circular source query references
     (check-for-circular-source-query-references card)
     (collection/check-collection-namespace Card (:collection_id card))))
@@ -184,7 +163,8 @@
       (field-values/update-field-values-for-on-demand-dbs! field-ids))))
 
 (defonce
-  ^{:doc "Atom containing a function used to check additional sandboxing constraints for Metabase Enterprise Edition. This is called as part of the `pre-update` method for a Card.
+  ^{:doc "Atom containing a function used to check additional sandboxing constraints for Metabase Enterprise Edition.
+  This is called as part of the `pre-update` method for a Card.
 
   For the OSS edition, there is no implementation for this function -- it is a no-op. For Metabase Enterprise Edition,
   the implementation of this function is

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1426,8 +1426,10 @@
 
       (testing "Cannot share an archived Card"
         (mt/with-temp Card [card {:archived true}]
-          (is (= {:message "The object has been archived.", :error_code "archived"}
-                 (mt/user-http-request :crowberto :post 404 (format "card/%d/public_link" (u/the-id card)))))))
+          (is (schema= {:message    (s/eq "The object has been archived.")
+                        :error_code (s/eq "archived")
+                        s/Keyword   s/Any}
+                       (mt/user-http-request :crowberto :post 404 (format "card/%d/public_link" (u/the-id card)))))))
 
       (testing "Cannot share a Card that doesn't exist"
         (is (= "Not found."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -9,7 +9,7 @@
             [metabase.api.card :as card-api]
             [metabase.api.pivots :as pivots]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
-            [metabase.http-client :as http :refer :all]
+            [metabase.http-client :as http]
             [metabase.models :refer [Card CardFavorite Collection Dashboard Database Pulse PulseCard PulseChannel
                                      PulseChannelRecipient Table ViewLog]]
             [metabase.models.permissions :as perms]
@@ -23,8 +23,7 @@
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
-            [toucan.db :as db]
-            [toucan.util.test :as tt])
+            [toucan.db :as db])
   (:import java.io.ByteArrayInputStream
            java.util.UUID))
 
@@ -270,7 +269,6 @@
 ;;; |                                        CREATING A CARD (POST /api/card)                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;;
 (deftest create-a-card
   (testing "POST /api/card"
     (testing "Test that we can create a new Card"
@@ -326,7 +324,7 @@
               (is (schema= {:id       su/IntGreaterThanZero
                             s/Keyword s/Any}
                            (mt/user-http-request :rasta :post 202 "card"
-                                                 (merge (tt/with-temp-defaults Card)
+                                                 (merge (mt/with-temp-defaults Card)
                                                         {:dataset_query query})))))
             (let [metadata (-> (qp/process-query query)
                                :data
@@ -337,7 +335,7 @@
                 (is (schema= {:id       su/IntGreaterThanZero
                               s/Keyword s/Any}
                              (mt/user-http-request :rasta :post 202 "card"
-                                                   (merge (tt/with-temp-defaults Card)
+                                                   (merge (mt/with-temp-defaults Card)
                                                           {:dataset_query   query
                                                            :result_metadata metadata}))))))))))))
 
@@ -517,6 +515,31 @@
             (is (nil? (some-> (db/select-one [Card :collection_id :collection_position] :name card-name)
                               (update :collection_id (partial = (u/the-id collection))))))))))))
 
+(deftest create-card-check-adhoc-query-permissions-test
+  (testing (str "Ad-hoc query perms should be required to save a Card -- otherwise people could save arbitrary "
+                "queries, then run them.")
+    ;; create a copy of the test data warehouse DB, then revoke permissions to it for All Users. Only admins should be
+    ;; able to ad-hoc query it now.
+    (mt/with-temp-copy-of-db
+      (perms/revoke-permissions! (perms-group/all-users) (mt/db))
+      (let [query        (mt/mbql-query :venues)
+            create-card! (fn [test-user expected-status-code]
+                           (mt/with-model-cleanup [Card]
+                             (mt/user-http-request test-user :post expected-status-code "card"
+                                                   (merge (mt/with-temp-defaults Card) {:dataset_query query}))))]
+        (testing "admin should be able to save a Card if All Users doesn't have ad-hoc data perms"
+          (is (some? (create-card! :crowberto 202))))
+        (testing "non-admin should get an error"
+          (testing "Permissions errors should be meaningful and include info for debugging (#14931)"
+            (is (schema= {:message        (s/eq "You cannot save this Question because you do not permissions to run its query.")
+                          :query          (s/eq (mt/obj->json->obj query))
+                          :required-perms [perms/ObjectPath]
+                          :actual-perms   [perms/UserPath]
+                          :trace          [s/Any]
+                          s/Keyword       s/Any}
+                         (create-card! :rasta 403)))))))))
+
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            FETCHING A SPECIFIC CARD                                            |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -591,19 +614,19 @@
                (set-archived! false)))))))
 
 (deftest we-shouldn-t-be-able-to-update-archived-status-if-we-don-t-have-collection--write--perms
-  (is (= "You don't have permissions to do that."
-         (mt/with-non-admin-groups-no-root-collection-perms
-           (mt/with-temp* [Collection [collection]
-                           Card       [card {:collection_id (u/the-id collection)}]]
-             (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp* [Collection [collection]
+                    Card       [card {:collection_id (u/the-id collection)}]]
+      (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+      (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :put 403 (str "card/" (u/the-id card)) {:archived true}))))))
 
-;; Can we clear the description of a Card? (#4738)
-(deftest can-we-clear-the-description-of-a-card----4738-
-  (is (nil? (mt/with-temp Card [card {:description "What a nice Card"}]
-              (with-cards-in-writeable-collection card
-                (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:description nil})
-                (db/select-one-field :description Card :id (u/the-id card)))))))
+(deftest clear-description-test
+  (testing "Can we clear the description of a Card? (#4738)"
+    (mt/with-temp Card [card {:description "What a nice Card"}]
+      (with-cards-in-writeable-collection card
+        (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:description nil})
+        (is (nil? (db/select-one-field :description Card :id (u/the-id card))))))))
 
 (deftest description-should-be-blankable-as-well
   (mt/with-temp Card [card {:description "What a nice Card"}]
@@ -932,6 +955,51 @@
                     "f" 2
                     "g" 3}
                    (get-name->collection-position :rasta collection-2)))))))))
+
+(deftest update-card-check-adhoc-query-permissions-test
+  (testing (str "Ad-hoc query perms should be required to update the query for a Card -- otherwise people could save "
+                "arbitrary queries, then run them.")
+    ;; create a copy of the test data warehouse DB, then revoke permissions to it for All Users. Only admins should be
+    ;; able to ad-hoc query it now.
+    (mt/with-temp-copy-of-db
+      (perms/revoke-permissions! (perms-group/all-users) (mt/db))
+      (mt/with-temp Card [{card-id :id} {:dataset_query (mt/mbql-query :venues)}]
+        (let [update-card! (fn [test-user expected-status-code request-body]
+                             (mt/user-http-request test-user :put expected-status-code (format "card/%d" card-id)
+                                                   request-body))]
+          (testing "\nadmin"
+            (testing "*should* be allowed to update query"
+              (is (schema= {:id            (s/eq card-id)
+                            :dataset_query (s/eq (mt/obj->json->obj (mt/mbql-query :checkins)))
+                            s/Keyword      s/Any}
+                           (update-card! :crowberto 202 {:dataset_query (mt/mbql-query :checkins)})))))
+
+          (testing "\nnon-admin"
+            (testing "should be allowed to update fields besides query"
+              (is (schema= {:id       (s/eq card-id)
+                            :name     (s/eq "Updated name")
+                            s/Keyword s/Any}
+                           (update-card! :rasta 202 {:name "Updated name"}))))
+
+            (testing "should *not* be allowed to update query"
+              (testing "Permissions errors should be meaningful and include info for debugging (#14931)"
+                (is (schema= {:message        (s/eq "You cannot save this Question because you do not permissions to run its query.")
+                              :query          (s/eq (mt/obj->json->obj (mt/mbql-query :users)))
+                              :required-perms [perms/ObjectPath]
+                              :actual-perms   [perms/UserPath]
+                              :trace          [s/Any]
+                              s/Keyword       s/Any}
+                             (update-card! :rasta 403 {:dataset_query (mt/mbql-query :users)}))))
+              (testing "make sure query hasn't changed in the DB"
+                (is (= (mt/mbql-query checkins)
+                       (db/select-one-field :dataset_query Card :id card-id)))))
+
+            (testing "should be allowed to update other fields if query is passed in but hasn't changed (##11719)"
+              (is (schema= {:id            (s/eq card-id)
+                            :name          (s/eq "Another new name")
+                            :dataset_query (s/eq (mt/obj->json->obj (mt/mbql-query :checkins)))
+                            s/Keyword      s/Any}
+                           (update-card! :rasta 202 {:name "Another new name", :dataset_query (mt/mbql-query checkins)}))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -531,7 +531,7 @@
           (is (some? (create-card! :crowberto 202))))
         (testing "non-admin should get an error"
           (testing "Permissions errors should be meaningful and include info for debugging (#14931)"
-            (is (schema= {:message        (s/eq "You cannot save this Question because you do not permissions to run its query.")
+            (is (schema= {:message        (s/eq "You cannot save this Question because you do not have permissions to run its query.")
                           :query          (s/eq (mt/obj->json->obj query))
                           :required-perms [perms/ObjectPath]
                           :actual-perms   [perms/UserPath]
@@ -983,7 +983,7 @@
 
             (testing "should *not* be allowed to update query"
               (testing "Permissions errors should be meaningful and include info for debugging (#14931)"
-                (is (schema= {:message        (s/eq "You cannot save this Question because you do not permissions to run its query.")
+                (is (schema= {:message        (s/eq "You cannot save this Question because you do not have permissions to run its query.")
                               :query          (s/eq (mt/obj->json->obj (mt/mbql-query :users)))
                               :required-perms [perms/ObjectPath]
                               :actual-perms   [perms/UserPath]

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -16,6 +16,7 @@
             [metabase.test.util :as tu :refer [random-name]]
             [metabase.util :as u]
             [metabase.util.i18n :as i18n]
+            [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]))
 
@@ -677,8 +678,9 @@
                ((mt/user->client :crowberto) :put 404 (format "user/%s/reactivate" Integer/MAX_VALUE)))))
 
       (testing " Attempting to reactivate an already active user should fail"
-        (is (= {:message "Not able to reactivate an active user"}
-               ((mt/user->client :crowberto) :put 400 (format "user/%s/reactivate" (mt/user->id :rasta)))))))
+        (is (schema= {:message  (s/eq "Not able to reactivate an active user")
+                      s/Keyword s/Any}
+                     (mt/user-http-request :crowberto :put 400 (format "user/%s/reactivate" (mt/user->id :rasta)))))))
 
     (testing (str "test that when disabling Google auth if a user gets disabled and re-enabled they are no longer "
                   "Google Auth (#3323)")

--- a/test/metabase/async/api_response_test.clj
+++ b/test/metabase/async/api_response_test.clj
@@ -110,7 +110,6 @@
 
         (testing "An error should be written to the output stream"
           (is (schema= {:message (s/eq "Input channel unexpectedly closed.")
-                        :type    (s/eq "class java.lang.InterruptedException")
                         :_status (s/eq 500)
                         :trace   s/Any
                         s/Any    s/Any}
@@ -153,7 +152,6 @@
         (a/>!! input-chan (Exception. "Broken"))
         (wait-for-close os-closed-chan)
         (is (schema= {:message  (s/eq "Broken")
-                      :type     (s/eq "class java.lang.Exception")
                       :trace    s/Any
                       :_status  (s/eq 500)
                       s/Keyword s/Any}
@@ -172,7 +170,6 @@
                  (wait-for-close os-closed-chan)))
           (testing "error should be written to output stream"
             (is (schema= {:message  (s/eq "No response after waiting 50.0 ms. Canceling request.")
-                          :type     (s/eq "class java.util.concurrent.TimeoutException")
                           :_status  (s/eq 500)
                           :trace    s/Any
                           s/Keyword s/Any}

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -572,7 +572,7 @@
         (testing "Card in the Root Collection"
           (mt/with-temp Collection [dest-card-collection]
             (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
-            (is (schema= {:message  (s/eq "You cannot save this Question because you do not permissions to run its query.")
+            (is (schema= {:message  (s/eq "You cannot save this Question because you do not have permissions to run its query.")
                           s/Keyword s/Any}
                          (save-card-via-API-with-native-source-query! 403 (mt/db) nil dest-card-collection)))))
 
@@ -580,7 +580,7 @@
           (mt/with-temp* [Collection [source-card-collection]
                           Collection [dest-card-collection]]
             (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
-            (is (schema= {:message  (s/eq "You cannot save this Question because you do not permissions to run its query.")
+            (is (schema= {:message  (s/eq "You cannot save this Question because you do not have permissions to run its query.")
                           s/Keyword s/Any}
                          (save-card-via-API-with-native-source-query! 403 (mt/db) source-card-collection dest-card-collection)))))
 

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -572,15 +572,17 @@
         (testing "Card in the Root Collection"
           (mt/with-temp Collection [dest-card-collection]
             (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
-            (is (= "You don't have permissions to do that."
-                   (save-card-via-API-with-native-source-query! 403 (mt/db) nil dest-card-collection)))))
+            (is (schema= {:message  (s/eq "You cannot save this Question because you do not permissions to run its query.")
+                          s/Keyword s/Any}
+                         (save-card-via-API-with-native-source-query! 403 (mt/db) nil dest-card-collection)))))
 
         (testing "Card in a different Collection for which we do not have perms"
           (mt/with-temp* [Collection [source-card-collection]
                           Collection [dest-card-collection]]
             (perms/grant-collection-readwrite-permissions! (group/all-users) dest-card-collection)
-            (is (= "You don't have permissions to do that."
-                   (save-card-via-API-with-native-source-query! 403 (mt/db) source-card-collection dest-card-collection)))))
+            (is (schema= {:message  (s/eq "You cannot save this Question because you do not permissions to run its query.")
+                          s/Keyword s/Any}
+                         (save-card-via-API-with-native-source-query! 403 (mt/db) source-card-collection dest-card-collection)))))
 
         (testing "similarly, if we don't have *write* perms for the dest collection it should also fail"
           (testing "Try to save in the Root Collection"

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -159,7 +159,8 @@
 
  [tt
   with-temp
-  with-temp*]
+  with-temp*
+  with-temp-defaults]
 
  [tu
   boolean-ids-and-timestamps


### PR DESCRIPTION
Fixes #11719
Fixes #14931
Fixes #6718

1. Tweak the `metabase.server.middleware.exceptions` middleware to include more info with most API responses. 
2. Remove redundant perms check login from Card `pre-insert` -- this is already handled in `metabase.api.card` -- move the more detailed error check code into `metabase.api.card`
3. Throw exceptions with more debugging info when you cannot save a Card due to ad-hoc query perms errors (in combination with the middleware tweaks, this fixes #14931)
4. Added a lot of tests around ad-hoc perms checks for saving/updating a Card via the API -- while writing these tests I figured out what was wrong with #11719 and fixed it real quick. #6718 is a similar bug that is fixed as well
5. I tweaked the log4j2 properties XML file format string to explicitly specify `%throwable`, which means Throwables are logged with `.toString()` instead of `.getMessage` -- for `clojure.lang.ExceptionInfo`s this prints the data map as well. For other format specifies I also replaced the specifier abbreviations (e.g. `%d`) with the full specifier (e.g. `%date`) for readability. 