### PR TITLE
Add Snowplow

### DIFF
--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -87,8 +87,8 @@ function _init(reducers, getRoutes, callback) {
   );
 
   // listen for location changes and use that as a trigger for page view tracking
-  history.listen(location => {
-    MetabaseAnalytics.trackPageView(location.pathname);
+  history.listen((location, ...rest) => {
+    MetabaseAnalytics.trackPageView(location);
   });
 
   registerVisualizations();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "yarn": ">=1.12.3"
   },
   "dependencies": {
+    "@snowplow/browser-tracker": "^3.0.0",
     "ace-builds": "^1.4.7",
     "chevrotain": "^6.5.0",
     "classlist-polyfill": "^1.2.0",

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -77,6 +77,8 @@
                   :img-src      ["*"
                                  "'self' data:"]
                   :connect-src  ["'self'"
+                                 ;; Snowplow server
+                                 "https://sp.metabase.com"
                                  ;; MailChimp. So people can sign up for the Metabase mailing list in the sign up process
                                  "metabase.us10.list-manage.com"
                                  (when config/is-dev?

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,6 +1058,33 @@
     winston "^2.1.1"
     ws "^1.0.1"
 
+"@snowplow/browser-tracker-core@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@snowplow/browser-tracker-core/-/browser-tracker-core-3.0.0.tgz#bea71823c98565d5ce4f5069f0136431c2c95605"
+  integrity sha512-HUJKDcWC+/1DAOMZGnDvWU2qotlFaGgiFnTM1ZtKIKF9EXZw5a7Qw+uY0p8bUAccdGCBb7sOF7ebVke0KHPQOA==
+  dependencies:
+    "@snowplow/tracker-core" "3.0.0"
+    sha1 "^1.1.1"
+    tslib "^2.1.0"
+    uuid "^3.4.0"
+
+"@snowplow/browser-tracker@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@snowplow/browser-tracker/-/browser-tracker-3.0.0.tgz#d5915fd6384d02eb09e5b1f476a80ee1fc0fe16e"
+  integrity sha512-V9k0uIYij/rlvFxczXrCTu45G6w8W2QYUMt3p9hBqniFyeFmbYF6WZGf0YvekYL6iQRXWM1p2HVnsjfUhF1PNA==
+  dependencies:
+    "@snowplow/browser-tracker-core" "3.0.0"
+    "@snowplow/tracker-core" "3.0.0"
+    tslib "^2.1.0"
+
+"@snowplow/tracker-core@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@snowplow/tracker-core/-/tracker-core-3.0.0.tgz#f7567eecdb34386f7dd391e6a2d334317e961707"
+  integrity sha512-IfLK0rdYhDOLjHT2WIlES50DODDLeKvju/kK10ecAxXm0Ja7Cuu/OqM7Vb1/lPuwg34waxcJSlYxS6KiDZqIIw==
+  dependencies:
+    tslib "^2.1.0"
+    uuid "^3.4.0"
+
 "@testing-library/cypress@^5.0.2":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-5.3.1.tgz#96c9bd0f72eb2330b4b5154dd71e81d2c644ce62"
@@ -3368,6 +3395,11 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
+"charenc@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
@@ -4113,6 +4145,11 @@ crossfilter@^1.3.12:
   version "1.3.12"
   resolved "https://registry.yarnpkg.com/crossfilter/-/crossfilter-1.3.12.tgz#147d7236a98c45c69f78bdc3a99d6fb00f70930c"
   integrity sha1-FH1yNqmMRcafeL3DqZ1vsA9wkww=
+
+"crypt@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -12345,6 +12382,14 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+sha1@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sha1/-/sha1-1.1.1.tgz#addaa7a93168f393f19eb2b15091618e2700f848"
+  integrity sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=
+  dependencies:
+    charenc ">= 0.0.1"
+    crypt ">= 0.0.1"
+
 shadow-cljs-jar@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
@@ -13393,6 +13438,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
 ttag@1.7.15:
   version "1.7.15"
   resolved "https://registry.yarnpkg.com/ttag/-/ttag-1.7.15.tgz#e0a97283071bc945b1cde09a7cd3b82a0d0921a6"
@@ -13846,7 +13896,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
This PR adds Snowplow alongside Google Analytics. Like our GA tracking, we will only send data if the instance has enabled anonymous tracking.

~I'm creating this as a draft until I verify the options and anonymization settings.~ I started hashing hostname and UUIDs in public paths. That behavior needs tests and we should do a broader audit.