### PR TITLE
Request IP address logic should use X-Forwarded-For by default

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -77,10 +77,7 @@
   ;; default to `true` if allow_tracking isn't specified. The setting will set itself correctly whether a boolean or
   ;; boolean string is specified
   (public-settings/anon-tracking-enabled (or (nil? allow-tracking?)
-                                             allow-tracking?))
-  ;; set `source-address-header` to "X-Forwarded-For" if such a header is present
-  (when (get-in request [:headers "x-forwarded-for"])
-    (public-settings/source-address-header "X-Forwarded-For")))
+                                             allow-tracking?)))
 
 (api/defendpoint POST "/"
   "Special endpoint for creating the first user during setup. This endpoint both creates the user AND logs them in and

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -283,8 +283,9 @@
 
 (defsetting source-address-header
   (deferred-tru "Identify the source of HTTP requests by this header's value, instead of its remote address.")
-  :getter (fn [] (some-> (setting/get-string :source-address-header)
-                         u/lower-case-en)))
+  :default "X-Forwarded-For"
+  :getter  (fn [] (some-> (setting/get-string :source-address-header)
+                          u/lower-case-en)))
 
 (defn remove-public-uuid-if-public-sharing-is-disabled
   "If public sharing is *disabled* and `object` has a `:public_uuid`, remove it so people don't try to use it (since it

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -84,6 +84,10 @@
   [{:keys [headers remote-addr]}]
   (some-> (or (some->> (public-settings/source-address-header) (get headers))
               remote-addr)
+          ;; first IP (if there are multiple) is the actual client -- see
+          ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+          (str/split #"\s*,\s*")
+          first
           ;; strip out non-ip-address characters like square brackets which we get sometimes
           (str/replace #"[^0-9a-fA-F.:]" "")))
 


### PR DESCRIPTION
Fixes #15437

The logic for determining request IP address would look at the `source-address-header` header in the request if that setting is set -- previously it would get set to `X-Forwarded-For` _during setup_ if that header was present. For existing instances like stats this effectively meant it never got set and `X-Forwarded-For` is ignored.

I changed this logic to make `X-Forwarded-For` the default value -- you can still set it to something else if you need, I assume that's why this Setting exists -- and removed the logic to set that value during set up. This means it should do the right thing on instances that predate that Setting going forward. It should also fix IP address login request throttling being incorrectly applied if it was using a reverse proxy or load balancer IP address for throttling -- this uses the same shared utility function to determine the request IP address.

I also made some tweaks to the function to properly handle `X-Forwarded-For` with comma-separated lists of IP addresses -- previously it did not handle those correctly (tests added)