### PR TITLE
#15445 Repro: Breakout binning popover is barely usable if rendered too low on the screen

### DIFF
--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -202,6 +202,51 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  "isVisibleInPopover",
+  {
+    prevSubject: true,
+  },
+  subject => {
+    cy.wrap(subject)
+      .closest(".PopoverContainer.PopoverContainer--open")
+      .then($popover => {
+        /**
+         * Helper function that:
+         *  1. Obtains the value of element's computed property, but it always returns it in px (for example: "12px")
+         *  2. Returns that value as a floating point number (strips away the "px") which enables us to use it in later calculations
+         */
+        function getElementPropertyValue(property) {
+          const propertyValue = window
+            .getComputedStyle(subject[0], null)
+            .getPropertyValue(property); /* [1] */
+
+          return parseFloat(propertyValue); /* [2] */
+        }
+
+        const elementRect = subject[0].getBoundingClientRect();
+        // We need to account for padding and borders to get the real height of an element because we're using `box-sizing: border-box`
+        const PT = getElementPropertyValue("padding-top");
+        const PB = getElementPropertyValue("padding-bottom");
+        const BT = getElementPropertyValue("border-top");
+        const BB = getElementPropertyValue("border-bottom");
+
+        const elementTop = elementRect.top + PT + BT;
+        const elementBottom = elementRect.bottom - PB - BB;
+
+        const popoverRect = $popover[0].getBoundingClientRect();
+        // We need the outermost dimensions for the container - no need to account for padding and borders
+        const popoverTop = popoverRect.top;
+        const popoverBottom = popoverRect.bottom;
+
+        expect(elementTop).to.be.greaterThan(popoverTop);
+        expect(elementBottom).to.be.greaterThan(popoverTop);
+        expect(elementTop).not.to.be.greaterThan(popoverBottom);
+        expect(elementBottom).not.to.be.greaterThan(popoverBottom);
+      });
+  },
+);
+
 /**
  * OVERWRITES
  */

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -584,6 +584,28 @@ describe("scenarios > question > notebook", () => {
       // Given that the previous step passes, we should now see this in the UI
       cy.findByText("User → Created At: Minute");
     });
+
+    it.skip("breakout binning popover should have normal height even when it's rendered lower on the screen (metabase#15445)", () => {
+      cy.visit("/question/1/notebook");
+      cy.findByText("Summarize").click();
+      cy.findByText("Count of rows").click();
+      // We first need to visualize results because it seems that this renders second popover very low on the screen
+      cy.findByText("Summarize")
+        .parent()
+        .find(".Icon-play")
+        .click();
+      cy.findByText("Pick a column to group by").click();
+      cy.findByText("Created At")
+        .closest(".List-item")
+        .findByText("by month")
+        .click({ force: true });
+      popover()
+        .last()
+        .invoke("height")
+        // Although you can see only "Minute" in the UI, Cypress "sees" all list items in the DOM so assertion like `element.should(be.visible)` will not work here
+        // I couldn't think of other assertion than that the height of this popover should be greater than 200px
+        .should("be.gt", 200);
+    });
   });
 
   describe("nested", () => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -589,22 +589,19 @@ describe("scenarios > question > notebook", () => {
       cy.visit("/question/1/notebook");
       cy.findByText("Summarize").click();
       cy.findByText("Count of rows").click();
-      // We first need to visualize results because it seems that this renders second popover very low on the screen
-      cy.findByText("Summarize")
-        .parent()
-        .find(".Icon-play")
-        .click();
       cy.findByText("Pick a column to group by").click();
       cy.findByText("Created At")
         .closest(".List-item")
         .findByText("by month")
         .click({ force: true });
-      popover()
-        .last()
-        .invoke("height")
-        // Although you can see only "Minute" in the UI, Cypress "sees" all list items in the DOM so assertion like `element.should(be.visible)` will not work here
-        // I couldn't think of other assertion than that the height of this popover should be greater than 200px
-        .should("be.gt", 200);
+      // First a reality check - "Minute" is the only string visible in UI and this should pass
+      cy.findAllByText("Minute")
+        .first() // TODO: cy.findAllByText(string).first() is necessary workaround that will be needed ONLY until (metabase#15446) gets fixed
+        .isVisibleInPopover();
+      // The actual check that will fail until this issue gets fixed
+      cy.findAllByText("Week")
+        .first()
+        .isVisibleInPopover();
     });
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15445
- Adds new Cypress custom command that allows us to check if the element is visually outside of popover (you need to scroll in order to see it)
    - Using built-in `.should("be.visible")` doesn't work because Cypress considers all elements in DOM to be visible, even if they are outside the viewport or outside some container and user cannot see them

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

*Having visual regression tests would help with this issue a lot

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/113734709-d89c1f00-96fb-11eb-8cf9-60853ac54018.png)


