### PR TITLE
Fix bad parameterized i18n template strings on FE

### DIFF
--- a/bin/i18n/src/i18n/create_artifacts/frontend.clj
+++ b/bin/i18n/src/i18n/create_artifacts/frontend.clj
@@ -29,7 +29,7 @@
                      (if (:plural? message)
                        {:msgid_plural (:id-plural message)
                         :msgstr       (:str-plural message)}
-                       {:msgstr [(:str message)]})])))
+                       {:msgstr [(->ttag-reference (:str message))]})])))
             messages)})
 
 (defn- ->i18n-map

--- a/bin/i18n/test/i18n/create_artifacts/backend_test.clj
+++ b/bin/i18n/test/i18n/create_artifacts/backend_test.clj
@@ -7,8 +7,9 @@
 (deftest edn-test
   (#'backend/write-edn-file! test-common/po-contents "/tmp/out.edn")
   (is (= ["{"
-          "\"No table description yet\""
-          "\"No hay una descripción de la tabla\""
+          "\"No table description yet\"" "\"No hay una descripción de la tabla\""
+          ""
+          "\"Count of {0}\"" "\"Número de {0}\""
           ""
           "}"]
          (some-> (slurp "/tmp/out.edn")

--- a/bin/i18n/test/i18n/create_artifacts/frontend_test.clj
+++ b/bin/i18n/test/i18n/create_artifacts/frontend_test.clj
@@ -20,6 +20,9 @@
                          {"No table description yet"
                           {:msgstr ["No hay una descripción de la tabla"]}
 
+                          "Count of ${ 0 }"
+                          {:msgstr ["Número de ${ 0 }"]}
+
                           "${ 0 } Queryable Table"
                           {:msgid_plural "{0} Queryable Tables"
                            :msgstr       ["{0] Tabla Consultable" "{0] Tablas consultables"]}}}}

--- a/bin/i18n/test/i18n/create_artifacts/test_common.clj
+++ b/bin/i18n/test/i18n/create_artifacts/test_common.clj
@@ -1,7 +1,7 @@
 (ns i18n.create-artifacts.test-common)
 
 (def singular-message-frontend
-  {:id                "No table description yet",
+  {:id                "No table description yet"
    :id-plural         nil
    :str               "No hay una descripción de la tabla"
    :str-plural        nil
@@ -11,9 +11,29 @@
    :comment           nil})
 
 (def singular-message-backend
-  {:id                "No table description yet",
+  {:id                "No table description yet"
    :id-plural         nil
    :str               "No hay una descripción de la tabla"
+   :str-plural        nil
+   :fuzzy?            false
+   :plural?           false
+   :source-references ["src/metabase/models/table.clj"]
+   :comment           nil})
+
+(def singular-template-message-frontend
+  {:id                "Count of {0}"
+   :id-plural         nil
+   :str               "Número de {0}"
+   :str-plural        nil
+   :fuzzy?            false
+   :plural?           false
+   :source-references ["frontend/src/metabase/reference/databases/TableDetail.jsx:38"]
+   :comment           nil})
+
+(def singular-template-message-backend
+  {:id                "Count of {0}"
+   :id-plural         nil
+   :str               "Número de {0}"
    :str-plural        nil
    :fuzzy?            false
    :plural?           false
@@ -33,6 +53,8 @@
 (def messages
   [singular-message-frontend
    singular-message-backend
+   singular-template-message-frontend
+   singular-template-message-backend
    plural-message-frontend])
 
 (def po-contents


### PR DESCRIPTION
Fixes #15561

In #15189 I converted our old untested node/bash scripts that generated i18n resources to Clojure ones with tests. For the frontend resources the new scripts were outputting parameterized singular strings incorrectly, like `Número de {0}` (unmodified from the source PO files) as opposed to `Número de ${ 0 }` (the format expected by the ttag library we use on the frontend). It was an easy fix, since we were already converting the `{0}` style references to `${ 0 }` ones elsewhere -- we just had to use that code in this spot as well. I've added new tests for it this specific situation to make sure we don't run into a regression in the future.

Here's a screenshot of it working correctly after the fix. Note you'll have to rebuild the translation resources and restart the server (or just reload the `metabase.server.routes.index` namespace if you're running from a REPL) to see the fixed behavior:

![image](https://user-images.githubusercontent.com/1455846/114605148-a1bf8f00-9c4e-11eb-880c-75e8d2434839.png)
