### PR TITLE
Fix BigQuery UNIX timestamps

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -147,13 +147,13 @@
     nil))
 
 (defmethod temporal-type (class Field)
-  [{base-type :base_type, database-type :database_type}]
+  [{base-type :base_type, effective-type :effective_type, database-type :database_type}]
   (case database-type
     "TIMESTAMP" :timestamp
     "DATETIME"  :datetime
     "DATE"      :date
     "TIME"      :time
-    (base-type->temporal-type base-type)))
+    (base-type->temporal-type (or effective-type base-type))))
 
 (defmethod temporal-type :absolute-datetime
   [[_ t _]]

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8045,11 +8045,12 @@ databaseChangeLog:
       validCheckSum:
         - 8:4fa37c8edede4a10c39bf5aca13bd1b5
         - 8:96af0fae84744857640d029cf4cd4bb6
+        - 8:8a8b10ff335892c18394a6e00676a446
       changes:
         - sql:
               sql: >-
                 UPDATE metabase_field
-                set effective_type    = 'type/DateTime',
+                set effective_type    = 'type/Instant',
                     coercion_strategy = (case semantic_type
                                           WHEN 'type/UNIXTimestampSeconds'      THEN 'Coercion/UNIXSeconds->DateTime'
                                           WHEN 'type/UNIXTimestampMilliSeconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
@@ -8063,11 +8064,14 @@ databaseChangeLog:
       id: 289
       author: dpsutton
       comment: Added 0.39 - Semantic type system - migrate unix timestamps (corrects typo- seconds was migrated correctly, not millis and micros)
+      validCheckSum:
+        - 8:c5398e06bc1bd497f9b56d3e8497b88a
+        - 8:9f7f2e9bbf3236f204c644dc8ea7abef
       changes:
         - sql:
               sql: >-
                 UPDATE metabase_field
-                set effective_type    = 'type/DateTime',
+                set effective_type    = 'type/Instant',
                     coercion_strategy = (case semantic_type
                                           WHEN 'type/UNIXTimestampMilliseconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
                                           WHEN 'type/UNIXTimestampMicroseconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'

--- a/shared/src/metabase/types.cljc
+++ b/shared/src/metabase/types.cljc
@@ -101,10 +101,10 @@
 ;; normalized to UTC, it is a DateTimeWithLocalTZ
 ;;
 ;; `Instant` if differentiated from other `DateTimeWithLocalTZ` columns in the same way `java.time.Instant` is
-;; different from `java.time.OffsetDateTime`
-;;
-;; TIMEZONE FIXME — not 100% sure this distinction is needed or makes sense.
+;; different from `java.time.OffsetDateTime`;
 (derive :type/Instant :type/DateTimeWithLocalTZ)
+
+;; TODO -- shouldn't we have a `:type/LocalDateTime` as well?
 
 (derive :type/UNIXTimestamp :type/Instant)
 (derive :type/UNIXTimestamp :type/Integer)
@@ -251,9 +251,9 @@
   ;; that's an intentional mapping or not. But it does mean that lots of extra columns will be offered a conversion
   ;; (think Price being offerred to be interpreted as a date)
   (let [numeric-types [:type/BigInteger :type/Integer :type/Decimal]]
-    (reduce #(assoc %1 %2 {:Coercion/UNIXMicroSeconds->DateTime :type/DateTime
-                           :Coercion/UNIXMilliSeconds->DateTime :type/DateTime
-                           :Coercion/UNIXSeconds->DateTime      :type/DateTime})
+    (reduce #(assoc %1 %2 {:Coercion/UNIXMicroSeconds->DateTime :type/Instant
+                           :Coercion/UNIXMilliSeconds->DateTime :type/Instant
+                           :Coercion/UNIXSeconds->DateTime      :type/Instant})
             {:type/Text   {:Coercion/ISO8601->Date     :type/Date
                            :Coercion/ISO8601->DateTime :type/DateTime
                            :Coercion/ISO8601->Time     :type/Time}}
@@ -268,12 +268,12 @@
   "The effective type resulting from a coercion."
   [coercion]
   ;;todo: unify this with the coercions map above
-  (get {:Coercion/ISO8601->Date :type/Date
-        :Coercion/ISO8601->DateTime :type/DateTime
-        :Coercion/ISO8601->Time :type/Time
-        :Coercion/UNIXMicroSeconds->DateTime :type/DateTime
-        :Coercion/UNIXMilliSeconds->DateTime :type/DateTime
-        :Coercion/UNIXSeconds->DateTime :type/DateTime}
+  (get {:Coercion/ISO8601->Date              :type/Date
+        :Coercion/ISO8601->DateTime          :type/DateTime
+        :Coercion/ISO8601->Time              :type/Time
+        :Coercion/UNIXMicroSeconds->DateTime :type/Instant
+        :Coercion/UNIXMilliSeconds->DateTime :type/Instant
+        :Coercion/UNIXSeconds->DateTime      :type/Instant}
        (keyword coercion)))
 
 (defn ^:export coercions-for-type

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -126,17 +126,17 @@
                   :semantic_type     nil
                   :name              "iso-time"}
                  {:base_type         :type/Integer
-                  :effective_type    :type/DateTime
+                  :effective_type    :type/Instant
                   :coercion_strategy :Coercion/UNIXSeconds->DateTime
                   :semantic_type     nil
                   :name              "unix-seconds"}
                  {:base_type         :type/Integer
-                  :effective_type    :type/DateTime
+                  :effective_type    :type/Instant
                   :coercion_strategy :Coercion/UNIXMilliSeconds->DateTime
                   :semantic_type     nil
                   :name              "unix-millis"}
                  {:base_type         :type/Integer
-                  :effective_type    :type/DateTime
+                  :effective_type    :type/Instant
                   :coercion_strategy :Coercion/UNIXMicroSeconds->DateTime
                   :semantic_type     nil
                   :name              "unix-micros"}])

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -72,7 +72,7 @@
                            :parent_id         nil
                            :table_id          $$sightings
                            :base_type         :type/BigInteger
