### PR TITLE
#15471 Repro: Visiting `/user/edit_current` when logged out results in a blank page

### DIFF
--- a/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js
@@ -67,6 +67,13 @@ describe("user > settings", () => {
     cy.findByText("Password").should("exist");
   });
 
+  it.skip("it should redirect to the login page when user is signed out but tries to visit `/user/edit_current` (metabase#15471)", () => {
+    cy.signOut();
+    cy.visit("/user/edit_current");
+    cy.url().should("include", "/auth/login");
+    cy.findByText("Sign in to Metabase");
+  });
+
   describe("when user is authenticated via ldap", () => {
     beforeEach(() => {
       cy.server();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15471 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/setup/user_settings.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/113873862-7c95d100-97b5-11eb-88fa-ef9b017d0fa7.png)

