### PR TITLE
Fix search matches with uppercase letters

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -287,7 +287,7 @@
 (defn order-clause
   "CASE expression that lets the results be ordered by whether they're an exact (non-fuzzy) match or not"
   [query]
-  (let [match             (wildcard-match query)
+  (let [match             (wildcard-match (scoring/normalize query))
         columns-to-search (->> all-search-columns
                                (filter (fn [[k v]] (= v :text)))
                                (map first))
@@ -354,6 +354,8 @@
   [q archived]
   {q        (s/maybe su/NonBlankString)
    archived (s/maybe su/BooleanString)}
-  (search (search-context q archived)))
+  (if q
+    (search (search-context q archived))
+    []))
 
 (api/define-routes)

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -145,7 +145,7 @@
   (apply search-request* identity args))
 
 (deftest order-clause-test
-  (testing "it includes all columns"
+  (testing "it includes all columns and normalizes the query"
     (is (= (hsql/call
             :case
              [:like (hsql/call :lower :model) "%foo%"] 0
@@ -158,7 +158,7 @@
              [:like (hsql/call :lower :table_name) "%foo%"] 0
              [:like (hsql/call :lower :table_description) "%foo%"] 0
              :else 1)
-           (api.search/order-clause "foo")))))
+           (api.search/order-clause "Foo")))))
 
 (deftest basic-test
   (testing "Basic search, should find 1 of each entity type, all items in the root collection"


### PR DESCRIPTION
This is the special scoring addendum that helps exact matches come to the top of the _SQL_ results, before the real scoring happens in Clojure-land. I'd lower-cased the columns to search but not the query :stuck_out_tongue: 