### PR TITLE
(#15460) Correct field names in native field filters

### DIFF
--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -527,7 +527,7 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it.skip("should be possible to use field filter on a query with joins where tables have similar columns (metabase#15460)", () => {
+  it("should be possible to use field filter on a query with joins where tables have similar columns (metabase#15460)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     visitQuestionAdhoc({
       name: "15460",

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -244,11 +244,11 @@
       (ops/operator? param-type)
       (let [[snippet & args]
             (->> (ops/to-clause (assoc params :target
-                                       [:template-tag [:field (:name field)
+                                       [:template-tag [:field (field->identifier driver field param-type)
                                                        {:base-type (:base_type field)}]]))
                  mbql.u/desugar-filter-clause
                  wrap-value-literals/wrap-value-literals-in-mbql
-                 (sql.qp/->honeysql driver/*driver*)
+                 (sql.qp/->honeysql driver)
                  hsql/format-predicate)]
         {:replacement-snippet snippet, :prepared-statement-args (vec args)})
       ;; convert date ranges to DateRange record types

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -114,47 +114,53 @@
                  2
                  [:string/contains         {:field    :name
                                             :value    ["foo"]
-                                            :expected ["select * from venues where (NAME like ?)"
+                                            :expected ["select * from venues where (\"PUBLIC\".\"VENUES\".\"NAME\" like ?)"
                                                        ["%foo%"]]}
                   :string/does-not-contain {:field    :name
                                             :value    ["foo"]
-                                            :expected ["select * from venues where (NOT (NAME like ?) OR NAME IS NULL)"
+                                            :expected ["select * from venues where (NOT (\"PUBLIC\".\"VENUES\".\"NAME\" like ?) OR \"PUBLIC\".\"VENUES\".\"NAME\" IS NULL)"
                                                        ["%foo%"]]}
                   :string/starts-with      {:field    :name
                                             :value    ["foo"]
-                                            :expected ["select * from venues where (NAME like ?)"
+                                            :expected ["select * from venues where (\"PUBLIC\".\"VENUES\".\"NAME\" like ?)"
                                                        ["foo%"]]}
                   :string/=                {:field    :name
                                             :value    ["foo"]
-                                            :expected ["select * from venues where NAME = ?"
+                                            :expected ["select * from venues where \"PUBLIC\".\"VENUES\".\"NAME\" = ?"
                                                        ["foo"]]}
                   :string/=                {:field    :name
                                             :value    ["foo" "bar" "baz"]
-                                            :expected ["select * from venues where (NAME = ? OR NAME = ? OR NAME = ?)" ["foo" "bar" "baz"]]}
+                                            :expected [(str "select * from venues where (\"PUBLIC\".\"VENUES\".\"NAME\" = ? OR \"PUBLIC\".\"VENUES\".\"NAME\" = ? "
+                                                            "OR \"PUBLIC\".\"VENUES\".\"NAME\" = ?)")
+                                                       ["foo" "bar" "baz"]]}
                   :string/!=               {:field    :name
                                             :value    ["foo" "bar"]
-                                            :expected ["select * from venues where ((NAME <> ? OR NAME IS NULL) AND (NAME <> ? OR NAME IS NULL))"
+                                            :expected [(str "select * from venues where ((\"PUBLIC\".\"VENUES\".\"NAME\" <> ? OR \"PUBLIC\".\"VENUES\".\"NAME\" IS NULL) "
+                                                            "AND (\"PUBLIC\".\"VENUES\".\"NAME\" <> ? OR \"PUBLIC\".\"VENUES\".\"NAME\" IS NULL))")
                                                        ["foo" "bar"]]}
                   :number/=                {:field    :price
                                             :value    [1]
-                                            :expected ["select * from venues where PRICE = 1" ()]}
+                                            :expected ["select * from venues where \"PUBLIC\".\"VENUES\".\"PRICE\" = 1" ()]}
                   :number/=                {:field    :price
                                             :value    [1 2 3]
-                                            :expected ["select * from venues where (PRICE = 1 OR PRICE = 2 OR PRICE = 3)" ()]}
+                                            :expected [(str "select * from venues where (\"PUBLIC\".\"VENUES\".\"PRICE\" = 1 OR \"PUBLIC\".\"VENUES\".\"PRICE\" = 2 "
+                                                            "OR \"PUBLIC\".\"VENUES\".\"PRICE\" = 3)")
+                                                       ()]}
                   :number/!=               {:field    :price
                                             :value    [1]
-                                            :expected ["select * from venues where (PRICE <> 1 OR PRICE IS NULL)" ()]}
+                                            :expected ["select * from venues where (\"PUBLIC\".\"VENUES\".\"PRICE\" <> 1 OR \"PUBLIC\".\"VENUES\".\"PRICE\" IS NULL)" ()]}
                   :number/!=               {:field    :price
                                             :value    [1 2 3]
-                                            :expected [(str "select * from venues where ((PRICE <> 1 OR PRICE IS NULL) "
-                                                            "AND (PRICE <> 2 OR PRICE IS NULL) AND (PRICE <> 3 OR PRICE IS NULL))")
+                                            :expected [(str "select * from venues where ((\"PUBLIC\".\"VENUES\".\"PRICE\" <> 1 OR \"PUBLIC\".\"VENUES\".\"PRICE\" IS NULL) "
+                                                            "AND (\"PUBLIC\".\"VENUES\".\"PRICE\" <> 2 OR \"PUBLIC\".\"VENUES\".\"PRICE\" IS NULL) "
+                                                            "AND (\"PUBLIC\".\"VENUES\".\"PRICE\" <> 3 OR \"PUBLIC\".\"VENUES\".\"PRICE\" IS NULL))")
                                                        ()]}
                   :number/>=               {:field    :price
                                             :value    [1]
-                                            :expected ["select * from venues where PRICE >= 1" ()]}
+                                            :expected ["select * from venues where \"PUBLIC\".\"VENUES\".\"PRICE\" >= 1" ()]}
                   :number/between          {:field    :price
                                             :value    [1 3]
-                                            :expected ["select * from venues where PRICE BETWEEN 1 AND 3" ()]}])]
+                                            :expected ["select * from venues where \"PUBLIC\".\"VENUES\".\"PRICE\" BETWEEN 1 AND 3" ()]}])]
           (testing operator
             (is (= expected
                    (substitute query {"param" (i/map->FieldFilter

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -2,10 +2,22 @@
   "Most of the code in `metabase.driver.sql.parameters.substitution` is actually tested by
   `metabase.driver.sql.parameters.substitute-test`."
   (:require [clojure.test :refer :all]
-            [metabase.driver.sql.parameters.substitution :as substitution]))
+            [metabase.driver.sql.parameters.substitution :as substitution]
+            [metabase.models :refer [Field]]
+            [metabase.test :as mt]))
 
 (deftest honeysql->replacement-snippet-info-test
   (testing "make sure we handle quotes inside names correctly!"
     (is (= {:replacement-snippet     "\"test-data\".\"PUBLIC\".\"checkins\".\"date\""
             :prepared-statement-args nil}
            (#'substitution/honeysql->replacement-snippet-info :h2 :test-data.PUBLIC.checkins.date)))))
+
+(deftest field-filter->replacement-snippet-info-test
+  (testing "Ensure native snippet expansion uses proper names for fields (#15460)"
+    (is (= {:replacement-snippet "\"PUBLIC\".\"VENUES\".\"NAME\" = ?"
+            :prepared-statement-args ["Doohickey"]}
+           (#'substitution/field-filter->replacement-snippet-info
+            :h2
+            {:field (Field (mt/id :venues :name))
+             :value {:type  :string/=
+                     :value ["Doohickey"]}})))))


### PR DESCRIPTION
Fixes #15460 

```sql
select p.created_at, products.category
from products
left join products p on p.id=products.id
where {{category}}
```

field filter is a string/= on category, a column in this twice due to
the self join.

Just mimic how the rest of this emits a column name

