### PR TITLE
Fix nested links error in `BrowseHeader` component

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseHeader.jsx
+++ b/frontend/src/metabase/browse/components/BrowseHeader.jsx
@@ -22,9 +22,9 @@ export default function BrowseHeader({ crumbs }) {
           >
             <div className="flex align-center text-medium text-brand-hover">
               <Icon className="flex align-center" size={14} name="reference" />
-              <Link className="ml1 flex align-center text-bold">
+              <span className="ml1 flex align-center text-bold">
                 {t`Learn about our data`}
-              </Link>
+              </span>
             </div>
           </Link>
         </div>

--- a/frontend/test/metabase/scenarios/home/browse.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/browse.cy.spec.js
@@ -1,0 +1,18 @@
+import { restore } from "__support__/cypress";
+
+describe("scenarios > browse data", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("basic UI flow should work", () => {
+    cy.visit("/");
+    cy.icon("table_spaced").click();
+    cy.location("pathname").should("eq", "/browse");
+    cy.findByText(/^Our data$/i);
+    cy.findByText("Sample Dataset");
+    cy.findByText("Learn about our data").click();
+    cy.location("pathname").should("eq", "/reference/databases");
+  });
+});


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes nested links error in `BrowseHeader` component

### How to verify it still works?
- Go to `/browse`
- Find "Learn about our data"
- It should:
    1. Turn blue on hover
    2. Take you to the `/reference/databases` on click
    
- Cypress test should pass

### Additional context:
- This is just one example of the error that we receive pretty often in the console: `<a> cannot appear as a descendant of <a>`
- it was easy to fix because the nested element didn't have `href` and thus, didn't have to be the `<Link />` component so I simply used `<span>` instead
    - Other examples will require some UI changes because both outer and inner elements are actual links