### PR TITLE
Fix toggles

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -650,7 +650,7 @@
       ;; should obfuscate them and still show the last two characters like we do for sensitive values that are set via
       ;; the UI.
       (or value-is-default? value-is-from-env-var?)
-      nil
+      parsed-value
 
       (= visibility :internal)
       (throw (Exception. (tru "Setting {0} is internal" k)))


### PR DESCRIPTION
The defn user-facing-value was retuning a nil when a variable was loaded via an env var:

(or value-is-default? value-is-from-env-var?)
nil

I switched to
(or value-is-default? value-is-from-env-var?)
parsed-value

there's a huge TODO which says:
;; TODO - Settings set via an env var aren't returned for security purposes. It is an open question whether we
;; should obfuscate them and still show the last two characters like we do for sensitive values that are set via
;; the UI.

The variables seem to have a visibility and also can be tagged as sensitive, so it shouldn't be the case when you load env vars, but I leave you to see it @camsaul 