### PR TITLE
Turn on `eslint-react/prop-types` rule and make it error out for new files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
     "react/no-is-mounted": 2,
     "react/prefer-es6-class": 2,
     "react/display-name": 1,
-    "react/prop-types": 0,
+    "react/prop-types": 2,
     "react/no-did-mount-set-state": 0,
     "react/no-did-update-set-state": 0,
     "react/no-find-dom-node": 0,

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditContent.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Radio from "metabase/components/Radio";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditSidebar.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { IndexLink } from "react-router";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditCustomView.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditCustomView.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import "./AuditTableVisualization";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import "./AuditTableVisualization";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { registerVisualization } from "metabase/visualizations/index";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionLoadAndDisplay.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionLoadAndDisplay.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditDashboardDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditDashboardDetail.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import AuditContent from "../components/AuditContent";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditDatabaseDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditDatabaseDetail.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import AuditContent from "../components/AuditContent";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import AuditContent from "../components/AuditContent";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQuestionDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQuestionDetail.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import AuditContent from "../components/AuditContent";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditTableDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditTableDetail.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import AuditContent from "../components/AuditContent";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditUserDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditUserDetail.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import AuditContent from "../components/AuditContent";

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SSOButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SSOButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { IFRAMED } from "metabase/lib/dom";

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsSAMLForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/GTAPModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { withRouter } from "react-router";

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/MappingEditor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Button from "metabase/components/Button";

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/containers/QuestionParameterTargetWidget.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/containers/QuestionParameterTargetWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ParameterTargetWidget from "metabase/parameters/components/ParameterTargetWidget";

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionRow.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionRow.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/enterprise/frontend/src/metabase-enterprise/store/components/StoreIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/store/components/StoreIcon.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Flex } from "grid-styled";
 import Icon from "metabase/components/Icon";

--- a/enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t } from "ttag";

--- a/enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/store/containers/StoreActivate.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t } from "ttag";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSchemeWidget.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSchemeWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ColorPicker from "metabase/components/ColorPicker";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoUpload.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import ScrollToTop from "metabase/hoc/ScrollToTop";

--- a/frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx
+++ b/frontend/src/metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import _ from "underscore";

--- a/frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx
+++ b/frontend/src/metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import _ from "underscore";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/datamodel/components/FormInput.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FormInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/admin/datamodel/components/FormLabel.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FormLabel.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/admin/datamodel/components/FormTextArea.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FormTextArea.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/admin/datamodel/components/MetricForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 import { reduxForm } from "redux-form";

--- a/frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";

--- a/frontend/src/metabase/admin/datamodel/components/Section.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/Section.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 

--- a/frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link, withRouter } from "react-router";

--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link, withRouter } from "react-router";

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { push } from "react-router-redux";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -3,7 +3,7 @@
  *
  * TODO Atte Keinänen 7/6/17: This uses the standard metadata API; we should migrate also other parts of admin section
  */
-
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Link } from "react-router";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/datamodel/containers/MetricApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";

--- a/frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricListApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentListApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx
+++ b/frontend/src/metabase/admin/datamodel/hoc/FilteredToUrlTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";

--- a/frontend/src/metabase/admin/datamodel/hoc/withTableMetadataLoaded.js
+++ b/frontend/src/metabase/admin/datamodel/hoc/withTableMetadataLoaded.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 export default ComposedComponent => {

--- a/frontend/src/metabase/admin/people/components/AddRow.jsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/admin/people/components/GroupDetail.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupDetail.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import _ from "underscore";

--- a/frontend/src/metabase/admin/people/components/GroupSelect.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupSelect.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/people/components/GroupSummary.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupSummary.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t, ngettext, msgid } from "ttag";

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 

--- a/frontend/src/metabase/admin/people/containers/EditUserModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/EditUserModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { compose } from "redux";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/people/containers/NewUserModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/NewUserModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { goBack, push } from "react-router-redux";

--- a/frontend/src/metabase/admin/people/containers/UserActivationModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/UserActivationModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { goBack } from "react-router-redux";

--- a/frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 import { t, jt } from "ttag";

--- a/frontend/src/metabase/admin/permissions/components/FixedHeaderGrid.jsx
+++ b/frontend/src/metabase/admin/permissions/components/FixedHeaderGrid.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { Grid, ScrollSync } from "react-virtualized";

--- a/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t, ngettext, msgid } from "ttag";

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";

