### PR TITLE
Show currency list in native queries and add Kyrgyz Som

### DIFF
--- a/frontend/src/metabase/lib/currency.js
+++ b/frontend/src/metabase/lib/currency.js
@@ -512,6 +512,15 @@ export default {
     code: "KES",
     name_plural: "Kenyan shillings",
   },
+  KGS: {
+    symbol: "KGS",
+    name: "Kyrgyz Som",
+    symbol_native: "сом",
+    decimal_digits: 2,
+    rounding: 0,
+    code: "KGS",
+    name_plural: "Kyrgyz soms",
+  },
   KHR: {
     symbol: "KHR",
     name: "Cambodian Riel",

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -327,8 +327,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     },
     default: "USD",
     getHidden: (column: Column, settings: ColumnSettings) =>
-      // NOTE: ideally we'd hide this if number_style != "currency" but that would result in a circular dependency
-      !isCurrency(column),
+      settings["number_style"] !== "currency",
   },
   currency_style: {
     title: t`Currency label style`,


### PR DESCRIPTION
Added the Kyrgyz Som to fix https://github.com/metabase/metabase/issues/9828 and also changed the control in the frontend so people can choose their currency in native queries, as they would do in GUI queries. Will fix https://github.com/metabase/metabase/issues/11233.

Please let me know the consequences of this change in relaxing the restrictions on showing the currency list on native queries, I don't see any but just in case.