### PR TITLE
docs - account settings page

### DIFF
--- a/docs/users-guide/account-settings.md
+++ b/docs/users-guide/account-settings.md
@@ -1,0 +1,24 @@
+## Account settings
+
+You can view account settings by clicking on the **gears** icon in the upper right of the main navigation bar, then selecting **Account settings**. Here you'll find three tabs:
+
+- [Profile](#account-profile)
+- [Password](#account-password)
+- [Login history](#account-login-history)
+
+### Account profile
+
+You can set your first and last names, change your email address, and set your language. See our list of [supported languages](../faq/general/what-languages-can-be-used-with-metabase.md#currently-available-languages).
+
+### Account password
+
+You can change your password here. If you're having trouble logging in, see our [How do I reset my password](../faq/using-metabase/how-do-i-reset-my-password.md).
+
+### Account login history
+
+The login history lists each login, along with some location information (if available), and some client information (like Browser (Firefox/Windows)).
+If you see any suspicious login attempts, change your password and notify your administrator.
+
+#### A note about new login emails
+
+Whenever you login from a new device, Metabase will send you an email just to let you know someone (hopefully you) has logged in from an unrecognized device. If you see this email, but don't remember logging in, or don't recognize the device, change your password and let your administrator know. 

--- a/docs/users-guide/account-settings.md
+++ b/docs/users-guide/account-settings.md
@@ -12,7 +12,9 @@ You can set your first and last names, change your email address, and set your l
 
 ### Account password
 
-You can change your password here. If you're having trouble logging in, see our [How do I reset my password](../faq/using-metabase/how-do-i-reset-my-password.md).
+You can change your password here. Note that if your Metabase uses Single Sign-On (SSO), your administrator will have disabled this password section, as your identity provider will manage logins.
+
+If you're having trouble logging in, see our [How do I reset my password](../faq/using-metabase/how-do-i-reset-my-password.md).
 
 ### Account login history
 

--- a/docs/users-guide/account-settings.md
+++ b/docs/users-guide/account-settings.md
@@ -1,6 +1,6 @@
 ## Account settings
 
-You can view account settings by clicking on the **gears** icon in the upper right of the main navigation bar, then selecting **Account settings**. Here you'll find three tabs:
+You can view your account settings by clicking on the **gears** icon in the upper right of the main navigation bar, then selecting **Account settings**. Here you'll find three tabs:
 
 - [Profile](#account-profile)
 - [Password](#account-password)
@@ -21,4 +21,4 @@ If you see any suspicious login attempts, change your password and notify your a
 
 #### A note about new login emails
 
-Whenever you login from a new device, Metabase will send you an email just to let you know someone (hopefully you) has logged in from an unrecognized device. If you see this email, but don't remember logging in, or don't recognize the device, change your password and let your administrator know. 
+Whenever you log in from a new device, Metabase will send you an email just to let you know someone (hopefully you) has logged in from an unrecognized device. If you see this email, but don't remember logging in, or don't recognize the device, change your password and let your administrator know. 

--- a/docs/users-guide/start.md
+++ b/docs/users-guide/start.md
@@ -33,5 +33,6 @@
 - [Referencing saved question in queries](referencing-saved-questions-in-queries.md)
 - [Getting automatic insights with X-rays](14-x-rays.md)
 - [Setting and getting alerts](15-alerts.md)
+- [Editing your account settings](account-settings.md)
 
 Let's get started with an overview of [What Metabase does](01-what-is-metabase.md).


### PR DESCRIPTION
Adds an account settings page to the user guide that briefly covers account:

- profile
- password
- login history