--- a/frontend/src/metabase/admin/permissions/components/PermissionsGrid.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsGrid.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx
+++ b/frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/permissions/containers/CollectionsPermissionsApp.jsx
+++ b/frontend/src/metabase/admin/permissions/containers/CollectionsPermissionsApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/admin/permissions/containers/DataPermissionsApp.jsx
+++ b/frontend/src/metabase/admin/permissions/containers/DataPermissionsApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx
+++ b/frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { withRouter } from "react-router";

--- a/frontend/src/metabase/admin/permissions/routes.jsx
+++ b/frontend/src/metabase/admin/permissions/routes.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Route } from "metabase/hoc/Title";
 import { IndexRedirect, IndexRoute } from "react-router";

--- a/frontend/src/metabase/admin/settings/components/SettingHeader.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 const SettingHeader = ({ setting }) => (

--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { assocIn } from "icepick";

--- a/frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 import { Flex } from "grid-styled";

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t, jt } from "ttag";

--- a/frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AuthenticationOption.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Link } from "react-router";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import { t } from "ttag";

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 import SettingsInput from "./SettingInput";

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HostingInfoLink.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import ExternalLink from "metabase/components/ExternalLink";
 

--- a/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/settings/components/widgets/MarginHostingCTA.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/MarginHostingCTA.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingColor.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingColor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ColorPicker from "metabase/components/ColorPicker";

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingInput.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import InputBlurChange from "metabase/components/InputBlurChange";

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingNumber.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingNumber.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import SettingInput from "./SettingInput";

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingRadio.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingRadio.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Radio from "metabase/components/Radio";

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelect.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelect.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Select, { Option } from "metabase/components/Select";

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingText.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingText.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import Toggle from "metabase/components/Toggle";

--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";

--- a/frontend/src/metabase/admin/tasks/containers/Help.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Help.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/tasks/containers/TaskModal.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TaskModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/TasksApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import { Box, Flex } from "grid-styled";

--- a/frontend/src/metabase/auth/components/AuthLayout.jsx
+++ b/frontend/src/metabase/auth/components/AuthLayout.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { Flex } from "grid-styled";

--- a/frontend/src/metabase/auth/components/AuthProviderButton.jsx
+++ b/frontend/src/metabase/auth/components/AuthProviderButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/auth/components/AuthScene.jsx
+++ b/frontend/src/metabase/auth/components/AuthScene.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-color-literals */
-
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import { connect } from "react-redux";

--- a/frontend/src/metabase/auth/components/GoogleButton.jsx
+++ b/frontend/src/metabase/auth/components/GoogleButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
+++ b/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
+++ b/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/auth/containers/LogoutApp.jsx
+++ b/frontend/src/metabase/auth/containers/LogoutApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
+++ b/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router";

--- a/frontend/src/metabase/browse/components/BrowseApp.jsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 

--- a/frontend/src/metabase/browse/components/BrowseHeader.jsx
+++ b/frontend/src/metabase/browse/components/BrowseHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/browse/containers/DatabaseBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/DatabaseBrowser.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/browse/containers/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";

--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t, msgid, ngettext } from "ttag";

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { dissoc } from "icepick";
 import { t } from "ttag";

--- a/frontend/src/metabase/collections/components/CollectionEditMenu.jsx
+++ b/frontend/src/metabase/collections/components/CollectionEditMenu.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/collections/components/CollectionSectionHeading.jsx
+++ b/frontend/src/metabase/collections/components/CollectionSectionHeading.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { color } from "metabase/lib/colors";
 

--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 

--- a/frontend/src/metabase/collections/components/Header.jsx
+++ b/frontend/src/metabase/collections/components/Header.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Flex } from "grid-styled";
 

--- a/frontend/src/metabase/collections/components/ItemList.jsx
+++ b/frontend/src/metabase/collections/components/ItemList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { assocIn } from "icepick";

--- a/frontend/src/metabase/collections/components/ItemTypeFilterBar.jsx
+++ b/frontend/src/metabase/collections/components/ItemTypeFilterBar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Flex } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/collections/components/NormalItem.jsx
+++ b/frontend/src/metabase/collections/components/NormalItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { entityTypeForObject } from "metabase/schema";

--- a/frontend/src/metabase/collections/components/PinnedItems.jsx
+++ b/frontend/src/metabase/collections/components/PinnedItems.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 import _ from "underscore";

