### PR TITLE
fix bugs causing native queries with only default values to fail to run

### DIFF
--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -13,6 +13,8 @@ import {
   dimensionFilterForParameter,
   variableFilterForParameter,
   PARAMETER_OPTIONS,
+  PARAMETER_OPERATOR_TYPES,
+  getOperatorDisplayName,
 } from "metabase/meta/Parameter";
 
 import { t } from "ttag";
@@ -32,45 +34,62 @@ export const PARAMETER_SECTIONS: ParameterSection[] = [
     id: "date",
     name: t`Time`,
     description: t`Date range, relative date, time of day, etc.`,
-    options: [],
+    options: PARAMETER_OPERATOR_TYPES["date"].map(option => {
+      return {
+        ...option,
+        sectionId: "date",
+        combinedName: getOperatorDisplayName(option, "date", t`Date`),
+      };
+    }),
   },
   {
     id: "location",
     name: t`Location`,
     description: t`City, State, Country, ZIP code.`,
-    options: [],
+    options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
+      return {
+        ...option,
+        sectionId: "location",
+        combinedName: getOperatorDisplayName(option, "string", t`Location`),
+      };
+    }),
   },
   {
     id: "id",
     name: t`ID`,
     description: t`User ID, product ID, event ID, etc.`,
-    options: [],
+    options: [
+      {
+        ..._.findWhere(PARAMETER_OPTIONS, { type: "id" }),
+        sectionId: "id",
+      },
+    ],
   },
   {
     id: "number",
     name: t`Number`,
     description: t`Subtotal, Age, Price, Quantity, etc.`,
-    options: [],
+    options: PARAMETER_OPERATOR_TYPES["number"].map(option => {
+      return {
+        ...option,
+        sectionId: "number",
+        combinedName: getOperatorDisplayName(option, "number", t`Number`),
+      };
+    }),
   },
   {
     id: "category",
     name: t`Other Categories`,
     description: t`Category, Type, Model, Rating, etc.`,
-    options: [],
+    options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
+      return {
+        ...option,
+        sectionId: "category",
+        combinedName: getOperatorDisplayName(option, "string", t`Category`),
+      };
+    }),
   },
 ];
