### PR TITLE
add download query button for all dashcards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -203,6 +203,15 @@ export default class DashCard extends Component {
                 token={dashcard.dashboard_id}
                 icon="download"
               />
+            ) : // show Download button for all Dashcards except those on Automagic dashboards
+            !dashboard.transient_name && !errors.length && !loading ? (
+              <QueryDownloadWidget
+                className="m1 text-brand-hover text-light"
+                classNameClose="hover-child"
+                card={dashcard.card}
+                result={getIn(dashcardData, [dashcard.id, dashcard.card.id])}
+                icon="download"
+              />
             ) : (
               undefined
             )


### PR DESCRIPTION
This PR adds the Download query widget button to all Dashcards (except those on automagic dashboards). Our users have requested this feature as it makes it easier to download query data straight from the Dashboard, rather than having to click the Dashcard, navigate to the Question, and then download the data. 

The data should have the correct Dashboard filters applied to it as well.

![image](https://user-images.githubusercontent.com/30878344/113891231-ddf87880-9792-11eb-9da0-d604cd077ac4.png)


### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/15515)
<!-- Reviewable:end -->
