### PR TITLE
Fix 24-hour format formatting of times after midnight

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.js
+++ b/frontend/src/metabase/lib/formatting/date.js
@@ -11,7 +11,7 @@ export type DateStyle =
   | "D MMMM, YYYY"
   | "dddd, MMMM D, YYYY";
 
-export type TimeStyle = "h:mm A" | "k:mm" | "h A";
+export type TimeStyle = "h:mm A" | "HH:mm" | "h A";
 
 export type MomentFormat = string; // moment.js format strings
 export type DateFormat = MomentFormat;

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -269,7 +269,7 @@ export const DATE_COLUMN_SETTINGS = {
         ...(column.unit === "hour-of-day"
           ? [timeStyleOption("h A", "12-hour clock without minutes")]
           : []),
-        timeStyleOption("k:mm", t`24-hour clock`),
+        timeStyleOption("HH:mm", t`24-hour clock`),
       ],
     }),
     getHidden: (column: Column, settings: ColumnSettings) =>

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -258,13 +258,13 @@ describe("formatting", () => {
         formatValue(24, {
           date_style: null,
           time_enabled: "minutes",
-          time_style: "k:mm",
+          time_style: "HH:mm",
           column: {
             base_type: "type/DateTime",
             unit: "hour-of-day",
           },
         }),
-      ).toEqual("24:00");
+      ).toEqual("00:00");
     });
   });
 


### PR DESCRIPTION
Naive search-and-replace based fix to display times for the hour after midnight as 00:xx rather than 24:xx.

This won't fix formatting of saved questions (format is saved with questions), but at least they will be correct going forward.

Fixes #9538.