### PR TITLE
Set resize throttle duration to 0 to temporary fix flaky tests

### DIFF
--- a/frontend/src/metabase/components/ExplicitSize.jsx
+++ b/frontend/src/metabase/components/ExplicitSize.jsx
@@ -7,6 +7,10 @@ import ResizeObserver from "resize-observer-polyfill";
 import cx from "classnames";
 import _ from "underscore";
 
+// After adding throttling for resize re-renders, our Cypress tests became flaky
+// due to queried DOM elements are getting detached after re-renders
+const throttleDuration = window.Cypress ? 0 : 500;
+
 export default ({ selector, wrapped } = {}) => ComposedComponent =>
   class extends Component {
     static displayName =
@@ -100,7 +104,7 @@ export default ({ selector, wrapped } = {}) => ComposedComponent =>
           this.setState({ width, height });
         }
       }
-    }, 500);
+    }, throttleDuration);
 
     render() {
       if (wrapped) {


### PR DESCRIPTION
Because of added throttling in `ExplicitSize` component tests have become flaky