### PR TITLE
Date breakout quicker fix #15445

### DIFF
--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -50,7 +50,7 @@ const SUBMENU_TETHER_OPTIONS = {
     {
       to: "window",
       attachment: "together",
-      pin: ["left", "right"],
+      pin: true,
     },
   ],
 };

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -127,7 +127,6 @@ export default class DimensionList extends Component {
               multiSelect,
             )}
             tetherOptions={multiSelect ? null : SUBMENU_TETHER_OPTIONS}
-            sizeToFit
           >
             {({ onClose }) => (
               <DimensionPicker

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -175,7 +175,7 @@ describe("scenarios > question > custom columns", () => {
 
     // add custom column
     cy.findByText("Custom column").click();
-    _typeUsingGet("[contenteditable='true']", "1 + 1");
+    _typeUsingGet("[contenteditable='true']", "1 + 1", 400);
     _typeUsingPlaceholder("Something nice and descriptive", "X");
     cy.findByText("Done").click();
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -601,7 +601,7 @@ describe("scenarios > question > notebook", () => {
       cy.findByText("37.65");
     });
 
-    it.skip("breakout binning popover should have normal height even when it's rendered lower on the screen (metabase#15445)", () => {
+    it("breakout binning popover should have normal height even when it's rendered lower on the screen (metabase#15445)", () => {
       cy.visit("/question/1/notebook");
       cy.findByText("Summarize").click();
       cy.findByText("Count of rows").click();


### PR DESCRIPTION
OK, after a long time investigating #15445 is really a compound of two root causes:

1. the secondary popover for the date breakout isn't pinned with respect to the overall window (so the window can occlude the popover) so that bit isn't reachable, and
2. the secondary popover for the date breakout doesn't follow the primary popover: it follows a little button inside a list inside the popover, so if you scroll the window without scrolling in the primary popover, the secondary popover won't move

fixing 1 is the included one-liner, fixing 2 necessitates basically close to a rewrite of like 3 components or a whole lot of terrible spooky action-at-a-distance