### PR TITLE
Don't add temporal subdimensions to a FieldIDDimension

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -752,7 +752,7 @@ export class FieldDimension extends Dimension {
     }
 
     // Add temporal dimensions
-    if (field.isDate()) {
+    if (field.isDate() && !this.isIntegerFieldId()) {
       const temporalDimensions = DATETIME_UNITS.map(unit =>
         this.withTemporalUnit(unit),
       );

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -160,7 +160,7 @@ describe("scenarios > question > new", () => {
             .click();
         });
       // this step is maybe redundant since it fails to even find "by month"
-      cy.findByText("Hour of day");
+      cy.findByText("Hour of Day");
     });
 
     it.skip("should display timeseries filter and granularity widgets at the bottom of the screen (metabase#11183)", () => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -656,7 +656,7 @@ describe("scenarios > question > notebook", () => {
         .click();
     });
 
-    it.skip("should not render duplicated values in date binning popover (metabase#15574)", () => {
+    it("should not render duplicated values in date binning popover (metabase#15574)", () => {
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Summarize").click();
       cy.findByText("Pick a column to group by").click();


### PR DESCRIPTION
This restores the behavior just like before MBQL field refactoring (back when FieldIDDimension still existed).

It fixes #15574.

**To Reproduce**
1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. For _Summarize_, Pick a column to group by
4. Created At click on "by month >" to open a popup

**Before**

The popup contains duplicated entries, e.g. for "Minutes".

![image](https://user-images.githubusercontent.com/7288/114432653-c85dc700-9b75-11eb-9c8e-194b9132a07c.png)

**After**
The popup does not have duplicated entries.

![image](https://user-images.githubusercontent.com/7288/114470030-07eed800-9ba3-11eb-8d5f-c1e194f27417.png)
