### PR TITLE
Open Chrome dev tools in Cypress `--open` by default

### DIFF
--- a/frontend/test/cypress-plugins.js
+++ b/frontend/test/cypress-plugins.js
@@ -26,4 +26,17 @@ module.exports = (on, config) => {
   };
 
   on("file:preprocessor", webpack(options));
+
+  /********************************************************************
+   **                         BROWSERS                               **
+   ********************************************************************/
+
+  //  Open dev tools in Chrome by default
+  on("before:browser:launch", (browser = {}, launchOptions) => {
+    if (browser.name === "chrome") {
+      launchOptions.args.push("--auto-open-devtools-for-tabs");
+
+      return launchOptions;
+    }
+  });
 };


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Opens Chrome dev tools by default when running Cypress GUI

### How to verify it works?
- All tests in CI should pass
- When running `yarn test-cypress-open` locally and IF you choose Chrome for a browser, you should see dev tools open every time you run a spec

### Additional notes
- Our CI runs Electron so this shouldn't affect anything other than local environment
- The reason behind this implementation is that 99,99% of the time I am running tests locally I need to have dev tools opened to examine either the Console, Elements or the Network tab. This eliminates the process of manually opening dev tools every single time