### PR TITLE
#15591 Repro: Data selector popover is too small

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -18,6 +18,34 @@ describe("scenarios > question > new", () => {
     cy.signInAsAdmin();
   });
 
+  it.skip("data selector popover should not be too small (metabase#15591)", () => {
+    // Add 10 more databases
+    for (let i = 0; i < 10; i++) {
+      cy.request("POST", "/api/database", {
+        engine: "h2",
+        name: "Sample" + i,
+        details: {
+          db:
+            "zip:./target/uberjar/metabase.jar!/sample-dataset.db;USER=GUEST;PASSWORD=guest",
+        },
+        auto_run_queries: false,
+        is_full_sync: false,
+        schedules: {},
+      });
+    }
+
+    // First test UI for Simple question
+    cy.visit("/question/new");
+    cy.findByText("Simple question").click();
+    cy.findByText("Pick your data");
+    cy.findByText("Sample3").isVisibleInPopover();
+
+    // Then move to the Custom question UI
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Sample3").isVisibleInPopover();
+  });
+
   describe("browse data", () => {
     it("should load orders table and summarize", () => {
       cy.visit("/");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15591 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/new.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
1. Simple question
![image](https://user-images.githubusercontent.com/31325167/114596884-7067b300-9c90-11eb-8bc9-f1dd2b115ba7.png)

2. Sanity check - if we skip simple question locally for testing purposes only! it should also fail for Custom question
![image](https://user-images.githubusercontent.com/31325167/114597088-a442d880-9c90-11eb-936b-ebbb60ee2d37.png)

