### PR TITLE
Add enterprise version links on Elastic Beanstalk documentation

### DIFF
--- a/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
+++ b/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
@@ -33,7 +33,7 @@ If you would like a reliable, scalable and fully managed Metabase, please consid
 
 ## Quick Launch
 
-Download the [Metabase AWS source bundle file](https://downloads.metabase.com/{{ site.latest_version }}/metabase-aws-eb.zip) to upload to Elastic Beanstalk.
+Download the [Metabase Community Edition AWS source bundle file](https://downloads.metabase.com/{{ site.latest_version }}/metabase-aws-eb.zip) to upload to Elastic Beanstalk. If you are looking to deploy our Enterprise Edition, you need to go to the link https://downloads.metabase.com/enterprise/version/metabase-aws-eb.zip. replacing the version part of the URL with the version that you want to deploy (e.g v1.38.3).
 
 Metabase provides several pre-configured Elastic Beanstalk launch URLs to help you get started. Open one of the links below in a new tab to create an Elastic Beanstalk deployment with a few choices pre-filled. Then just follow the step-by-step instructions below to complete your installation. 
 


### PR DESCRIPTION
Tried to add a few words to guide users that want to download our Enterprise bundle but don't know how to