### PR TITLE
Log error on failure of any /api/session endpoints

### DIFF
--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -349,5 +349,12 @@
       (throttle/with-throttling [(login-throttlers :ip-address) (request.u/ip-address request)]
         (do-google-auth request)))))
 
+(defn- +log-all-request-failures [handler]
+  (fn [request respond raise]
+    (try
+      (handler request respond raise)
+      (catch Throwable e
+        (log/error e (trs "Authentication endpoint error"))
+        (throw e)))))
 
-(api/define-routes)
+(api/define-routes +log-all-request-failures)


### PR DESCRIPTION
Implements #14317

EE SSO endpoints (SAML/JWT) already have logging in place