### PR TITLE
Various improvements to version update checks

### DIFF
--- a/bin/release/README.md
+++ b/bin/release/README.md
@@ -59,3 +59,11 @@ clojure -M -m release
 If you're running into issues running the release script, it's helpful to first check that you can run `./bin/build`
 -- this is the real meat and potatoes of the release process and more likely to be the cause of your issues. If you
 can run that but still need help, talk to Cam.
+
+To start an nREPL (ex: to run and debug tests), use:
+```
+clojure -MnREPL
+```
+
+Add any JVM options (individually) by prefixing each with `-J` before the `-M`, and any additional nREPL options after
+it as outlined [here](https://nrepl.org/nrepl/usage/server.html#using-clojure-cli-tools).

--- a/bin/release/deps.edn
+++ b/bin/release/deps.edn
@@ -1,5 +1,4 @@
-{:paths ["src"]
-
+{
  :deps
  {common/common        {:local/root "../common"}
   build/build          {:local/root "../build-mb"}
@@ -13,5 +12,10 @@
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                  :sha     "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
-         :main-opts   ["-m" "cognitect.test-runner"]}}}
+                                                  :sha     "209b64504cb3bd3b99ecfec7937b358a879f55c1"}
+                       org.clojure/data.json     {:mvn/version "2.0.2"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}
+  :nREPL {:extra-paths ["test"]
+          :extra-deps  {nrepl/nrepl           {:mvn/version "0.8.3"}
+                        org.clojure/data.json {:mvn/version "2.0.2"}}
+          :main-opts   ["-m" "nrepl.cmdline" "-i"]}}}

