### PR TITLE
#15372 Repro: Visiting old hash results in a blank screen

### DIFF
--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -584,6 +584,22 @@ describe("scenarios > question > notebook", () => {
       // Given that the previous step passes, we should now see this in the UI
       cy.findByText("User → Created At: Minute");
     });
+
+    it("should handle ad-hoc question with old syntax (metabase#15372)", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            filter: ["=", ["field-id", ORDERS.USER_ID], 1],
+          },
+          database: 1,
+        },
+      });
+
+      cy.findByText("User ID is 1");
+      cy.findByText("37.65");
+    });
   });
 
   describe("nested", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15372 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #15497

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/113852937-61b76280-979d-11eb-8e24-e50b7b02f3b6.png)

