### PR TITLE
Send email when logging in from new device for the first time.

### DIFF
--- a/src/metabase/api/login_history.clj
+++ b/src/metabase/api/login_history.clj
@@ -11,10 +11,10 @@
   ;; TODO -- should this only return history in some window, e.g. last 3 months? I think for auditing purposes it's
   ;; nice to be able to see every log in that's every happened with an account. Maybe we should page this, or page the
   ;; API endpoint?
-  (for [history-item (db/select [LoginHistory :timestamp :session_id :device_description :ip_address]
-                                :user_id (u/the-id user-or-id)
-                                {:order-by [[:timestamp :desc]]})]
-    (login-history/human-friendly-info history-item)))
+  (login-history/human-friendly-infos
+   (db/select [LoginHistory :timestamp :session_id :device_description :ip_address]
+              :user_id (u/the-id user-or-id)
+              {:order-by [[:timestamp :desc]]})))
 
 (api/defendpoint GET "/current"
   "Fetch recent logins for the current user."

--- a/src/metabase/api/login_history.clj
+++ b/src/metabase/api/login_history.clj
@@ -2,30 +2,8 @@
   (:require [compojure.core :refer [GET]]
             [metabase.api.common :as api]
             [metabase.models.login-history :as login-history :refer [LoginHistory]]
-            [metabase.server.request.util :as request.u]
             [metabase.util :as u]
-            [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as i18n]
             [toucan.db :as db]))
-
-(defn- timezone-display-name [^java.time.ZoneId zone-id]
-  (when zone-id
-    (.getDisplayName zone-id
-                     java.time.format.TextStyle/SHORT_STANDALONE
-                     (i18n/user-locale))))
-
-(defn- format-login-history
-  "Return a human-friendly version of the info in a LoginHistory instance. Powers the login history API endpoint."
-  [history-item]
-  (let [{location-description :description, timezone :timezone} (request.u/geocode-ip-address (:ip_address history-item))]
-    (-> history-item
-        (assoc :location location-description
-               :timezone (timezone-display-name timezone))
-        (update :timestamp (fn [timestamp]
-                             (if (and timestamp timezone)
-                               (u.date/with-time-zone-same-instant timestamp timezone)
-                               timestamp)))
-        (update :device_description request.u/describe-user-agent))))
 
 (defn login-history
   "Return complete login history (sorted by most-recent -> least-recent) for `user-or-id`"
@@ -36,7 +14,7 @@
   (for [history-item (db/select [LoginHistory :timestamp :session_id :device_description :ip_address]
                                 :user_id (u/the-id user-or-id)
                                 {:order-by [[:timestamp :desc]]})]
-    (format-login-history history-item)))
+    (login-history/human-friendly-info history-item)))
 
 (api/defendpoint GET "/current"
   "Fetch recent logins for the current user."

--- a/src/metabase/email/login_from_new_device.mustache
+++ b/src/metabase/email/login_from_new_device.mustache
@@ -1,13 +1,13 @@
 {{> metabase/email/_header }}
 <div style="margin: 2em 4em; border: 1px solid #dddddd; border-radius: 2px; background-color: white; box-shadow: 0 1px 2px rgba(0, 0, 0, .08); text-align: center;">
   <h2 style="font-weight: normal; color: #4C545B;line-height: 1.65rem;">
-    We've noticed a new login on your Metabase account.
+    We've noticed a new login on your {{applicationName}} account.
   </h2>
   <p style="margin-top: 1em">
     Hi {{first-name}},
   </p>
   <p style="margin-top: 1em">
-    We noticed a login on your Metabase account from a new device.
+    We noticed a login on your {{applicationName}} account from a new device.
   </p>
 
   <p style="margin-top: 1em;">

--- a/src/metabase/email/login_from_new_device.mustache
+++ b/src/metabase/email/login_from_new_device.mustache
@@ -1,10 +1,13 @@
 {{> metabase/email/_header }}
 <div style="margin: 2em 4em; border: 1px solid #dddddd; border-radius: 2px; background-color: white; box-shadow: 0 1px 2px rgba(0, 0, 0, .08); text-align: center;">
   <h2 style="font-weight: normal; color: #4C545B;line-height: 1.65rem;">
-    We've Noticed a New Login, {{first-name}}
+    We've noticed a new login on your Metabase account.
   </h2>
   <p style="margin-top: 1em">
-    We noticed a login from a device you don't usually use.
+    Hi {{first-name}},
+  </p>
+  <p style="margin-top: 1em">
+    We noticed a login on your Metabase account from a new device.
   </p>
 
   <p style="margin-top: 1em;">

--- a/src/metabase/email/login_from_new_device.mustache
+++ b/src/metabase/email/login_from_new_device.mustache
@@ -1,0 +1,23 @@
+{{> metabase/email/_header }}
+<div style="margin: 2em 4em; border: 1px solid #dddddd; border-radius: 2px; background-color: white; box-shadow: 0 1px 2px rgba(0, 0, 0, .08); text-align: center;">
+  <h2 style="font-weight: normal; color: #4C545B;line-height: 1.65rem;">
+    We've Noticed a New Login, {{first-name}}
+  </h2>
+  <p style="margin-top: 1em">
+    We noticed a login from a device you don't usually use.
+  </p>
+
+  <p style="margin-top: 1em;">
+    {{device}} - {{location}}
+  </p>
+
+  <p style="margin-top: 1em;">
+    {{timestamp}}
+  </p>
+
+  <p style="margin-top: 1em;">
+    If this was you, you can safely disregard this email. If this wasn't you, you should change your password
+    immediately.
+  </p>
+</div>
+{{> metabase/email/_footer }}

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -186,7 +186,7 @@
 
 (defn send-login-from-new-device-email!
   "Format and send an email informing the user that this is the first time we've seen a login from this device. Expects
-  login history infomation as returned by `metabase.models.login-history/human-friendly-info`."
+  login history infomation as returned by `metabase.models.login-history/human-friendly-infos`."
   [{user-id :user_id, :keys [timestamp timezone], :as login-history}]
   (let [user-info    (db/select-one ['User [:first_name :first-name] :email :locale] :id user-id)
         timestamp    (cond-> timestamp

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -201,7 +201,7 @@
         message-body (stencil/render-file "metabase/email/login_from_new_device"
                        context)]
     (email/send-message!
-      :subject      (trs "We''ve Noticed a New Login, {0}" (:first-name user-info))
+      :subject      (trs "We''ve Noticed a New {0} Login, {1}" (app-name-trs) (:first-name user-info))
       :recipients   [(:email user-info)]
       :message-type :html
       :message      message-body)))

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -19,7 +19,8 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.streaming.interface :as qp.streaming.i]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [deferred-trs trs tru]]
+            [metabase.util.date-2 :as u.date]
+            [metabase.util.i18n :as i18n :refer [deferred-trs trs tru]]
             [metabase.util.quotation :as quotation]
             [metabase.util.urls :as url]
             [stencil.core :as stencil]
@@ -163,7 +164,6 @@
                               :joinedUserEditUrl (str (public-settings/site-url) "/admin/people")}
                              (random-quote-context))))))
 
