### PR TITLE
Fix `react/no-unescaped-entities` errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,7 @@
     "react/no-find-dom-node": 0,
     "react/no-children-prop": 0,
     "react/no-string-refs": 0,
-    "react/no-unescaped-entities": 0,
+    "react/no-unescaped-entities": 2,
     "react/jsx-no-target-blank": 2,
     "react/jsx-key": 0,
     "prefer-const": [1, { "destructuring": "all" }],

--- a/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx
@@ -82,7 +82,7 @@ export default class Revision extends Component {
               {moment(revision.timestamp).format("MMMM DD, YYYY")}
             </span>
           </div>
-          {message && <p>"{message}"</p>}
+          {message && <p>&quot;{message}&quot;</p>}
           {diffKeys.map(key => (
             <RevisionDiff
               key={key}

--- a/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx
@@ -44,7 +44,7 @@ export default class RevisionHistory extends Component {
             />
             <div className="wrapper py4" style={{ maxWidth: 950 }}>
               <h2 className="mb4">
-                {t`Revision History for`} "{object.name}"
+                {t`Revision History for`} &quot;{object.name}&quot;
               </h2>
               <ol>
                 {revisions.map(revision => (

--- a/frontend/src/metabase/admin/datamodel/components/revisions/TextDiff.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/revisions/TextDiff.jsx
@@ -16,7 +16,7 @@ export default class TextDiff extends Component {
     } = this.props;
     return (
       <div>
-        "
+        &quot;
         {before != null && after != null ? (
           diffWords(before, after).map((section, index) => (
             <span>
@@ -36,7 +36,7 @@ export default class TextDiff extends Component {
         ) : (
           <strong>{after}</strong>
         )}
-        "
+        &quot;
       </div>
     );
   }

--- a/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
@@ -268,7 +268,7 @@ export default class SettingsSlackForm extends Component {
           </div>
           <div className="py2">
             {jt`Once you're there, give it a name and click ${(
-              <strong>"Add bot integration"</strong>
+              <strong>&quot;{t`Add bot integration`}&quot;</strong>
             )}. Then copy and paste the Bot API Token into the field below. Once you are done, create a "metabase_files" channel in Slack. Metabase needs this to upload graphs.`}
           </div>
         </div>

--- a/frontend/src/metabase/internal/pages/TypePage.jsx
+++ b/frontend/src/metabase/internal/pages/TypePage.jsx
@@ -80,7 +80,7 @@ const TypePage = () => (
         <Text>Used for page headings, etc</Text>
 
         <Example>
-          <Heading>Title o' the page</Heading>
+          <Heading>Title o&apos; the page</Heading>
         </Example>
       </Box>
       <Box mb={3}>

--- a/frontend/src/metabase/internal/pages/WelcomePage.jsx
+++ b/frontend/src/metabase/internal/pages/WelcomePage.jsx
@@ -21,9 +21,9 @@ const WelcomePage = () => {
 
       <Subhead>Documentation progress</Subhead>
       <Text>
-        Documenting our component library is an ongoing process. Here's what
-        percentage of the code in <code>metabase/components</code> has some form
-        of documentation so far.
+        Documenting our component library is an ongoing process. Here&apos;s
+        what percentage of the code in <code>metabase/components</code> has some
+        form of documentation so far.
       </Text>
 
       <Box mt={3}>


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes eslint `react/no-unescaped-entities` error
- Enables that rule in the `.eslintrc` and sets it to error

### Additional notes:
The error fixes are a cherry-pick of dbddc439f17938150b93e1e10d7d78dae84a05c6 (original PR #15111)