### PR TITLE
Fix subdimensions for a joined/FK dimension

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -722,8 +722,19 @@ export class FieldDimension extends Dimension {
     );
   }
 
-  dimensions(): FieldDimension[] {
-    let dimensions = super.dimensions();
+  dimensions(DimensionTypes?: typeof Dimension[]): FieldDimension[] {
+    let dimensions = super.dimensions(DimensionTypes);
+
+    const joinAlias = this.joinAlias();
+    if (joinAlias) {
+      return dimensions.map(d => d.withJoinAlias(joinAlias));
+    }
+
+    const sourceField = this.getOption("source-field");
+    if (sourceField) {
+      return dimensions.map(d => d.withOption("source-field", sourceField));
+    }
+
     const field = this.field();
 
     // Add FK dimensions if this field is an FK

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -535,7 +535,7 @@ describe("scenarios > question > notebook", () => {
       cy.get(".DashCard");
     });
 
-    it.skip("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {
+    it("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {
       cy.createQuestion({
         name: "15446",
         query: {
@@ -577,7 +577,7 @@ describe("scenarios > question > notebook", () => {
       popover()
         .last()
         .within(() => {
-          cy.findByText("Hour of Day").scrollIntoView();
+          cy.findByText("Hour of day").scrollIntoView();
           // This is an implicit assertion - test fails when there is more than one string when using `findByText` instead of `findAllByText`
           cy.findByText("Minute").click();
         });


### PR DESCRIPTION
This restores the behavior just like before MBQL field refactoring (back when the specialized class JoinedDimension and FKDimension still existed): the subdimensions for a joined/FK dimension are exactly those of the parent class, Dimension.dimensions(), and not more.  Also, each subdimension must still carry the join alias/source field option.

This fixes #15446. To verify, run the Cypress test:

```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js
```

**Steps** to reproduce:
1. Ask a question, Custom question.
2. Sample Dataset, Orders table.
3. Join Data, People table.
4. Summarize, "Sum of Total"
5. Group by: "People - Users" and then "Created At".
6. Hover and then click on the "by month >"
7. The pop-up should show a list of binning choices.

**Before**:

There are duplicated entries in the pop-up. Note that the pop-up is too small (vertically), scroll around to check that in fact some entries (e.g. "Minute") appear twice.

![image](https://user-images.githubusercontent.com/7288/113781386-7c2e0500-96e5-11eb-9ba1-de69d5e050cc.png)

**After**:

There is no more duplication in the pop-up.

![image](https://user-images.githubusercontent.com/7288/113781417-86e89a00-96e5-11eb-9528-84654121dc0a.png)