-                           :effective_type    :type/DateTime
+                           :effective_type    :type/Instant
                            :coercion_strategy :Coercion/UNIXSeconds->DateTime})
                   :value {:type  :date/range
                           :value "2020-02-01~2020-02-29"}}

--- a/test/metabase/test/data/dataset_definitions/sad-toucan-incidents.edn
+++ b/test/metabase/test/data/dataset_definitions/sad-toucan-incidents.edn
@@ -2,7 +2,7 @@
                 :base-type  :type/Integer}
                {:field-name    "timestamp"
                 :base-type     :type/BigInteger
-                :effective-type :type/DateTime
+                :effective-type :type/Instant
                 :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime}]
    [[4 1433587200000]
     [0 1433965860000]

--- a/test/metabase/test/data/dataset_definitions/tupac-sightings.edn
+++ b/test/metabase/test/data/dataset_definitions/tupac-sightings.edn
@@ -185,7 +185,7 @@
                 :fk         :categories}
                {:field-name        "timestamp"
                 :base-type         :type/BigInteger
-                :effective-type    :type/DateTime
+                :effective-type    :type/Instant
                 :coercion-strategy :Coercion/UNIXSeconds->DateTime}]
   [[23 14 927183600]
    [65 13 978854400]


### PR DESCRIPTION
I changed the effective type of UNIXTimestamp->*Seconds to `:type/Instant` (a subtype of `:type/DateTime` that refers to an instant in time since the UNIX epoch). This distinction is important because DATETIME and TIMESTAMPs cannot be compared in BigQuery. If we think a column is `:type/Datetime` the BigQuery QP ends up generating code for a DATETIME rather than a TIMESTAMP and the resulting SQL doesn't work. UNIX timestamps should be treated as TIMESTAMPs

Fixes #15376