--- a/bin/release/src/release/common.clj
+++ b/bin/release/src/release/common.clj
@@ -42,6 +42,15 @@
   ;; strip off initial `v` if present
   (swap! build-options assoc :version (str/replace new-version #"^v" "")))
 
+(defn github-milestone
+  "Name of GitHub milestone to query for fixed issue descriptions. Same as version, except for enterprise edition, in
+  which case the leading 0 is replaced by 1."
+  []
+  (build-option-or-throw :github-milestone))
+
+(defn set-github-milestone! [new-github-milestone]
+  (swap! build-options assoc :github-milestone new-github-milestone))
+
 (defn branch
   "Branch we are building from, e.g. `release-0.36.x`"
   []

--- a/bin/release/src/release/common/github.clj
+++ b/bin/release/src/release/common/github.clj
@@ -27,7 +27,7 @@
   []
   (some
    (fn [{:keys [title], :as milestone}]
-     (when (str/starts-with? (c/version) title)
+     (when (str/starts-with? (c/github-milestone) title)
        milestone))
    (milestones)))
 

--- a/bin/release/src/release/set_build_options.clj
+++ b/bin/release/src/release/set_build_options.clj
@@ -1,16 +1,18 @@
 (ns release.set-build-options
   (:require [metabuild-common.core :as u]
-            [release.common :as c]))
+            [release.common :as c]
+            [clojure.string :as str]))
 
 (defn prompt-and-set-build-options! []
   (let [[current-branch] (u/step "Determine current branch"
                            (u/sh "git" "symbolic-ref" "--short" "HEAD"))]
     (loop []
-      (let [version (u/read-line-with-prompt "What version are we building (e.g. 0.36.0)?")
-            branch  current-branch
-            edition (case (first version)
-                      \0 :oss
-                      \1 :ee)]
+      (let [version                    (u/read-line-with-prompt "What version are we building (e.g. 0.36.0)?")
+            branch                     current-branch
+            [github-milestone edition] (case (first version)
+                                         \0 [version :oss]
+                                         ;; always query GitHub milestone on the basis of OSS form of version
+                                         \1 [(str/replace version #"^1" "0") :ee])]
         (if-not (u/yes-or-no-prompt (format "Building %s version %s from branch %s. Is this correct?"
                                             (pr-str edition) (pr-str version) (pr-str branch)))
           (do
@@ -19,4 +21,5 @@
           (do
             (c/set-version! version)
             (c/set-branch! branch)
-            (c/set-edition! edition)))))))
+            (c/set-edition! edition)
+            (c/set-github-milestone! github-milestone)))))))

--- a/bin/release/test/release/version_info_test.clj
+++ b/bin/release/test/release/version_info_test.clj
@@ -1,0 +1,48 @@
+(ns release.version-info-test
+  (:require [clojure.data.json :as json]
+            [clojure.test :refer :all]
+            [release.common :as c]
+            [release.common.github :as github]
+            [release.version-info :as v-info])
+  (:import (java.time.format DateTimeFormatter)
+           (java.time LocalDate)))
+
+(defn- make-version-map [version released patch highlights enterprise?]
+  {:version    (format "v%d.%s" (if enterprise? 1 0) version)
+   :released   released
+   :patch      patch
+   :highlights highlights})
+
+(def ^:private today (.format (DateTimeFormatter/ofPattern "yyyy-MM-dd") (LocalDate/now)))
+
+(def ^:private test-versions [["39.0" today false ["Super New Fix 1" "Super New Fix 2"]]
+                              ["38.3" "2021-04-01" true ["Fix 1" "Fix 2"]]
+                              ["38.2" "2021-03-21" true ["Older Fix 1" "Older Fix 2"]]
+                              ["38.1" "2021-03-14" true ["Much Older Fix 1" "Much Older Fix 2"]]
+                              ["38.0" "2021-02-15" true ["Super Old Fix 1" "Super Old Fix 2"]]])
+
+(defn- make-version-info [edition versions]
+  (let [enterprise? (= edition :ee)]
+    {:latest (apply make-version-map (conj (first versions) enterprise?))
+     :older  (map (fn [v]
+                    (apply make-version-map (conj v enterprise?)))
+                  (rest versions))}))
+
+(deftest build-info-test
+  (doseq [edition [:oss :ee]]
+    (testing (format "build-info.json file for %s edition is correct" (name edition))
+      (with-redefs [v-info/current-version-info (constantly (make-version-info edition (rest test-versions)))
+                    github/milestone-issues     (constantly (mapv (fn [title]
+                                                                    {:title title})
+                                                                  (last (first test-versions))))]
+        (c/set-version! (case edition :oss "0.39.0" "1.39.0"))
+        (c/set-branch!  "testing")
+        (c/set-edition! edition)
+        (#'v-info/generate-version-info!)
+        (let [actual (-> (#'v-info/tmp-version-info-filename)
+                         (slurp)
+                         (json/read-json true))
+              expected (make-version-info edition test-versions)]
+          (is (= expected actual)))))))
+
+

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -4,9 +4,6 @@ import MetabaseSettings from "metabase/lib/settings";
 
 // NOTE: temporarily use "latest" for Enterprise Edition docs
 MetabaseSettings.docsTag = () => "latest";
-// NOTE: use the "enterprise" key from version-info.json
-MetabaseSettings.versionInfo = () =>
-  MetabaseSettings.get("version-info", {}).enterprise || {};
 MetabaseSettings.isEnterprise = () => true;
 // PLUGINS:
 

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -46,7 +46,11 @@ export default class SettingsUpdatesForm extends Component {
                 "Updates Settings; Update link clicked; " + latestVersion
               }
               className="Button Button--white Button--medium borderless"
-              href="https://metabase.com/start/"
+              href={
+                "https://www.metabase.com/docs/" +
+                latestVersion +
+                "/operations-guide/upgrading-metabase.html"
+              }
               target="_blank"
             >
               {t`Update`}
@@ -70,7 +74,8 @@ export default class SettingsUpdatesForm extends Component {
       );
     } else {
       return (
-        <div>{t`Sorry, we were unable to check for updates at this time.`}</div>
+        <div>{t`Sorry, we were unable to check for updates at this time. Last successful check was
+         ${MetabaseSettings.versionInfoLastChecked()}.`}</div>
       );
     }
   }

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -41,8 +41,6 @@ class Settings {
   _listeners: { [key: SettingName]: Function[] };
 
   constructor(settings: SettingsMap) {
-    console.log("settings: ");
-    console.dir(settings);
     this._settings = settings;
     this._listeners = {};
   }
@@ -133,7 +131,7 @@ class Settings {
         .local()
         .format("MMMM Do YYYY, h:mm:ss a");
     } else {
-      return "never";
+      return t`never`;
     }
   }
 

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -1,6 +1,8 @@
 import _ from "underscore";
 import { t, ngettext, msgid } from "ttag";
+import { parseTimestamp } from "metabase/lib/time";
 import MetabaseUtils from "metabase/lib/utils";
+import moment from "moment";
 
 // TODO: dump this from backend settings definitions
 export type SettingName =
@@ -28,7 +30,8 @@ export type SettingName =
   | "site-url"
   | "types"
   | "version"
-  | "version-info";
+  | "version-info"
+  | "version-info-last-checked";
 
 type SettingsMap = { [key: SettingName]: any };
 
@@ -38,6 +41,8 @@ class Settings {
   _listeners: { [key: SettingName]: Function[] };
 
   constructor(settings: SettingsMap) {
+    console.log("settings: ");
+    console.dir(settings);
     this._settings = settings;
     this._listeners = {};
   }
@@ -117,6 +122,19 @@ class Settings {
 
   trackingEnabled() {
     return this.get("anon-tracking-enabled") || false;
+  }
+
+  versionInfoLastChecked() {
+    const ts = this.get("version-info-last-checked");
+    if (ts) {
+      // app DB stores this timestamp in UTC, so convert it to the local zone to render
+      return moment
+        .utc(parseTimestamp(ts))
+        .local()
+        .format("MMMM Do YYYY, h:mm:ss a");
+    } else {
+      return "never";
+    }
   }
 
   docsUrl(page = "", anchor = "") {

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -24,6 +24,7 @@
    ;; other application settings
    :mb-password-complexity "normal"
    :mb-version-info-url    "http://static.metabase.com/version-info.json"
+   :mb-version-info-ee-url "http://static.metabase.com/version-info-ee.json"
    :mb-ns-trace            ""                                             ; comma-separated namespaces to trace
    :max-session-age        "20160"                                        ; session length in minutes (14 days)
    :mb-colorize-logs       (str (not is-windows?))                        ; since PowerShell and cmd.exe don't support ANSI color escape codes or emoji,

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -21,7 +21,8 @@
             [metabase.util.i18n :refer [deferred-trs trs]]
             [toucan.db :as db]))
 
-(def ^:private ee-available?
+;; this existed long before 0.39.0, but that's when it was made public
+(def ^{:doc "Indicates whether Enterprise Edition extensions are available" :added "0.39.0"} ee-available?
   (try
     (classloader/require 'metabase-enterprise.core)
     true

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -46,6 +46,12 @@
   :type    :json
   :default {})
 
+(defsetting version-info-last-checked
+  (deferred-tru "Indicates when Metabase last checked for new versions.")
+  :visibility :public
+  :type       :timestamp
+  :default    nil)
+
 (defsetting site-name
   (deferred-tru "The name used for this instance of Metabase.")
   :default "Metabase")
@@ -89,7 +95,7 @@
                 (log/error e (trs "site-url is invalid; returning nil for now. Will be reset on next request.")))))
   :setter (fn [new-value]
             (let [new-value (some-> new-value normalize-site-url)
-                  https?    (some-> new-value (str/starts-with?  "https:" ))]
+                  https?    (some-> new-value (str/starts-with?  "https:"))]
               ;; if the site URL isn't HTTPS then disable force HTTPS redirects if set
               (when-not https?
                 (redirect-all-requests-to-https false))


### PR DESCRIPTION
# Release project changes

Updating version_info.clj code to build version-info-ee.json file for Enterprise Edition build

Adding test for both oss and ee version info file generation logic

Decoupling GitHub milestone from version and setting it to be the OSS value for :ee release build

Adding nREPL alias for release deps.edn project and usage note

# Core product changes

Adding new :ee version of :mb-version-info-url (:mb-version-info-ee-url) with default value to match the file name generated by the release code

Making enterprise-edition? public from core.clj, since it's now needed from the upgrade check code to switch between the URLs

Adding new setting to store when updates were last checked (since it's on a 12-hour interval)

Changing update check code to both set this new timestamp setting (always) to the current time, and set version-info itself to nil if the update check fails (so that users won't see "latest and greatest" if the update check succeeded at some point in the past, but then started failing

## Frontend changes

Showing the "last checked" timestamp (in user's browser timezone) when we show the "Sorry" text because of being unable to check for updates, so they know when the last check was made

Removing custom implementation of MetabaseSettings.versionInfo from EE frontend code since it's no longer needed (and never worked), because the EE backend will now be hitting a different URL with the version info specifically for EE releases

Linking to `https://www.metabase.com/docs/<newVersion>/operations-guide/upgrading-metabase.html` URL instead of simply `/start` as before
