### PR TITLE
Keep spaces in firefox when they've been getting whacked by firefox in custom expressions

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -365,7 +365,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           className={cx(inputClassName, {
             "border-error": compileError,
           })}
-          style={{ ...inputStyle, paddingLeft: 26 }}
+          style={{ ...inputStyle, paddingLeft: 26, whiteSpace: "pre-wrap" }}
           placeholder={placeholder}
           value={source}
           syntaxTree={syntaxTree}


### PR DESCRIPTION
Pursuant to issue #15243. The problem replicates only on Firefox. It seems to have to do with Firefox's space handling: it will just whack a normal space in contenteditables, but it won't a nbsp. This is a hack: a full reckoning with how to handle whitespace and futzing with it would need a full state machine, I think.