--- a/frontend/src/metabase/collections/containers/CollectionCreate.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionCreate.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { goBack } from "react-router-redux";

--- a/frontend/src/metabase/collections/containers/CollectionEdit.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionEdit.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import { connect } from "react-redux";

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { Box } from "grid-styled";

--- a/frontend/src/metabase/components/AdminAwareEmptyState.jsx
+++ b/frontend/src/metabase/components/AdminAwareEmptyState.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import EmptyState from "metabase/components/EmptyState";
 import { getUser } from "metabase/selectors/user";

--- a/frontend/src/metabase/components/AdminContentTable.jsx
+++ b/frontend/src/metabase/components/AdminContentTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 const AdminContentTable = ({ columnTitles, children }) => (

--- a/frontend/src/metabase/components/AdminHeader.jsx
+++ b/frontend/src/metabase/components/AdminHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import SaveStatus from "metabase/components/SaveStatus";

--- a/frontend/src/metabase/components/AdminLayout.jsx
+++ b/frontend/src/metabase/components/AdminLayout.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import AdminHeader from "./AdminHeader";

--- a/frontend/src/metabase/components/AdminPaneLayout.jsx
+++ b/frontend/src/metabase/components/AdminPaneLayout.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Button from "metabase/components/Button";

--- a/frontend/src/metabase/components/Alert.jsx
+++ b/frontend/src/metabase/components/Alert.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import Modal from "metabase/components/Modal";

--- a/frontend/src/metabase/components/ArchiveCollectionModal.jsx
+++ b/frontend/src/metabase/components/ArchiveCollectionModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { connect } from "react-redux";

--- a/frontend/src/metabase/components/ArchiveModal.jsx
+++ b/frontend/src/metabase/components/ArchiveModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Link from "metabase/components/Link";

--- a/frontend/src/metabase/components/BodyComponent.jsx
+++ b/frontend/src/metabase/components/BodyComponent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/src/metabase/components/BrowserCrumbs.jsx
+++ b/frontend/src/metabase/components/BrowserCrumbs.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Flex } from "grid-styled";
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/components/BulkActionBar.jsx
+++ b/frontend/src/metabase/components/BulkActionBar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 import Card from "metabase/components/Card";

--- a/frontend/src/metabase/components/Button.jsx
+++ b/frontend/src/metabase/components/Button.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/ButtonBar.jsx
+++ b/frontend/src/metabase/components/ButtonBar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { Flex } from "grid-styled";

--- a/frontend/src/metabase/components/Calendar.jsx
+++ b/frontend/src/metabase/components/Calendar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";

--- a/frontend/src/metabase/components/CollectionEmptyState.jsx
+++ b/frontend/src/metabase/components/CollectionEmptyState.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import { withRouter } from "react-router";

--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Flex } from "grid-styled";
 

--- a/frontend/src/metabase/components/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import { Box, Flex } from "grid-styled";

--- a/frontend/src/metabase/components/ColorPicker.jsx
+++ b/frontend/src/metabase/components/ColorPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/ConfirmContent.jsx
+++ b/frontend/src/metabase/components/ConfirmContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ModalContent from "metabase/components/ModalContent";

--- a/frontend/src/metabase/components/CreateDashboardModal.jsx
+++ b/frontend/src/metabase/components/CreateDashboardModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/components/DebouncedFrame.jsx
+++ b/frontend/src/metabase/components/DebouncedFrame.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/components/DirectionalButton.jsx
+++ b/frontend/src/metabase/components/DirectionalButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import Icon from "metabase/components/Icon";
 

--- a/frontend/src/metabase/components/DisclosureTriangle.jsx
+++ b/frontend/src/metabase/components/DisclosureTriangle.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Motion, spring, presets } from "react-motion";
 

--- a/frontend/src/metabase/components/DownloadButton.jsx
+++ b/frontend/src/metabase/components/DownloadButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import { Box, Flex } from "grid-styled";

--- a/frontend/src/metabase/components/Ellipsified.jsx
+++ b/frontend/src/metabase/components/Ellipsified.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import Tooltip from "metabase/components/Tooltip";

--- a/frontend/src/metabase/components/EmptyState.jsx
+++ b/frontend/src/metabase/components/EmptyState.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/components/EntityMenu.info.js
+++ b/frontend/src/metabase/components/EntityMenu.info.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import EntityMenu from "metabase/components/EntityMenu";

