### PR TITLE
#15444 Repro: Can't run native query with default field filter values set

### DIFF
--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -568,4 +568,42 @@ describe("scenarios > question > native", () => {
       cy.findAllByText("Gizmo").should("not.exist");
     });
   });
+
+  it.skip("should run with the default field filter set (metabase#15444)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    cy.visit("/");
+    cy.icon("sql").click();
+    cy.get(".ace_content").type("select * from products where {{category}}", {
+      parseSpecialCharSequences: false,
+    });
+    // Change filter type from "Text" to Field Filter
+    cy.get(".AdminSelect")
+      .contains("Text")
+      .click();
+    popover()
+      .findByText("Field Filter")
+      .click();
+    popover()
+      .findByText("Products")
+      .click();
+    popover()
+      .findByText("Category")
+      .click();
+    cy.findByText("Required?").scrollIntoView();
+    // Add the default value
+    cy.findByText("Enter a default value...").click();
+    popover()
+      .findByText("Doohickey")
+      .click();
+    cy.findByRole("button", { name: "Add filter" }).click();
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.wait("@dataset").then(xhr => {
+      expect(xhr.response.body.error).not.to.exist;
+    });
+    cy.get(".Visualization").within(() => {
+      cy.findAllByText("Doohickey");
+      cy.findAllByText("Gizmo").should("not.exist");
+    });
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15444

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/native.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/113617847-2579ea00-9657-11eb-973b-b77ee65c32ad.png)
