### PR TITLE
Fix `react/no-children-prop` errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "react/no-did-mount-set-state": 0,
     "react/no-did-update-set-state": 0,
     "react/no-find-dom-node": 0,
-    "react/no-children-prop": 0,
+    "react/no-children-prop": 2,
     "react/no-string-refs": 0,
     "react/no-unescaped-entities": 2,
     "react/jsx-no-target-blank": 2,

--- a/frontend/src/metabase/components/Tooltip.jsx
+++ b/frontend/src/metabase/components/Tooltip.jsx
@@ -124,13 +124,9 @@ export default class Tooltip extends Component {
       <React.Fragment>
         {React.Children.only(this.props.children)}
         {tooltip && isEnabled && isOpen && (
-          <TooltipPopover
-            isOpen={true}
-            target={this}
-            hasArrow
-            {...this.props}
-            children={this.props.tooltip}
-          />
+          <TooltipPopover isOpen={true} target={this} hasArrow {...this.props}>
+            {this.props.tooltip}
+          </TooltipPopover>
         )}
       </React.Fragment>
     );

--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -158,11 +158,12 @@ export default ComposedComponent =>
           {triggerElement}
           <ComposedComponent
             {...this.props}
-            children={children}
             isOpen={isOpen}
             onClose={this.onClose}
             target={() => this.target()}
-          />
+          >
+            {children}
+          </ComposedComponent>
         </a>
       );
     }