--- a/frontend/src/metabase/components/EntityMenuItem.jsx
+++ b/frontend/src/metabase/components/EntityMenuItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import styled from "styled-components";
 import { Link } from "react-router";

--- a/frontend/src/metabase/components/EntityMenuTrigger.jsx
+++ b/frontend/src/metabase/components/EntityMenuTrigger.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon, { IconWrapper } from "metabase/components/Icon";

--- a/frontend/src/metabase/components/ErrorDetails.jsx
+++ b/frontend/src/metabase/components/ErrorDetails.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/components/ExpandingContent.jsx
+++ b/frontend/src/metabase/components/ExpandingContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/src/metabase/components/ExternalLink.jsx
+++ b/frontend/src/metabase/components/ExternalLink.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { getUrlTarget } from "metabase/lib/dom";

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { t, jt } from "ttag";

--- a/frontend/src/metabase/components/Grabber.jsx
+++ b/frontend/src/metabase/components/Grabber.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/components/Grid.jsx
+++ b/frontend/src/metabase/components/Grid.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/src/metabase/components/HeaderModal.jsx
+++ b/frontend/src/metabase/components/HeaderModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import BodyComponent from "metabase/components/BodyComponent";

--- a/frontend/src/metabase/components/Icon.jsx
+++ b/frontend/src/metabase/components/Icon.jsx
@@ -1,5 +1,5 @@
 /*eslint-disable react/no-danger */
-
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import styled from "styled-components";
 import { color, space, hover } from "styled-system";

--- a/frontend/src/metabase/components/IconBorder.jsx
+++ b/frontend/src/metabase/components/IconBorder.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";

--- a/frontend/src/metabase/components/Input.jsx
+++ b/frontend/src/metabase/components/Input.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/components/LeftNavPane.jsx
+++ b/frontend/src/metabase/components/LeftNavPane.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Link, IndexLink } from "react-router";
 import { t } from "ttag";

--- a/frontend/src/metabase/components/Link.jsx
+++ b/frontend/src/metabase/components/Link.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Link as ReactRouterLink } from "react-router";
 import styled from "styled-components";

--- a/frontend/src/metabase/components/ListSearchField.jsx
+++ b/frontend/src/metabase/components/ListSearchField.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/LoadingSpinner.jsx
+++ b/frontend/src/metabase/components/LoadingSpinner.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import "./LoadingSpinner.css";

--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";

--- a/frontend/src/metabase/components/ModalContent.info.js
+++ b/frontend/src/metabase/components/ModalContent.info.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import ModalContent from "metabase/components/ModalContent";
 import Button from "metabase/components/Button";

--- a/frontend/src/metabase/components/ModalContent.jsx
+++ b/frontend/src/metabase/components/ModalContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";

--- a/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
+++ b/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/components/Swapper.jsx
+++ b/frontend/src/metabase/components/Swapper.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Motion, spring } from "react-motion";
 

--- a/frontend/src/metabase/components/TextEditor.jsx
+++ b/frontend/src/metabase/components/TextEditor.jsx
@@ -1,5 +1,5 @@
 /*global ace*/
-
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/components/Toggle.jsx
+++ b/frontend/src/metabase/components/Toggle.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/ToggleLarge.jsx
+++ b/frontend/src/metabase/components/ToggleLarge.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/components/TokenField.info.js
+++ b/frontend/src/metabase/components/TokenField.info.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import TokenField from "metabase/components/TokenField";
 

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import pure from "recompose/pure";
 import cx from "classnames";

--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/src/metabase/components/VirtualizedList.jsx
+++ b/frontend/src/metabase/components/VirtualizedList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { List, WindowScroller, AutoSizer } from "react-virtualized";

--- a/frontend/src/metabase/components/__mocks__/Popover.jsx
+++ b/frontend/src/metabase/components/__mocks__/Popover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";

--- a/frontend/src/metabase/components/form/CustomForm.jsx
+++ b/frontend/src/metabase/components/form/CustomForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/components/form/FormMessage.jsx
+++ b/frontend/src/metabase/components/form/FormMessage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import cx from "classnames";
 import { t } from "ttag";

--- a/frontend/src/metabase/components/form/FormWidget.jsx
+++ b/frontend/src/metabase/components/form/FormWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import FormInputWidget from "./widgets/FormInputWidget";

--- a/frontend/src/metabase/components/form/StandardForm.jsx
+++ b/frontend/src/metabase/components/form/StandardForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import CustomForm from "./CustomForm";

