### PR TITLE
Fix flakiness in `scatter` visualization tests

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -53,11 +53,13 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       // drag across to filter
       cy.get(".Visualization")
         .trigger("mousedown", 100, 200)
-        .trigger("mousemove", 200, 200)
-        .trigger("mouseup", 200, 200);
+        .trigger("mousemove", 210, 200)
+        .trigger("mouseup", 210, 200);
 
       // new filter applied
-      cy.contains("Created At between May, 2016 September, 2016");
+      // Note: Test was flaking because apparently mouseup doesn't always happen at the same position.
+      //       It is enough that we assert that the filter exists and that it starts with May, 2016
+      cy.contains(/^Created At between May, 2016/);
       // more granular axis labels
       cy.contains("June, 2016");
       // confirm that product category is still broken out

--- a/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
@@ -37,12 +37,7 @@ describe("scenarios > visualizations > scatter", () => {
       },
     });
 
-    cy.wait("@dataset");
-
-    cy.get(".bubble")
-      .eq(13) // Random bubble
-      .trigger("mousemove");
-
+    triggerPopoverForBubble();
     popover().within(() => {
       cy.findByText("Created At:");
       cy.findByText("Count:");
@@ -68,12 +63,7 @@ describe("scenarios > visualizations > scatter", () => {
       },
     });
 
-    cy.wait("@dataset");
-
-    cy.get(".bubble")
-      .eq(13)
-      .trigger("mousemove");
-
+    triggerPopoverForBubble();
     popover().within(() => {
       cy.findByText("Created At:");
       cy.findByText("Orders count:");
@@ -81,3 +71,17 @@ describe("scenarios > visualizations > scatter", () => {
     });
   });
 });
+
+function triggerPopoverForBubble(index = 13) {
+  cy.wait("@dataset");
+  // Hack that is needed because of the flakiness caused by adding throttle to the ExplicitSize component
+  // See: https://github.com/metabase/metabase/pull/15235
+  cy.get("[class*=ViewFooter]").within(() => {
+    cy.icon("table2").click(); // Switch to the tabular view...
+    cy.icon("bubble").click(); // ... and then back to the scatter visualization (that now seems to be stable enough to make assertions about)
+  });
+
+  cy.get(".bubble")
+    .eq(index) // Random bubble
+    .trigger("mousemove");
+}


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes a flake in `scatter.cy.spec.js` that started appearing after throttle was introduced to the ExplicitSize component in https://github.com/metabase/metabase/pull/15235
- Also fixes a flake with brush filter that apparently wasn't fully fixed in the [previous attempt](https://github.com/metabase/metabase/pull/15505)

### Additional Info:
- Stress testing this fix in isolation with GitHub actions shows [20/20 runs passing](https://github.com/nemanjaglumac/metabase-tests/runs/2290336453) ✅
- Stress testing "brush date filter" revealed that it still fails approximately 4-5x out of 20!
    - The reason seems to be that `mouseup` event doesn't always happen at the same time so the resulting filter doesn't have the same ending month every time (for example I've seen: "Created At between May, 2016 September, 2016", "Created At between May, 2016 July, 2016" and even "Created At between May, 2016 May, 2016")
    - It is more than enough that we assert that this filter exists in the first place so I changed the assertion to: `cy.contains(/^Created At between May, 2016/);` since the beginning of this string is the only thing we care about