### PR TITLE
#15596 Repro: Not possible to scroll vertically after fullscreen layer is closed

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -742,6 +742,35 @@ describe("scenarios > dashboard", () => {
       });
     });
   });
+
+  it.skip("should be possible to scroll vertically after fullscreen layer is closed (metabase#15596)", () => {
+    // Make this dashboard card extremely tall so that it spans outside of visible viewport
+    cy.request("PUT", "/api/dashboard/1/cards", {
+      cards: [
+        {
+          id: 1,
+          card_id: 1,
+          row: 0,
+          col: 0,
+          sizeX: 12,
+          sizeY: 20,
+          series: [],
+          visualization_settings: {},
+          parameter_mappings: [],
+        },
+      ],
+    });
+
+    cy.visit("/dashboard/1");
+    cy.contains("37.65");
+    assertScrollBarExists();
+    cy.icon("share").click();
+    cy.findByText("Sharing and embedding").click();
+    // Fullscreen modal opens - close it now
+    cy.icon("close").click();
+    cy.get(".Modal--full").should("not.exist");
+    assertScrollBarExists();
+  });
 });
 
 function checkOptionsForFilter(filter) {
@@ -756,4 +785,13 @@ function checkOptionsForFilter(filter) {
 
   // Get rid of the open popover to be able to select another filter
   cy.findByText("Pick one or more filters to update").click();
+}
+
+function assertScrollBarExists() {
+  cy.get("body").then($body => {
+    const bodyWidth = $body[0].getBoundingClientRect().width;
+    cy.window()
+      .its("innerWidth")
+      .should("be.gt", bodyWidth);
+  });
 }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15596 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/114613921-32748a00-9ca4-11eb-92f8-66838c627d9c.png)

