### PR TITLE
Restore Clojure deps when building FE for uberjar in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -796,6 +796,7 @@ jobs:
           checksum: '{{ checksum ".FRONTEND-CHECKSUMS" }}'
           steps:
             - restore-fe-deps-cache
+            - restore-be-deps-cache
             - run:
                 name: Build frontend
                 environment:


### PR DESCRIPTION
Clojure build script is used to build the FE in this CI step. If we don't restore all the deps we waste time fetching them again, and fetching that many deps randomly fails on CircleCI very frequently -- maybe they randomly disable network connectivity in test nodes to help us make sure our tests themselves are robust? 😆 