### PR TITLE
[SCHEDULED, Week 19] Fix `react/no-string-refs` errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,7 @@
     "react/no-did-update-set-state": 0,
     "react/no-find-dom-node": 0,
     "react/no-children-prop": 2,
-    "react/no-string-refs": 0,
+    "react/no-string-refs": 2,
     "react/no-unescaped-entities": 2,
     "react/jsx-no-target-blank": 2,
     "react/jsx-key": 0,

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -94,6 +94,9 @@ export default class DatabaseEditApp extends Component {
     this.state = {
       currentTab: TABS[0].value,
     };
+
+    this.discardSavedFieldValuesModal = React.createRef();
+    this.deleteDatabaseModal = React.createRef();
   }
 
   static propTypes = {
@@ -233,14 +236,14 @@ export default class DatabaseEditApp extends Component {
                   <ol>
                     <li>
                       <ModalWithTrigger
-                        ref="discardSavedFieldValuesModal"
+                        ref={this.discardSavedFieldValuesModal}
                         triggerClasses="Button Button--danger Button--discardSavedFieldValues"
                         triggerElement={t`Discard saved field values`}
                       >
                         <ConfirmContent
                           title={t`Discard saved field values`}
                           onClose={() =>
-                            this.refs.discardSavedFieldValuesModal.toggle()
+                            this.discardSavedFieldValuesModal.current.toggle()
                           }
                           onAction={() =>
                             this.props.discardSavedFieldValues(database.id)
@@ -251,13 +254,15 @@ export default class DatabaseEditApp extends Component {
 
                     <li className="mt2">
                       <ModalWithTrigger
-                        ref="deleteDatabaseModal"
+                        ref={this.deleteDatabaseModal}
                         triggerClasses="Button Button--deleteDatabase Button--danger"
                         triggerElement={t`Remove this database`}
                       >
                         <DeleteDatabaseModal
                           database={database}
-                          onClose={() => this.refs.deleteDatabaseModal.toggle()}
+                          onClose={() =>
+                            this.deleteDatabaseModal.current.toggle()
+                          }
                           onDelete={() =>
                             this.props.deleteDatabase(database.id, true)
                           }

--- a/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx
@@ -50,6 +50,15 @@ const mapDispatchToProps = {
   mapDispatchToProps,
 )
 export default class DatabaseList extends Component {
+  constructor(props) {
+    super(props);
+
+    this.createdDatabaseModal = React.createRef();
+    props.databases.map(database => {
+      this["deleteDatabaseModal_" + database.id] = React.createRef();
+    });
+  }
+
   static propTypes = {
     databases: PropTypes.array,
     hasSampleDataset: PropTypes.bool,
@@ -60,7 +69,7 @@ export default class DatabaseList extends Component {
 
   UNSAFE_componentWillReceiveProps(newProps) {
     if (!this.props.created && newProps.created) {
-      this.refs.createdDatabaseModal.open();
+      this.createdDatabaseModal.current.open();
     }
   }
 
@@ -129,16 +138,16 @@ export default class DatabaseList extends Component {
                         ) : (
                           <td className="Table-actions">
                             <ModalWithTrigger
-                              ref={"deleteDatabaseModal_" + database.id}
+                              ref={this["deleteDatabaseModal_" + database.id]}
                               triggerClasses="Button Button--danger"
                               triggerElement={t`Delete`}
                             >
                               <DeleteDatabaseModal
                                 database={database}
                                 onClose={() =>
-                                  this.refs[
+                                  this[
                                     "deleteDatabaseModal_" + database.id
-                                  ].close()
+                                  ].current.close()
                                 }
                                 onDelete={() =>
                                   this.props.deleteDatabase(database.id)
@@ -184,11 +193,14 @@ export default class DatabaseList extends Component {
             </div>
           ) : null}
         </section>
-        <ModalWithTrigger ref="createdDatabaseModal" isInitiallyOpen={created}>
+        <ModalWithTrigger
+          ref={this.createdDatabaseModal}
+          isInitiallyOpen={created}
+        >
           <CreatedDatabaseModal
             databaseId={parseInt(created)}
-            onDone={() => this.refs.createdDatabaseModal.toggle()}
-            onClose={() => this.refs.createdDatabaseModal.toggle()}
+            onDone={() => this.createdDatabaseModal.current.toggle()}
+            onClose={() => this.createdDatabaseModal.current.toggle()}
           />
         </ModalWithTrigger>
       </div>

--- a/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
@@ -34,6 +34,8 @@ export default class FieldRemapping extends React.Component {
 
   constructor(props, context) {
     super(props, context);
+
+    this.fkPopover = React.createRef();
   }
 
   getMappingTypeForField = field => {
@@ -192,7 +194,7 @@ export default class FieldRemapping extends React.Component {
 
       await fetchTableMetadata({ id: table.id }, { reload: true });
 
-      this.refs.fkPopover.close();
+      this.fkPopover.current.close();
     } else {
       throw new Error(t`The selected field isn't a foreign key`);
     }
@@ -269,7 +271,7 @@ export default class FieldRemapping extends React.Component {
           {mappingType === MAP_OPTIONS.foreign && [
             <SelectSeparator classname="flex" key="foreignKeySeparator" />,
             <PopoverWithTrigger
-              ref="fkPopover"
+              ref={this.fkPopover}
               triggerElement={
                 <SelectButton
                   hasValue={hasFKMappingValue}

--- a/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
@@ -11,6 +11,11 @@ import ObjectRetireModal from "./ObjectRetireModal";
 import { capitalize } from "metabase/lib/formatting";
 
 export default class ObjectActionsSelect extends Component {
+  constructor(props) {
+    super(props);
+
+    this.retireModal = React.createRef();
+  }
   static propTypes = {
     object: PropTypes.object.isRequired,
     objectType: PropTypes.string.isRequired,
@@ -19,7 +24,7 @@ export default class ObjectActionsSelect extends Component {
 
   async onRetire(object) {
     await this.props.onRetire(object);
-    this.refs.retireModal.close();
+    this.retireModal.current.close();
   }
 
   render() {
@@ -27,7 +32,6 @@ export default class ObjectActionsSelect extends Component {
     return (
       <div>
         <PopoverWithTrigger
-          ref="popover"
           triggerElement={
             <span className="text-light text-brand-hover">
               <Icon name={"ellipsis"} />
@@ -61,7 +65,7 @@ export default class ObjectActionsSelect extends Component {
             </li>
             <li className="mt1 border-top">
               <ModalWithTrigger
-                ref="retireModal"
+                ref={this.retireModal}
                 triggerElement={"Retire " + capitalize(objectType)}
                 triggerClasses="block p2 bg-error-hover text-error text-white-hover cursor-pointer"
               >
@@ -69,7 +73,7 @@ export default class ObjectActionsSelect extends Component {
                   object={object}
                   objectType={objectType}
                   onRetire={this.onRetire.bind(this)}
-                  onClose={() => this.refs.retireModal.close()}
+                  onClose={() => this.retireModal.current.close()}
                 />
               </ModalWithTrigger>
             </li>

--- a/frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import ActionButton from "metabase/components/ActionButton";
 import ModalContent from "metabase/components/ModalContent";
@@ -13,12 +12,13 @@ export default class ObjectRetireModal extends Component {
     this.state = {
       valid: false,
     };
+    this.revisionMessage = React.createRef();
   }
 
   async handleSubmit() {
     const payload = {
       id: this.props.object.id,
-      revision_message: ReactDOM.findDOMNode(this.refs.revision_message).value,
+      revision_message: this.revisionMessage.current.value,
     };
 
     await this.props.onRetire(payload);
@@ -38,7 +38,7 @@ export default class ObjectRetireModal extends Component {
             <p className="text-paragraph">{t`Saved questions and other things that depend on this ${objectType} will continue to work, but this ${objectType} will no longer be selectable from the query builder.`}</p>
             <p className="text-paragraph">{t`If you're sure you want to retire this ${objectType}, please write a quick explanation of why it's being retired:`}</p>
             <textarea
-              ref="revision_message"
+              ref={this.revisionMessage}
               className="input full"
               placeholder={t`This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this ${objectType}.`}
               onChange={e => this.setState({ valid: !!e.target.value })}

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx
@@ -37,18 +37,6 @@ export default class MetadataHeader extends Component {
     this.setDatabaseIdIfUnset();
   }
 
-  setSaving() {
-    this.refs.status.setSaving.apply(this, arguments);
-  }
-
-  setSaved() {
-    this.refs.status.setSaved.apply(this, arguments);
-  }
-
-  setSaveError() {
-    this.refs.status.setSaveError.apply(this, arguments);
-  }
-
   // Show a gear to access Table settings page if we're currently looking at a Table. Otherwise show nothing.
   // TODO - it would be nicer just to disable the gear so the page doesn't jump around once you select a Table.
   renderTableSettingsButton() {
@@ -81,7 +69,7 @@ export default class MetadataHeader extends Component {
           />
         </div>
         <div className="MetadataEditor-headerSection flex flex-align-right align-center flex-no-shrink">
-          <SaveStatus ref="status" />
+          <SaveStatus />
           <div className="mr1 text-medium">{t`Show original schema`}</div>
           <Toggle
             value={this.props.isShowingSchema}

--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -239,7 +239,7 @@ export default class FieldApp extends React.Component {
                 </div>
               )}
               <div className="absolute top right mt4 mr4">
-                <SaveStatus ref={ref => (this.saveStatus = ref)} />
+                <SaveStatus ref={this.saveStatus} />
               </div>
 
               {section == null || section === "general" ? (

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -79,7 +79,6 @@ export default class MetadataEditor extends Component {
     return (
       <div className="p4">
         <MetadataHeader
-          ref="header"
           databaseId={databaseId}
           selectDatabase={this.props.selectDatabase}
           isShowingSchema={this.state.isShowingSchema}

--- a/frontend/src/metabase/admin/people/components/UserGroupSelect.jsx
+++ b/frontend/src/metabase/admin/people/components/UserGroupSelect.jsx
@@ -19,10 +19,6 @@ export default class UserGroupSelect extends Component {
     isInitiallyOpen: false,
   };
 
-  toggle() {
-    this.refs.popover.toggle();
-  }
-
   render() {
     const {
       user,

--- a/frontend/src/metabase/admin/permissions/components/PermissionsGrid.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsGrid.jsx
@@ -209,6 +209,7 @@ class GroupPermissionCell extends Component {
       confirmAction: null,
       hovered: false,
     };
+    this.popover = React.createRef();
   }
   hoverEnter() {
     // only change the hover state if the group is not the admin
@@ -249,7 +250,7 @@ class GroupPermissionCell extends Component {
 
     return (
       <PopoverWithTrigger
-        ref="popover"
+        ref={this.popover}
         disabled={!isEditable}
         triggerClasses="cursor-pointer flex flex-full layout-centered border-column-divider"
         triggerElement={
@@ -337,7 +338,7 @@ class GroupPermissionCell extends Component {
             } else {
               confirmAction();
             }
-            this.refs.popover.close();
+            this.popover.current.close();
           }}
         />
         {actions && actions.length > 0 ? (

--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -58,6 +58,11 @@ export default class SettingsEditorApp extends Component {
     updateSetting: PropTypes.func.isRequired,
   };
 
+  constructor(props) {
+    super(props);
+    this.saveStatusRef = React.createRef();
+  }
+
   UNSAFE_componentWillMount() {
     this.props.initializeSettings();
   }
@@ -65,7 +70,7 @@ export default class SettingsEditorApp extends Component {
   updateSetting = async (setting, newValue) => {
     const { settingValues, updateSetting } = this.props;
 
-    this.layout.setSaving();
+    this.saveStatusRef.current.setSaving();
 
     const oldValue = setting.value;
 
@@ -83,7 +88,7 @@ export default class SettingsEditorApp extends Component {
         );
       }
 
-      this.layout.setSaved();
+      this.saveStatusRef.current.setSaved();
 
       const value = prepareAnalyticsValue(setting);
 
@@ -97,7 +102,7 @@ export default class SettingsEditorApp extends Component {
     } catch (error) {
       const message =
         error && (error.message || (error.data && error.data.message));
-      this.layout.setSaveError(message);
+      this.saveStatusRef.current.setSaveError(message);
       MetabaseAnalytics.trackEvent(
         "General Settings",
         setting.display_name,
@@ -213,7 +218,7 @@ export default class SettingsEditorApp extends Component {
   render() {
     return (
       <AdminLayout
-        ref={layout => (this.layout = layout)}
+        saveStatusRef={this.saveStatusRef}
         title={t`Settings`}
         sidebar={this.renderSettingsSections()}
       >

--- a/frontend/src/metabase/components/AdminHeader.jsx
+++ b/frontend/src/metabase/components/AdminHeader.jsx
@@ -11,7 +11,7 @@ export default class AdminHeader extends Component {
           {this.props.title}
         </div>
         <div className="MetadataEditor-headerSection absolute right float-right top bottom flex layout-centered">
-          <SaveStatus />
+          <SaveStatus ref={this.props.saveStatusRef} />
         </div>
       </div>
     );

--- a/frontend/src/metabase/components/AdminHeader.jsx
+++ b/frontend/src/metabase/components/AdminHeader.jsx
@@ -11,7 +11,7 @@ export default class AdminHeader extends Component {
           {this.props.title}
         </div>
         <div className="MetadataEditor-headerSection absolute right float-right top bottom flex layout-centered">
-          <SaveStatus ref="status" />
+          <SaveStatus />
         </div>
       </div>
     );

--- a/frontend/src/metabase/components/AdminLayout.jsx
+++ b/frontend/src/metabase/components/AdminLayout.jsx
@@ -4,21 +4,11 @@ import React, { Component } from "react";
 import AdminHeader from "./AdminHeader";
 
 export default class AdminLayout extends Component {
-  setSaving = () => {
-    this.refs.header.refs.status.setSaving();
-  };
-  setSaved = () => {
-    this.refs.header.refs.status.setSaved();
-  };
-  setSaveError = error => {
-    this.refs.header.refs.status.setSaveError(error);
-  };
-
   render() {
     const { title, sidebar, children } = this.props;
     return (
       <div className="MetadataEditor full-height flex flex-column flex-full p4">
-        <AdminHeader ref="header" title={title} />
+        <AdminHeader title={title} />
         <div className="MetadataEditor-main flex flex-row flex-full mt2">
           {sidebar}
           <div className="px2 full">{children}</div>

--- a/frontend/src/metabase/components/AdminLayout.jsx
+++ b/frontend/src/metabase/components/AdminLayout.jsx
@@ -5,10 +5,10 @@ import AdminHeader from "./AdminHeader";
 
 export default class AdminLayout extends Component {
   render() {
-    const { title, sidebar, children } = this.props;
+    const { title, sidebar, children, saveStatusRef } = this.props;
     return (
       <div className="MetadataEditor full-height flex flex-column flex-full p4">
-        <AdminHeader title={title} />
+        <AdminHeader saveStatusRef={saveStatusRef} title={title} />
         <div className="MetadataEditor-main flex flex-row flex-full mt2">
           {sidebar}
           <div className="px2 full">{children}</div>

--- a/frontend/src/metabase/components/ColorPicker.jsx
+++ b/frontend/src/metabase/components/ColorPicker.jsx
@@ -23,6 +23,11 @@ const ColorSquare = ({ color, size }) => (
 );
 
 class ColorPicker extends Component {
+  constructor(props) {
+    super(props);
+
+    this.colorPopover = React.createRef();
+  }
   static defaultProps = {
     size: DEFAULT_COLOR_SQUARE_SIZE,
     triggerSize: DEFAULT_COLOR_SQUARE_SIZE,
@@ -43,7 +48,7 @@ class ColorPicker extends Component {
     return (
       <div className="inline-block">
         <PopoverWithTrigger
-          ref="colorPopover"
+          ref={this.colorPopover}
           triggerElement={
             <div
               className="bordered rounded flex align-center"
@@ -65,7 +70,7 @@ class ColorPicker extends Component {
                 />
               </div>
               <div className="p1 border-top">
-                <Button onClick={() => this.refs.colorPopover.close()}>
+                <Button onClick={() => this.colorPopover.current.close()}>
                   Done
                 </Button>
               </div>
@@ -85,7 +90,7 @@ class ColorPicker extends Component {
                     key={index}
                     onClick={() => {
                       onChange(color);
-                      this.refs.colorPopover.close();
+                      this.colorPopover.current.close();
                     }}
                   >
                     <ColorSquare color={color} size={size} />

--- a/frontend/src/metabase/components/Confirm.jsx
+++ b/frontend/src/metabase/components/Confirm.jsx
@@ -6,6 +6,12 @@ import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import ConfirmContent from "./ConfirmContent";
 
 export default class Confirm extends Component {
+  constructor(props) {
+    super(props);
+
+    this.modal = React.createRef();
+  }
+
   static propTypes = {
     action: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
@@ -18,7 +24,7 @@ export default class Confirm extends Component {
     const { action, children, title, content, triggerClasses } = this.props;
     return (
       <ModalWithTrigger
-        ref="modal"
+        ref={this.modal}
         triggerElement={children}
         triggerClasses={triggerClasses}
       >
@@ -26,7 +32,7 @@ export default class Confirm extends Component {
           title={title}
           content={content}
           onClose={() => {
-            this.refs.modal.close();
+            this.modal.current.close();
           }}
           onAction={action}
         />

--- a/frontend/src/metabase/components/EditBar.jsx
+++ b/frontend/src/metabase/components/EditBar.jsx
@@ -22,7 +22,6 @@ class EditBar extends Component {
         className={cx("EditHeader wrapper py1 flex align-center", {
           "EditHeader--admin": admin,
         })}
-        ref="editHeader"
       >
         <span className="EditHeader-title">{title}</span>
         {subtitle && (

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 import HeaderModal from "metabase/components/HeaderModal";
@@ -25,6 +24,7 @@ export default class Header extends Component {
     this.state = {
       headerHeight: 0,
     };
+    this.header = React.createRef();
   }
 
   componentDidMount() {
@@ -39,11 +39,11 @@ export default class Header extends Component {
   }
 
   updateHeaderHeight() {
-    if (!this.refs.header) {
+    if (!this.header.current) {
       return;
     }
 
-    const rect = ReactDOM.findDOMNode(this.refs.header).getBoundingClientRect();
+    const rect = this.header.current.getBoundingClientRect();
     const headerHeight = rect.top + getScrollY();
     if (this.state.headerHeight !== headerHeight) {
       this.setState({ headerHeight });
@@ -142,7 +142,7 @@ export default class Header extends Component {
             "QueryBuilder-section flex align-center " +
             this.props.headerClassName
           }
-          ref="header"
+          ref={this.header}
         >
           <div className="Entity py3">
             <span className="inline-block mb1">{titleAndDescription}</span>

--- a/frontend/src/metabase/components/NewsletterForm.jsx
+++ b/frontend/src/metabase/components/NewsletterForm.jsx
@@ -1,7 +1,6 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
@@ -27,6 +26,8 @@ export default class NewsletterForm extends Component {
         top: "-12px",
       },
     };
+
+    this.email = React.createRef();
   }
 
   static propTypes = {
@@ -37,7 +38,7 @@ export default class NewsletterForm extends Component {
     e.preventDefault();
 
     const formData = new FormData();
-    formData.append("EMAIL", ReactDOM.findDOMNode(this.refs.email).value);
+    formData.append("EMAIL", this.email.current.value);
     formData.append("b_869fec0e4689e8fd1db91e795_b9664113a8", "");
 
     const req = new XMLHttpRequest();
@@ -86,7 +87,7 @@ export default class NewsletterForm extends Component {
                 {!submitted ? (
                   <div className="">
                     <input
-                      ref="email"
+                      ref={this.email}
                       style={this.styles.input}
                       className="AdminInput bordered rounded h3 inline-block"
                       type="email"

--- a/frontend/src/metabase/components/PasswordReveal.jsx
+++ b/frontend/src/metabase/components/PasswordReveal.jsx
@@ -46,7 +46,6 @@ export default class PasswordReveal extends Component {
 
         {visible ? (
           <input
-            ref="input"
             style={styles.input}
             className="text-light text-normal mr3 borderless"
             value={password}

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -106,6 +106,8 @@ export default class TokenField extends Component {
       isAllSelected: false,
       listIsHovered: false,
     };
+
+    this.inputRef = React.createRef();
   }
 
   static defaultProps = {
@@ -325,7 +327,7 @@ export default class TokenField extends Component {
 
   onInputBlur = () => {
     if (this.props.updateOnInputBlur && this.props.parseFreeformValue) {
-      const input = findDOMNode(this.refs.input);
+      const input = this.inputRef.current;
       const value = this.props.parseFreeformValue(input.value);
       if (
         value != null &&
@@ -358,7 +360,7 @@ export default class TokenField extends Component {
   };
 
   onMouseDownCapture = e => {
-    const input = findDOMNode(this.refs.input);
+    const input = this.inputRef.current;
     input.focus();
     // prevents clicks from blurring input while still allowing text selection:
     if (input !== e.target) {
@@ -373,7 +375,7 @@ export default class TokenField extends Component {
   addSelectedOption(e) {
     const { multi } = this.props;
     const { filteredOptions, selectedOptionValue } = this.state;
-    const input = findDOMNode(this.refs.input);
+    const input = this.inputRef.current;
     const option = _.find(filteredOptions, option =>
       this._valueIsEqual(selectedOptionValue, this._value(option)),
     );
@@ -461,7 +463,7 @@ export default class TokenField extends Component {
     }
     // if we added a value then scroll to the last item (the input)
     if (this.props.value.length > prevProps.value.length) {
-      const input = findDOMNode(this.refs.input);
+      const input = this.inputRef.current;
       if (input && isObscured(input)) {
         input.scrollIntoView({ block: "nearest" });
       }
@@ -566,7 +568,7 @@ export default class TokenField extends Component {
         ))}
         <li className={cx("flex-full flex align-center mr1 mb1 p1")}>
           <input
-            ref="input"
+            ref={this.inputRef}
             style={{ ...defaultStyleValue, ...valueStyle }}
             className={cx("full no-focus borderless px1")}
             // set size to be small enough that it fits in a parameter.
@@ -598,11 +600,6 @@ export default class TokenField extends Component {
           {filteredOptions.map(option => (
             <li className="mr1" key={this._key(option)}>
               <div
-                ref={
-                  this._valueIsEqual(selectedOptionValue, this._value(option))
-                    ? _ => (this.scrollElement = _)
-                    : null
-                }
                 className={cx(
                   `py1 pl1 pr2 block rounded text-bold text-${color}-hover inline-block full cursor-pointer`,
                   `bg-light-hover`,

--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import { isObscured } from "metabase/lib/dom";
 
@@ -27,6 +26,7 @@ export default ComposedComponent =>
       this._startCheckObscured = this._startCheckObscured.bind(this);
       this._stopCheckObscured = this._stopCheckObscured.bind(this);
       this.onClose = this.onClose.bind(this);
+      this.trigger = React.createRef();
     }
 
     static defaultProps = {
@@ -47,11 +47,7 @@ export default ComposedComponent =>
 
     onClose(e) {
       // don't close if clicked the actual trigger, it will toggle
-      if (
-        e &&
-        e.target &&
-        ReactDOM.findDOMNode(this.refs.trigger).contains(e.target)
-      ) {
+      if (e && e.target && this.trigger.current.contains(e.target)) {
         return;
       }
 
@@ -66,7 +62,7 @@ export default ComposedComponent =>
       if (this.props.target) {
         return this.props.target();
       } else {
-        return this.refs.trigger;
+        return this.trigger.current;
       }
     }
 
@@ -89,7 +85,7 @@ export default ComposedComponent =>
     _startCheckObscured() {
       if (this._offscreenTimer == null) {
         this._offscreenTimer = setInterval(() => {
-          const trigger = ReactDOM.findDOMNode(this.refs.trigger);
+          const trigger = this.trigger.current;
           if (isObscured(trigger)) {
             this.close();
           }
@@ -139,7 +135,7 @@ export default ComposedComponent =>
       return (
         <a
           id={triggerId}
-          ref="trigger"
+          ref={this.trigger}
           onClick={event => {
             event.preventDefault();
             !this.props.disabled && this.toggle();

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-string-refs */
 import React from "react";
 import { t } from "ttag";
 import cx from "classnames";

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -76,7 +76,12 @@ type State = {
 };
 
 export default class DashboardHeader extends Component {
-  props: Props;
+  constructor(props: Props) {
+    super(props);
+
+    this.addQuestionModal = React.createRef();
+  }
+
   state: State = {
     modal: null,
   };
@@ -197,7 +202,7 @@ export default class DashboardHeader extends Component {
       buttons.push(
         <ModalWithTrigger
           key="add-a-question"
-          ref="addQuestionModal"
+          ref={this.addQuestionModal}
           triggerElement={
             <Tooltip tooltip={t`Add question`}>
               <Icon name="add" data-metabase-event="Dashboard;Add Card Modal" />
@@ -208,7 +213,7 @@ export default class DashboardHeader extends Component {
             dashboard={dashboard}
             addCardToDashboard={this.props.addCardToDashboard}
             onEditingChange={this.props.onEditingChange}
-            onClose={() => this.refs.addQuestionModal.toggle()}
+            onClose={() => this.addQuestionModal.current.toggle()}
           />
         </ModalWithTrigger>,
       );

--- a/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/RefreshWidget.jsx
@@ -21,6 +21,11 @@ const OPTIONS = [
 ];
 
 export default class RefreshWidget extends Component {
+  constructor(props) {
+    super(props);
+
+    this.popover = React.createRef();
+  }
   state = { elapsed: null };
 
   UNSAFE_componentWillMount() {
@@ -46,7 +51,7 @@ export default class RefreshWidget extends Component {
     const remaining = period - elapsed;
     return (
       <PopoverWithTrigger
-        ref="popover"
+        ref={this.popover}
         triggerElement={
           elapsed == null ? (
             <Tooltip tooltip={t`Auto-refresh`}>
@@ -84,7 +89,7 @@ export default class RefreshWidget extends Component {
                 period={option.period}
                 selected={option.period === period}
                 onClick={() => {
-                  this.refs.popover.close();
+                  this.popover.current.close();
                   onChangePeriod(option.period);
                 }}
               />

--- a/frontend/src/metabase/parameters/components/ParameterTargetWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterTargetWidget.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger.jsx";

--- a/frontend/src/metabase/parameters/components/ParameterTargetWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterTargetWidget.jsx
@@ -21,7 +21,11 @@ type Props = {
 };
 
 export default class ParameterTargetWidget extends React.Component {
-  props: Props;
+  constructor(props: Props) {
+    super(props);
+
+    this.popover = React.createRef();
+  }
 
   static defaultProps = {
     children: ({ selected, placeholder }) => (
@@ -45,7 +49,7 @@ export default class ParameterTargetWidget extends React.Component {
 
     return (
       <PopoverWithTrigger
-        ref="popover"
+        ref={this.popover}
         triggerClasses={cx({ disabled: disabled })}
         sizeToFit
         triggerElement={
@@ -57,7 +61,7 @@ export default class ParameterTargetWidget extends React.Component {
         <ParameterTargetList
           onChange={target => {
             onChange(target);
-            this.refs.popover.close();
+            this.popover.current.close();
           }}
           target={target}
           mappingOptions={mappingOptions}

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -98,6 +98,9 @@ export default class ParameterValueWidget extends Component {
     if (_.isEmpty(this.props.values)) {
       this.updateFieldValues(this.props);
     }
+
+    this.valuePopover = React.createRef();
+    this.trigger = React.createRef();
   }
 
   componentDidUpdate(prevProps) {
@@ -127,13 +130,13 @@ export default class ParameterValueWidget extends Component {
   };
 
   onPopoverClose = () => {
-    if (this.refs.valuePopover) {
-      this.refs.valuePopover.close();
+    if (this.valuePopover.current) {
+      this.valuePopover.current.close();
     }
   };
 
   getTargetRef = () => {
-    return this.refs.trigger;
+    return this.trigger.current;
   };
 
   render() {
@@ -185,10 +188,10 @@ export default class ParameterValueWidget extends Component {
 
       return (
         <PopoverWithTrigger
-          ref="valuePopover"
+          ref={this.valuePopover}
           triggerElement={
             <div
-              ref="trigger"
+              ref={this.trigger}
               className={cx(S.parameter, className, { [S.selected]: hasValue })}
             >
               {showTypeIcon && <ParameterTypeIcon parameter={parameter} />}

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -42,6 +42,12 @@ export default class PulseEdit extends Component {
     initialCollectionId: PropTypes.number,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.pulseInfo = React.createRef();
+  }
+
   componentDidMount() {
     this.props.setEditingPulse(
       this.props.pulseId,
@@ -140,18 +146,18 @@ export default class PulseEdit extends Component {
         <div className="PulseEdit-header flex align-center border-bottom py3">
           <h1>{pulse && pulse.id != null ? t`Edit pulse` : t`New pulse`}</h1>
           <ModalWithTrigger
-            ref="pulseInfo"
+            ref={this.pulseInfo}
             className="Modal WhatsAPulseModal"
             triggerElement={t`What's a Pulse?`}
             triggerClasses="text-brand text-bold flex-align-right"
           >
-            <ModalContent onClose={() => this.refs.pulseInfo.close()}>
+            <ModalContent onClose={() => this.pulseInfo.current.close()}>
               <div className="mx4 mb4">
                 <WhatsAPulse
                   button={
                     <button
                       className="Button Button--primary"
-                      onClick={() => this.refs.pulseInfo.close()}
+                      onClick={() => this.pulseInfo.current.close()}
                     >{t`Got it`}</button>
                   }
                 />

--- a/frontend/src/metabase/pulse/components/PulseEditName.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditName.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import { t } from "ttag";
 
 import _ from "underscore";
@@ -14,6 +13,8 @@ export default class PulseEditName extends Component {
       valid: true,
     };
 
+    this.name = React.createRef();
+
     _.bindAll(this, "setName", "validate");
   }
 
@@ -26,7 +27,7 @@ export default class PulseEditName extends Component {
   }
 
   validate() {
-    this.setState({ valid: !!ReactDOM.findDOMNode(this.refs.name).value });
+    this.setState({ valid: !!this.name.current.value });
   }
 
   render() {
@@ -39,14 +40,14 @@ export default class PulseEditName extends Component {
         </p>
         <div className="my3">
           <input
-            ref="name"
+            ref={this.name}
             className={cx("input text-bold", {
               "border-error": !this.state.valid,
             })}
             style={{ width: "400px" }}
             value={pulse.name || ""}
             onChange={this.setName}
-            onBlur={this.refs.name && this.validate}
+            onBlur={this.name.current && this.validate}
             placeholder={t`Important metrics`}
             autoFocus
           />

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -154,6 +154,7 @@ export class UnconnectedDataSelector extends Component {
       ...state,
       ...computedState,
     };
+    this.popover = React.createRef();
   }
 
   static propTypes = {
@@ -432,7 +433,7 @@ export class UnconnectedDataSelector extends Component {
     const nextStep = this.getNextStep();
     if (!nextStep) {
       await this.setStateWithComputedState(stateChange);
-      this.refs.popover.toggle();
+      this.popover.current.toggle();
     } else {
       await this.switchToStep(nextStep, stateChange, skipSteps);
     }
@@ -664,7 +665,7 @@ export class UnconnectedDataSelector extends Component {
     return (
       <PopoverWithTrigger
         id="DataPopover"
-        ref="popover"
+        ref={this.popover}
         isInitiallyOpen={this.props.isInitiallyOpen}
         triggerElement={this.getTriggerElement()}
         triggerClasses={this.getTriggerClasses()}

--- a/frontend/src/metabase/query_builder/components/FieldWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldWidget.jsx
@@ -50,7 +50,7 @@ export default class FieldWidget extends React.Component {
   renderPopover() {
     if (this.state.isOpen) {
       return (
-        <Popover ref="popover" className="FieldPopover" onClose={this.toggle}>
+        <Popover className="FieldPopover" onClose={this.toggle}>
           <FieldList
             className={"text-" + this.props.color}
             field={this.props.field}

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+/* eslint-disable react/no-string-refs */
 import React from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
@@ -48,7 +49,13 @@ type State = {
 };
 
 export default class GuiQueryEditor extends React.Component {
-  props: Props;
+  constructor(props: Props) {
+    super(props);
+
+    this.filterPopover = React.createRef();
+    this.guiBuilder = React.createRef();
+  }
+
   state: State = {
     expanded: true,
   };
@@ -151,10 +158,9 @@ export default class GuiQueryEditor extends React.Component {
         <div className="mx2">
           <PopoverWithTrigger
             id="FilterPopover"
-            ref="filterPopover"
+            ref={this.filterPopover}
             triggerElement={addFilterButton}
             triggerClasses="flex align-center"
-            getTarget={() => this.refs.addFilterTarget}
             horizontalAttachments={["left", "center"]}
             autoWidth
           >
@@ -164,7 +170,7 @@ export default class GuiQueryEditor extends React.Component {
               onChangeFilter={filter =>
                 query.filter(filter).update(setDatasetQuery)
               }
-              onClose={() => this.refs.filterPopover.close()}
+              onClose={() => this.filterPopover.current.close()}
               showCustom={false}
             />
           </PopoverWithTrigger>
@@ -334,7 +340,7 @@ export default class GuiQueryEditor extends React.Component {
     return (
       <div
         className="GuiBuilder-section GuiBuilder-filtered-by flex align-center"
-        ref="filterSection"
+        ref={this.filterSection}
       >
         <span className="GuiBuilder-section-label Query-label">{t`Filtered by`}</span>
         {this.renderFilters()}
@@ -377,7 +383,7 @@ export default class GuiQueryEditor extends React.Component {
   }
 
   componentDidUpdate() {
-    const guiBuilder = ReactDOM.findDOMNode(this.refs.guiBuilder);
+    const guiBuilder = this.guiBuilder.current;
     if (!guiBuilder) {
       return;
     }
@@ -405,7 +411,7 @@ export default class GuiQueryEditor extends React.Component {
         className={cx("GuiBuilder rounded shadowed", {
           "GuiBuilder--expand": this.state.expanded,
         })}
-        ref="guiBuilder"
+        ref={this.guiBuilder}
       >
         <div className="GuiBuilder-row flex">
           {this.renderDataSection()}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -1,7 +1,6 @@
 /*global ace*/
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import cx from "classnames";
 
 import "./NativeQueryEditor.css";
@@ -148,6 +147,9 @@ export default class NativeQueryEditor extends Component {
     // e.x. https://github.com/metabase/metabase/issues/2801
     // $FlowFixMe
     this.onChange = _.debounce(this.onChange.bind(this), 1);
+
+    this.editor = React.createRef();
+    this.resizeBox = React.createRef();
   }
 
   maxAutoSizeLines() {
@@ -218,7 +220,7 @@ export default class NativeQueryEditor extends Component {
       this._localUpdate = false;
     }
 
-    const editorElement = ReactDOM.findDOMNode(this.refs.editor);
+    const editorElement = this.editor.current;
     if (query.hasWritePermission()) {
       this._editor.setReadOnly(false);
       editorElement.classList.remove("read-only");
@@ -310,7 +312,7 @@ export default class NativeQueryEditor extends Component {
   loadAceEditor() {
     const { query } = this.props;
 
-    const editorElement = ReactDOM.findDOMNode(this.refs.editor);
+    const editorElement = this.editor.current;
 
     // $FlowFixMe
     if (typeof ace === "undefined" || !ace || !ace.edit) {
@@ -412,7 +414,7 @@ export default class NativeQueryEditor extends Component {
 
   _updateSize() {
     const doc = this._editor.getSession().getDocument();
-    const element = ReactDOM.findDOMNode(this.refs.resizeBox);
+    const element = this.resizeBox.current;
     // set the newHeight based on the line count, but ensure it's within
     // [MIN_HEIGHT_LINES, this.maxAutoSizeLines()]
     const newHeight = getEditorLineHeight(
@@ -605,7 +607,7 @@ export default class NativeQueryEditor extends Component {
           )}
         </div>
         <ResizableBox
-          ref="resizeBox"
+          ref={this.resizeBox}
           className={cx("border-top flex ", { hide: !isNativeEditorOpen })}
           height={this.state.initialHeight}
           minConstraints={[Infinity, getEditorLineHeight(MIN_HEIGHT_LINES)]}
@@ -617,14 +619,10 @@ export default class NativeQueryEditor extends Component {
           }}
           resizeHandles={["s"]}
         >
-          <div className="flex-full" id="id_sql" ref="editor" />
+          <div className="flex-full" id="id_sql" ref={this.editor} />
           <Popover
             isOpen={this.state.isSelectedTextPopoverOpen}
-            target={() =>
-              ReactDOM.findDOMNode(this.refs.editor).querySelector(
-                ".ace_selection",
-              )
-            }
+            target={() => this.editor.current.querySelector(".ace_selection")}
           >
             <div className="flex flex-column">
               <a className="p2 bg-medium-hover flex" onClick={this.runQuery}>

--- a/frontend/src/metabase/query_builder/components/SearchBar.jsx
+++ b/frontend/src/metabase/query_builder/components/SearchBar.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 import { t } from "ttag";
 
 export default class SearchBar extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.handleInputChange = this.handleInputChange.bind(this);
+    this.filterTextInput = React.createRef();
   }
 
   static propTypes = {
@@ -15,7 +15,7 @@ export default class SearchBar extends React.Component {
   };
 
   handleInputChange() {
-    this.props.onFilter(ReactDOM.findDOMNode(this.refs.filterTextInput).value);
+    this.props.onFilter(this.filterTextInput.current.value);
   }
 
   render() {
@@ -23,7 +23,7 @@ export default class SearchBar extends React.Component {
       <input
         className="SearchBar"
         type="text"
-        ref="filterTextInput"
+        ref={this.filterTextInput}
         value={this.props.filter}
         placeholder={t`Search for`}
         onChange={this.handleInputChange}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 
 import { t } from "ttag";
 import _ from "underscore";
@@ -104,6 +103,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       // except currently we exclude `startRule` and `query` since they shouldn't change
       [source, targetOffset].join(","),
     );
+    this.input = React.createRef();
   }
 
   static propTypes = {
@@ -266,14 +266,14 @@ export default class ExpressionEditorTextfield extends React.Component {
   };
 
   _setCaretPosition = (position, autosuggest) => {
-    setCaretPosition(ReactDOM.findDOMNode(this.refs.input), position);
+    setCaretPosition(this.input.current, position);
     if (autosuggest) {
       setTimeout(() => this._triggerAutosuggest());
     }
   };
 
   onExpressionChange(source) {
-    const inputElement = ReactDOM.findDOMNode(this.refs.input);
+    const inputElement = this.input.current;
     if (!inputElement) {
       return;
     }
@@ -383,7 +383,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           {"= "}
         </div>
         <TokenizedInput
-          ref="input"
+          ref={this.input}
           type="text"
           className={cx(inputClassName, {
             "border-error": compileError,

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { Component } from "react";
+import React, { Component, forwardRef } from "react";
 import ReactDOM from "react-dom";
 import ReactDOMServer from "react-dom/server";
 
@@ -16,7 +16,7 @@ const KEYCODE_LEFT = 37;
 const KEYCODE_RIGHT = 39;
 const KEYCODE_FORWARD_DELETE = 46;
 
-export default class TokenizedInput extends Component {
+class TokenizedInput extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -161,9 +161,10 @@ export default class TokenizedInput extends Component {
   }
 
   render() {
-    const { className, onFocus, onBlur, style } = this.props;
+    const { className, onFocus, onBlur, style, forwardedRef } = this.props;
     return (
       <div
+        ref={forwardedRef}
         className={className}
         style={{ ...style }}
         contentEditable
@@ -181,3 +182,7 @@ export default class TokenizedInput extends Component {
     );
   }
 }
+
+export default forwardRef(function TokenizedInputWithForwardedRef(props, ref) {
+  return <TokenizedInput forwardedRef={ref} {...props} />;
+});

--- a/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterWidget.jsx
@@ -105,7 +105,6 @@ export default class FilterWidget extends Component {
       return (
         <Popover
           id="FilterPopover"
-          ref="filterPopover"
           className="FilterPopover"
           isInitiallyOpen={this.props.filter[1] === null}
           onClose={this.close}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
@@ -98,7 +98,6 @@ export default class SpecificDatePicker extends Component {
                 this.onChange(null);
               }
             }}
-            ref="value"
           />
 
           {calendar && (

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
@@ -212,13 +211,6 @@ export default class QueryBuilder extends Component {
     }
   }
 
-  componentDidUpdate() {
-    const viz = ReactDOM.findDOMNode(this.refs.viz);
-    if (viz) {
-      viz.style.opacity = 1.0;
-    }
-  }
-
   componentWillUnmount() {
     // cancel the query if one is running
     this.props.cancelQuery();
@@ -234,10 +226,6 @@ export default class QueryBuilder extends Component {
   // Debounce the function to improve resizing performance.
   handleResize = e => {
     this.forceUpdateDebounced();
-    const viz = ReactDOM.findDOMNode(this.refs.viz);
-    if (viz) {
-      viz.style.opacity = 0.2;
-    }
   };
 
   // NOTE: these were lifted from QueryHeader. Move to Redux?

--- a/frontend/src/metabase/reference/components/RevisionMessageModal.jsx
+++ b/frontend/src/metabase/reference/components/RevisionMessageModal.jsx
@@ -15,11 +15,17 @@ export default class RevisionMessageModal extends Component {
     children: PropTypes.any,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.modal = React.createRef();
+  }
+
   render() {
     const { action, children, field, submitting } = this.props;
 
     const onClose = () => {
-      this.refs.modal.close();
+      this.modal.current.close();
     };
 
     const onAction = () => {
@@ -28,7 +34,7 @@ export default class RevisionMessageModal extends Component {
     };
 
     return (
-      <ModalWithTrigger ref="modal" triggerElement={children}>
+      <ModalWithTrigger ref={this.modal} triggerElement={children}>
         <ModalContent title={t`Reason for changes`} onClose={onClose}>
           <div className={S.modalBody}>
             <textarea

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -1,6 +1,5 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import ExternalLink from "metabase/components/ExternalLink";
@@ -31,6 +30,12 @@ export default class Setup extends Component {
     setActiveStep: PropTypes.func.isRequired,
     databaseDetails: PropTypes.object,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.databaseSchedulingStepContainer = React.createRef();
+  }
 
   completeWelcome() {
     this.props.setActiveStep(LANGUAGE_STEP_NUMBER);
@@ -77,10 +82,8 @@ export default class Setup extends Component {
       nextProps.activeStep === 3
     ) {
       setTimeout(() => {
-        if (this.refs.databaseSchedulingStepContainer) {
-          const node = ReactDOM.findDOMNode(
-            this.refs.databaseSchedulingStepContainer,
-          );
+        if (this.databaseSchedulingStepContainer.current) {
+          const node = this.databaseSchedulingStepContainer.current;
           node && node.scrollIntoView && node.scrollIntoView();
         }
       }, 10);
@@ -145,7 +148,7 @@ export default class Setup extends Component {
               />
 
               {/* Have the ref for scrolling in UNSAFE_componentWillReceiveProps */}
-              <div ref="databaseSchedulingStepContainer">
+              <div ref={this.databaseSchedulingStepContainer}>
                 {/* Show db scheduling step only if the user has explicitly set the "Let me choose when Metabase syncs and scans" toggle to true */}
                 {databaseDetails &&
                   databaseDetails.details &&

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -16,9 +15,15 @@ import Question from "metabase-lib/lib/Question";
 import { updateLatLonFilter } from "metabase/modes/lib/actions";
 
 export default class LeafletMap extends Component {
+  constructor(props) {
+    super(props);
+
+    this.mapRef = React.createRef();
+  }
+
   componentDidMount() {
     try {
-      const element = ReactDOM.findDOMNode(this.refs.map);
+      const element = this.mapRef.current;
 
       const map = (this.map = L.map(element, {
         scrollWheelZoom: false,
@@ -164,7 +169,7 @@ export default class LeafletMap extends Component {
 
   render() {
     const { className } = this.props;
-    return <div className={className} ref="map" />;
+    return <div className={className} ref={this.mapRef} />;
   }
 
   _getLatLonIndexes() {

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/prop-types */
+/* eslint-disable react/no-string-refs */
 import React, { Component } from "react";
+import ReactDOM from "react-dom";
 import styles from "./Legend.css";
 
 import LegendItem from "./LegendItem";
@@ -7,13 +9,6 @@ import LegendItem from "./LegendItem";
 import cx from "classnames";
 
 export default class LegendHorizontal extends Component {
-  constructor(props) {
-    super(props);
-
-    props.titles.map((title, index) => {
-      this["legendItem" + index] = React.createRef();
-    });
-  }
   render() {
     const { className, titles, colors, hovered, onHoverChange } = this.props;
     return (
@@ -32,7 +27,9 @@ export default class LegendHorizontal extends Component {
                 onHoverChange &&
                 onHoverChange({
                   index,
-                  element: this["legendItem" + index].current,
+                  element: ReactDOM.findDOMNode(
+                    this.refs["legendItem" + index],
+                  ),
                 })
               }
               onMouseLeave={() => onHoverChange && onHoverChange(null)}

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import styles from "./Legend.css";
 
 import LegendItem from "./LegendItem";
@@ -8,17 +7,21 @@ import LegendItem from "./LegendItem";
 import cx from "classnames";
 
 export default class LegendHorizontal extends Component {
+  constructor(props) {
+    super(props);
+
+    props.titles.map((title, index) => {
+      this["legendItem" + index] = React.createRef();
+    });
+  }
   render() {
     const { className, titles, colors, hovered, onHoverChange } = this.props;
     return (
-      <ol
-        ref="container"
-        className={cx(className, styles.Legend, styles.horizontal)}
-      >
+      <ol className={cx(className, styles.Legend, styles.horizontal)}>
         {titles.map((title, index) => (
           <li key={index}>
             <LegendItem
-              ref={"legendItem" + index}
+              ref={this["legendItem" + index]}
               title={title}
               color={colors[index % colors.length]}
               isMuted={
@@ -29,9 +32,7 @@ export default class LegendHorizontal extends Component {
                 onHoverChange &&
                 onHoverChange({
                   index,
-                  element: ReactDOM.findDOMNode(
-                    this.refs["legendItem" + index],
-                  ),
+                  element: this["legendItem" + index].current,
                 })
               }
               onMouseLeave={() => onHoverChange && onHoverChange(null)}

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -7,10 +7,6 @@ import Ellipsified from "metabase/components/Ellipsified";
 
 import cx from "classnames";
 
-// Don't use a <a> tag if there's no href
-const LegendLink = props =>
-  props.href ? <a {...props} /> : <span {...props} />;
-
 export default class LegendItem extends Component {
   constructor(props, context) {
     super(props, context);
@@ -42,8 +38,9 @@ export default class LegendItem extends Component {
       onClick,
       infoClassName,
     } = this.props;
+
     return (
-      <LegendLink
+      <span
         className={cx(
           className,
           "LegendItem",
@@ -85,7 +82,7 @@ export default class LegendItem extends Component {
             )}
           </div>
         )}
-      </LegendLink>
+      </span>
     );
   }
 }

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+/* eslint-disable react/no-string-refs */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import styles from "./Legend.css";
@@ -64,10 +65,7 @@ export default class LegendVertical extends Component {
       items = titles;
     }
     return (
-      <ol
-        ref="container"
-        className={cx(className, styles.Legend, styles.vertical)}
-      >
+      <ol className={cx(className, styles.Legend, styles.vertical)}>
         {items.map((title, index) => (
           <li
             key={index}

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import ReactDOM from "react-dom";
 
 import styles from "./Table.css";
 
@@ -62,6 +61,10 @@ export default class TableSimple extends Component {
       sortColumn: null,
       sortDescending: false,
     };
+
+    this.headerRef = React.createRef();
+    this.footerRef = React.createRef();
+    this.firstRowRef = React.createRef();
   }
 
   static propTypes = {
@@ -81,15 +84,12 @@ export default class TableSimple extends Component {
   }
 
   componentDidUpdate() {
-    const headerHeight = ReactDOM.findDOMNode(
-      this.refs.header,
-    ).getBoundingClientRect().height;
-    const footerHeight = this.refs.footer
-      ? ReactDOM.findDOMNode(this.refs.footer).getBoundingClientRect().height
+    const headerHeight = this.headerRef.current.getBoundingClientRect().height;
+    const footerHeight = this.footerRef.current
+      ? this.footerRef.current.getBoundingClientRect().height
       : 0;
     const rowHeight =
-      ReactDOM.findDOMNode(this.refs.firstRow).getBoundingClientRect().height +
-      1;
+      this.firstRowRef.current.getBoundingClientRect().height + 1;
     const pageSize = Math.max(
       1,
       Math.floor((this.props.height - headerHeight - footerHeight) / rowHeight),
@@ -163,7 +163,7 @@ export default class TableSimple extends Component {
                 "fullscreen-night-text",
               )}
             >
-              <thead ref="header">
+              <thead ref={this.headerRef}>
                 <tr>
                   {cols.map((col, colIndex) => (
                     <th
@@ -199,7 +199,7 @@ export default class TableSimple extends Component {
                 {rowIndexes.slice(start, end + 1).map((rowIndex, index) => (
                   <tr
                     key={rowIndex}
-                    ref={index === 0 ? "firstRow" : null}
+                    ref={index === 0 ? this.firstRowRef : null}
                     data-testid="table-row"
                   >
                     {rows[rowIndex].map((value, columnIndex) => {
@@ -293,7 +293,7 @@ export default class TableSimple extends Component {
         </div>
         {pageSize < rows.length ? (
           <div
-            ref="footer"
+            ref={this.footerRef}
             className="p1 flex flex-no-shrink flex-align-right fullscreen-normal-text fullscreen-night-text"
           >
             <span className="text-bold">{paginateMessage}</span>

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import styles from "./PieChart.css";
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import ReactDOM from "react-dom";
 import styles from "./PieChart.css";
 import { t } from "ttag";
 import ChartTooltip from "../components/ChartTooltip";
@@ -42,7 +41,12 @@ const PERCENT_REGEX = /percent/i;
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
 export default class PieChart extends Component {
-  props: VisualizationProps;
+  constructor(props: VisualizationProps) {
+    super(props);
+
+    this.chartDetail = React.createRef();
+    this.chartGroup = React.createRef();
+  }
 
   static uiName = t`Pie`;
   static identifier = "pie";
@@ -194,8 +198,8 @@ export default class PieChart extends Component {
 
   componentDidUpdate() {
     requestAnimationFrame(() => {
-      const groupElement = ReactDOM.findDOMNode(this.refs.group);
-      const detailElement = ReactDOM.findDOMNode(this.refs.detail);
+      const groupElement = this.chartGroup.current;
+      const detailElement = this.chartDetail.current;
       if (groupElement.getBoundingClientRect().width < 120) {
         detailElement.classList.add("hide");
       } else {
@@ -420,7 +424,7 @@ export default class PieChart extends Component {
         isDashboard={this.props.isDashboard}
       >
         <div className={styles.ChartAndDetail}>
-          <div ref="detail" className={styles.Detail}>
+          <div ref={this.chartDetail} className={styles.Detail}>
             <div
               data-testid="detail-value"
               className={cx(
@@ -438,7 +442,7 @@ export default class PieChart extends Component {
               viewBox="0 0 100 100"
               style={{ maxWidth: MAX_PIE_SIZE, maxHeight: MAX_PIE_SIZE }}
             >
-              <g ref="group" transform={`translate(50,50)`}>
+              <g ref={this.chartGroup} transform={`translate(50,50)`}>
                 {pie(slices).map((slice, index) => (
                   <path
                     data-testid="slice"

--- a/frontend/src/metabase/visualizations/visualizations/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import { t } from "ttag";

--- a/frontend/src/metabase/visualizations/visualizations/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress.jsx
@@ -20,7 +20,14 @@ const MAX_BAR_HEIGHT = 65;
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
 export default class Progress extends Component {
-  props: VisualizationProps;
+  constructor(props: VisualizationProps) {
+    super(props);
+
+    this.containerRef = React.createRef();
+    this.labelRef = React.createRef();
+    this.pointerRef = React.createRef();
+    this.barRef = React.createRef();
+  }
 
   static uiName = t`Progress`;
   static identifier = "progress";
@@ -75,10 +82,10 @@ export default class Progress extends Component {
 
   componentDidUpdate() {
     const component = ReactDOM.findDOMNode(this);
-    const pointer = ReactDOM.findDOMNode(this.refs.pointer);
-    const label = ReactDOM.findDOMNode(this.refs.label);
-    const container = ReactDOM.findDOMNode(this.refs.container);
-    const bar = ReactDOM.findDOMNode(this.refs.bar);
+    const pointer = this.pointerRef.current;
+    const label = this.labelRef.current;
+    const container = this.containerRef.current;
+    const bar = this.barRef.current;
 
     // Safari not respecting `height: 25%` so just do it here ¯\_(ツ)_/¯
     bar.style.height = Math.min(MAX_BAR_HEIGHT, component.offsetHeight) + "px";
@@ -171,17 +178,17 @@ export default class Progress extends Component {
           style={{ padding: 10, paddingTop: 0 }}
         >
           <div
-            ref="container"
+            ref={this.containerRef}
             className="relative text-bold text-medium"
             style={{ height: 20 }}
           >
-            <div ref="label" style={{ position: "absolute" }}>
+            <div ref={this.labelRef} style={{ position: "absolute" }}>
               {formatValue(value, settings.column(column))}
             </div>
           </div>
           <div className="relative" style={{ height: 10, marginBottom: 5 }}>
             <div
-              ref="pointer"
+              ref={this.pointerRef}
               style={{
                 width: 0,
                 height: 0,
@@ -195,7 +202,7 @@ export default class Progress extends Component {
             />
           </div>
           <div
-            ref="bar"
+            ref={this.barRef}
             className={cx("relative", { "cursor-pointer": isClickable })}
             style={{
               backgroundColor: restColor,


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes eslint `react/no-string-refs` error
- Enables that rule in the `.eslintrc` and sets it to error
- Additionally, there were 4 more files with `react/prop-types` errors that were breaking the build
    - Linting in those files is now disabled

### Additional notes:
The error fixes are a cherry-pick of 531b25f877c63798a3cab96065020254edcb92c8 (original PR #15427)