--- a/frontend/src/metabase/components/form/widgets/FormCheckBoxWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormCheckBoxWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import CheckBox from "metabase/components/CheckBox";
 
 import React from "react";

--- a/frontend/src/metabase/components/form/widgets/FormCollectionWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormCollectionWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import CollectionSelect from "metabase/containers/CollectionSelect";

--- a/frontend/src/metabase/components/form/widgets/FormColorWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormColorWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ColorPicker from "metabase/components/ColorPicker";

--- a/frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import GroupSelect from "metabase/admin/people/components/GroupSelect";

--- a/frontend/src/metabase/components/form/widgets/FormHiddenWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormHiddenWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { formDomOnlyProps } from "metabase/lib/redux";

--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { formDomOnlyProps } from "metabase/lib/redux";

--- a/frontend/src/metabase/components/form/widgets/FormNumericInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormNumericInputWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { formDomOnlyProps } from "metabase/lib/redux";

--- a/frontend/src/metabase/components/form/widgets/FormSelectWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormSelectWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Select, { Option } from "metabase/components/Select";

--- a/frontend/src/metabase/components/form/widgets/FormSnippetCollectionWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormSnippetCollectionWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ItemSelect from "metabase/containers/ItemSelect";

--- a/frontend/src/metabase/components/form/widgets/FormTextAreaWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormTextAreaWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/components/form/widgets/FormTextFileWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormTextFileWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 import { formDomOnlyProps } from "metabase/lib/redux";

--- a/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Toggle from "metabase/components/Toggle";

--- a/frontend/src/metabase/components/icons/ClockIcon.jsx
+++ b/frontend/src/metabase/components/icons/ClockIcon.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 const ClockIcon = ({

--- a/frontend/src/metabase/components/icons/CountdownIcon.jsx
+++ b/frontend/src/metabase/components/icons/CountdownIcon.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 const CountdownIcon = ({

--- a/frontend/src/metabase/components/icons/FullscreenIcon.jsx
+++ b/frontend/src/metabase/components/icons/FullscreenIcon.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/components/type/Heading.jsx
+++ b/frontend/src/metabase/components/type/Heading.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import Text from "metabase/components/type/Text";
 

--- a/frontend/src/metabase/components/type/Label.jsx
+++ b/frontend/src/metabase/components/type/Label.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import Text from "metabase/components/type/Text";
 

--- a/frontend/src/metabase/components/type/Subhead.jsx
+++ b/frontend/src/metabase/components/type/Subhead.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import Text from "metabase/components/type/Text";
 

--- a/frontend/src/metabase/containers/CollectionName.jsx
+++ b/frontend/src/metabase/containers/CollectionName.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Collection, { ROOT_COLLECTION } from "metabase/entities/collections";

--- a/frontend/src/metabase/containers/ErrorPages.jsx
+++ b/frontend/src/metabase/containers/ErrorPages.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Flex } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/containers/Form.jsx
+++ b/frontend/src/metabase/containers/Form.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/containers/HistoryModal.jsx
+++ b/frontend/src/metabase/containers/HistoryModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import HistoryModal from "metabase/components/HistoryModal";

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";

--- a/frontend/src/metabase/containers/ItemSelect.jsx
+++ b/frontend/src/metabase/containers/ItemSelect.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import _ from "underscore";
 import { Box, Flex } from "grid-styled";

--- a/frontend/src/metabase/containers/QuestionName.jsx
+++ b/frontend/src/metabase/containers/QuestionName.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Question from "metabase/entities/questions";

--- a/frontend/src/metabase/containers/QuestionPicker.jsx
+++ b/frontend/src/metabase/containers/QuestionPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/containers/RemappedValue.jsx
+++ b/frontend/src/metabase/containers/RemappedValue.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { formatValue } from "metabase/lib/formatting";

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/containers/dnd/DropArea.jsx
+++ b/frontend/src/metabase/containers/dnd/DropArea.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/containers/dnd/ItemDragSource.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemDragSource.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { DragSource } from "react-dnd";

--- a/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { DragLayer } from "react-dnd";
 import _ from "underscore";

--- a/frontend/src/metabase/containers/dnd/PinPositionDropTarget.jsx
+++ b/frontend/src/metabase/containers/dnd/PinPositionDropTarget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { DropTarget } from "react-dnd";
 import cx from "classnames";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t, jt, ngettext, msgid } from "ttag";
 import { getIn } from "icepick";

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import _ from "underscore";

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";

--- a/frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -1,5 +1,5 @@
 // TODO: merge with metabase/dashboard/containers/Dashboard.jsx
-
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Box } from "grid-styled";

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { withRouter } from "react-router";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardDetailsModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { withRouter } from "react-router";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import HistoryModal from "metabase/containers/HistoryModal";

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { withRouter } from "react-router";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import styles from "./RefreshWidget.css";
 

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/dashboard/components/grid/GridItem.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import { DraggableCore } from "react-draggable";

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/ArchiveDashboardModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import cx from "classnames";

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.jsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { dissoc } from "icepick";
 import { t } from "ttag";

--- a/frontend/src/metabase/entities/containers/EntityForm.jsx
+++ b/frontend/src/metabase/entities/containers/EntityForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import _ from "underscore";

--- a/frontend/src/metabase/entities/containers/EntityName.jsx
+++ b/frontend/src/metabase/entities/containers/EntityName.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import EntityObjectLoader from "./EntityObjectLoader";

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { createSelector } from "reselect";

--- a/frontend/src/metabase/entities/containers/EntityType.jsx
+++ b/frontend/src/metabase/entities/containers/EntityType.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";

--- a/frontend/src/metabase/entities/containers/index.js
+++ b/frontend/src/metabase/entities/containers/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import EntityListLoader, { entityListLoader } from "./EntityListLoader";

--- a/frontend/src/metabase/entities/databases/big-query-fields.js
+++ b/frontend/src/metabase/entities/databases/big-query-fields.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t, jt } from "ttag";
 

