### PR TITLE
Support both 0 and null values in a dimension for X axis

### DIFF
--- a/frontend/src/metabase/lib/constants.js
+++ b/frontend/src/metabase/lib/constants.js
@@ -1,0 +1,7 @@
+import { t } from "ttag";
+
+// A part of hack required to work with both null and 0
+// values in numeric dimensions
+export const NULL_NUMERIC_VALUE = -Infinity;
+
+export const NULL_DISPLAY_VALUE = t`(empty)`;

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -39,6 +39,7 @@ import {
   hasHour,
 } from "metabase/lib/formatting/date";
 import { renderLinkTextForClick } from "metabase/lib/formatting/link";
+import { NULL_NUMERIC_VALUE, NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 
 import type Field from "metabase-lib/lib/metadata/Field";
 import type { Column, Value } from "metabase-types/types/Dataset";
@@ -737,7 +738,9 @@ export function formatValueRaw(value: Value, options: FormattingOptions = {}) {
     return remapped;
   }
 
-  if (value == null) {
+  if (value === NULL_NUMERIC_VALUE) {
+    return NULL_DISPLAY_VALUE;
+  } else if (value == null) {
     return null;
   } else if (
     options.click_behavior &&

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -53,6 +53,7 @@ import {
   isRemappedToString,
   isMultiCardSeries,
   hasClickBehavior,
+  replaceNullValuesForOrdinal,
 } from "./renderer_utils";
 
 import lineAndBarOnRender from "./LineAreaBarPostRender";
@@ -99,14 +100,20 @@ function getXAxisProps(props, datas, warn) {
   const rawXValues = getXValues(props);
   const isHistogram = isHistogramBar(props);
   const xInterval = getXInterval(props, rawXValues, warn);
+  const isWaterfallWithTotalColumn =
+    props.chartType === "waterfall" && props.settings["waterfall.show_total"];
 
-  // For histograms we add a fake x value one xInterval to the right
-  // This compensates for the barshifting we do align ticks
-  const xValues = isHistogram
-    ? [...rawXValues, Math.max(...rawXValues) + xInterval]
-    : props.chartType === "waterfall" && props.settings["waterfall.show_total"]
-    ? [...rawXValues, xValueForWaterfallTotal(props)]
-    : rawXValues;
+  let xValues = rawXValues;
+
+  if (isHistogram) {
+    // For histograms we add a fake x value one xInterval to the right
+    // This compensates for the barshifting we do align ticks
+    xValues = [...rawXValues, Math.max(...rawXValues) + xInterval];
+  } else if (isWaterfallWithTotalColumn) {
+    xValues = [...rawXValues, xValueForWaterfallTotal(props)];
+  } else if (isOrdinal(props.settings)) {
+    xValues = xValues.map(x => replaceNullValuesForOrdinal(x));
+  }
 
   return {
     isHistogramBar: isHistogram,

--- a/frontend/src/metabase/visualizations/lib/numeric.js
+++ b/frontend/src/metabase/visualizations/lib/numeric.js
@@ -5,14 +5,10 @@ export function dimensionIsNumeric({ cols, rows }, i = 0) {
     return true;
   }
 
-  let hasAtLeastOneNumber = false;
-
-  const hasNumbersOrNullsOnly = rows.every(row => {
-    const isNumber = typeof row[i] === "number";
-    hasAtLeastOneNumber |= isNumber;
-
-    return isNumber || row[i] === null;
-  });
+  const hasAtLeastOneNumber = rows.some(row => typeof row[i] === "number");
+  const hasNumbersOrNullsOnly = rows.every(
+    row => typeof row[i] === "number" || row[i] === null,
+  );
 
   return hasNumbersOrNullsOnly && hasAtLeastOneNumber;
 }

--- a/frontend/src/metabase/visualizations/lib/numeric.js
+++ b/frontend/src/metabase/visualizations/lib/numeric.js
@@ -1,7 +1,20 @@
 import { isNumeric } from "metabase/lib/schema_metadata";
 
 export function dimensionIsNumeric({ cols, rows }, i = 0) {
-  return isNumeric(cols[i]) || typeof (rows[0] && rows[0][i]) === "number";
+  if (isNumeric(cols[i])) {
+    return true;
+  }
+
+  let hasAtLeastOneNumber = false;
+
+  const hasNumbersOrNullsOnly = rows.every(row => {
+    const isNumber = typeof row[i] === "number";
+    hasAtLeastOneNumber |= isNumber;
+
+    return isNumber || row[i] === null;
+  });
+
+  return hasNumbersOrNullsOnly && hasAtLeastOneNumber;
 }
 
 // We seem to run into float bugs if we get any more precise than this.

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -6,6 +6,7 @@ import { t } from "ttag";
 
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { parseTimestamp } from "metabase/lib/time";
+import { NULL_DISPLAY_VALUE, NULL_NUMERIC_VALUE } from "metabase/lib/constants";
 
 import {
   computeTimeseriesDataInverval,
@@ -144,16 +145,25 @@ function getParseOptions({ settings, data }) {
 export function getDatas({ settings, series }, warn) {
   const isNotOrdinal = !isOrdinal(settings);
   return series.map(({ data }) => {
+    const parseOptions = getParseOptions({ settings, data });
+
+    let rows = data.rows;
+
     // non-ordinal dimensions can't display null values,
     // so we filter them out and display a warning
-    const rows = isNotOrdinal
-      ? data.rows.filter(([x]) => x !== null)
-      : data.rows;
+    if (isNotOrdinal) {
+      rows = data.rows.filter(([x]) => x !== null);
+    } else if (parseOptions.isNumeric) {
+      rows = data.rows.map(([x, ...rest]) => [
+        replaceNullValuesForOrdinal(x),
+        ...rest,
+      ]);
+    }
+
     if (rows.length < data.rows.length) {
       warn(nullDimensionWarning());
     }
 
-    const parseOptions = getParseOptions({ settings, data });
     return rows.map(row => {
       const [x, ...rest] = row;
       const newRow = [parseXValue(x, parseOptions, warn), ...rest];
@@ -348,7 +358,7 @@ export const isHistogram = settings =>
   settings["graph.x_axis._scale_original"] === "histogram" ||
   settings["graph.x_axis.scale"] === "histogram";
 export const isOrdinal = settings =>
-  !isTimeseries(settings) && !isHistogram(settings);
+  settings["graph.x_axis.scale"] === "ordinal";
 
 // bar histograms have special tick formatting:
 // * aligned with beginning of bar to show bin boundaries
@@ -392,7 +402,12 @@ export const isMultiCardSeries = series =>
   series.length > 1 &&
   getIn(series, [0, "card", "id"]) !== getIn(series, [1, "card", "id"]);
 
-const NULL_DISPLAY_VALUE = t`(empty)`;
 export function formatNull(value) {
   return value === null ? NULL_DISPLAY_VALUE : value;
+}
+
+// Hack: for numeric dimensions we have to replace null values
+// with anything else since crossfilter groups merge 0 and null
+export function replaceNullValuesForOrdinal(value) {
+  return value === null ? NULL_NUMERIC_VALUE : value;
 }

--- a/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
@@ -1,0 +1,54 @@
+import { restore, visitQuestionAdhoc } from "__support__/cypress";
+
+describe("scenarios > visualizations > bar chart", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  describe("with numeric dimension", () => {
+    const query = `
+      select null as "a", 10 as "b" union all
+      select 5 as "a", 2 as "b" union all
+      select 0 as "a", 1 as "b"
+    `;
+
+    function getQuestion(visualizationSettings) {
+      return {
+        dataset_query: {
+          type: "native",
+          native: { query, "template-tags": {} },
+          database: 1,
+        },
+        display: "bar",
+        visualization_settings: visualizationSettings,
+      };
+    }
+
+    it("should not show a bar for null values (metabase#12138)", () => {
+      visitQuestionAdhoc(
+        getQuestion({
+          "graph.dimensions": ["a"],
+          "graph.metrics": ["b"],
+        }),
+      );
+
+      cy.wait("@dataset");
+      cy.findByText("(empty)").should("not.exist");
+    });
+
+    it("should show an (empty) bar for null values when X axis is ordinal (metabase#12138)", () => {
+      visitQuestionAdhoc(
+        getQuestion({
+          "graph.dimensions": ["a"],
+          "graph.metrics": ["b"],
+          "graph.x_axis.scale": "ordinal",
+        }),
+      );
+
+      cy.wait("@dataset");
+      cy.findByText("(empty)");
+    });
+  });
+});

--- a/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/apply_tooltips.unit.spec.js
@@ -157,7 +157,13 @@ describe("getClickHoverObject", () => {
     const cols = [StringColumn(), NumberColumn()];
     const rows = [["foobar", 1], [null, 2], ["barfoo", 3]];
     const otherArgs = {
-      ...seriesAndData({ cols, rows }),
+      ...seriesAndData({
+        cols,
+        rows,
+        settings: {
+          "graph.x_axis.scale": "ordinal",
+        },
+      }),
       seriesIndex: 0,
       classList: [],
       event: {},
@@ -168,8 +174,8 @@ describe("getClickHoverObject", () => {
   });
 });
 
-function seriesAndData({ cols, rows }) {
+function seriesAndData({ cols, rows, settings = {} }) {
   const series = [{ data: { cols, rows }, card: {} }];
-  const datas = getDatas({ series, settings: {} });
+  const datas = getDatas({ series, settings });
   return { series, datas };
 }

--- a/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -123,8 +123,9 @@ describe("getXValues", () => {
       "2019-08-13T00:00:00Z",
     ]);
   });
-  it("should include nulls by default", () => {
-    const xValues = getXValuesForRows([[["foo"], [null], ["bar"]]]);
+  it("should include nulls for ordinal", () => {
+    const settings = { "graph.x_axis.scale": "ordinal" };
+    const xValues = getXValuesForRows([[["foo"], [null], ["bar"]]], settings);
     expect(xValues).toEqual(["foo", "(empty)", "bar"]);
   });
   it("should exclude nulls for histograms", () => {
@@ -162,8 +163,8 @@ describe("parseXValue", () => {
 });
 
 describe("getDatas", () => {
-  it("should include rows with a null dimension by default", () => {
-    const settings = {};
+  it("should include rows with a null dimension for ordinal axis", () => {
+    const settings = { "graph.x_axis.scale": "ordinal" };
     const series = [{ data: { rows: [["foo"], [null], ["bar"]], cols: [{}] } }];
     const warn = jest.fn();
     const xValues = getDatas({ settings, series }, warn);


### PR DESCRIPTION
### Description

When numeric dimensions with `null` values were used for X-axis it did not work correctly because Crossfilter merged these keys into a single one `0`. Crossfilter groups were also corrupted when using our null replacement string `(empty)` depending on its order in the dimension.

The solution is hacky, so feel free to suggest better ideas. If we replace `null` with `-Infinity` to perform reduce operation it works correctly. Then we just format it as `(empty)` in axes and tooltips.

### Screenshots

#### Linear scale

Before:
<img width="957" alt="Screen Shot 2021-04-09 at 23 15 03" src="https://user-images.githubusercontent.com/14301985/114393391-a2025080-9ba2-11eb-982c-eb42c93d0380.png">

After:
<img width="904" alt="Screen Shot 2021-04-12 at 15 16 43" src="https://user-images.githubusercontent.com/14301985/114393491-ba726b00-9ba2-11eb-86d0-078d6a3e85a3.png">

#### Ordinal scale

Before:
<img width="949" alt="Screen Shot 2021-04-09 at 23 14 23" src="https://user-images.githubusercontent.com/14301985/114393527-c827f080-9ba2-11eb-8b7f-f6df3c1694e9.png">

After:
<img width="906" alt="Screen Shot 2021-04-12 at 15 17 16" src="https://user-images.githubusercontent.com/14301985/114393614-df66de00-9ba2-11eb-8530-192e1a82f29b.png">

#### Original issue with grouping by an hour of day

After:

Data:
<img width="363" alt="Screen Shot 2021-04-12 at 15 18 12" src="https://user-images.githubusercontent.com/14301985/114393721-058c7e00-9ba3-11eb-8672-326c21dd4648.png">

Linear:
<img width="1265" alt="Screen Shot 2021-04-12 at 15 18 05" src="https://user-images.githubusercontent.com/14301985/114393782-189f4e00-9ba3-11eb-96b8-11dd2bc5344c.png">

Ordinal:
<img width="1119" alt="Screen Shot 2021-04-12 at 15 18 35" src="https://user-images.githubusercontent.com/14301985/114393828-28b72d80-9ba3-11eb-91d6-4928f0acccdf.png">


Fixes https://github.com/metabase/metabase/issues/12138