### PR TITLE
Lazy loading routes extreme performance edition

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/routes.clj
@@ -1,10 +1,7 @@
 (ns metabase-enterprise.sandbox.api.routes
   "Multi-tenant API routes."
   (:require [compojure.core :as compojure]
-            [metabase-enterprise.sandbox.api.field :as field]
-            [metabase-enterprise.sandbox.api.gtap :as gtap]
-            [metabase-enterprise.sandbox.api.table :as table]
-            [metabase-enterprise.sandbox.api.user :as user]
+            [metabase.api.routes.lazy :as lazy]
             [metabase.server.middleware.auth :as middleware.auth]))
 
 ;; this is copied from `metabase.api.routes` because if we require that above we will destroy startup times for `lein
@@ -14,12 +11,9 @@
   middleware.auth/enforce-authentication)
 
 (compojure/defroutes ^{:doc "Ring routes for mt API endpoints."} routes
-  (compojure/context
-   "/mt"
-   []
-
-   (compojure/routes
-    (compojure/context "/gtap" [] (+auth gtap/routes))
-    (compojure/context "/user" [] (+auth user/routes))))
-  (compojure/context "/field" [] (+auth field/routes))
-  (compojure/context "/table" [] (+auth table/routes)))
+  (lazy/context "/mt" (lazy/routes metabase-enterprise.sandbox.api
+                        (+auth gtap)
+                        (+auth user)))
+  (lazy/routes metabase-enterprise.sandbox.api
+    (+auth field)
+    (+auth table)))

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -24,6 +24,7 @@
   <Loggers>
     <Logger name="metabase" level="INFO"/>
     <Logger name="metabase-enterprise" level="INFO"/>
+    <Logger name="metabase.api.routes.lazy" level="DEBUG"/>
     <Logger name="metabase.plugins" level="DEBUG"/>
     <Logger name="metabase.server.middleware" level="DEBUG"/>
     <Logger name="metabase.query-processor.async" level="DEBUG"/>

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -321,7 +321,9 @@
   [& middleware]
   (let [api-route-fns (namespace->api-route-fns *ns*)
         routes        `(compojure/routes ~@api-route-fns)]