--- a/frontend/src/metabase/containers/CollectionItemsLoader.jsx
+++ b/frontend/src/metabase/containers/CollectionItemsLoader.jsx
@@ -9,15 +9,14 @@ type Props = {
 };
 
 const CollectionItemsLoader = ({ collectionId, children, ...props }: Props) => (
-  <Collection.Loader
-    {...props}
-    id={collectionId}
-    children={({ object }) => (
+  <Collection.Loader {...props} id={collectionId}>
+    {({ object }) => (
       <Search.ListLoader
         {...props}
         query={{ collection: collectionId }}
         wrapped
-        children={({ list }) =>
+      >
+        {({ list }) =>
           object &&
           list &&
           children({
@@ -25,9 +24,9 @@ const CollectionItemsLoader = ({ collectionId, children, ...props }: Props) => (
             items: list,
           })
         }
-      />
+      </Search.ListLoader>
     )}
-  />
+  </Collection.Loader>
 );
 
 export default CollectionItemsLoader;

--- a/frontend/src/metabase/containers/QuestionLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionLoader.jsx
@@ -64,16 +64,19 @@ const QuestionLoader = ({
   children,
 }: Props) =>
   questionObject != null ? (
-    <AdHocQuestionLoader
-      questionHash={serializeCardForUrl(questionObject)}
-      children={children}
-    />
+    <AdHocQuestionLoader questionHash={serializeCardForUrl(questionObject)}>
+      {children}
+    </AdHocQuestionLoader>
   ) : // if there's a questionHash it means we're in ad-hoc land
   questionHash != null && questionHash !== "" ? (
-    <AdHocQuestionLoader questionHash={questionHash} children={children} />
+    <AdHocQuestionLoader questionHash={questionHash}>
+      {children}
+    </AdHocQuestionLoader>
   ) : // otherwise if there's a non-null questionId it means we're in saved land
   questionId != null ? (
-    <SavedQuestionLoader questionId={questionId} children={children} />
+    <SavedQuestionLoader questionId={questionId}>
+      {children}
+    </SavedQuestionLoader>
   ) : // finally, if neither is present, just don't do anything
   null;
 

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -181,12 +181,9 @@ export default class EntityListLoader extends React.Component {
     const { allFetched, allError } = this.props;
     const { loadingAndErrorWrapper } = this.props;
     return loadingAndErrorWrapper ? (
-      <LoadingAndErrorWrapper
-        loading={!allFetched}
-        error={allError}
-        children={this.renderChildren}
-        noWrapper
-      />
+      <LoadingAndErrorWrapper loading={!allFetched} error={allError} noWrapper>
+        {this.renderChildren}
+      </LoadingAndErrorWrapper>
     ) : (
       this.renderChildren()
     );

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -142,9 +142,10 @@ export default class EntityObjectLoader extends React.Component {
       <LoadingAndErrorWrapper
         loading={!fetched && entityId != null}
         error={error}
-        children={this.renderChildren}
         noWrapper
-      />
+      >
+        {this.renderChildren}
+      </LoadingAndErrorWrapper>
     ) : (
       this.renderChildren()
     );

--- a/frontend/src/metabase/hoc/RenderPropToHOC.jsx
+++ b/frontend/src/metabase/hoc/RenderPropToHOC.jsx
@@ -3,11 +3,8 @@ import React from "react";
 export default function renderPropToHoc(RenderPropComponent) {
   // eslint-disable-next-line react/display-name
   return ComposedComponent => props => (
-    <RenderPropComponent
-      {...props}
-      children={childrenProps => (
-        <ComposedComponent {...props} {...childrenProps} />
-      )}
-    />
+    <RenderPropComponent {...props}>
+      {childrenProps => <ComposedComponent {...props} {...childrenProps} />}
+    </RenderPropComponent>
   );
 }

--- a/frontend/src/metabase/query_builder/components/FilterList.jsx
+++ b/frontend/src/metabase/query_builder/components/FilterList.jsx
@@ -39,8 +39,9 @@ export default class FilterList extends Component {
             filter={filter}
             metadata={metadata}
             maxDisplayValues={this.props.maxDisplayValues}
-            children={filterRenderer}
-          />
+          >
+            {filterRenderer}
+          </Filter>
         ))}
       </div>
     );

--- a/frontend/src/metabase/setup/containers/PostSetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/PostSetupApp.jsx
@@ -40,9 +40,8 @@ export default class PostSetupApp extends Component {
           style={{ maxWidth: 587 }}
           className="ml-auto mr-auto mt-auto mb-auto py2"
         >
-          <CandidateListLoader
-            databaseId={this.props.params.databaseId}
-            children={({ candidates, sampleCandidates, isSample }) => {
+          <CandidateListLoader databaseId={this.props.params.databaseId}>
+            {({ candidates, sampleCandidates, isSample }) => {
               if (!candidates) {
                 return (
                   <div>
@@ -87,7 +86,7 @@ export default class PostSetupApp extends Component {
                 </Card>
               );
             }}
-          />
+          </CandidateListLoader>
           <div className="m4 text-centered">
             <Link
               to="/"

--- a/frontend/test/metabase/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/test/metabase/containers/AdHocQuestionLoader.unit.spec.js
@@ -29,8 +29,9 @@ describe("AdHocQuestionLoader", () => {
       <AdHocQuestionLoader
         questionHash={questionHash}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </AdHocQuestionLoader>,
     );
     expect(mockChild.mock.calls[0][0].loading).toEqual(true);
     expect(mockChild.mock.calls[0][0].error).toEqual(null);
@@ -57,8 +58,9 @@ describe("AdHocQuestionLoader", () => {
       <AdHocQuestionLoader
         questionHash={originalQuestionHash}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </AdHocQuestionLoader>,
     );
 
     expect(loadQuestionSpy).toHaveBeenCalledWith(originalQuestionHash);
@@ -69,8 +71,9 @@ describe("AdHocQuestionLoader", () => {
       <AdHocQuestionLoader
         questionHash={newQuestionHash}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </AdHocQuestionLoader>,
     );
 
     // question loading should begin with the new ID

--- a/frontend/test/metabase/containers/SavedQuestionLoader.unit.spec.js
+++ b/frontend/test/metabase/containers/SavedQuestionLoader.unit.spec.js
@@ -34,8 +34,9 @@ describe("SavedQuestionLoader", () => {
       <SavedQuestionLoader
         questionId={questionId}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </SavedQuestionLoader>,
     );
     expect(mockChild.mock.calls[0][0].loading).toEqual(true);
     expect(mockChild.mock.calls[0][0].error).toEqual(null);
@@ -60,8 +61,9 @@ describe("SavedQuestionLoader", () => {
       <SavedQuestionLoader
         questionId={originalQuestionId}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </SavedQuestionLoader>,
     );
 
     expect(loadQuestionSpy).toHaveBeenCalledWith(originalQuestionId);
@@ -71,8 +73,9 @@ describe("SavedQuestionLoader", () => {
       <SavedQuestionLoader
         questionId={newQuestionId}
         loadMetadataForCard={loadMetadataSpy}
-        children={mockChild}
-      />,
+      >
+        {mockChild}
+      </SavedQuestionLoader>,
     );
 
     // question loading should begin with the new ID


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes eslint `react/no-children-prop` error
- Enables that rule in the `.eslintrc` and sets it to error

### Additional notes:
The error fixes are a cherry-pick of 298eafd4435f4016e2802f13d603761d8cec9dcf (original PR #15122)