### PR TITLE
Fix subdimensions for a join table

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -748,6 +748,23 @@ export class FieldDimension extends Dimension {
       dimensions = [...dimensions, ...temporalDimensions];
     }
 
+    if (this.joinAlias()) {
+      const matchAlias = this.joinAlias();
+      const filtered = dimensions.filter(d => {
+        const alias = d.joinAlias();
+        return alias && alias === matchAlias;
+      });
+      dimensions = filtered;
+    }
+    if (this.fk()) {
+      const matchFK = this.fk().key();
+      const filtered = dimensions.filter(d => {
+        const fk = d.fk();
+        return fk && fk.key() === matchFK;
+      });
+      dimensions = filtered;
+    }
+
     return dimensions;
   }
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -535,7 +535,7 @@ describe("scenarios > question > notebook", () => {
       cy.get(".DashCard");
     });
 
-    it.skip("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {
+    it("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {
       cy.createQuestion({
         name: "15446",
         query: {
@@ -577,7 +577,7 @@ describe("scenarios > question > notebook", () => {
       popover()
         .last()
         .within(() => {
-          cy.findByText("Hour of Day").scrollIntoView();
+          cy.findByText("Hour of day").scrollIntoView();
           // This is an implicit assertion - test fails when there is more than one string when using `findByText` instead of `findAllByText`
           cy.findByText("Minute").click();
         });


### PR DESCRIPTION
This fixes #15446. To verify, run the Cypress test:

```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js
```

**Steps** to reproduce:
1. Ask a question, Custom question.
2. Sample Dataset, Orders table.
3. Join Data, People table.
4. Summarize, "Sum of Total"
5. Group by: "People - Users" and then "Created At".
6. Hover and then click on the "by month >"
7. The pop-up should show a list of binning choices.

**Before**:

There are duplicated entries in the pop-up. Note that the pop-up is too small (vertically), scroll around to check that in fact some entries (e.g. "Minute") appear twice.

![image](https://user-images.githubusercontent.com/7288/113781386-7c2e0500-96e5-11eb-9ba1-de69d5e050cc.png)

**After**:

There is no more duplication in the pop-up.

![image](https://user-images.githubusercontent.com/7288/113781417-86e89a00-96e5-11eb-9528-84654121dc0a.png)