--- a/frontend/src/metabase/entities/databases/mongo-fields.js
+++ b/frontend/src/metabase/entities/databases/mongo-fields.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/hoc/AutoExpanding.jsx
+++ b/frontend/src/metabase/hoc/AutoExpanding.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ExplicitSize from "metabase/components/ExplicitSize";

--- a/frontend/src/metabase/hoc/Background.jsx
+++ b/frontend/src/metabase/hoc/Background.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 export const withBackground = className => ComposedComponent => {

--- a/frontend/src/metabase/hoc/ModalRoute.jsx
+++ b/frontend/src/metabase/hoc/ModalRoute.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Route } from "react-router";
 import { push } from "react-router-redux";

--- a/frontend/src/metabase/hoc/PaginationState.jsx
+++ b/frontend/src/metabase/hoc/PaginationState.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 const paginationState = () => ComposedComponent =>

--- a/frontend/src/metabase/hoc/Remapped.jsx
+++ b/frontend/src/metabase/hoc/Remapped.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/hoc/Routeless.jsx
+++ b/frontend/src/metabase/hoc/Routeless.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import { connect } from "react-redux";

--- a/frontend/src/metabase/hoc/ScrollToTop.js
+++ b/frontend/src/metabase/hoc/ScrollToTop.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { withRouter } from "react-router";
 

--- a/frontend/src/metabase/hoc/Toast.jsx
+++ b/frontend/src/metabase/hoc/Toast.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/hoc/Tooltipify.jsx
+++ b/frontend/src/metabase/hoc/Tooltipify.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import Tooltip from "metabase/components/Tooltip";

--- a/frontend/src/metabase/hoc/Typeahead.jsx
+++ b/frontend/src/metabase/hoc/Typeahead.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/home/components/SidebarSection.jsx
+++ b/frontend/src/metabase/home/components/SidebarSection.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t, jt } from "ttag";

--- a/frontend/src/metabase/internal/components/EntitiesApp.jsx
+++ b/frontend/src/metabase/internal/components/EntitiesApp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Route, IndexRoute } from "react-router";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/internal/components/Example.jsx
+++ b/frontend/src/metabase/internal/components/Example.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 import reactElementToJSXString from "react-element-to-jsx-string";

--- a/frontend/src/metabase/internal/components/Layout.jsx
+++ b/frontend/src/metabase/internal/components/Layout.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import fitViewport from "metabase/hoc/FitViewPort";
 import Link from "metabase/components/Link";

