### PR TITLE
Replace "Other Categories" with "Text or Category" section

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -33,7 +33,7 @@ import { syncTableColumnsToQuery } from "metabase/lib/dataset";
 import { getParametersWithExtras, isTransientId } from "metabase/meta/Card";
 import {
   parameterToMBQLFilter,
-  mapUIParameterToQueryParameter,
+  normalizeParameterValue,
 } from "metabase/meta/Parameter";
 import {
   aggregate,
@@ -828,7 +828,11 @@ export default class Question {
       // only the superset of parameters object that API expects
       .map(param => _.pick(param, "type", "target", "value"))
       .map(({ type, value, target }) => {
-        return mapUIParameterToQueryParameter(type, value, target);
+        return {
+          type,
+          value: normalizeParameterValue(type, value),
+          target,
+        };
       });
 
     if (canUseCardApiEndpoint) {

--- a/frontend/src/metabase/meta/Card.js
+++ b/frontend/src/metabase/meta/Card.js
@@ -2,7 +2,7 @@ import {
   getTemplateTagParameters,
   getParameterTargetFieldId,
   parameterToMBQLFilter,
-  mapUIParameterToQueryParameter,
+  normalizeParameterValue,
 } from "metabase/meta/Parameter";
 
 import * as Query from "metabase/lib/query/query";
@@ -192,16 +192,21 @@ export function applyParameters(
           },
     );
 
+    const type = parameter.type;
     if (mapping) {
       // mapped target, e.x. on a dashboard
-      datasetQuery.parameters.push(
-        mapUIParameterToQueryParameter(parameter.type, value, mapping.target),
-      );
+      datasetQuery.parameters.push({
+        type,
+        value: normalizeParameterValue(type, value),
+        target: mapping.target,
+      });
     } else if (parameter.target) {
       // inline target, e.x. on a card
-      datasetQuery.parameters.push(
-        mapUIParameterToQueryParameter(parameter.type, value, parameter.target),
-      );
+      datasetQuery.parameters.push({
+        type,
+        value: normalizeParameterValue(type, value),
+        target: parameter.target,
+      });
     }
   }
 

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -33,27 +33,28 @@ export type ParameterSection = {
 const areFieldFilterOperatorsEnabled = () =>
   MetabaseSettings.get("field-filter-operators-enabled?");
 
+const LOCATION_OPTIONS = [
+  {
+    type: "location/city",
+    name: t`City`,
+  },
+  {
+    type: "location/state",
+    name: t`State`,
+  },
+  {
+    type: "location/zip_code",
+    name: t`ZIP or Postal Code`,
+  },
+  {
+    type: "location/country",
+    name: t`Country`,
+  },
+];
+const CATEGORY_OPTIONS = [{ type: "category", name: t`Category` }];
+
 export function getParameterSections(): ParameterSection[] {
   const parameterOptions = getParameterOptions();
-  const LOCATION_OPTIONS = areFieldFilterOperatorsEnabled()
-    ? PARAMETER_OPERATOR_TYPES["string"].map(option => {
-        return {
-          ...option,
-          sectionId: "location",
-          combinedName: getOperatorDisplayName(option, "string", t`Location`),
-        };
-      })
-    : parameterOptions.filter(option => option.type.startsWith("location"));
-
-  const CATEGORY_OPTIONS = areFieldFilterOperatorsEnabled()
-    ? PARAMETER_OPERATOR_TYPES["string"].map(option => {
-        return {
-          ...option,
-          sectionId: "category",
-          combinedName: getOperatorDisplayName(option, "string", t`Category`),
-        };
-      })
-    : parameterOptions.filter(option => option.type.startsWith("category"));
 
   return [
     {
@@ -94,6 +95,18 @@ export function getParameterSections(): ParameterSection[] {
           ...option,
           sectionId: "number",
           combinedName: getOperatorDisplayName(option, "number", t`Number`),
+        };
+      }),
+    },
+    areFieldFilterOperatorsEnabled() && {
+      id: "string",
+      name: t`String`,
+      description: t`Name, Review, Description, etc.`,
+      options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
+        return {
+          ...option,
+          sectionId: "string",
+          combinedName: getOperatorDisplayName(option, "string", t`String`),
         };
       }),
     },

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -91,7 +91,7 @@ export function getParameterSections(): ParameterSection[] {
     {
       id: "id",
       name: t`ID`,
-      description: t`User ID, product ID, event ID, etc.`,
+      description: t`User ID, Product ID, Event ID, etc.`,
       options: [
         {
           ..._.findWhere(parameterOptions, { type: "id" }),
@@ -115,7 +115,7 @@ export function getParameterSections(): ParameterSection[] {
       ? {
           id: "string",
           name: t`Text or Category`,
-          description: t`Name, Review, Description, etc.`,
+          description: t`Name, Rating, Description, etc.`,
           options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
             return {
               ...option,

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -100,17 +100,17 @@ export function getParameterSections(): ParameterSection[] {
     },
     areFieldFilterOperatorsEnabled() && {
       id: "string",
-      name: t`String`,
+      name: t`Text or Category`,
       description: t`Name, Review, Description, etc.`,
       options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
         return {
           ...option,
           sectionId: "string",
-          combinedName: getOperatorDisplayName(option, "string", t`String`),
+          combinedName: getOperatorDisplayName(option, "string", t`Text`),
         };
       }),
     },
-    {
+    !areFieldFilterOperatorsEnabled() && {
       id: "category",
       name: t`Other Categories`,
       description: t`Category, Type, Model, Rating, etc.`,

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -73,8 +73,21 @@ export function getParameterSections(): ParameterSection[] {
       id: "location",
       name: t`Location`,
       description: t`City, State, Country, ZIP code.`,
-      options: LOCATION_OPTIONS,
+      options: areFieldFilterOperatorsEnabled()
+        ? PARAMETER_OPERATOR_TYPES["string"].map(option => {
+            return {
+              ...option,
+              sectionId: "location",
+              combinedName: getOperatorDisplayName(
+                option,
+                "string",
+                t`Location`,
+              ),
+            };
+          })
+        : LOCATION_OPTIONS,
     },
+
     {
       id: "id",
       name: t`ID`,
@@ -98,24 +111,25 @@ export function getParameterSections(): ParameterSection[] {
         };
       }),
     },
-    areFieldFilterOperatorsEnabled() && {
-      id: "string",
-      name: t`Text or Category`,
-      description: t`Name, Review, Description, etc.`,
-      options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
-        return {
-          ...option,
-          sectionId: "string",
-          combinedName: getOperatorDisplayName(option, "string", t`Text`),
-        };
-      }),
-    },
-    !areFieldFilterOperatorsEnabled() && {
-      id: "category",
-      name: t`Other Categories`,
-      description: t`Category, Type, Model, Rating, etc.`,
-      options: CATEGORY_OPTIONS,
-    },
+    areFieldFilterOperatorsEnabled()
+      ? {
+          id: "string",
+          name: t`Text or Category`,
+          description: t`Name, Review, Description, etc.`,
+          options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
+            return {
+              ...option,
+              sectionId: "string",
+              combinedName: getOperatorDisplayName(option, "string", t`Text`),
+            };
+          }),
+        }
+      : {
+          id: "category",
+          name: t`Other Categories`,
+          description: t`Category, Type, Model, Rating, etc.`,
+          options: CATEGORY_OPTIONS,
+        },
   ].filter(Boolean);
 }
 

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -232,12 +232,7 @@ function fieldFilterForParameter(parameter: Parameter): FieldPredicate {
           case "country":
             return field.isCountry();
           default:
-            return (
-              field.isCity() ||
-              field.isState() ||
-              field.isZipCode() ||
-              field.isCountry()
-            );
+            return field.isLocation();
         }
       };
     case "number":

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -232,7 +232,12 @@ function fieldFilterForParameter(parameter: Parameter): FieldPredicate {
           case "country":
             return field.isCountry();
           default:
-            return false;
+            return (
+              field.isCity() ||
+              field.isState() ||
+              field.isZipCode() ||
+              field.isCountry()
+            );
         }
       };
     case "number":

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -245,8 +245,8 @@ function fieldFilterForParameter(parameter: Parameter): FieldPredicate {
     case "string":
       return (field: Field) => {
         return subtype === "=" || subtype === "!="
-          ? field.isCategory()
-          : field.isString();
+          ? field.isCategory() && !field.isLocation()
+          : field.isString() && !field.isLocation();
       };
   }
 

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -174,29 +174,7 @@ export function getParameterOptions(): ParameterOption[] {
       ? OPTIONS_WITH_OPERATOR_SUBTYPES.map(option =>
           buildOperatorSubtypeOptions(option),
         )
-      : [
-          ...PARAMETER_OPERATOR_TYPES["date"],
-          {
-            type: "category",
-            name: t`Category`,
-          },
-          {
-            type: "location/city",
-            name: t`City`,
-          },
-          {
-            type: "location/state",
-            name: t`State`,
-          },
-          {
-            type: "location/zip_code",
-            name: t`ZIP or Postal Code`,
-          },
-          {
-            type: "location/country",
-            name: t`Country`,
-          },
-        ]),
+      : [...PARAMETER_OPERATOR_TYPES["date"]]),
   ].flat();
 }
 
