### PR TITLE
Don't show duplicate descriptions in search results

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -54,7 +54,7 @@
 
 (def ^:const displayed-columns
   "All of the result components that by default are displayed by the frontend."
-  #{:name :display_name :collection_name})
+  #{:name :display_name :collection_name :description})
 
 (defmulti searchable-columns-for-model
   "The columns that will be searched for the query."

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -4,7 +4,7 @@
             [java-time :as t]
             [metabase.search.config :as search-config]
             [schema.core :as s])
-    (:import java.util.PriorityQueue))
+  (:import java.util.PriorityQueue))
 
 ;;; Utility functions
 


### PR DESCRIPTION
Fixes an issue where  if the "matched column" was `description` then the FE would show it both as the description and as the context.