--- a/frontend/src/metabase/internal/components/Props.jsx
+++ b/frontend/src/metabase/internal/components/Props.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 const Props = ({ of }) => {

--- a/frontend/src/metabase/internal/pages/ColorsPage.jsx
+++ b/frontend/src/metabase/internal/pages/ColorsPage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 import { Box, Flex } from "grid-styled";

--- a/frontend/src/metabase/internal/pages/ComponentsPage.jsx
+++ b/frontend/src/metabase/internal/pages/ComponentsPage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 

--- a/frontend/src/metabase/internal/pages/ModalsPage.jsx
+++ b/frontend/src/metabase/internal/pages/ModalsPage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import d3 from "d3";
 import inflection from "inflection";
 import moment from "moment-timezone";

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import ReactDOM from "react-dom";
 import { Flex } from "grid-styled";

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/new_query/components/NewQueryOption.jsx
+++ b/frontend/src/metabase/new_query/components/NewQueryOption.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import cx from "classnames";
 import { Link } from "react-router";

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import { connect } from "react-redux";

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t, jt } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/parameters/components/ParameterTargetList.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterTargetList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import AccordionList from "metabase/components/AccordionList";

--- a/frontend/src/metabase/parameters/components/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ParameterValueWidget from "./ParameterValueWidget";

--- a/frontend/src/metabase/parameters/components/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import querystring from "querystring";

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import {
   SortableContainer,

--- a/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import cx from "classnames";
 import { t } from "ttag";

--- a/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import YearPicker from "./YearPicker";
 import { Flex } from "grid-styled";

--- a/frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import YearPicker from "./YearPicker";

--- a/frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Calendar from "metabase/components/Calendar";

--- a/frontend/src/metabase/parameters/components/widgets/YearPicker.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/YearPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Select from "metabase/components/Select";

--- a/frontend/src/metabase/plugins/builtin/auth/password.js
+++ b/frontend/src/metabase/plugins/builtin/auth/password.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import { PLUGIN_AUTH_PROVIDERS } from "metabase/plugins";
 
 import React from "react";

--- a/frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/public/components/widgets/PreviewPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/PreviewPane.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/pulse/components/PulseEditCollection.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCollection.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
 import { t } from "ttag";

--- a/frontend/src/metabase/pulse/components/PulseEditName.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditName.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";

--- a/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { t, jt } from "ttag";

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { t, jt, ngettext, msgid } from "ttag";

--- a/frontend/src/metabase/query_builder/components/BreakoutWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/BreakoutWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/query_builder/components/Clearable.jsx
+++ b/frontend/src/metabase/query_builder/components/Clearable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import _ from "underscore";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/ExpandableString.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpandableString.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 import Humanize from "humanize-plus";

--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ExpressionEditorTextfield from "./expressions/ExpressionEditorTextfield";

--- a/frontend/src/metabase/query_builder/components/ExtendedOptions.jsx
+++ b/frontend/src/metabase/query_builder/components/ExtendedOptions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";

--- a/frontend/src/metabase/query_builder/components/FieldWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/query_builder/components/Filter.jsx
+++ b/frontend/src/metabase/query_builder/components/Filter.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Value from "metabase/components/Value";

--- a/frontend/src/metabase/query_builder/components/FilterList.jsx
+++ b/frontend/src/metabase/query_builder/components/FilterList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/query_builder/components/LimitPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/LimitWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/LimitWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -1,5 +1,5 @@
 /*global ace*/
-
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/components/QueryDefinition.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDefinition.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import { Box } from "grid-styled";

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/RunButton.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import Modal from "metabase/components/Modal";

--- a/frontend/src/metabase/query_builder/components/SelectionModule.jsx
+++ b/frontend/src/metabase/query_builder/components/SelectionModule.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/query_builder/components/SidebarContent.jsx
+++ b/frontend/src/metabase/query_builder/components/SidebarContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ViewButton from "./view/ViewButton";

--- a/frontend/src/metabase/query_builder/components/SidebarHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/SortWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/SortWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/query_builder/components/Warnings.jsx
+++ b/frontend/src/metabase/query_builder/components/Warnings.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Tooltip from "metabase/components/Tooltip";

--- a/frontend/src/metabase/query_builder/components/__mocks__/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/__mocks__/NativeQueryEditor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Parameters from "metabase/parameters/components/Parameters";

--- a/frontend/src/metabase/query_builder/components/dataref/UseForButton.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/UseForButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import "./TokenizedExpression.css";

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import ReactDOMServer from "react-dom/server";

--- a/frontend/src/metabase/query_builder/components/filters/DateUnitSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/DateUnitSelector.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Select, { Option } from "metabase/components/Select";

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopoverHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopoverHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopoverPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopoverPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import DatePicker from "../filters/pickers/DatePicker";

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import NumberPicker from "./NumberPicker";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import NumericInput from "metabase/components/NumericInput";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import NotebookStep from "./NotebookStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ClauseStep from "./ClauseStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { Flex } from "grid-styled";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t, jt } from "ttag";
 import Code from "metabase/components/Code";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/snippet-sidebar/SnippetRow.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Badge, { MaybeLink } from "metabase/components/Badge";

