### PR TITLE
#15502 Repro: Popover rendering issues

### DIFF
--- a/frontend/test/__support__/commands.js
+++ b/frontend/test/__support__/commands.js
@@ -247,6 +247,23 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  "isInViewport",
+  {
+    prevSubject: true,
+  },
+  subject => {
+    const viewportTop = 0;
+    const viewportBottom = Cypress.$(cy.state("window")).height();
+    const element = subject[0].getBoundingClientRect();
+
+    expect(element.top).to.be.greaterThan(viewportTop);
+    expect(element.bottom).to.be.greaterThan(viewportTop);
+    expect(element.top).not.to.be.greaterThan(viewportBottom);
+    expect(element.bottom).not.to.be.greaterThan(viewportBottom);
+  },
+);
+
 /**
  * OVERWRITES
  */

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -605,6 +605,42 @@ describe("scenarios > question > notebook", () => {
     });
   });
 
+  describe.skip("popover rendering issues (metabase#15502)", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+      cy.viewport(1280, 720);
+      cy.visit("/question/new");
+      cy.findByText("Custom question").click();
+      cy.findByText("Sample Dataset").click();
+      cy.findByText("Orders").click();
+    });
+
+    it("popover should not render outside of viewport regardless of the screen resolution (metabase#15502-1)", () => {
+      // Initial filter popover usually renders correctly within the viewport
+      cy.findByText("Add filters to narrow your answer")
+        .as("filter")
+        .click();
+      popover().isInViewport();
+      // Click anywhere outside this popover to close it because the issue with rendering happens when popover opens for the second time
+      cy.icon("gear").click();
+      cy.get("@filter").click();
+      popover().isInViewport();
+    });
+
+    it("popover should not cover the button that invoked it (metabase#15502-2)", () => {
+      // Initial summarize/metric popover usually renders initially without blocking the button
+      cy.findByText("Pick the metric you want to see")
+        .as("metric")
+        .click();
+      // Click outside to close this popover
+      cy.icon("gear").click();
+      // Popover invoked again blocks the button making it impossible to click the button for the third time
+      cy.get("@metric").click();
+      cy.get("@metric").click();
+    });
+  });
+
   describe("nested", () => {
     it("should create a nested question with post-aggregation filter", () => {
       openProductsTable({ mode: "notebook" });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15502 in 2 variants

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js`
- Replace `describet.skip()` with `describe.only()` to run the test in isolation
- Both tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure both tests are passing and
- Merge them together with the fix

### Screenshots:
Repro #1 (popover renders outside of the screen)
![image](https://user-images.githubusercontent.com/31325167/113859863-a810bf80-97a5-11eb-9eb2-d54842783ee6.png)


Repro #2 (popover renders above the button that invoked it)
![image](https://user-images.githubusercontent.com/31325167/113859700-7ef02f00-97a5-11eb-96e1-a916b1c8feff.png)
