### PR TITLE
Fix tooltip value on unaggregated data

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -882,7 +882,7 @@ export default function lineAreaBar(
 
   applyYAxisSettings(parent, yAxisProps);
 
-  setupTooltips(props, datas, parent, brushChangeFunctions);
+  setupTooltips(props, datas, parent, brushChangeFunctions, groups);
 
   parent.render();
 

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -3,6 +3,7 @@
 import d3 from "d3";
 import moment from "moment";
 import { getIn } from "icepick";
+import _ from "underscore";
 
 import { formatValue } from "metabase/lib/formatting";
 
@@ -22,6 +23,7 @@ export function getClickHoverObject(
     event,
     element,
     settings,
+    groups,
   },
 ) {
   let { cols } = series[seriesIndex].data;
@@ -89,14 +91,29 @@ export function getClickHoverObject(
       ([x]) => key === x || (moment.isMoment(key) && key.isSame(x)),
     );
 
+    const xIndex = _.findIndex(
+      groups[0][0].all(),
+      groupedRow =>
+        key === groupedRow.key ||
+        (moment.isMoment(groupedRow.key) && key.isSame(groupedRow.key)),
+    );
+
+    const groupByColumnName = {};
+    series.forEach((s, index) => {
+      const seriesGroup = groups[index];
+
+      if (seriesGroup) {
+        groupByColumnName[s.card._seriesKey] = seriesGroup[0];
+      }
+    });
+
     // try to get row from _origin but fall back to the row we already have
     const rawRow = (row && row._origin && row._origin.row) || row;
 
     // Loop over *all* of the columns and create the new array
     if (rawRow) {
       data = rawCols.map((col, i) => {
-        const isSeriesValueColumn = cols[1].field_ref === col.field_ref;
-
+        const isSeriesValueColumn = _.isEqual(cols[1].field_ref, col.field_ref);
         if (isNormalized && isSeriesValueColumn) {
           return {
             key: getColumnDisplayName(cols[1]),
@@ -109,9 +126,13 @@ export function getClickHoverObject(
           };
         }
 
+        const columnGroup = groupByColumnName[col.name];
+        const groupedRow = columnGroup ? columnGroup.all()[xIndex] : null;
+
         const value = formatNull(
-          isSeriesValueColumn ? d.data.value : rawRow[i],
+          groupedRow != null ? groupedRow.value : rawRow[i],
         );
+
         return {
           key: getColumnDisplayName(col),
           value,
@@ -200,6 +221,7 @@ export function setupTooltips(
   datas,
   chart,
   { isBrushing },
+  groups,
 ) {
   const stacked = isStacked(settings, datas);
   const normalized = isNormalized(settings, datas);
@@ -231,6 +253,7 @@ export function setupTooltips(
       event: d3.event,
       element: target,
       settings,
+      groups,
     });
   };
 

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -95,7 +95,9 @@ export function getClickHoverObject(
     // Loop over *all* of the columns and create the new array
     if (rawRow) {
       data = rawCols.map((col, i) => {
-        if (isNormalized && cols[1].field_ref === col.field_ref) {
+        const isSeriesValueColumn = cols[1].field_ref === col.field_ref;
+
+        if (isNormalized && isSeriesValueColumn) {
           return {
             key: getColumnDisplayName(cols[1]),
             value: formatValue(d.data.value, {
@@ -106,9 +108,13 @@ export function getClickHoverObject(
             col: col,
           };
         }
+
+        const value = formatNull(
+          isSeriesValueColumn ? d.data.value : rawRow[i],
+        );
         return {
           key: getColumnDisplayName(col),
-          value: formatNull(rawRow[i]),
+          value,
           col: col,
         };
       });

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -269,7 +269,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("There was a problem with your question").should("not.exist");
   });
 
-  it.skip("should display correct value in a tooltip for unaggregated data (metabase#11907)", () => {
+  it("should display correct value in a tooltip for unaggregated data (metabase#11907)", () => {
     cy.createNativeQuestion({
       name: "11907",
       native: {

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
@@ -124,10 +124,9 @@ describe("LineAreaBarRenderer", () => {
     const dateColumn = DateTimeColumn({
       unit: "week",
       name: Math.random().toString(36),
-      field_ref: "key",
     });
 
-    const cols = [dateColumn, NumberColumn({ field_ref: "value" })];
+    const cols = [dateColumn, NumberColumn()];
     const chartType = "line";
     const series = [{ data: { cols, rows }, card: { display: chartType } }];
     const settings = getComputedSettingsForSeries(series);
@@ -160,10 +159,9 @@ describe("LineAreaBarRenderer", () => {
     const dateColumn = DateTimeColumn({
       unit: "month",
       name: columnName,
-      field_ref: "key",
     });
 
-    const cols = [dateColumn, NumberColumn({ field_ref: "value" })];
+    const cols = [dateColumn, NumberColumn()];
     const chartType = "line";
     const column_settings = {
       [`["name","${columnName}"]`]: {

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
@@ -124,9 +124,10 @@ describe("LineAreaBarRenderer", () => {
     const dateColumn = DateTimeColumn({
       unit: "week",
       name: Math.random().toString(36),
+      field_ref: "key",
     });
 
-    const cols = [dateColumn, NumberColumn()];
+    const cols = [dateColumn, NumberColumn({ field_ref: "value" })];
     const chartType = "line";
     const series = [{ data: { cols, rows }, card: { display: chartType } }];
     const settings = getComputedSettingsForSeries(series);
@@ -156,9 +157,13 @@ describe("LineAreaBarRenderer", () => {
     // column settings are cached based on name.
     // we need something unique to not conflict with other tests.
     const columnName = Math.random().toString(36);
-    const dateColumn = DateTimeColumn({ unit: "month", name: columnName });
+    const dateColumn = DateTimeColumn({
+      unit: "month",
+      name: columnName,
+      field_ref: "key",
+    });
 
-    const cols = [dateColumn, NumberColumn()];
+    const cols = [dateColumn, NumberColumn({ field_ref: "value" })];
     const chartType = "line";
     const column_settings = {
       [`["name","${columnName}"]`]: {

--- a/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -14,10 +14,7 @@ import {
 describe("getClickHoverObject", () => {
   it("should return data for tooltip", () => {
     const d = { data: { key: "foobar", value: 123 } };
-    const cols = [
-      StringColumn({ field_ref: "key" }),
-      NumberColumn({ field_ref: "value" }),
-    ];
+    const cols = [StringColumn(), NumberColumn()];
     const rows = [["foobar", 123]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),
@@ -38,10 +35,7 @@ describe("getClickHoverObject", () => {
         value: 2,
       },
     };
-    const cols = [
-      DateTimeColumn({ unit: "month" }, { field_ref: "key" }),
-      NumberColumn({ field_ref: "value" }),
-    ];
+    const cols = [DateTimeColumn({ unit: "month" }), NumberColumn()];
     const rows = [
       ["2016-03-01T00:00:00.000Z", 1],
       ["2016-04-01T00:00:00.000Z", 2],
@@ -67,10 +61,7 @@ describe("getClickHoverObject", () => {
       },
     };
 
-    const cols = [
-      DateTimeColumn({ unit: "month" }, { field_ref: "key" }),
-      NumberColumn({ field_ref: "value" }),
-    ];
+    const cols = [DateTimeColumn({ unit: "month" }), NumberColumn()];
     const rows = [["2016-03", 1], ["2016-04", 2], ["2016-05", 3]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),
@@ -143,10 +134,7 @@ describe("getClickHoverObject", () => {
 
   it("should parse boolean strings in boolean columns", () => {
     const d = { data: { key: "foobar", value: "true" } };
-    const cols = [
-      StringColumn({ field_ref: "key" }),
-      BooleanColumn({ field_ref: "value" }),
-    ];
+    const cols = [StringColumn(), BooleanColumn()];
     const rows = [["foobar", "true"]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),
@@ -167,10 +155,7 @@ describe("getClickHoverObject", () => {
 
   it("should show correct tooltip for nulls", () => {
     const d = { data: { key: "(empty)", value: "2" } };
-    const cols = [
-      StringColumn({ field_ref: "key" }),
-      NumberColumn({ field_ref: "value" }),
-    ];
+    const cols = [StringColumn(), NumberColumn()];
     const rows = [["foobar", 1], [null, 2], ["barfoo", 3]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),
@@ -187,5 +172,13 @@ describe("getClickHoverObject", () => {
 function seriesAndData({ cols, rows }) {
   const series = [{ data: { cols, rows }, card: {} }];
   const datas = getDatas({ series, settings: {} });
-  return { series, datas };
+  const groups = [
+    [
+      {
+        all: () => rows,
+      },
+    ],
+  ];
+
+  return { series, datas, groups };
 }

--- a/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -14,7 +14,10 @@ import {
 describe("getClickHoverObject", () => {
   it("should return data for tooltip", () => {
     const d = { data: { key: "foobar", value: 123 } };
-    const cols = [StringColumn(), NumberColumn()];
+    const cols = [
+      StringColumn({ field_ref: "key" }),
+      NumberColumn({ field_ref: "value" }),
+    ];
     const rows = [["foobar", 123]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),
@@ -32,10 +35,13 @@ describe("getClickHoverObject", () => {
     const d = {
       data: {
         key: moment("2016-04-01T00:00:00.000Z", "YYYY-MM-DDTHH:mm:ss.SSSSZ"),
-        value: 123,
+        value: 2,
       },
     };
-    const cols = [DateTimeColumn({ unit: "month" }), NumberColumn()];
+    const cols = [
+      DateTimeColumn({ unit: "month" }, { field_ref: "key" }),
+      NumberColumn({ field_ref: "value" }),
+    ];
     const rows = [
       ["2016-03-01T00:00:00.000Z", 1],
       ["2016-04-01T00:00:00.000Z", 2],
@@ -57,10 +63,14 @@ describe("getClickHoverObject", () => {
     const d = {
       data: {
         key: moment("2016-04-01T00:00:00.000Z", "YYYY-MM-DDTHH:mm:ss.SSSSZ"),
-        value: 123,
+        value: 2,
       },
     };
-    const cols = [DateTimeColumn({ unit: "month" }), NumberColumn()];
+
+    const cols = [
+      DateTimeColumn({ unit: "month" }, { field_ref: "key" }),
+      NumberColumn({ field_ref: "value" }),
+    ];
     const rows = [["2016-03", 1], ["2016-04", 2], ["2016-05", 3]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),
@@ -133,7 +143,10 @@ describe("getClickHoverObject", () => {
 
   it("should parse boolean strings in boolean columns", () => {
     const d = { data: { key: "foobar", value: "true" } };
-    const cols = [StringColumn(), BooleanColumn()];
+    const cols = [
+      StringColumn({ field_ref: "key" }),
+      BooleanColumn({ field_ref: "value" }),
+    ];
     const rows = [["foobar", "true"]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),
@@ -153,8 +166,11 @@ describe("getClickHoverObject", () => {
   });
 
   it("should show correct tooltip for nulls", () => {
-    const d = { data: { key: "(empty)", value: "true" } };
-    const cols = [StringColumn(), NumberColumn()];
+    const d = { data: { key: "(empty)", value: "2" } };
+    const cols = [
+      StringColumn({ field_ref: "key" }),
+      NumberColumn({ field_ref: "value" }),
+    ];
     const rows = [["foobar", 1], [null, 2], ["barfoo", 3]];
     const otherArgs = {
       ...seriesAndData({ cols, rows }),


### PR DESCRIPTION
### Description

In order to show correct values inside the tooltip when data is unaggregated, we have to retrieve metric value from crossfilter groups

Query:
```
SELECT 1 AS "d", 1 AS "c", 100 as "j" UNION ALL
SELECT 1 AS "d", 2 AS "c", 200 as "j" UNION ALL
SELECT 3 AS "d", 10 AS "c", 500 as "j" 
```
Result:
<img width="855" alt="Screen Shot 2021-04-07 at 03 06 20" src="https://user-images.githubusercontent.com/14301985/113792327-55f07f80-974e-11eb-98e7-f1c536ee1a31.png">
It shows grouped values `c = 3` and `j = 300` for `d = 1`


Fixes https://github.com/metabase/metabase/issues/11907