### PR TITLE
Use GitHub Actions to run front-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,28 +710,12 @@ jobs:
                   - /home/circleci/metabase/metabase/node_modules
                   - /home/circleci/.cache/Cypress
 
-  fe-tests-unit:
-    executor: clojure-and-node
-    steps:
-      - run-yarn-command:
-          command-name: Run frontend unit tests
-          command: run test-unit
-          skip-when-no-change: true
-
   shared-tests-cljs:
     executor: clojure-and-node
     steps:
       - run-yarn-command:
           command-name: Run Cljs tests for shared/ code
           command: run test-cljs
-          skip-when-no-change: true
-
-  fe-tests-timezones:
-    executor: clojure-and-node
-    steps:
-      - run-yarn-command:
-          command-name: Run frontend timezone tests
-          command: run test-timezones
           skip-when-no-change: true
 
   # Unlike the other build-uberjar steps, this step should be run once overall and the results can be shared between
@@ -1176,13 +1160,7 @@ workflows:
       - fe-deps:
           requires:
             - checkout
-      - fe-tests-unit:
-          requires:
-            - fe-deps
       - shared-tests-cljs:
-          requires:
-            - fe-deps
-      - fe-tests-timezones:
           requires:
             - fe-deps
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -16,7 +16,7 @@ on:
     - 'shared/**'
     - 'enterprise/frontend/**'
     - 'docs/**'
-    - '**/package.lock'
+    - '**/package.json'
     - '**/yarn.lock'
     - '.github/workflows/**'
 
@@ -75,3 +75,39 @@ jobs:
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run lint-docs-links
       name: Run docs links checker
+
+  fe-tests-unit:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: yarn run test-unit
+      name: Run frontend unit tests
+
+  fe-tests-timezones:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: yarn run test-timezones
+      name: Run frontend timezones tests


### PR DESCRIPTION
Same spirit as PR #14701, #14050, etc: frees more Circle CI containers to run other priority tasks (e.g. Cypress tests).