@@ -244,21 +222,17 @@ function fieldFilterForParameter(parameter: Parameter): FieldPredicate {
       return (field: Field) => field.isCategory();
     case "location":
       return (field: Field) => {
-        if (areFieldFilterOperatorsEnabled()) {
-          return field.isLocation();
-        } else {
-          switch (subtype) {
-            case "city":
-              return field.isCity();
-            case "state":
-              return field.isState();
-            case "zip_code":
-              return field.isZipCode();
-            case "country":
-              return field.isCountry();
-            default:
-              return false;
-          }
+        switch (subtype) {
+          case "city":
+            return field.isCity();
+          case "state":
+            return field.isState();
+          case "zip_code":
+            return field.isZipCode();
+          case "country":
+            return field.isCountry();
+          default:
+            return false;
         }
       };
     case "number":
@@ -557,28 +531,13 @@ export function getParameterIconName(parameter: ?Parameter) {
   }
 }
 
-export function mapUIParameterToQueryParameter(type, value, target) {
-  if (!areFieldFilterOperatorsEnabled()) {
-    return { type, value, target };
-  }
+export function normalizeParameterValue(type, value) {
+  const [fieldType] = splitType(type);
 
-  const [fieldType, maybeOperatorName] = splitType(type);
-  const operatorName = getParameterOperatorName(maybeOperatorName);
-
-  if (fieldType === "location" || fieldType === "category") {
-    return {
-      type: `string/${operatorName}`,
-      value: [].concat(value),
-      target,
-    };
-  } else if (fieldType === "number" || fieldType === "string") {
-    return {
-      type,
-      value: [].concat(value),
-      target,
-    };
+  if (["string", "number"].includes(fieldType)) {
+    return value == null ? [] : [].concat(value);
   } else {
-    return { type, value, target };
+    return value;
   }
 }
 
@@ -599,8 +558,6 @@ function getParameterOperatorType(parameterType) {
   switch (parameterType) {
     case "number":
       return NUMBER;
-    case "location":
-    case "category":
     case "string":
       return STRING;
     case "id":

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -238,7 +238,11 @@ function fieldFilterForParameter(parameter: Parameter): FieldPredicate {
     case "number":
       return (field: Field) => field.isNumber() && !field.isCoordinate();
     case "string":
-      return (field: Field) => field.isString();
+      return (field: Field) => {
+        return subtype === "=" || subtype === "!="
+          ? field.isCategory()
+          : field.isString();
+      };
   }
 
   return (field: Field) => false;

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -14,7 +14,7 @@ import Sidebar from "metabase/dashboard/components/Sidebar";
 import Collections from "metabase/entities/collections";
 import Pulses from "metabase/entities/pulses";
 import User from "metabase/entities/users";
-import { mapUIParameterToQueryParameter } from "metabase/meta/Parameter";
+import { normalizeParameterValue } from "metabase/meta/Parameter";
 
 import { connect } from "react-redux";
 
@@ -229,17 +229,14 @@ class SharingSidebar extends React.Component {
           value,
           id,
         } = parameter;
-        const {
-          type: mappedType,
-          value: mappedValue,
-        } = mapUIParameterToQueryParameter(type, value);
+        const normalizedValue = normalizeParameterValue(type, value);
         return {
           default: defaultValue,
           id,
           name,
           slug,
-          type: mappedType,
-          value: mappedValue,
+          type,
+          value: normalizedValue,
         };
       },
     );

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -123,7 +123,7 @@ describe("scenarios > dashboard > chained filter", () => {
       // add a state filter
       cy.icon("filter").click();
       popover().within(() => {
-        cy.findByText("Text or Category").click();
+        cy.findByText("Location").click();
         cy.findByText("Dropdown").click();
       });
 
@@ -160,14 +160,14 @@ describe("scenarios > dashboard > chained filter", () => {
         .parent()
         .within(() => {
           // turn on the toggle
-          cy.findByText("Text")
+          cy.findByText("Location")
             .parent()
             .within(() => {
               cy.get("a").click();
             });
 
           // open up the list of linked columns
-          cy.findByText("Text").click();
+          cy.findByText("Location").click();
           // It's hard to assert on the "table.column" pairs.
           // We just assert that the headers are there to know that something appeared.
           cy.findByText("Filtering column");

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -179,12 +179,12 @@ describe("scenarios > dashboard > chained filter", () => {
 
       // now test that it worked!
       // Select Alaska as a state. We should see Anchorage as a option but not Anacoco
-      cy.findByText("Text").click();
+      cy.findByText("Location").click();
       popover().within(() => {
         cy.findByText("AK").click();
         cy.findByText("Add filter").click();
       });
-      cy.findByText("Location").click();
+      cy.findByText("Location 1").click();
       popover().within(() => {
         cy.findByPlaceholderText(
           has_field_values === "search" ? "Search by City" : "Search the list",

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -123,7 +123,7 @@ describe("scenarios > dashboard > chained filter", () => {
       // add a state filter
       cy.icon("filter").click();
       popover().within(() => {
-        cy.findByText("String").click();
+        cy.findByText("Text or Category").click();
         cy.findByText("Dropdown").click();
       });
 
@@ -142,7 +142,7 @@ describe("scenarios > dashboard > chained filter", () => {
       cy.findByText("add another dashboard filter").click();
       popover().within(() => {
         cy.findByText("Location").click();
-        cy.findByText("City").click();
+        cy.findByText("Dropdown").click();
       });
 
       // connect that to person.city
@@ -160,14 +160,14 @@ describe("scenarios > dashboard > chained filter", () => {
         .parent()
         .within(() => {
           // turn on the toggle
-          cy.findByText("String")
+          cy.findByText("Text")
             .parent()
             .within(() => {
               cy.get("a").click();
             });
 
           // open up the list of linked columns
-          cy.findByText("String").click();
+          cy.findByText("Text").click();
           // It's hard to assert on the "table.column" pairs.
           // We just assert that the headers are there to know that something appeared.
           cy.findByText("Filtering column");
@@ -179,12 +179,12 @@ describe("scenarios > dashboard > chained filter", () => {
 
       // now test that it worked!
       // Select Alaska as a state. We should see Anchorage as a option but not Anacoco
-      cy.findByText("String").click();
+      cy.findByText("Text").click();
       popover().within(() => {
         cy.findByText("AK").click();
         cy.findByText("Add filter").click();
       });
-      cy.findByText("City").click();
+      cy.findByText("Location").click();
       popover().within(() => {
         cy.findByPlaceholderText(
           has_field_values === "search" ? "Search by City" : "Search the list",

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -123,7 +123,7 @@ describe("scenarios > dashboard > chained filter", () => {
       // add a state filter
       cy.icon("filter").click();
       popover().within(() => {
-        cy.findByText("Location").click();
+        cy.findByText("String").click();
         cy.findByText("Dropdown").click();
       });
 
@@ -142,7 +142,7 @@ describe("scenarios > dashboard > chained filter", () => {
       cy.findByText("add another dashboard filter").click();
       popover().within(() => {
         cy.findByText("Location").click();
-        cy.findByText("Dropdown").click();
+        cy.findByText("City").click();
       });
 
       // connect that to person.city
@@ -160,14 +160,14 @@ describe("scenarios > dashboard > chained filter", () => {
         .parent()
         .within(() => {
           // turn on the toggle
-          cy.findByText("Location")
+          cy.findByText("String")
             .parent()
             .within(() => {
               cy.get("a").click();
             });
 
           // open up the list of linked columns
-          cy.findByText("Location").click();
+          cy.findByText("String").click();
           // It's hard to assert on the "table.column" pairs.
           // We just assert that the headers are there to know that something appeared.
           cy.findByText("Filtering column");
@@ -179,12 +179,12 @@ describe("scenarios > dashboard > chained filter", () => {
 
       // now test that it worked!
       // Select Alaska as a state. We should see Anchorage as a option but not Anacoco
-      cy.findByText("Location").click();
+      cy.findByText("String").click();
       popover().within(() => {
         cy.findByText("AK").click();
         cy.findByText("Add filter").click();
       });
-      cy.findByText("Location 1").click();
+      cy.findByText("City").click();
       popover().within(() => {
         cy.findByPlaceholderText(
           has_field_values === "search" ? "Search by City" : "Search the list",

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -52,7 +52,7 @@ describe("scenarios > dashboard", () => {
     // Adding location/state doesn't make much sense for this case,
     // but we're testing just that the filter is added to the dashboard
     cy.findByText("Location").click();
-    cy.findByText("Dropdown").click();
+    cy.findByText("State").click();
     cy.findByText("Select…").click();
 
     popover().within(() => {
@@ -67,7 +67,7 @@ describe("scenarios > dashboard", () => {
 
     cy.log("Assert that the selected filter is present in the dashboard");
     cy.icon("location");
-    cy.findByText("Location");
+    cy.findByText("State");
   });
 
   it("should add a question", () => {
@@ -137,7 +137,6 @@ describe("scenarios > dashboard", () => {
     cy.icon("filter").click();
     popover().within(() => {
       cy.findByText("Other Categories").click();
-      cy.findByText("Starts with").click();
     });
     // and connect it to the card
     selectDashboardFilter(cy.get(".DashCard"), "Category");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -52,7 +52,7 @@ describe("scenarios > dashboard", () => {
     // Adding location/state doesn't make much sense for this case,
     // but we're testing just that the filter is added to the dashboard
     cy.findByText("Location").click();
-    cy.findByText("State").click();
+    cy.findByText("Dropdown").click();
     cy.findByText("Select…").click();
 
     popover().within(() => {
@@ -67,7 +67,7 @@ describe("scenarios > dashboard", () => {
 
     cy.log("Assert that the selected filter is present in the dashboard");
     cy.icon("location");
-    cy.findByText("State");
+    cy.findByText("Location");
   });
 
   it("should add a question", () => {
@@ -136,7 +136,8 @@ describe("scenarios > dashboard", () => {
     // add third filter
     cy.icon("filter").click();
     popover().within(() => {
-      cy.findByText("Other Categories").click();
+      cy.findByText("Text or Category").click();
+      cy.findByText("Starts with").click();
     });
     // and connect it to the card
     selectDashboardFilter(cy.get(".DashCard"), "Category");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  popover,
-  selectDashboardFilter,
-  mockSessionProperty,
-} from "__support__/cypress";
+import { restore, popover, selectDashboardFilter } from "__support__/cypress";
 
 function filterDashboard(suggests = true) {
   cy.visit("/dashboard/1");
@@ -26,8 +21,6 @@ function filterDashboard(suggests = true) {
 
 describe("support > permissions (metabase#8472)", () => {
   beforeEach(() => {
-    mockSessionProperty("field-filter-operators-enabled?", true);
-
     restore();
     cy.signInAsAdmin();
 
@@ -39,10 +32,6 @@ describe("support > permissions (metabase#8472)", () => {
     cy.icon("filter").click();
     popover()
       .contains("Other Categories")
-      .click();
-
-    popover()
-      .contains("Dropdown")
       .click();
 
     // Filter the first card by product category

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -6,10 +6,10 @@ function filterDashboard(suggests = true) {
 
   // We should get a suggested response and be able to click it if we're an admin
   if (suggests) {
-    cy.contains("Category").type("Aero");
+    cy.contains("Text").type("Aero");
     cy.contains("Aerodynamic").click();
   } else {
-    cy.contains("Category").type("Aerodynamic Bronze Hat");
+    cy.contains("Text").type("Aerodynamic Bronze Hat");
     cy.wait("@search").should(xhr => {
       expect(xhr.status).to.equal(403);
     });
@@ -31,7 +31,11 @@ describe("support > permissions (metabase#8472)", () => {
 
     cy.icon("filter").click();
     popover()
-      .contains("Other Categories")
+      .contains("Text or Category")
+      .click();
+
+    popover()
+      .contains("Dropdown")
       .click();
 
     // Filter the first card by product category

--- a/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
@@ -91,12 +91,13 @@ var iframeUrl = METABASE_SITE_URL + "/embed/dashboard/" + token + "#bordered=tru
       .type("text text text");
     cy.icon("filter").click();
     popover().within(() => {
-      cy.findByText("Other Categories").click();
+      cy.findByText("Text or Category").click();
+      cy.findByText("Dropdown").click();
     });
     cy.findByText("Save").click();
 
     // confirm text box and filter are still there
     cy.findByText("text text text");
-    cy.findByPlaceholderText("Category");
+    cy.findByPlaceholderText("Text");
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/embed.cy.spec.js
@@ -92,7 +92,6 @@ var iframeUrl = METABASE_SITE_URL + "/embed/dashboard/" + token + "#bordered=tru
     cy.icon("filter").click();
     popover().within(() => {
       cy.findByText("Other Categories").click();
-      cy.findByText("Dropdown").click();
     });
     cy.findByText("Save").click();
 

--- a/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
@@ -16,13 +16,13 @@ describe("scenarios > dashboard > parameters", () => {
     cy.icon("filter").click();
 
     cy.findByText("Number").should("not.exist");
+    cy.findByText("String").should("not.exist");
 
     cy.findByText("Location").click();
     cy.findByText("Contains").should("not.exist");
     cy.findByText("City").should("exist");
 
     cy.icon("filter").click();
-    cy.findByText("Contains").should("not.exist");
   });
 
   it("should filter by city", () => {

--- a/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
@@ -16,7 +16,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.icon("filter").click();
 
     cy.findByText("Number").should("not.exist");
-    cy.findByText("String").should("not.exist");
+    cy.findByText("Text or Category").should("not.exist");
 
     cy.findByText("Location").click();
     cy.findByText("Contains").should("not.exist");

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -15,7 +15,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.icon("pencil").click();
     cy.icon("filter").click();
     cy.findByText("Location").click();
-    cy.findByText("Dropdown").click();
+    cy.findByText("City").click();
 
     // Link that filter to the card
     cy.findByText("Select…").click();
@@ -60,7 +60,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     // add a category filter
     cy.icon("filter").click();
-    cy.contains("Other Categories").click();
+    cy.contains("String").click();
     cy.findByText("Dropdown").click();
 
     // connect it to people.name and product.category
@@ -75,7 +75,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.contains("You're editing this dashboard.").should("not.exist");
 
     // confirm that typing searches both fields
-    cy.contains("Category").click();
+    cy.contains("String").click();
 
     // After typing "Ga", you should see this name
     popover()
@@ -156,7 +156,7 @@ describe("scenarios > dashboard > parameters", () => {
     // Add a filter tied to a field that triggers a search for field values
     cy.icon("pencil").click();
     cy.icon("filter").click();
-    cy.findByText("Location").click();
+    cy.findByText("String").click();
     cy.findByText("Starts with").click();
 
     // Link that filter to the card
@@ -167,8 +167,8 @@ describe("scenarios > dashboard > parameters", () => {
 
     // Add a filter with few enough values that it does not search
     cy.icon("filter").click();
-    cy.findByText("Other Categories").click();
-    cy.findByText("Starts with").click();
+    cy.findByText("String").click();
+    cy.findByText("Ends with").click();
 
     // Link that filter to the card
     cy.findByText("Select…").click();
@@ -179,17 +179,17 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Save").click();
     cy.findByText("You're editing this dashboard.").should("not.exist");
 
-    cy.contains("Location starts with").click();
+    cy.contains("String starts with").click();
     cy.findByPlaceholderText("Enter some text")
       .click()
       .type("Bake");
     cy.findByText("Baker").should("not.exist");
     cy.findByText("Add filter").click();
 
-    cy.contains("Category starts with").click();
+    cy.contains("String ends with").click();
     cy.findByPlaceholderText("Enter some text")
       .click()
-      .type("Widge");
+      .type("dget");
     cy.findByText("Widget").should("not.exist");
     cy.findByText("Add filter").click();
   });
@@ -203,7 +203,7 @@ describe("scenarios > dashboard > parameters", () => {
     // Add filter and save dashboard
     cy.icon("pencil").click();
     cy.icon("filter").click();
-    cy.contains("Other Categories").click();
+    cy.contains("String").click();
     cy.contains("Ends with").click();
 
     // map the parameter to the Category field
@@ -215,7 +215,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.contains("You're editing this dashboard.").should("not.exist");
 
     // populate the filter input
-    cy.findByText("Category ends with").click();
+    cy.findByText("String ends with").click();
     popover()
       .find("input")
       .type("zmo");
@@ -227,14 +227,14 @@ describe("scenarios > dashboard > parameters", () => {
     cy.log(
       "**URL is updated correctly with the given parameter at this point**",
     );
-    cy.url().should("include", "category_ends_with=zmo");
+    cy.url().should("include", "string_ends_with=zmo");
 
     // Remove filter name
     cy.icon("pencil").click();
     cy.get(".Dashboard")
       .find(".Icon-gear")
       .click();
-    cy.findByDisplayValue("Category ends with")
+    cy.findByDisplayValue("String ends with")
       .click()
       .clear();
     cy.findByText("Save").click();

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -15,7 +15,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.icon("pencil").click();
     cy.icon("filter").click();
     cy.findByText("Location").click();
-    cy.findByText("City").click();
+    cy.findByText("Dropdown").click();
 
     // Link that filter to the card
     cy.findByText("Select…").click();
@@ -60,7 +60,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     // add a category filter
     cy.icon("filter").click();
-    cy.contains("String").click();
+    cy.contains("Text or Category").click();
     cy.findByText("Dropdown").click();
 
     // connect it to people.name and product.category
@@ -75,7 +75,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.contains("You're editing this dashboard.").should("not.exist");
 
     // confirm that typing searches both fields
-    cy.contains("String").click();
+    cy.contains("Text").click();
 
     // After typing "Ga", you should see this name
     popover()
@@ -156,7 +156,7 @@ describe("scenarios > dashboard > parameters", () => {
     // Add a filter tied to a field that triggers a search for field values
     cy.icon("pencil").click();
     cy.icon("filter").click();
-    cy.findByText("String").click();
+    cy.findByText("Text or Category").click();
     cy.findByText("Starts with").click();
 
     // Link that filter to the card
@@ -167,7 +167,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     // Add a filter with few enough values that it does not search
     cy.icon("filter").click();
-    cy.findByText("String").click();
+    cy.findByText("Text or Category").click();
     cy.findByText("Ends with").click();
 
     // Link that filter to the card
@@ -179,14 +179,14 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Save").click();
     cy.findByText("You're editing this dashboard.").should("not.exist");
 
-    cy.contains("String starts with").click();
+    cy.contains("Text starts with").click();
     cy.findByPlaceholderText("Enter some text")
       .click()
       .type("Bake");
     cy.findByText("Baker").should("not.exist");
     cy.findByText("Add filter").click();
 
-    cy.contains("String ends with").click();
+    cy.contains("Text ends with").click();
     cy.findByPlaceholderText("Enter some text")
       .click()
       .type("dget");
@@ -203,7 +203,7 @@ describe("scenarios > dashboard > parameters", () => {
     // Add filter and save dashboard
     cy.icon("pencil").click();
     cy.icon("filter").click();
-    cy.contains("String").click();
+    cy.contains("Text or Category").click();
     cy.contains("Ends with").click();
 
     // map the parameter to the Category field
@@ -215,7 +215,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.contains("You're editing this dashboard.").should("not.exist");
 
     // populate the filter input
-    cy.findByText("String ends with").click();
+    cy.findByText("Text ends with").click();
     popover()
       .find("input")
       .type("zmo");
@@ -227,14 +227,14 @@ describe("scenarios > dashboard > parameters", () => {
     cy.log(
       "**URL is updated correctly with the given parameter at this point**",
     );
-    cy.url().should("include", "string_ends_with=zmo");
+    cy.url().should("include", "text_ends_with=zmo");
 
     // Remove filter name
     cy.icon("pencil").click();
     cy.get(".Dashboard")
       .find(".Icon-gear")
       .click();
-    cy.findByDisplayValue("String ends with")
+    cy.findByDisplayValue("Text ends with")
       .click()
       .clear();
     cy.findByText("Save").click();

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -162,7 +162,7 @@ describe("scenarios > dashboard > parameters", () => {
     // Link that filter to the card
     cy.findByText("Select…").click();
     popover().within(() => {
-      cy.findByText("City").click();
+      cy.findByText("Name").click();
     });
 
     // Add a filter with few enough values that it does not search
@@ -182,8 +182,8 @@ describe("scenarios > dashboard > parameters", () => {
     cy.contains("Text starts with").click();
     cy.findByPlaceholderText("Enter some text")
       .click()
-      .type("Bake");
-    cy.findByText("Baker").should("not.exist");
+      .type("Corbin");
+    cy.findByText("Corbin Mertz").should("not.exist");
     cy.findByText("Add filter").click();
 
     cy.contains("Text ends with").click();

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -263,10 +263,9 @@ function addParametersToDashboard() {
   // edit dashboard
   cy.icon("pencil").click();
 
-  // add Category > Dropdown "Name" filter
+  // add Category "Name" filter
   cy.icon("filter").click();
   cy.findByText("Other Categories").click();
-  cy.findByText("Dropdown").click();
 
   cy.findByText("Select…").click();
   popover().within(() => {
@@ -285,10 +284,9 @@ function addParametersToDashboard() {
     .contains("Add filter")
     .click();
 
-  // add Category > Dropdown "Category" filter
+  // add Category "Category" filter
   cy.icon("filter").click();
   cy.findByText("Other Categories").click();
-  cy.findByText("Dropdown").click();
   cy.findByText("Select…").click();
   popover().within(() => {
     cy.findByText("Category").click();

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -211,7 +211,7 @@ describe("scenarios > dashboard > subscriptions", () => {
           .contains("Update filter")
           .click();
 
-        cy.findAllByText("Category 1")
+        cy.findAllByText("Text 1")
           .last()
           .click();
         popover()
@@ -225,7 +225,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
         clickButton("Done");
         cy.wait("@pulsePut");
-        cy.findByText("Category is 2 selections and 1 more filter");
+        cy.findByText("Text is 2 selections and 1 more filter");
       });
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -155,10 +155,10 @@ describe("scenarios > dashboard > subscriptions", () => {
 
       it("should have a list of the default parameters applied to the subscription", () => {
         assignRecipient();
-        cy.findByText("Category is Corbin Mertz");
+        cy.findByText("Text is Corbin Mertz");
         clickButton("Done");
 
-        cy.findByText("Category is Corbin Mertz");
+        cy.findByText("Text is Corbin Mertz");
       });
     });
   });
@@ -189,7 +189,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         assignRecipient();
         clickButton("Done");
 
-        cy.findByText("Category is Corbin Mertz");
+        cy.findByText("Text is Corbin Mertz");
       });
 
       it("should allow for setting parameters in subscription", () => {
@@ -263,9 +263,10 @@ function addParametersToDashboard() {
   // edit dashboard
   cy.icon("pencil").click();
 
-  // add Category "Name" filter
+  // add Category > Dropdown "Name" filter
   cy.icon("filter").click();
-  cy.findByText("Other Categories").click();
+  cy.findByText("Text or Category").click();
+  cy.findByText("Dropdown").click();
 
   cy.findByText("Select…").click();
   popover().within(() => {
@@ -284,9 +285,10 @@ function addParametersToDashboard() {
     .contains("Add filter")
     .click();
 
-  // add Category "Category" filter
+  // add Category > Dropdown "Category" filter
   cy.icon("filter").click();
-  cy.findByText("Other Categories").click();
+  cy.findByText("Text or Category").click();
+  cy.findByText("Dropdown").click();
   cy.findByText("Select…").click();
   popover().within(() => {
     cy.findByText("Category").click();

--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -79,12 +79,14 @@ describe.skip("scenarios > public", () => {
 
       cy.icon("filter").click();
 
-      popover()
-        .contains("Other Categories")
-        .click();
+      popover().within(() => {
+        cy.findByText("Text or Category").click();
+        cy.findByText("Dropdown").click();
+      });
+
       cy.contains("Select…").click();
       popover()
-        .contains("Category")
+        .contains("Text")
         .click();
 
       cy.contains("Done").click();
@@ -92,13 +94,13 @@ describe.skip("scenarios > public", () => {
       cy.findByText("You're editing this dashboard.").should("not.exist");
 
       cy.contains(COUNT_ALL);
-      cy.contains("Category")
+      cy.contains("Text")
         .parent()
         .parent()
         .find("fieldset")
         .should("not.exist");
 
-      cy.findByText("Category").click();
+      cy.findByText("Text").click();
 
       popover().within(() => {
         cy.findByText("Doohickey").click();
@@ -107,7 +109,7 @@ describe.skip("scenarios > public", () => {
       cy.contains(COUNT_DOOHICKEY);
 
       cy.url()
-        .should("match", /\/dashboard\/\d+\?category=Doohickey$/)
+        .should("match", /\/dashboard\/\d+\?text=Doohickey$/)
         .then(url => {
           dashboardId = parseInt(url.match(/dashboard\/(\d+)/)[1]);
         });


### PR DESCRIPTION
Currently, there are a number of string-based fields that can't be filtered on in dashboards. A great example are the "Body" and "Reviewer" fields on the Reviews sample dataset table. These fields are not considered categories, so we cannot map them to category parameter widgets. 

This PR exposes these string-based fields by doing the following:
- the "Other Categories" section becomes the "Text or Category" section
- for the first two options in the section (which map to an = or != operator), we let the user map to fields that are categories
- for the rest of the options in the section (contains, starts-with, etc.), we let the user map to all fields that are strings (not locations though since they have their own section)

![Screen Shot 2021-04-13 at 9 54 19 AM](https://user-images.githubusercontent.com/13057258/114591374-a9773780-9c3e-11eb-84b8-c1c968ff7fd8.png)

![Screen Shot 2021-04-13 at 10 10 35 AM](https://user-images.githubusercontent.com/13057258/114593124-96fdfd80-9c40-11eb-8262-76d0905c27bd.png)

![Screen Shot 2021-04-13 at 10 10 56 AM](https://user-images.githubusercontent.com/13057258/114593125-97969400-9c40-11eb-9914-2fb1c108f973.png)
