### PR TITLE
Fix druid throwing "Invalid type marker byte 0x3c for expected value token" errors if limit is 1048575 

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/execute.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/execute.clj
@@ -155,7 +155,13 @@
                      query)
         query-type (or query-type
                        (keyword (namespace ::druid.qp/query) (name (:queryType query))))
-        results    (execute* details query)
+        results    (try
+                     (execute* details query)
+                     (catch Throwable e
+                       (throw (ex-info (tru "Error executing query")
+                                       {:type  qp.error-type/db
+                                        :query query}
+                                       e))))
         result     (try (post-process query-type projections
                                       {:timezone   (resolve-timezone mbql-query)
                                        :middleware middleware}

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -1095,9 +1095,8 @@
 
 (defmethod handle-limit ::scan
   [_ {limit :limit} druid-query]
-  (if-not limit
-    druid-query
-    (assoc-in druid-query [:query :limit] (adjust-limit limit))))
+  (cond-> druid-query
+    limit (assoc-in [:query :limit] (adjust-limit limit))))
 
 (defmethod handle-limit ::timeseries
   [_ {limit :limit} druid-query]
@@ -1109,13 +1108,13 @@
 
 (defmethod handle-limit ::topN
   [_ {limit :limit} druid-query]
-  (if-not limit
-    druid-query
-    (assoc-in druid-query [:query :threshold] (adjust-limit limit))))
+  (cond-> druid-query
+    limit (assoc-in [:query :threshold] (adjust-limit limit))))
 
 (defmethod handle-limit ::groupBy
   [_ {limit :limit} druid-query]
-  (cond-> (assoc-in [:query :limitSpec :type]  :default)
+  (cond-> druid-query
+    true  (assoc-in [:query :limitSpec :type]  :default)
     limit (assoc-in [:query :limitSpec :limit] (adjust-limit limit))))
 
 


### PR DESCRIPTION
Druid tests are failing in `release-x.38.x`, and I worked out that this started happening after #15414. Believe it or not, this is not an April Fool's joke, but apparently Druid queries fail with 

> Invalid type marker byte 0x3c for expected value token

if the limit is `1048575` (the new value) but `1048576` (the old value) is totally fine. I don't have time to think about why this is the case -- so for Druid I'm just reverting to the old limit for now.

I tweaked the error code for Druid a bit as well to provide more info while I was debugging this.