-
-for (const option of PARAMETER_OPTIONS) {
-  const sectionId = option.type.split("/")[0];
-  let section = _.findWhere(PARAMETER_SECTIONS, { id: sectionId });
-  if (!section) {
-    section = _.findWhere(PARAMETER_SECTIONS, { id: "category" });
-  }
-  if (section) {
-    section.options = section.options || [];
-    section.options.push(option);
-  }
-}
 
 export function getParameterMappingOptions(
   metadata: Metadata,
@@ -149,11 +168,13 @@ export function createParameter(
   while (_.any(parameters, p => p.name === name)) {
     name = option.name + " " + ++nameIndex;
   }
+
   const parameter = {
     name: "",
     slug: "",
     id: Math.floor(Math.random() * Math.pow(2, 32)).toString(16),
     type: option.type,
+    sectionId: option.sectionId,
   };
   return setParameterName(parameter, name);
 }

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -13,7 +13,6 @@ import type {
   ParameterValue,
   ParameterValueOrArray,
   ParameterValues,
-  ParameterType,
 } from "metabase-types/types/Parameter";
 import type { FieldId } from "metabase-types/types/Field";
 import type Metadata from "metabase-lib/lib/metadata/Metadata";

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -193,9 +193,9 @@ export function getOperatorDisplayName(option, operatorType, sectionName) {
 // OR it is a PARAMETER_OPTION entry. In those situations,
 // a `type` will exist like "category" or "location/city" or "string/="
 // we split on the `/` and take the first entry to get the field type
-function getParameterType(parameterOrParameterOption) {
-  const { sectionId, type } = parameterOrParameterOption;
-  return sectionId || splitType(type)[0];
+function getParameterType(parameter) {
+  const { sectionId } = parameter;
+  return sectionId || splitType(parameter)[0];
 }
 
 function getParameterSubType(parameter) {
@@ -493,8 +493,8 @@ export function parameterToMBQLFilter(
   }
 }
 
-export function getParameterIconName(parameterType: ?ParameterType) {
-  const [type] = splitType(parameterType);
+export function getParameterIconName(parameter: ?Parameter) {
+  const type = getParameterType(parameter);
   switch (type) {
     case "date":
       return "calendar";

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -42,120 +42,126 @@ type VariableFilter = (variable: Variable) => boolean;
 export const PARAMETER_OPERATOR_TYPES = {
   number: [
     {
+      type: "number/=",
       operator: "=",
       name: t`Equal to`,
     },
     {
+      type: "number/!=",
       operator: "!=",
       name: t`Not equal to`,
     },
     {
+      type: "number/between",
       operator: "between",
       name: t`Between`,
     },
     {
+      type: "number/>=",
       operator: ">=",
       name: t`Greater than or equal to`,
     },
     {
+      type: "number/<=",
       operator: "<=",
       name: t`Less than or equal to`,
     },
-    // {
-    //   operator: "all-options",
-    //   name: t`All options`,
-    //   description: t`Contains all of the above`,
-    // },
   ],
   string: [
     {
+      type: "string/=",
       operator: "=",
       name: t`Dropdown`,
       description: t`Select one or more values from a list or search box.`,
     },
     {
+      type: "string/!=",
       operator: "!=",
       name: t`Is not`,
       description: t`Exclude one or more specific values.`,
     },
     {
+      type: "string/contains",
       operator: "contains",
       name: t`Contains`,
       description: t`Match values that contain the entered text.`,
     },
     {
+      type: "string/does-not-contain",
       operator: "does-not-contain",
       name: t`Does not contain`,
       description: t`Filter out values that contain the entered text.`,
     },
     {
+      type: "string/starts-with",
       operator: "starts-with",
       name: t`Starts with`,
       description: t`Match values that begin with the entered text.`,
     },
     {
+      type: "string/ends-with",
       operator: "ends-with",
       name: t`Ends with`,
       description: t`Match values that end with the entered text.`,
     },
-    // {
-    //   operator: "all-options",
-    //   name: t`All options`,
-    //   description: t`Users can pick from any of the above`,
-    // },
+  ],
+  date: [
+    {
+      type: "date/month-year",
+      operator: "month-year",
+      name: t`Month and Year`,
+      description: t`Like January, 2016`,
+    },
+    {
+      type: "date/quarter-year",
+      operator: "quarter-year",
+      name: t`Quarter and Year`,
+      description: t`Like Q1, 2016`,
+    },
+    {
+      type: "date/single",
+      operator: "single",
+      name: t`Single Date`,
+      description: t`Like January 31, 2016`,
+    },
+    {
+      type: "date/range",
+      operator: "range",
+      name: t`Date Range`,
+      description: t`Like December 25, 2015 - February 14, 2016`,
+    },
+    {
+      type: "date/relative",
+      operator: "relative",
+      name: t`Relative Date`,
+      description: t`Like "the last 7 days" or "this month"`,
+    },
+    {
+      type: "date/all-options",
+      operator: "all-options",
+      name: t`Date Filter`,
+      menuName: t`All Options`,
+      description: t`Contains all of the above`,
+    },
   ],
 };
 
 const OPTIONS_WITH_OPERATOR_SUBTYPES = [
   {
-    section: "location",
-    operatorType: "string",
-    sectionName: t`Location`,
+    type: "date",
+    typeName: t`Date`,
   },
   {
-    section: "category",
-    operatorType: "string",
-    sectionName: t`Category`,
+    type: "string",
+    typeName: t`String`,
   },
   {
-    section: "number",
-    operatorType: "number",
-    sectionName: t`Number`,
+    type: "number",
+    typeName: t`Number`,
   },
 ];
 
 export const PARAMETER_OPTIONS: ParameterOption[] = [
-  {
-    type: "date/month-year",
-    name: t`Month and Year`,
-    description: t`Like January, 2016`,
-  },
-  {
-    type: "date/quarter-year",
-    name: t`Quarter and Year`,
-    description: t`Like Q1, 2016`,
-  },
-  {
-    type: "date/single",
-    name: t`Single Date`,
-    description: t`Like January 31, 2016`,
-  },
-  {
-    type: "date/range",
-    name: t`Date Range`,
-    description: t`Like December 25, 2015 - February 14, 2016`,
-  },
-  {
-    type: "date/relative",
-    name: t`Relative Date`,
-    description: t`Like "the last 7 days" or "this month"`,
-  },
-  {
-    type: "date/all-options",
-    name: t`Date Filter`,
-    menuName: t`All Options`,
-    description: t`Contains all of the above`,
-  },
   {
     type: "id",
     name: t`ID`,
@@ -165,27 +171,40 @@ export const PARAMETER_OPTIONS: ParameterOption[] = [
   ),
 ].flat();
 
-function buildOperatorSubtypeOptions({ section, operatorType, sectionName }) {
-  return PARAMETER_OPERATOR_TYPES[operatorType].map(option => ({
+function buildOperatorSubtypeOptions({ type, typeName }) {
+  return PARAMETER_OPERATOR_TYPES[type].map(option => ({
     ...option,
-    combinedName:
-      operatorType === "string" && option.operator === "="
-        ? `${sectionName}`
-        : sectionName === "Number"
-        ? `${option.name}`
-        : `${sectionName} ${option.name.toLowerCase()}`,
-    type: `${section}/${option.operator}`,
+    combinedName: getOperatorDisplayName(option, type, typeName),
   }));
 }
 
-function fieldFilterForParameter(parameter: Parameter) {
-  return fieldFilterForParameterType(parameter.type);
+export function getOperatorDisplayName(option, operatorType, sectionName) {
+  if (operatorType === "date" || operatorType === "number") {
+    return option.name;
+  } else if (operatorType === "string" && option.operator === "=") {
+    return sectionName;
+  } else {
+    return `${sectionName} ${option.name.toLowerCase()}`;
+  }
 }
 
-function fieldFilterForParameterType(
-  parameterType: ParameterType,
-): FieldPredicate {
-  const [type] = splitType(parameterType);
+// sectionId will match a type of field (category, location, number, date, id, etc.)
+// if sectionId is undefined, it is an old parameter that did have it set
+// OR it is a PARAMETER_OPTION entry. In those situations,
+// a `type` will exist like "category" or "location/city" or "string/="
+// we split on the `/` and take the first entry to get the field type
+function getParameterType(parameterOrParameterOption) {
+  const { sectionId, type } = parameterOrParameterOption;
+  return sectionId || splitType(type)[0];
+}
+
+function getParameterSubType(parameter) {
+  const [, subtype] = splitType(parameter);
+  return subtype;
+}
+
+function fieldFilterForParameter(parameter: Parameter): FieldPredicate {
+  const type = getParameterType(parameter);
   switch (type) {
     case "date":
       return (field: Field) => field.isDate();
@@ -201,6 +220,8 @@ function fieldFilterForParameterType(
         field.isCountry();
     case "number":
       return (field: Field) => field.isNumber() && !field.isCoordinate();
+    case "string":
+      return (field: Field) => field.isString();
   }
 
   return (field: Field) => false;
@@ -208,7 +229,7 @@ function fieldFilterForParameterType(
 
 export function parameterOptionsForField(field: Field): ParameterOption[] {
   return PARAMETER_OPTIONS.filter(option =>
-    fieldFilterForParameterType(option.type)(field),
+    fieldFilterForParameter(option)(field),
   ).map(option => {
     return {
       ...option,
@@ -238,7 +259,8 @@ export function variableFilterForParameter(
 }
 
 function tagFilterForParameter(parameter: Parameter): TemplateTagFilter {
-  const [type, subtype] = splitType(parameter);
+  const type = getParameterType(parameter);
+  const subtype = getParameterSubType(parameter);
   const operator = getParameterOperatorName(subtype);
   if (operator !== "=") {
     return (tag: TemplateTag) => false;
@@ -255,6 +277,8 @@ function tagFilterForParameter(parameter: Parameter): TemplateTagFilter {
       return (tag: TemplateTag) => tag.type === "number" || tag.type === "text";
     case "number":
       return (tag: TemplateTag) => tag.type === "number";
+    case "string":
+      return (tag: TemplateTag) => tag.type === "text";
   }
   return (tag: TemplateTag) => false;
 }
@@ -270,7 +294,7 @@ export function getTemplateTagParameters(tags: TemplateTag[]): Parameter[] {
       id: tag.id,
       type:
         tag["widget-type"] ||
-        (tag.type === "date" ? "date/single" : "category"),
+        (tag.type === "date" ? "date/single" : "string/="),
       target:
         tag.type === "dimension"
           ? ["dimension", ["template-tag", tag.name]]
@@ -418,7 +442,7 @@ export function stringParameterValueToMBQL(
   fieldRef: LocalFieldReference | ForeignFieldReference,
 ): ?FieldFilter {
   const parameterValue: ParameterValueOrArray = parameter.value;
-  const [, subtype] = splitType(parameter);
+  const subtype = getParameterSubType(parameter);
   const operatorName = getParameterOperatorName(subtype);
 
   return [operatorName, fieldRef].concat(parameterValue);
@@ -429,7 +453,7 @@ export function numberParameterValueToMBQL(
   fieldRef: LocalFieldReference | ForeignFieldReference,
 ): ?FieldFilter {
   const parameterValue: ParameterValue = parameter.value;
-  const [, subtype] = splitType(parameter);
+  const subtype = getParameterSubType(parameter);
   const operatorName = getParameterOperatorName(subtype);
 
   return [operatorName, fieldRef].concat(
@@ -496,7 +520,7 @@ export function mapUIParameterToQueryParameter(type, value, target) {
       value: [].concat(value),
       target,
     };
-  } else if (fieldType === "number") {
+  } else if (fieldType === "number" || fieldType === "string") {
     return {
       type,
       value: [].concat(value),
@@ -512,9 +536,10 @@ function getParameterOperatorName(maybeOperatorName) {
 }
 
 export function deriveFieldOperatorFromParameter(parameter) {
-  const [parameterType, maybeOperatorName] = splitType(parameter);
-  const operatorType = getParameterOperatorType(parameterType);
-  const operatorName = getParameterOperatorName(maybeOperatorName);
+  const type = getParameterType(parameter);
+  const subtype = getParameterSubType(parameter);
+  const operatorType = getParameterOperatorType(type);
+  const operatorName = getParameterOperatorName(subtype);
 
   return getOperatorByTypeAndName(operatorType, operatorName);
 }
@@ -525,6 +550,7 @@ function getParameterOperatorType(parameterType) {
       return NUMBER;
     case "location":
     case "category":
+    case "string":
       return STRING;
     case "id":
       // id can technically be a FK but doesn't matter as both use default filter operators

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -306,7 +306,7 @@ function getWidgetDefinition(metadata, parameter) {
 function ParameterTypeIcon({ parameter }) {
   return (
     <Icon
-      name={getParameterIconName(parameter.type)}
+      name={getParameterIconName(parameter)}
       className="flex-align-left mr1 flex-no-shrink"
       size={14}
     />

--- a/frontend/test/metabase/meta/Parameter.unit.spec.js
+++ b/frontend/test/metabase/meta/Parameter.unit.spec.js
@@ -168,8 +168,9 @@ describe("metabase/meta/Parameter", () => {
       isZipCode: () => false,
       isCountry: () => false,
       isNumber: () => false,
+      isString: () => false,
     };
-    it("should relevantly typed options for date field", () => {
+    it("should return relevantly typed options for date field", () => {
       const dateField = {
         ...field,
         isDate: () => true,
@@ -181,15 +182,15 @@ describe("metabase/meta/Parameter", () => {
       ).toBe(true);
     });
 
-    it("should relevantly typed options for location field", () => {
-      const countryField = {
+    it("should return relevantly typed options for location field", () => {
+      const stringField = {
         ...field,
-        isCountry: () => true,
+        isString: () => true,
       };
-      const availableOptions = parameterOptionsForField(countryField);
+      const availableOptions = parameterOptionsForField(stringField);
       expect(
         availableOptions.length > 0 &&
-          availableOptions.every(option => option.type.startsWith("location")),
+          availableOptions.every(option => option.type.startsWith("string")),
       ).toBe(true);
     });
   });

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -569,7 +569,7 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it.skip("should run with the default field filter set (metabase#15444)", () => {
+  it("should run with the default field filter set (metabase#15444)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     cy.visit("/");

--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -212,10 +212,11 @@
   [template-tags]
   (into {} (for [[tag-name tag-def] template-tags]
              [(mbql.u/qualified-name tag-name)
-              (let [tag-def (normalize-tokens tag-def :ignore-path)]
-                (cond-> tag-def
-                  (:type tag-def)        (update :type maybe-normalize-token)
-                  (:widget-type tag-def) (update :widget-type maybe-normalize-token)))])))
+              (let [tag-def' (normalize-tokens (dissoc tag-def :default) :ignore-path)]
+                (cond-> tag-def'
+                  (:default tag-def)      (assoc :default (:default tag-def)) ;; don't normalize default values
+                  (:type tag-def')        (update :type maybe-normalize-token)
+                  (:widget-type tag-def') (update :widget-type maybe-normalize-token)))])))
 
 (defn- normalize-query-parameter [{:keys [type target], :as param}]
   (cond-> param

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -1009,7 +1009,31 @@
               {:type       :query
                :query      {:source-table 1}
                :parameters [{:type "id", :target ["dimension" ["fk->" 3265 4575]], :value ["field-id"]}
-                            {:type "date/all-options", :target ["dimension" ["field-id" 3270]], :value "thismonth"}]})))))
+                            {:type "date/all-options", :target ["dimension" ["field-id" 3270]], :value "thismonth"}]}))))
+  (t/testing "Make sure default values do not get normalized"
+    (t/is (= {:database 1
+              ;;                       tag name not normalized
+              :native {:template-tags {"name" {:id "1f56330b-3dcb-75a3-8f3d-5c2c2792b749"
+                                               :name "name"
+                                               :display-name "Name"
+                                               :type :dimension
+                                               :dimension [:field 14 nil]  ;; field normalized
+                                               :widget-type :string/=      ;; widget-type normalize
+                                               :default ["Hudson Borer"]}} ;; default values not keyworded
+                       :query "select * from PEOPLE where {{name}}"}
+              :type :native}
+             (normalize/normalize
+              {:database 1
+               :native {:template-tags {"name" {:id "1f56330b-3dcb-75a3-8f3d-5c2c2792b749"
+                                               :name "name"
+                                               :display-name "Name"
+                                               :type "dimension"
+                                               :dimension ["field" 14 nil]
+                                               :widget-type "string/="
+                                               :default ["Hudson Borer"]}}
+                        :query "select * from PEOPLE where {{name}}"}
+               :type "native"
+               :parameters []})))))
 
 (t/deftest e2e-source-metadata-test
   (t/testing "make sure `:source-metadata` gets normalized the way we'd expect:"

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -134,7 +134,7 @@
         :when                         (and tag-type
                                            (or widget-type (not= tag-type :dimension)))]
     {:id      (:id tag)
-     :type    (or widget-type (if (= tag-type :date) :date/single :category))
+     :type    (or widget-type (if (= tag-type :date) :date/single :string/=))
      :target  (if (= tag-type :dimension)
                 [:dimension [:template-tag (:name tag)]]
                 [:variable  [:template-tag (:name tag)]])


### PR DESCRIPTION
fixes #15444 

concerning the FE, rewrote some of the logic in `metabase/meta/Parameter.js` and `metabase/meta/Dashboard.js` to make the location/category logic specific to dashboard parameters so that we can avoid dealing with it in native questions. In native questions, we'll simply show what location/category options really are -- string operations.

<img width="1434" alt="Screen Shot 2021-04-05 at 4 27 42 PM" src="https://user-images.githubusercontent.com/13057258/113638768-7a543b00-962c-11eb-9617-012c0e41b901.png">

<img width="343" alt="Screen Shot 2021-04-05 at 4 27 56 PM" src="https://user-images.githubusercontent.com/13057258/113638774-7d4f2b80-962c-11eb-9c63-93f39f2ec387.png">
