### PR TITLE
Quarantine flaky test in `auditing.cy.spec.js`

### DIFF
--- a/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
+++ b/enterprise/frontend/test/metabase-enterprise/audit/auditing.cy.spec.js
@@ -140,7 +140,8 @@ describeWithToken("audit > auditing", () => {
       cy.contains(year);
     });
 
-    it("should load both tabs in Schemas", () => {
+    // [quarantine] flaky
+    it.skip("should load both tabs in Schemas", () => {
       // Overview tab
       cy.visit("/admin/audit/schemas/overview");
       cy.get("svg").should("have.length", 2);


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR do?
- Quarantines flaky test in `auditing.cy.spec.js` that appears quite often in failed CI logs.
    - Here's [the example](https://app.circleci.com/pipelines/github/metabase/metabase/14728/workflows/db1c9a1c-0fbd-488b-8eb8-3195c057f8ef/jobs/563363) of the last occurrence

### Additional Notes
- All flaky tests are listed in https://github.com/metabase/metabase/issues/13682
- It seems this flake has been present a long time. The warning about it appears in [one info card](https://github.com/orgs/metabase/projects/5#card-41804571) in Cypress Testing board that I inherited from the previous developer - meaning, it was there at least 6 months ago.