-    `(def ~(vary-meta 'routes assoc :doc (api-routes-docstring *ns* api-route-fns middleware))
+    `(def ~(vary-meta 'routes assoc
+                      :doc (api-routes-docstring *ns* api-route-fns middleware)
+                      :arglists ''([request respond raise]))
        ~(if (seq middleware)
           `(-> ~routes ~@middleware)
           routes))))

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -1,50 +1,11 @@
 (ns metabase.api.routes
-  (:require [compojure.core :refer [context defroutes]]
-            [compojure.route :as route]
-            [metabase.api.activity :as activity]
-            [metabase.api.alert :as alert]
-            [metabase.api.automagic-dashboards :as magic]
-            [metabase.api.card :as card]
-            [metabase.api.collection :as collection]
-            [metabase.api.dashboard :as dashboard]
-            [metabase.api.database :as database]
-            [metabase.api.dataset :as dataset]
-            [metabase.api.email :as email]
-            [metabase.api.embed :as embed]
-            [metabase.api.field :as field]
-            [metabase.api.geojson :as geojson]
-            [metabase.api.ldap :as ldap]
-            [metabase.api.login-history :as login-history]
-            [metabase.api.metastore :as metastore]
-            [metabase.api.metric :as metric]
-            [metabase.api.native-query-snippet :as native-query-snippet]
-            [metabase.api.notify :as notify]
-            [metabase.api.permissions :as permissions]
-            [metabase.api.preview-embed :as preview-embed]
-            [metabase.api.public :as public]
-            [metabase.api.pulse :as pulse]
-            [metabase.api.revision :as revision]
-            [metabase.api.search :as search]
-            [metabase.api.segment :as segment]
-            [metabase.api.session :as session]
-            [metabase.api.setting :as setting]
-            [metabase.api.setup :as setup]
-            [metabase.api.slack :as slack]
-            [metabase.api.table :as table]
-            [metabase.api.task :as task]
-            [metabase.api.testing :as testing]
-            [metabase.api.tiles :as tiles]
-            [metabase.api.transform :as transform]
-            [metabase.api.user :as user]
-            [metabase.api.util :as util]
+  (:require [clojure.tools.logging :as log]
+            [metabase.api.routes.lazy :as lazy]
             [metabase.config :as config]
             [metabase.plugins.classloader :as classloader]
             [metabase.server.middleware.auth :as middleware.auth]
             [metabase.server.middleware.exceptions :as middleware.exceptions]
-            [metabase.util :as u]
-            [metabase.util.i18n :refer [deferred-tru]]))
-
-(u/ignore-exceptions (classloader/require '[metabase-enterprise.sandbox.api.routes :as ee.sandbox.routes]))
+            [metabase.util :as u]))
 
 (def ^:private +generic-exceptions
   "Wrap `routes` so any Exception thrown is just returned as a generic 400, to prevent details from leaking in public
@@ -61,50 +22,28 @@
   middleware.auth/enforce-api-key)
 
 (def ^:private +auth
-  "Wrap `routes` so they may only be accessed with proper authentication credentials."
+  "Wrap `handler` so it may only be accessed with proper authentication credentials."
   middleware.auth/enforce-authentication)
 
-(defroutes ^{:doc "Ring routes for API endpoints."} routes
-  (or (some-> (resolve 'ee.sandbox.routes/routes) var-get)
-      (fn [_ respond _]
-        (respond nil)))
-  (context "/activity"             [] (+auth activity/routes))
-  (context "/alert"                [] (+auth alert/routes))
-  (context "/automagic-dashboards" [] (+auth magic/routes))
-  (context "/card"                 [] (+auth card/routes))
-  (context "/collection"           [] (+auth collection/routes))
-  (context "/dashboard"            [] (+auth dashboard/routes))
-  (context "/database"             [] (+auth database/routes))
-  (context "/dataset"              [] (+auth dataset/routes))
-  (context "/email"                [] (+auth email/routes))
-  (context "/embed"                [] (+message-only-exceptions embed/routes))
-  (context "/field"                [] (+auth field/routes))
-  (context "/geojson"              [] geojson/routes)
-  (context "/ldap"                 [] (+auth ldap/routes))
-  (context "/login-history"        [] (+auth login-history/routes))
-  (context "/metastore"            [] (+auth metastore/routes))
-  (context "/metric"               [] (+auth metric/routes))
-  (context "/native-query-snippet" [] (+auth native-query-snippet/routes))
-  (context "/notify"               [] (+apikey notify/routes))
-  (context "/permissions"          [] (+auth permissions/routes))
-  (context "/preview_embed"        [] (+auth preview-embed/routes))
-  (context "/public"               [] (+generic-exceptions public/routes))
-  (context "/pulse"                [] (+auth pulse/routes))
-  (context "/revision"             [] (+auth revision/routes))
-  (context "/search"               [] (+auth search/routes))
-  (context "/segment"              [] (+auth segment/routes))
-  (context "/session"              [] session/routes)
-  (context "/setting"              [] (+auth setting/routes))
-  (context "/setup"                [] setup/routes)
-  (context "/slack"                [] (+auth slack/routes))
-  (context "/table"                [] (+auth table/routes))
-  (context "/task"                 [] (+auth task/routes))
-  (context "/testing"              [] (if (or (not config/is-prod?)
-                                              (config/config-bool :mb-enable-test-endpoints))
-                                        testing/routes
-                                        (fn [_ respond _] (respond nil))))
-  (context "/tiles"                [] (+auth tiles/routes))
-  (context "/transform"            [] (+auth transform/routes))
-  (context "/user"                 [] (+auth user/routes))
-  (context "/util"                 [] util/routes)
-  (route/not-found (constantly {:status 404, :body (deferred-tru "API endpoint does not exist.")})))
+(defn- pass-thru-handler
+  "A no-op handler that always passes thru to the next handler."
+  [_ respond _]
+  (respond nil))
+
+(defn- +enable-for-testing
+  "Wrap `handler` so it is only enabled for non-prod run configs, or if env var `MB_ENABLE_TEST_ENDPOINTS` is truthy."
+  [handler]
+  (if (or (not config/is-prod?)
+          (config/config-bool :mb-enable-test-endpoints))
+    handler
+    pass-thru-handler))
+
+(def ^:private lazy-ee-handler
+  "Lazy handler that attempts to load the EE-specific routes on the first request."
+  (lazy/handler
+   (fn []
+     (or (u/ignore-exceptions
+           (classloader/require 'metabase-enterprise.sandbox.api.routes)
+           (log/trace "Lazy-loaded Metabase Enterprise API routes")
+           (resolve 'metabase-enterprise.sandbox.api.routes/routes) var-get)
+         pass-thru-handler))))

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -48,7 +48,7 @@
      (or (u/ignore-exceptions
            (classloader/require 'metabase-enterprise.sandbox.api.routes)
            (log/trace "Lazy-loaded Metabase Enterprise API routes")
-           (resolve 'metabase-enterprise.sandbox.api.routes/routes) var-get)
+           (resolve 'metabase-enterprise.sandbox.api.routes/routes))
          pass-thru-handler))))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/src/metabase/api/routes/lazy.clj
+++ b/src/metabase/api/routes/lazy.clj
@@ -1,5 +1,8 @@
 (ns metabase.api.routes.lazy
-  "Utils for creating lazy-loading Compojure routes, for fast Metabase startup times."
+  "Utils for creating lazy-loading Compojure routes, for fast Metabase startup times.
+
+  Some of the code here relies on a little bit of knowledge about Compojure/Clout internals -- look at the way normal
+  Compojure `routes` and `context` work if the things we're doing here aren't clear."
   (:require [clojure.tools.logging :as log]
             [compojure.core :as compojure]
             [metabase.plugins.classloader :as classloader]))
@@ -25,29 +28,73 @@
      (log/debugf "Lazy-loading API routes in %s" ns-symb)
      ;; classloader/require is thread-safe
      (classloader/require ns-symb)
-     (ns-resolve ns-symb 'routes))))
+     (var-get (ns-resolve ns-symb 'routes)))))
 
-(defmacro context
+(defn context
   "Basically the same as normal Compojure `context`, but avoids reevaluating the `handler` form on every request, which
   is important for lazy-loading stuff. One difference: doesn't take an args vector, which we don't make a lot of use
   of in Metabase.
 
     (lazy/context \"/mt\" my-handler)"
   [route handler]
-  `(let [handler# ~handler]
-     (compojure/context ~route [] handler#)))
+  (compojure/make-context
+   (#'compojure/context-route route)
+   (constantly handler)))
 
-(defmacro form-context
-  "Impl for `routes` macro; don't use directly."
+(defn- route+handler
+  "Convert a form passed to `routes*` to a pair of `[route handler]`.
+
+    (route+handler 'metabase.api '(+auth card)) ;-> [\"/card/\" (+auth (ns-handler 'metabase.api.card))]"
   [root-namespace form]
   (letfn [(unwrap [form]
             (if (symbol? form)
-              [(str "/" form) `(ns-handler '~(symbol (str root-namespace \. form)))]
+              [(str "/" form) (ns-handler (symbol (str root-namespace \. form)))]
               (let [[middleware nested-form] form
                     [route handler]           (unwrap nested-form)]
                 [route (list middleware handler)])))]
-    (let [[route handler] (unwrap form)]
-      `(context ~route ~handler))))
+    (unwrap form)))
+
+(defn- path-info
+  "Get the current path for the request. This is the same thing Compojure/Clout do under the hood. `:path-info` is the
+  part of the request path we haven't handled yet; e.g. for `GET /api/card` the handler in `metabase.api.routes` would
+  see a `:path-info` of `/card`."
+  [request]
+  (or (:path-info request)
+      (:uri request)))
+
+(defn- split-context
+  "Split a request URI like `/card/1` into two parts, the 'context' (`/card`) and everything else (`/1`). The context is
+  used for routing to send this request to the appropriate handler. The other stuff is passed along to the next
+  handler so it can do whatever is appropriate with it.
+
+  Splitting a string with `loop` is significantly faster than using a regex -- I profiled a bunch of different things
+  and this is the fastest method I came up with."
+  [^String s]
+  (let [len (count s)]
+    (loop [i 1]
+      (when (< i len)
+        (if (= (.charAt s i) \/)
+          [(.substring s 0 i)
+           (.substring s i (count s))]
+          (recur (inc i)))))))
+
+(defn routes*
+  "Impl for `routes` macro; don't call directly."
+  [root-namespace forms]
+  ;; build a map of route context -> handler e.g.
+  ;; {"/card" <card-handler>
+  ;;  "/dashboard" <dashboard-handler>}
+  (let [handler-map (into {} (for [form forms]
+                               (route+handler root-namespace form)))]
+    (fn [request respond raise]
+      ;; look for a matching handler based on the context.
+      (let [[context more] (split-context (path-info request))]
+        (if-let [handler (get handler-map context)]
+          ;; If we find one, update `:path-info` with everything after `context` and forward the request to it -- this
+          ;; is the same thing Compojure does under the hood
+          (handler (assoc request :path-info more) respond raise)
+          ;; otherwise return `nil`; Compojure will try the next handler
+          (respond nil))))))
 
 (defmacro routes
   "Similar to normal Compojure `routes` in combination with `context`, but lazy loads routes upon first matching
@@ -71,5 +118,4 @@
   understand what it does. <3 Cam"
   {:style/indent 1}
   [root-namespace & forms]
-  `(compojure/routes ~@(for [form forms]
-                         `(form-context ~root-namespace ~form))))
+  `(routes* '~root-namespace '~forms))

--- a/src/metabase/api/routes/lazy.clj
+++ b/src/metabase/api/routes/lazy.clj
@@ -1,0 +1,76 @@
+(ns metabase.api.routes.lazy
+  "Utils for creating lazy-loading Compojure routes, for fast Metabase startup times."
+  (:require [clojure.tools.logging :as log]
+            [compojure.core :as compojure]
+            [metabase.plugins.classloader :as classloader]))
+
+(defn handler
+  "Create a lazy-loading Ring request handler. `thunk` is called on the first request, and should return a handler; this
+  value is cached and used for all subsequent requests."
+  [thunk]
+  (let [dlay (delay (thunk))]
+    (fn [request respond raise]
+      (@dlay request respond raise))))
+
+(defn ns-handler
+  "A lazy-loading Ring request handler that requires (in a thread-safe way) the namespace named by `ns-symb` and looks
+  for the var named `routes`.
+
+    (ns-handler 'metabase.api.util) -> <lazy-handler>
+
+    (<lazy-handler> request respond raise) -> (metabase.api.util/routes request respond raise)"
+  [ns-symb]
+  (handler
+   (fn []
+     (log/debugf "Lazy-loading API routes in %s" ns-symb)
+     (println (format "Lazy-loading API routes in %s" ns-symb)) ;; NOCOMMIT
+     ;; classloader/require is thread-safe
+     (classloader/require ns-symb)
+     (ns-resolve ns-symb 'routes))))
+
+(defmacro context
+  "Basically the same as normal Compojure `context`, but avoids reevaluating the `handler` form on every request, which
+  is important for lazy-loading stuff. One difference: doesn't take an args vector, which we don't make a lot of use
+  of in Metabase.
+
+    (lazy/context \"/mt\" my-handler)"
+  [route handler]
+  `(let [handler# ~handler]
+     (compojure/context ~route [] handler#)))
+
+(defmacro form-context
+  "Impl for `routes` macro; don't use directly."
+  [root-namespace form]
+  (letfn [(unwrap [form]
+            (if (symbol? form)
+              [(str "/" form) `(ns-handler '~(symbol (str root-namespace \. form)))]
+              (let [[middleware nested-form] form
+                    [route handler]           (unwrap nested-form)]
+                [route (list middleware handler)])))]
+    (let [[route handler] (unwrap form)]
+      `(context ~route ~handler))))
+
+(defmacro routes
+  "Similar to normal Compojure `routes` in combination with `context`, but lazy loads routes upon first matching
+  request. Syntax is more concise:
+
+    ;; compojure.core/routes
+    (routes
+     (context \"/card\" [] (+auth metabase.api.card/routes))
+     (context \"/util\" [] metabase.api.util/routes))
+
+    ;; equivalent metabase.api.routes.lazy/routes
+    (lazy/routes metabase.api
+      (+auth card)
+      util)
+
+  The namespace to load is determined prepending `root-namespace` to the symbol in a given form. The `context` is the
+  same as the symbol. This means your namespaces have to match the API corresponding routes! (I think this is a good
+  constraint.)
+
+  Macroexpand usages of this if it's not clear what it's doing -- I implemented this as a macro so it's easier to
+  understand what it does. <3 Cam"
+  {:style/indent 1}
+  [root-namespace & forms]
+  `(compojure/routes ~@(for [form forms]
+                         `(form-context ~root-namespace ~form))))

--- a/src/metabase/api/routes/lazy.clj
+++ b/src/metabase/api/routes/lazy.clj
@@ -23,7 +23,6 @@
   (handler
    (fn []
      (log/debugf "Lazy-loading API routes in %s" ns-symb)
-     (println (format "Lazy-loading API routes in %s" ns-symb)) ;; NOCOMMIT
      ;; classloader/require is thread-safe
      (classloader/require ns-symb)
      (ns-resolve ns-symb 'routes))))


### PR DESCRIPTION
This is an alternate implementation of #15429 that uses some deep Compojure/Clout internals to push the performance of our endpoint handlers. It shaves a few microseconds off of every request. Not sure the modest gains are worth the added complexity