### PR TITLE
hide field search when using non-exact operator

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -175,7 +175,10 @@ export class FieldValuesWidget extends Component {
   }
 
   shouldList() {
-    return this.props.fields.every(field => field.has_field_values === "list");
+    return (
+      !this.props.disableSearch &&
+      this.props.fields.every(field => field.has_field_values === "list")
+    );
   }
 
   hasList() {

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -84,6 +84,7 @@ type Props = {
   minWidth?: number,
   optionsMaxHeight?: Number,
   alwaysShowOptions?: boolean,
+  disableSearch?: boolean,
 
   dashboard?: DashboardWithCards,
   parameter?: Parameter,
@@ -121,6 +122,7 @@ export class FieldValuesWidget extends Component {
     style: {},
     formatOptions: {},
     maxWidth: 500,
+    disableSearch: false,
   };
 
   // if [dashboard] parameter ID is specified use the fancy new Chain Filter API endpoints to fetch parameter values.
@@ -188,8 +190,9 @@ export class FieldValuesWidget extends Component {
   }
 
   isSearchable() {
-    const { fields } = this.props;
+    const { fields, disableSearch } = this.props;
     return (
+      !disableSearch &&
       // search is available if:
       // all fields have a valid search field
       fields.every(this.searchField) &&

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -751,3 +751,8 @@ export function getFilterArgumentFormatOptions(filterOperator, index) {
 export function isEqualsOperator(operator) {
   return !!operator && operator.name === "=";
 }
+
+export function isFuzzyOperator(operator) {
+  const { name } = operator || {};
+  return !["=", "!="].includes(name);
+}

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -147,7 +147,7 @@ export function createParameter(
   let nameIndex = 0;
   // get a unique name
   while (_.any(parameters, p => p.name === name)) {
-    name = option.name + " " + ++nameIndex;
+    name = (option.combinedName || option.name) + " " + ++nameIndex;
   }
   const parameter = {
     name: "",

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
@@ -18,6 +18,7 @@ import cx from "classnames";
 import {
   getFilterArgumentFormatOptions,
   isEqualsOperator,
+  isFuzzyOperator,
 } from "metabase/lib/schema_metadata";
 
 type Props = {
@@ -115,7 +116,7 @@ export default class ParameterFieldWidget extends Component<*, Props, State> {
     const savedValue = normalizeValue(this.props.value);
     const unsavedValue = normalizeValue(this.state.value);
     const isEqualsOp = isEqualsOperator(operator);
-
+    const disableSearch = isFuzzyOperator(operator);
     const defaultPlaceholder = isFocused
       ? ""
       : this.props.placeholder || t`Enter a value...`;
@@ -184,7 +185,7 @@ export default class ParameterFieldWidget extends Component<*, Props, State> {
                   fields={fields}
                   autoFocus={index === 0}
                   multi={multi}
-                  alwaysShowOptions={numFields === 1}
+                  disableSearch={disableSearch}
                   formatOptions={
                     operator && getFilterArgumentFormatOptions(operator, index)
                   }

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -7,7 +7,10 @@ import TextPicker from "./TextPicker";
 
 import FieldValuesWidget from "metabase/components/FieldValuesWidget";
 
-import { getFilterArgumentFormatOptions } from "metabase/lib/schema_metadata";
+import {
+  getFilterArgumentFormatOptions,
+  isFuzzyOperator,
+} from "metabase/lib/schema_metadata";
 
 import type Filter from "metabase-lib/lib/queries/structured/Filter";
 
@@ -40,6 +43,7 @@ export default function DefaultPicker({
   const dimension = filter.dimension();
   const field = dimension && dimension.field();
   const operatorFields = operator.fields || [];
+  const disableSearch = isFuzzyOperator(operator);
   const fieldWidgets = operatorFields
     .map((operatorField, index) => {
       let values, onValuesChange;
@@ -85,6 +89,7 @@ export default function DefaultPicker({
             autoFocus={index === 0}
             alwaysShowOptions={operator.fields.length === 1}
             formatOptions={getFilterArgumentFormatOptions(operator, index)}
+            disableSearch={disableSearch}
             minWidth={minWidth}
             maxWidth={maxWidth}
             optionsMaxHeight={isSidebar ? null : undefined}

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -12,6 +12,7 @@ import {
   isEqualsOperator,
   doesOperatorExist,
   getOperatorByTypeAndName,
+  isFuzzyOperator,
 } from "metabase/lib/schema_metadata";
 
 import { TYPE } from "metabase/lib/types";
@@ -131,6 +132,18 @@ describe("schema_metadata", () => {
         validArgumentsFilters: [expect.any(Function), expect.any(Function)],
         verboseName: "Between",
       });
+    });
+  });
+
+  describe("isFuzzyOperator", () => {
+    it("should return false for operators that expect an exact match", () => {
+      expect(isFuzzyOperator({ name: "=" })).toBe(false);
+      expect(isFuzzyOperator({ name: "!=" })).toBe(false);
+    });
+
+    it("should return true for operators that are not exact", () => {
+      expect(isFuzzyOperator({ name: "contains" })).toBe(true);
+      expect(isFuzzyOperator({ name: "between" })).toBe(true);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -142,7 +142,7 @@ describe("scenarios > dashboard > chained filter", () => {
       cy.findByText("add another dashboard filter").click();
       popover().within(() => {
         cy.findByText("Location").click();
-        cy.findByText("Starts with").click();
+        cy.findByText("Dropdown").click();
       });
 
       // connect that to person.city
@@ -184,7 +184,7 @@ describe("scenarios > dashboard > chained filter", () => {
         cy.findByText("AK").click();
         cy.findByText("Add filter").click();
       });
-      cy.findByText("Location starts with").click();
+      cy.findByText("Location 1").click();
       popover().within(() => {
         cy.findByPlaceholderText(
           has_field_values === "search" ? "Search by City" : "Search the list",

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > dashboard > parameters", () => {
     // add a category filter
     cy.icon("filter").click();
     cy.contains("Other Categories").click();
-    cy.findByText("Starts with").click();
+    cy.findByText("Dropdown").click();
 
     // connect it to people.name and product.category
     // (this doesn't make sense to do, but it illustrates the feature)
@@ -148,6 +148,50 @@ describe("scenarios > dashboard > parameters", () => {
     // There should be 8849 orders with a rating >= 3 && <= 4
     cy.get(".DashCard").contains("8,849");
     cy.url().should("include", "between=3&between=4");
+  });
+
+  it("should not search field for results non-exact parameter string operators", () => {
+    cy.visit("/dashboard/1");
+
+    // Add a filter tied to a field that triggers a search for field values
+    cy.icon("pencil").click();
+    cy.icon("filter").click();
+    cy.findByText("Location").click();
+    cy.findByText("Starts with").click();
+
+    // Link that filter to the card
+    cy.findByText("Select…").click();
+    popover().within(() => {
+      cy.findByText("City").click();
+    });
+
+    // Add a filter with few enough values that it does not search
+    cy.icon("filter").click();
+    cy.findByText("Other Categories").click();
+    cy.findByText("Starts with").click();
+
+    // Link that filter to the card
+    cy.findByText("Select…").click();
+    popover().within(() => {
+      cy.findByText("Category").click();
+    });
+
+    cy.findByText("Save").click();
+    cy.findByText("You're editing this dashboard.").should("not.exist");
+
+    cy.contains("Location starts with").click();
+    cy.findByPlaceholderText("Enter some text")
+      .click()
+      .type("Bake");
+    cy.findByText("Baker").should("not.exist");
+    cy.findByText("Add filter").click();
+
+    cy.contains("Category starts with").click();
+    cy.findByPlaceholderText("Enter some text")
+      .click()
+      .type("Widge");
+    cy.findByText("Widget").should("not.exist");
+    cy.findByText("Add filter").click();
   });
 
   it("should remove previously deleted dashboard parameter from URL (metabase#10829)", () => {


### PR DESCRIPTION
Disabling `FieldValueWidget` search/field value list UI when the string operator is not = or != as it doesn't really make sense in the other scenarios.

A few examples:

!=
<img width="406" alt="Screen Shot 2021-04-05 at 3 54 28 PM" src="https://user-images.githubusercontent.com/13057258/113636443-6eb24580-9627-11eb-877c-69e9f73899b4.png">

contains
<img width="389" alt="Screen Shot 2021-04-05 at 3 54 35 PM" src="https://user-images.githubusercontent.com/13057258/113636453-7540bd00-9627-11eb-8280-e76617cfcb52.png">

starts-with
<img width="371" alt="Screen Shot 2021-04-05 at 3 54 42 PM" src="https://user-images.githubusercontent.com/13057258/113636473-82f64280-9627-11eb-8b91-cf4cf452d113.png">