-
 (defn send-password-reset-email!
   "Format and send an email informing the user how to reset their password."
   [email google-auth? hostname password-reset-url]
@@ -181,6 +181,26 @@
     (email/send-message!
       :subject      (trs "[{0}] Password Reset Request" (app-name-trs))
       :recipients   [email]
+      :message-type :html
+      :message      message-body)))
+
+(defn send-login-from-new-device-email!
+  [{user-id :user_id, :keys [timestamp timezone], :as login-history}]
+  (let [user-info    (db/select-one ['User [:first_name :first-name] :email :locale] :id user-id)
+        timestamp    (cond-> timestamp
+                       timezone (u.date/with-time-zone-same-instant timezone)
+                       true     (u.date/format-human-readable (or (:locale user-info)
+                                                                  (i18n/site-locale))))
+        context      (merge (common-context)
+                            {:first-name (:first-name user-info)
+                             :device     (:device_description login-history)
+                             :location   (:location login-history)
+                             :timestamp  timestamp})
+        message-body (stencil/render-file "metabase/email/login_from_new_device"
+                       context)]
+    (email/send-message!
+      :subject      (trs "We''ve Noticed a New Login, {0}" (:first-name user-info))
+      :recipients   [(:email user-info)]
       :message-type :html
       :message      message-body)))
 

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -185,10 +185,12 @@
       :message      message-body)))
 
 (defn send-login-from-new-device-email!
+  "Format and send an email informing the user that this is the first time we've seen a login from this device. Expects
+  login history infomation as returned by `metabase.models.login-history/human-friendly-info`."
   [{user-id :user_id, :keys [timestamp timezone], :as login-history}]
   (let [user-info    (db/select-one ['User [:first_name :first-name] :email :locale] :id user-id)
         timestamp    (cond-> timestamp
-                       timezone (u.date/with-time-zone-same-instant timezone)
+                       timezone (u.date/with-time-zone-same-instant (t/zone-id timezone))
                        true     (u.date/format-human-readable (or (:locale user-info)
                                                                   (i18n/site-locale))))
         context      (merge (common-context)

--- a/src/metabase/models/login_history.clj
+++ b/src/metabase/models/login_history.clj
@@ -3,7 +3,6 @@
             [metabase.email.messages :as email.messages]
             [metabase.models.setting :refer [defsetting]]
             [metabase.server.request.util :as request.u]
-            [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :as i18n :refer [trs tru]]
             [toucan.db :as db]
@@ -17,7 +16,10 @@
 
 (defn human-friendly-info
   "Return a human-friendly version of the info in a LoginHistory instance. Powers the login history API endpoint and
-  login on new device email."
+  login on new device email.
+
+  This can potentially take a few seconds to complete, if the request to geocode the API request hangs for one reason
+  or another -- keep that in mind when using this."
   [history-item]
   (let [{location-description :description, timezone :timezone} (request.u/geocode-ip-address (:ip_address history-item))]
     (-> history-item

--- a/src/metabase/models/login_history.clj
+++ b/src/metabase/models/login_history.clj
@@ -58,14 +58,13 @@
           (= 1)))
 
 (defn- post-insert [{user-id :user_id, device-id :device_id, :as login-history}]
-  (u/prog1 login-history
-    (when (and (send-email-on-first-login-from-new-device)
-               (first-login-on-this-device? login-history)
-               (not (first-login-ever? login-history)))
-      (try
-        (email.messages/send-login-from-new-device-email! (human-friendly-info login-history))
-        (catch Throwable e
-          (log/error e (trs "Error sending ''login from new device'' notification email"))))))
+  (when (and (send-email-on-first-login-from-new-device)
+             (first-login-on-this-device? login-history)
+             (not (first-login-ever? login-history)))
+    (try
+      (email.messages/send-login-from-new-device-email! (human-friendly-info login-history))
+      (catch Throwable e
+        (log/error e (trs "Error sending ''login from new device'' notification email")))))
   login-history)
 
 (defn- pre-update [login-history]

--- a/src/metabase/models/login_history.clj
+++ b/src/metabase/models/login_history.clj
@@ -1,10 +1,11 @@
 (ns metabase.models.login-history
-  (:require [metabase.email.messages :as email.messages]
+  (:require [clojure.tools.logging :as log]
+            [metabase.email.messages :as email.messages]
             [metabase.models.setting :refer [defsetting]]
             [metabase.server.request.util :as request.u]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as i18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [trs tru]]
             [toucan.db :as db]
             [toucan.models :as models]))
 
@@ -55,7 +56,10 @@
   (u/prog1 login-history
     (when (and (send-email-on-first-login-from-new-device)
                (first-login-for-user-on-this-device? login-history))
-      (email.messages/send-login-from-new-device-email! (human-friendly-info login-history))))
+      (try
+        (email.messages/send-login-from-new-device-email! (human-friendly-info login-history))
+        (catch Throwable e
+          (log/error e (trs "Error sending ''login from new device'' notification email"))))))
   login-history)
 
 (defn- pre-update [login-history]

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -11,7 +11,8 @@
             [metabase.util.i18n :as ui18n :refer [trs tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
-            [user-agent :as user-agent]))
+            [user-agent :as user-agent]
+            [metabase.config :as config]))
 
 (defn api-call?
   "Is this ring request an API call (does path start with `/api`)?"
@@ -135,7 +136,7 @@
   (when-not (str/blank? ip-address)
     (try
       (let [url  (format "https://get.geojs.io/v1/ip/geo/%s.json" ip-address)
-            info (-> (http/get url)
+            info (-> (http/get url {:headers {"User-Agent" config/mb-app-id-string}})
                      :body
                      (json/parse-string true))]
         {:description (or (describe-location info)

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -890,3 +890,9 @@
       (if (pred# x#)
         x#
         (or-with pred# ~@more)))))
+
+(defn ip-address?
+  "Whether string `s` is a valid IP (v4 or v6) address."
+  [^String s]
+  (and (string? s)
+       (.isValid (org.apache.commons.validator.routines.InetAddressValidator/getInstance) s)))

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -101,17 +101,17 @@
 (def ^:private ^{:arglists '(^java.time.format.DateTimeFormatter [klass])} class->human-readable-formatter
   {LocalDate      (DateTimeFormatter/ofLocalizedDate FormatStyle/LONG)
    LocalTime      (DateTimeFormatter/ofLocalizedTime FormatStyle/MEDIUM)
-   LocalDateTime  (.toFormatter
-                   (doto (DateTimeFormatterBuilder.)
-                     (.appendLocalized FormatStyle/LONG FormatStyle/MEDIUM)))
-   OffsetTime     (.toFormatter
-                   (doto (DateTimeFormatterBuilder.)
-                     (.append (DateTimeFormatter/ofLocalizedTime FormatStyle/MEDIUM))
-                     (.appendPattern " (OOOO)")))
-   OffsetDateTime (.toFormatter
-                   (doto (DateTimeFormatterBuilder.)
-                     (.appendLocalized FormatStyle/LONG FormatStyle/MEDIUM)
-                     (.appendPattern " (OOOO)")))
+   LocalDateTime  (let [builder (doto (DateTimeFormatterBuilder.)
+                                  (.appendLocalized FormatStyle/LONG FormatStyle/MEDIUM))]
+                    (.toFormatter builder))
+   OffsetTime     (let [builder (doto (DateTimeFormatterBuilder.)
+                                  (.append (DateTimeFormatter/ofLocalizedTime FormatStyle/MEDIUM))
+                                  (.appendPattern " (OOOO)"))]
+                    (.toFormatter builder))
+   OffsetDateTime (let [builder (doto (DateTimeFormatterBuilder.)
+                                  (.appendLocalized FormatStyle/LONG FormatStyle/MEDIUM)
+                                  (.appendPattern " (OOOO)"))]
+                    (.toFormatter builder))
    ZonedDateTime  (DateTimeFormatter/ofLocalizedDateTime FormatStyle/LONG)})
 
 (defn format-human-readable

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -43,7 +43,7 @@
             (is (schema= {(s/eq email)
                           [{:from    su/Email
                             :to      (s/eq [email])
-                            :subject (s/eq (format "We've Noticed a New Login, %s" first-name))
+                            :subject (s/eq (format "We've Noticed a New Metabase Login, %s" first-name))
                             :body    [(s/one {:type    (s/eq "text/html; charset=utf-8")
                                               :content s/Str}
                                              "HTML body")]}]}
@@ -52,8 +52,8 @@
               (testing (format "\nMessage = %s" (pr-str message))
                 (is (string? message))
                 (when (string? message)
-                  (is (str/includes? message (format "We've Noticed a New Login, %s" first-name)))
-                  (is (str/includes? message "We noticed a login from a device you don't usually use."))
+                  (is (str/includes? message "We've noticed a new login on your Metabase account."))
+                  (is (str/includes? message "We noticed a login on your Metabase account from a new device."))
                   (is (str/includes? message "Browser (Chrome/Windows) - Unknown location"))
                   (if (= (mdb/db-type) :h2)
                     (str/includes? message "April 2 3:52 PM (GMT-07:00)")

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [environ.core :as env]
+            [metabase.db :as mdb]
             [metabase.models :refer [LoginHistory User]]
             [metabase.models.login-history :as login-history]
             [metabase.models.setting.cache :as setting.cache]
@@ -54,7 +55,9 @@
                   (is (str/includes? message (format "We've Noticed a New Login, %s" first-name)))
                   (is (str/includes? message "We noticed a login from a device you don't usually use."))
                   (is (str/includes? message "Browser (Chrome/Windows) - Unknown location"))
-                  (is (str/includes? message "April 2 10:52 PM (GMT)")))))
+                  (if (= (mdb/db-type) :h2)
+                    (str/includes? message "April 2 3:52 PM (GMT-07:00)")
+                    (str/includes? message "April 2 10:52 PM (GMT)")))))
 
             (testing "don't send email on subsequent login from same device"
               (mt/reset-inbox!)

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -6,33 +6,41 @@
             [metabase.models.login-history :as login-history]
             [metabase.models.setting.cache :as setting.cache]
             [metabase.test :as mt]
+            [metabase.util.schema :as su]
             [schema.core :as s]))
 
-(deftest first-login-for-user-on-this-device?-test
+(deftest first-login-on-this-device?-test
   (let [device-1 (str (java.util.UUID/randomUUID))
         device-2 (str (java.util.UUID/randomUUID))]
     (mt/with-temp* [User         [{user-id :id}]
                     LoginHistory [history-1 {:user_id user-id, :device_id device-1}]]
       (testing "one login to device 1 -- should be the first login with this device"
         (is (= true
-               (#'login-history/first-login-for-user-on-this-device? history-1))))
+               (#'login-history/first-login-on-this-device? history-1)))
+        (is (= true
+               (#'login-history/first-login-ever? history-1))))
       (testing "add a history item for a *different* device -- should be the first login with this device"
         (mt/with-temp LoginHistory [history-2 {:user_id user-id, :device_id device-2}]
           (is (= true
-                 (#'login-history/first-login-for-user-on-this-device? history-1)))
+                 (#'login-history/first-login-on-this-device? history-1)))
+          (is (= false
+                 (#'login-history/first-login-ever? history-1)))
           (testing "add a second history item for device 1 -- should *not* be the first login with this device"
             (mt/with-temp LoginHistory [history-2 {:user_id user-id, :device_id device-1}]
               (is (= false
-                     (#'login-history/first-login-for-user-on-this-device? history-1))))))))))
+                     (#'login-history/first-login-on-this-device? history-1)))
+              (is (= false
+                 (#'login-history/first-login-ever? history-1))))))))))
 
 (deftest send-email-on-first-login-from-new-device-test
   (mt/with-temp User [{user-id :id, email :email, first-name :first_name}]
     (let [device (str (java.util.UUID/randomUUID))]
-      (testing "send email on first login from new device"
+      (testing "send email on first login from *new* device (but not first login ever)"
         (mt/with-fake-inbox
-          (mt/with-temp LoginHistory [_ {:user_id user-id, :device_id device, :timestamp #t "2021-04-02T15:52:00-07:00[US/Pacific]"}]
+          (mt/with-temp* [LoginHistory [_ {:user_id user-id, :device_id (str (java.util.UUID/randomUUID))}]
+                          LoginHistory [_ {:user_id user-id, :device_id device, :timestamp #t "2021-04-02T15:52:00-07:00[US/Pacific]"}]]
             (is (schema= {(s/eq email)
-                          [{:from    (s/eq "metamailman@metabase.com")
+                          [{:from    su/Email
                             :to      (s/eq [email])
                             :subject (s/eq (format "We've Noticed a New Login, %s" first-name))
                             :body    [(s/one {:type    (s/eq "text/html; charset=utf-8")
@@ -41,10 +49,12 @@
                          @mt/inbox))
             (let [message (-> @mt/inbox (get email) first :body first :content)]
               (testing (format "\nMessage = %s" (pr-str message))
-                (is (str/includes? message (format "We've Noticed a New Login, %s" first-name)))
-                (is (str/includes? message "We noticed a login from a device you don't usually use."))
-                (is (str/includes? message "Browser (Chrome/Windows) - Unknown location"))
-                (is (str/includes? message "April 2 10:52 PM (GMT)"))))
+                (is (string? message))
+                (when (string? message)
+                  (is (str/includes? message (format "We've Noticed a New Login, %s" first-name)))
+                  (is (str/includes? message "We noticed a login from a device you don't usually use."))
+                  (is (str/includes? message "Browser (Chrome/Windows) - Unknown location"))
+                  (is (str/includes? message "April 2 10:52 PM (GMT)")))))
 
             (testing "don't send email on subsequent login from same device"
               (mt/reset-inbox!)
@@ -61,7 +71,8 @@
             (with-redefs [env/env (assoc env/env :mb-send-email-on-first-login-from-new-device "FALSE")]
               ;; flush the Setting cache so it picks up the env var value for the `send-email-on-first-login-from-new-device` setting
               (setting.cache/restore-cache!)
-              (mt/with-temp LoginHistory [_ {:user_id user-id, :device_id (str (java.util.UUID/randomUUID))}]
+              (mt/with-temp* [LoginHistory [_ {:user_id user-id, :device_id (str (java.util.UUID/randomUUID))}]
+                              LoginHistory [_ {:user_id user-id, :device_id (str (java.util.UUID/randomUUID))}]]
                 (is (= {}
                        @mt/inbox)))))
           (finally

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -52,7 +52,7 @@
                 (is (= {}
                        @mt/inbox)))))))))
 
-  (testing "don't send email if the setting is disabled"
+  (testing "don't send email if the setting is disabled by setting MB_SEND_EMAIL_ON_FIRST_LOGIN_FROM_NEW_DEVICE=FALSE"
     (mt/with-temp User [{user-id :id, email :email, first-name :first_name}]
       (testing "send email on first login from new device"
         (try

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -1,0 +1,70 @@
+(ns metabase.models.login-history-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [environ.core :as env]
+            [metabase.models :refer [LoginHistory User]]
+            [metabase.models.login-history :as login-history]
+            [metabase.models.setting.cache :as setting.cache]
+            [metabase.test :as mt]
+            [schema.core :as s]))
+
+(deftest first-login-for-user-on-this-device?-test
+  (let [device-1 (str (java.util.UUID/randomUUID))
+        device-2 (str (java.util.UUID/randomUUID))]
+    (mt/with-temp* [User         [{user-id :id}]
+                    LoginHistory [history-1 {:user_id user-id, :device_id device-1}]]
+      (testing "one login to device 1 -- should be the first login with this device"
+        (is (= true
+               (#'login-history/first-login-for-user-on-this-device? history-1))))
+      (testing "add a history item for a *different* device -- should be the first login with this device"
+        (mt/with-temp LoginHistory [history-2 {:user_id user-id, :device_id device-2}]
+          (is (= true
+                 (#'login-history/first-login-for-user-on-this-device? history-1)))
+          (testing "add a second history item for device 1 -- should *not* be the first login with this device"
+            (mt/with-temp LoginHistory [history-2 {:user_id user-id, :device_id device-1}]
+              (is (= false
+                     (#'login-history/first-login-for-user-on-this-device? history-1))))))))))
+
+(deftest send-email-on-first-login-from-new-device-test
+  (mt/with-temp User [{user-id :id, email :email, first-name :first_name}]
+    (let [device (str (java.util.UUID/randomUUID))]
+      (testing "send email on first login from new device"
+        (mt/with-fake-inbox
+          (mt/with-temp LoginHistory [_ {:user_id user-id, :device_id device, :timestamp #t "2021-04-02T15:52:00-07:00[US/Pacific]"}]
+            (is (schema= {(s/eq email)
+                          [{:from    (s/eq "metamailman@metabase.com")
+                            :to      (s/eq [email])
+                            :subject (s/eq (format "We've Noticed a New Login, %s" first-name))
+                            :body    [(s/one {:type    (s/eq "text/html; charset=utf-8")
+                                              :content s/Str}
+                                             "HTML body")]}]}
+                         @mt/inbox))
+            (let [message (-> @mt/inbox (get email) first :body first :content)]
+              (testing (format "\nMessage = %s" (pr-str message))
+                (is (str/includes? message (format "We've Noticed a New Login, %s" first-name)))
+                (is (str/includes? message "We noticed a login from a device you don't usually use."))
+                (is (str/includes? message "Browser (Chrome/Windows) - Unknown location"))
+                (is (str/includes? message "April 2 10:52 PM (GMT)"))))
+
+            (testing "don't send email on subsequent login from same device"
+              (mt/reset-inbox!)
+              (mt/with-temp LoginHistory [_ {:user_id user-id, :device_id device}]
+                (is (= {}
+                       @mt/inbox)))))))))
+
+  (testing "don't send email if the setting is disabled"
+    (mt/with-temp User [{user-id :id, email :email, first-name :first_name}]
+      (testing "send email on first login from new device"
+        (try
+          (mt/with-fake-inbox
+            ;; can't use `mt/with-temporary-setting-values` here because it's a read-only setting
+            (with-redefs [env/env (assoc env/env :mb-send-email-on-first-login-from-new-device "FALSE")]
+              ;; flush the Setting cache so it picks up the env var value for the `send-email-on-first-login-from-new-device` setting
+              (setting.cache/restore-cache!)
+              (mt/with-temp LoginHistory [_ {:user_id user-id, :device_id (str (java.util.UUID/randomUUID))}]
+                (is (= {}
+                       @mt/inbox)))))
+          (finally
+            ;; flush the cache again so the original value of `send-email-on-first-login-from-new-device` gets
+            ;; restored
+            (setting.cache/restore-cache!)))))))

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -50,33 +50,34 @@
     nil
     nil))
 
-(deftest geocode-ip-address-test
-  (are [ip-address expected] (= expected (request.u/geocode-ip-address ip-address))
-    "8.8.8.8"
-    {:description "United States", :timezone (t/zone-id "America/Chicago")}
+(deftest geocode-ip-addresses-test
+  (are [ip-addresses expected] (= expected (request.u/geocode-ip-addresses ip-addresses))
+    ["8.8.8.8"]
+    {"8.8.8.8" {:description "United States", :timezone (t/zone-id "America/Chicago")}}
 
     ;; this is from the MaxMind sample high-risk IP address list https://www.maxmind.com/en/high-risk-ip-sample-list
-    "185.233.100.23"
-    {:description "Begles, Nouvelle-Aquitaine, France", :timezone (t/zone-id "Europe/Paris")}
+    ["185.233.100.23"]
+    {"185.233.100.23" {:description "Begles, Nouvelle-Aquitaine, France", :timezone (t/zone-id "Europe/Paris")}}
 
-    "127.0.0.1"
-    {:description "Unknown location", :timezone nil}
+    ["127.0.0.1"]
+    {"127.0.0.1" {:description "Unknown location", :timezone nil}}
 
-    "0:0:0:0:0:0:0:1"
-    {:description "Unknown location", :timezone nil}
+    ["0:0:0:0:0:0:0:1"]
+    {"0:0:0:0:0:0:0:1" {:description "Unknown location", :timezone nil}}
 
-    ;; store.metabase.com
-    "52.206.149.9"
-    {:description "Ashburn, Virginia, United States", :timezone (t/zone-id "America/New_York")}
+    ;; multiple addresses at once
+    ;; store.metabase.com, Google DNS
+    ["52.206.149.9" "2001:4860:4860::8844"]
+    {"52.206.149.9"         {:description "Ashburn, Virginia, United States", :timezone (t/zone-id "America/New_York")}
+     "2001:4860:4860::8844" {:description "United States", :timezone (t/zone-id "America/Chicago")}}
 
-    ;; Google DNS
-    "2001:4860:4860::8844"
-    {:description "United States", :timezone (t/zone-id "America/Chicago")}
-
-    "wow"
+    ["wow"]
     nil
 
-    "   "
+    ["   "]
+    nil
+
+    []
     nil
 
     nil

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -11,8 +11,8 @@
             [java-time :as t]
             [metabase.driver :as driver]
             [metabase.models :refer [Card Collection Dashboard DashboardCardSeries Database Dimension Field FieldValues
-                                     Metric NativeQuerySnippet Permissions PermissionsGroup Pulse PulseCard PulseChannel
-                                     Revision Segment Table TaskHistory User]]
+                                     LoginHistory Metric NativeQuerySnippet Permissions PermissionsGroup Pulse PulseCard
+                                     PulseChannel Revision Segment Table TaskHistory User]]
             [metabase.models.collection :as collection]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
@@ -147,6 +147,11 @@
             :name          (random-name)
             :position      1
             :table_id      (data/id :checkins)})
+
+   LoginHistory
+   (fn [_] {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
+            :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/89.0.4389.86 Safari/537.36"
+            :ip_address         "0:0:0:0:0:0:0:1"})
 
    Metric
    (fn [_] {:creator_id  (rasta-id)

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -157,39 +157,45 @@
 (deftest format-human-readable-test
   ;; strings are localized slightly differently on Java 8.
   (let [java-8? (str/starts-with? (System/getProperty "java.version") "1.8")]
-    (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]"
-                          {:en-US "April 2 2:42 PM (Pacific Daylight Time)"
+    (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]" ; ZonedDateTime
+                          {:en-US (if java-8?
+                                    "April 2, 2021 2:42:09 PM PDT"
+                                    "April 2, 2021 at 2:42:09 PM PDT")
                            :es-MX (if java-8?
-                                    "abril 2 2:42 PM (Hora de verano del Pacífico)"
-                                    "abril 2 2:42 p. m. (hora de verano del Pacífico)")}
+                                    "2 de abril de 2021 02:42:09 PM PDT"
+                                    "2 de abril de 2021 a las 14:42:09 PDT")}
 
-                          #t "2021-04-02T14:42:09.524392-07:00"
-                          {:en-US "April 2 2:42 PM (GMT-07:00)"
+                          #t "2021-04-02T14:42:09.524392-07:00" ; OffsetDateTime
+                          {:en-US (if java-8?
+                                    "April 2, 2021 2:42:09 PM (GMT-07:00)"
+                                    "April 2, 2021, 2:42:09 PM (GMT-07:00)")
                            :es-MX (if java-8?
-                                    "abril 2 2:42 PM (GMT-07:00)"
-                                    "abril 2 2:42 p. m. (GMT-07:00)")}
+                                    "2 de abril de 2021 02:42:09 PM (GMT-07:00)"
+                                    "2 de abril de 2021 14:42:09 (GMT-07:00)")}
 
-                          #t "2021-04-02T14:42:09.524392"
-                          {:en-US "April 2 2:42 PM"
+                          #t "2021-04-02T14:42:09.524392" ; LocalDateTime
+                          {:en-US (if java-8?
+                                    "April 2, 2021 2:42:09 PM"
+                                    "April 2, 2021, 2:42:09 PM")
                            :es-MX (if java-8?
-                                    "abril 2 2:42 PM"
-                                    "abril 2 2:42 p. m.")}
+                                    "2 de abril de 2021 02:42:09 PM"
+                                    "2 de abril de 2021 14:42:09")}
 
-                          #t "2021-04-02"
-                          {:en-US "April 2"
-                           :es-MX "abril 2"}
+                          #t "2021-04-02" ; LocalDate
+                          {:en-US "April 2, 2021"
+                           :es-MX "2 de abril de 2021"}
 
-                          #t "14:42:09.524392-07:00"
-                          {:en-US "2:42 PM (GMT-07:00)"
+                          #t "14:42:09.524392-07:00" ; OffsetTime
+                          {:en-US "2:42:09 PM (GMT-07:00)"
                            :es-MX (if java-8?
-                                    "2:42 PM (GMT-07:00)"
-                                    "2:42 p. m. (GMT-07:00)")}
+                                    "02:42:09 PM (GMT-07:00)"
+                                    "14:42:09 (GMT-07:00)")}
 
-                          #t "14:42:09.524392"
-                          {:en-US "2:42 PM"
+                          #t "14:42:09.524392" ; LocalTime
+                          {:en-US "2:42:09 PM"
                            :es-MX (if java-8?
-                                    "2:42 PM"
-                                    "2:42 p. m.")}}
+                                    "02:42:09 PM"
+                                    "14:42:09")}}
             [locale expected] expected]
       (mt/with-user-locale locale
         (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -155,26 +155,25 @@
         "Passing `nil` should return `nil`")))
 
 (deftest format-human-readable-test
-  ;; strings are localized slightly differently on Java 8. Note the weird Unicode space in `p. m.` below -- not a
-  ;; normal space.
+  ;; strings are localized slightly differently on Java 8.
   (let [java-8? (str/starts-with? (System/getProperty "java.version") "1.8")]
     (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]"
                           {:en-US "April 2 2:42 PM (Pacific Daylight Time)"
                            :es-MX (if java-8?
                                     "abril 2 2:42 PM (Hora de verano del Pacífico)"
-                                    "abril 2 2:42 p. m. (hora de verano del Pacífico)")}
+                                    "abril 2 2:42 p. m. (hora de verano del Pacífico)")}
 
                           #t "2021-04-02T14:42:09.524392-07:00"
                           {:en-US "April 2 2:42 PM (GMT-07:00)"
                            :es-MX (if java-8?
                                     "abril 2 2:42 PM (GMT-07:00)"
-                                    "abril 2 2:42 p. m. (GMT-07:00)")}
+                                    "abril 2 2:42 p. m. (GMT-07:00)")}
 
                           #t "2021-04-02T14:42:09.524392"
                           {:en-US "April 2 2:42 PM"
                            :es-MX (if java-8?
                                     "abril 2 2:42 PM"
-                                    "abril 2 2:42 p. m.")}
+                                    "abril 2 2:42 p. m.")}
 
                           #t "2021-04-02"
                           {:en-US "April 2"
@@ -184,18 +183,19 @@
                           {:en-US "2:42 PM (GMT-07:00)"
                            :es-MX (if java-8?
                                     "2:42 PM (GMT-07:00)"
-                                    "2:42 p. m. (GMT-07:00)")}
+                                    "2:42 p. m. (GMT-07:00)")}
 
                           #t "14:42:09.524392"
                           {:en-US "2:42 PM"
                            :es-MX (if java-8?
                                     "2:42 PM"
-                                    "2:42 p. m.")}}
+                                    "2:42 p. m.")}}
             [locale expected] expected]
       (mt/with-user-locale locale
         (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
           (is (= expected
-                 (u.date/format-human-readable t))))))))
+                 ;; for some reason this includes weird unicode spaces on Java 14 on my computer -- remove them
+                 (str/replace (u.date/format-human-readable t) #" " " "))))))))
 
 (deftest format-sql-test
   (testing "LocalDateTime"

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -194,7 +194,6 @@
             [locale expected] expected]
       (mt/with-user-locale locale
         (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
-          (testing (str "(class (u.date/format-human-readable t)): " (class (u.date/format-human-readable t))) ; NOCOMMIT
             (is (= expected
                    (u.date/format-human-readable t)))))))))
 

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -194,8 +194,8 @@
             [locale expected] expected]
       (mt/with-user-locale locale
         (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
-            (is (= expected
-                   (u.date/format-human-readable t)))))))))
+          (is (= expected
+                 (u.date/format-human-readable t))))))))
 
 (deftest format-sql-test
   (testing "LocalDateTime"

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -154,6 +154,36 @@
            (u.date/format nil))
         "Passing `nil` should return `nil`")))
 
+(deftest format-human-readable-test
+  (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]"
+                        {:en "April 2 2:42 PM (Pacific Daylight Time)"
+                         :es "abril 2 2:42 PM (Hora de verano del Pacífico)"}
+
+                        #t "2021-04-02T14:42:09.524392-07:00"
+                        {:en "April 2 2:42 PM (GMT-07:00)"
+                         :es "abril 2 2:42 PM (GMT-07:00)"}
+
+                        #t "2021-04-02T14:42:09.524392"
+                        {:en "April 2 at 2:42 PM"
+                         :es "abril 2 2:42 PM"}
+
+                        #t "2021-04-02"
+                        {:en "April 2"
+                         :es "abril 2"}
+
+                        #t "14:42:09.524392-07:00"
+                        {:en "2:42 PM (GMT-07:00)"
+                         :es "2:42 PM (GMT-07:00)"}
+
+                        #t "14:42:09.524392"
+                        {:en "2:42 PM"
+                         :es "2:42 PM"}}
+          [locale expected] expected]
+    (mt/with-user-locale locale
+      (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
+        (is (= expected
+               (u.date/format-human-readable t)))))))
+
 (deftest format-sql-test
   (testing "LocalDateTime"
     (is (= "2019-11-05 19:27:00"

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -155,34 +155,48 @@
         "Passing `nil` should return `nil`")))
 
 (deftest format-human-readable-test
-  (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]"
-                        {:en "April 2 2:42 PM (Pacific Daylight Time)"
-                         :es "abril 2 2:42 PM (Hora de verano del Pacífico)"}
+  ;; strings are localized slightly differently on Java 8. Note the weird Unicode space in `p. m.` below -- not a
+  ;; normal space.
+  (let [java-8? (str/starts-with? (System/getProperty "java.version") "1.8")]
+    (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]"
+                          {:en-US "April 2 2:42 PM (Pacific Daylight Time)"
+                           :es-MX (if java-8?
+                                    "abril 2 2:42 PM (Hora de verano del Pacífico)"
+                                    "abril 2 2:42 p. m. (hora de verano del Pacífico)")}
 
-                        #t "2021-04-02T14:42:09.524392-07:00"
-                        {:en "April 2 2:42 PM (GMT-07:00)"
-                         :es "abril 2 2:42 PM (GMT-07:00)"}
+                          #t "2021-04-02T14:42:09.524392-07:00"
+                          {:en-US "April 2 2:42 PM (GMT-07:00)"
+                           :es-MX (if java-8?
+                                    "abril 2 2:42 PM (GMT-07:00)"
+                                    "abril 2 2:42 p. m. (GMT-07:00)")}
 
-                        #t "2021-04-02T14:42:09.524392"
-                        {:en "April 2 at 2:42 PM"
-                         :es "abril 2 2:42 PM"}
+                          #t "2021-04-02T14:42:09.524392"
+                          {:en-US "April 2 2:42 PM"
+                           :es-MX (if java-8?
+                                    "abril 2 2:42 PM"
+                                    "abril 2 2:42 p. m.")}
 
-                        #t "2021-04-02"
-                        {:en "April 2"
-                         :es "abril 2"}
+                          #t "2021-04-02"
+                          {:en-US "April 2"
+                           :es-MX "abril 2"}
 
-                        #t "14:42:09.524392-07:00"
-                        {:en "2:42 PM (GMT-07:00)"
-                         :es "2:42 PM (GMT-07:00)"}
+                          #t "14:42:09.524392-07:00"
+                          {:en-US "2:42 PM (GMT-07:00)"
+                           :es-MX (if java-8?
+                                    "2:42 PM (GMT-07:00)"
+                                    "2:42 p. m. (GMT-07:00)")}
 
-                        #t "14:42:09.524392"
-                        {:en "2:42 PM"
-                         :es "2:42 PM"}}
-          [locale expected] expected]
-    (mt/with-user-locale locale
-      (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
-        (is (= expected
-               (u.date/format-human-readable t)))))))
+                          #t "14:42:09.524392"
+                          {:en-US "2:42 PM"
+                           :es-MX (if java-8?
+                                    "2:42 PM"
+                                    "2:42 p. m.")}}
+            [locale expected] expected]
+      (mt/with-user-locale locale
+        (testing (format "%s %s" (.getCanonicalName (class t)) (pr-str t))
+          (testing (str "(class (u.date/format-human-readable t)): " (class (u.date/format-human-readable t))) ; NOCOMMIT
+            (is (= expected
+                   (u.date/format-human-readable t)))))))))
 
 (deftest format-sql-test
   (testing "LocalDateTime"

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -259,8 +259,8 @@
     (is (nil? (u/or-with even? 1 3 5)))))
 
 (deftest ip-address?-test
-  (mt/are+ [x expected] (is (= expected
-                               (u/ip-address? x)))
+  (mt/are+ [x expected] (= expected
+                           (u/ip-address? x))
     "8.8.8.8"              true
     "185.233.100.23"       true
     "500.1.1.1"            false

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -258,6 +258,18 @@
   (testing "failure"
     (is (nil? (u/or-with even? 1 3 5)))))
 
-;; Local Variables:
-;; eval: (add-to-list (make-local-variable 'clojure-align-cond-forms) "mt/are+")
-;; End:
+(deftest ip-address?-test
+  (mt/are+ [x expected] (is (= expected
+                               (u/ip-address? x)))
+    "8.8.8.8"              true
+    "185.233.100.23"       true
+    "500.1.1.1"            false
+    "192.168.1.a"          false
+    "0:0:0:0:0:0:0:1"      true
+    "52.206.149.9"         true
+    "2001:4860:4860::8844" true
+    "wow"                  false
+    "   "                  false
+    ""                     false
+    nil                    false
+    100                    false))


### PR DESCRIPTION
Implements #14313

The email isn't the world's prettiest but we can do styling as a follow-on... I want to cheat a little and squeeze this in to 39.

![image](https://user-images.githubusercontent.com/1455846/113461672-539ac800-93d2-11eb-9e12-b4dfddeb86ae.png)

Per @andreychirikba's request you can disable this functionality by setting the env var `MB_SEND_EMAIL_ON_FIRST_LOGIN_FROM_NEW_DEVICE=FALSE` (not configurable via the admin panel because that would allow someone who compromised an admin's credentials to cover their tracks when they used them)