### PR TITLE
Escape brackets in CE

### DIFF
--- a/frontend/src/metabase/lib/expressions/index.js
+++ b/frontend/src/metabase/lib/expressions/index.js
@@ -110,7 +110,7 @@ function quoteString(string, character) {
   } else if (character === "'") {
     return swapQuotes(JSON.stringify(swapQuotes(string)));
   } else if (character === "[") {
-    const escapedString = string.replace(/\[/g, '\\\[').replace(/\]/g, '\\\]')
+    const escapedString = string.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
     return `[${escapedString}]`;
   } else if (character === "") {
     // unquoted

--- a/frontend/src/metabase/lib/expressions/index.js
+++ b/frontend/src/metabase/lib/expressions/index.js
@@ -110,11 +110,8 @@ function quoteString(string, character) {
   } else if (character === "'") {
     return swapQuotes(JSON.stringify(swapQuotes(string)));
   } else if (character === "[") {
-    // TODO: escape brackets
-    if (string.match(/\[|\]/)) {
-      throw new Error("String currently can't contain brackets: " + string);
-    }
-    return `[${string}]`;
+    const newString = string.replace(/\[/g, '\[').replace(/\]/g, '\]')
+    return `[${newString}]`;
   } else if (character === "") {
     // unquoted
     return string;

--- a/frontend/src/metabase/lib/expressions/index.js
+++ b/frontend/src/metabase/lib/expressions/index.js
@@ -110,8 +110,8 @@ function quoteString(string, character) {
   } else if (character === "'") {
     return swapQuotes(JSON.stringify(swapQuotes(string)));
   } else if (character === "[") {
-    const newString = string.replace(/\[/g, '\[').replace(/\]/g, '\]')
-    return `[${newString}]`;
+    const escapedString = string.replace(/\[/g, '\\\[').replace(/\]/g, '\\\]')
+    return `[${escapedString}]`;
   } else if (character === "") {
     // unquoted
     return string;


### PR DESCRIPTION
Pursuant to #15316. Escaping is unfortunately not present in the CE tokenizer and parser itself yet, until ariya merges the new lexer, so can't land until that one lands with the added escaper or if we really need it, adding it to the current lexer.