--- a/frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t, ngettext, msgid } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import moment from "moment";

--- a/frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Toggle from "metabase/components/Toggle";

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { ngettext, msgid, t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/SnippetSidebarButton.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/components/view/ViewPill.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewPill.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/query_builder/components/view/ViewSection.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSection.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { Flex } from "grid-styled";

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import _ from "underscore";
 import { t } from "ttag";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx
+++ b/frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Badge from "metabase/components/Badge";

--- a/frontend/src/metabase/reference/components/FieldToGroupBy.jsx
+++ b/frontend/src/metabase/reference/components/FieldToGroupBy.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import pure from "recompose/pure";

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import styled from "styled-components";

--- a/frontend/src/metabase/setup/components/LanguageStep.jsx
+++ b/frontend/src/metabase/setup/components/LanguageStep.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 import { t } from "ttag";

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";

--- a/frontend/src/metabase/user/components/LoginHistoryList.jsx
+++ b/frontend/src/metabase/user/components/LoginHistoryList.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import cx from "classnames";
 import { assocIn } from "icepick";

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import styles from "./ChartWithLegend.css";
 

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-color-literals */
-
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 import LoadingSpinner from "metabase/components/LoadingSpinner";

--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/src/metabase/visualizations/components/LegacyChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LegacyChoropleth.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import { isSameSeries } from "metabase/visualizations/lib/utils";

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styles from "./Legend.css";

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import styles from "./Legend.css";

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import styles from "./Legend.css";

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/components/MiniBar.jsx
+++ b/frontend/src/metabase/visualizations/components/MiniBar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { color, alpha } from "metabase/lib/colors";

--- a/frontend/src/metabase/visualizations/components/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue.jsx
@@ -1,7 +1,7 @@
 /*
  * Shared component for Scalar and SmartScalar to make sure our number presentation stays in sync
  */
-
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import _ from "underscore";
 import { getIn } from "icepick";

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import ColumnItem from "./ColumnItem";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingButtonGroup.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingButtonGroup.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import ColorPicker from "metabase/components/ColorPicker";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorsPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import ChartSettingColorPicker from "./ChartSettingColorPicker";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
 import ChartSettingFieldPicker from "./ChartSettingFieldPicker";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInput.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import InputBlurChange from "metabase/components/InputBlurChange";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputGroup.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputGroup.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import InputBlurChange from "metabase/components/InputBlurChange";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 
 import cx from "classnames";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingRadio.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingRadio.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Radio from "metabase/components/Radio";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Select, { Option } from "metabase/components/Select";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingToggle.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Toggle from "metabase/components/Toggle";

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { t, jt } from "ttag";

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
 import _ from "underscore";

--- a/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
 import ChoroplethMap, {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t, jt } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
 import { t, jt } from "ttag";

--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactMarkdown from "react-markdown";
 import styles from "./Text.css";

--- a/frontend/test/__support__/sample_dataset_fixture.js
+++ b/frontend/test/__support__/sample_dataset_fixture.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { Provider } from "react-redux";
 import { getStore } from "metabase/store";

--- a/frontend/test/metabase/components/TokenField.unit.spec.js
+++ b/frontend/test/metabase/components/TokenField.unit.spec.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/display-name */
+/* eslint-disable react/prop-types */
 
 import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";

--- a/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
+++ b/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import { render } from "@testing-library/react";


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Turns on Eslint `"react/prop-types"` rule and sets it to error
- Disables eslint check for `react/prop-types` in hundreds of affected files

### Additional context
- There is already an ongoing effort to get rid of common React errors in https://github.com/metabase/metabase/pull/15098
- Eslint rule `"react/prop-types"` was globally disabled (set to `0`) which made it easy to introduce new errors to already insanely large number of them
- Once enabled, it revealed over 4k `prop-types` errors
- That was too much to handle in one take so we agreed to use the following approach:
1. Turn on the rule and set it to error out for any new code
2. Disable linting for each of the already affected files 

**Developers working on files that have `/* eslint-disable react/prop-types */` should handle those errors while working on that file. This way, we can gradually deal with large number of errors.**

### Why do this?
Prevent introduction of new `prop-types` errors to the code base.
