### PR TITLE
re-enable search for category and location/* params

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
@@ -116,7 +116,7 @@ export default class ParameterFieldWidget extends Component<*, Props, State> {
     const savedValue = normalizeValue(this.props.value);
     const unsavedValue = normalizeValue(this.state.value);
     const isEqualsOp = isEqualsOperator(operator);
-    const disableSearch = isFuzzyOperator(operator);
+    const disableSearch = operator && isFuzzyOperator(operator);
     const defaultPlaceholder = isFocused
       ? ""
       : this.props.placeholder || t`Enter a value...`;


### PR DESCRIPTION
I accidentally disabled search for `category` and `location/*` parameter types as they don't have an associated `operator` prop here. Checking for that fixes things.

<img width="204" alt="Screen Shot 2021-04-09 at 3 33 08 PM" src="https://user-images.githubusercontent.com/13057258/114247071-1641b780-9949-11eb-8fac-b67c074fe7cf.png">
Before:
<img width="365" alt="Screen Shot 2021-04-09 at 3 32 26 PM" src="https://user-images.githubusercontent.com/13057258/114247073-180b7b00-9949-11eb-8e9e-3029152c4ad9.png">
After:
<img width="390" alt="Screen Shot 2021-04-09 at 3 32 54 PM" src="https://user-images.githubusercontent.com/13057258/114247075-193ca800-9949-11eb-8662-34ccfe43e801.png">
