### PR TITLE
Fix ee Dockerhub build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN lein deps
 
 FROM adoptopenjdk/openjdk11:alpine as builder
 
-ARG MB_EDITION=$MB_EDITION
+ARG MB_EDITION=oss
 
 WORKDIR /app/source
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@
 
 FROM node:12.20.1-alpine as frontend
 
-ARG MB_EDITION=oss
-
 WORKDIR /app/source
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
@@ -19,8 +17,6 @@ RUN yarn install --frozen-lockfile
 ###################
 
 FROM adoptopenjdk/openjdk11:alpine as backend
-
-ARG MB_EDITION=oss
 
 WORKDIR /app/source
 
@@ -46,7 +42,7 @@ RUN lein deps
 
 FROM adoptopenjdk/openjdk11:alpine as builder
 
-ARG MB_EDITION=oss
+ARG MB_EDITION=$MB_EDITION
 
 WORKDIR /app/source
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+# for posterity
+# SOURCE_BRANCH: the name of the branch or the tag that is currently being tested.
+# SOURCE_COMMIT: the SHA1 hash of the commit being tested.
+# COMMIT_MSG: the message from the commit being tested and built.
+# DOCKER_REPO: the name of the Docker repository being built.
+# DOCKERFILE_PATH: the dockerfile currently being built.
+# DOCKER_TAG: the Docker repository tag being built.
+# IMAGE_NAME: the name and tag of the Docker repository being built. (This variable is a combination of DOCKER_REPO:DOCKER_TAG.)
+
+docker build -t $IMAGE_NAME --build-arg MB_EDITION=$MB_EDITION .


### PR DESCRIPTION
Dockerhub has a very nice quirk when it comes to building images: they offer "Build environment variables" in the automated builds but they don't populate the "build-args" when it comes to building. The fix is to create a hooks folder with a script that will populate that build arg on the run.

I even enabled the buildkit run in both repositories to make builds faster, just in case.

Sorry about all the iterations @camsaul