### PR TITLE
Fix archive search (#15080)

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -162,7 +162,7 @@ describe("scenarios > collection_defaults", () => {
     });
 
     describe("archive", () => {
-      it.skip("should show archived items (metabase#15080)", () => {
+      it("should show archived items (metabase#15080)", () => {
         cy.visit("collection/root");
         openEllipsisMenuFor("Orders");
         cy.findByText("Archive this item").click();

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -161,6 +161,20 @@ describe("scenarios > collection_defaults", () => {
       });
     });
 
+    describe("archive", () => {
+      it.skip("should show archived items (metabase#15080)", () => {
+        cy.visit("collection/root");
+        openEllipsisMenuFor("Orders");
+        cy.findByText("Archive this item").click();
+        cy.findByText("Archived question")
+          .siblings(".Icon-close")
+          .click();
+        cy.findByText("View archive").click();
+        cy.location("pathname").should("eq", "/archive");
+        cy.findByText("Orders");
+      });
+    });
+
     // [quarantine]: cannot run tests that rely on email setup in CI (yet)
     describe.skip("a new pulse", () => {
       it("should be in the root collection", () => {

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -326,7 +326,7 @@
                                                        :let  [query (search-query-for-model model search-ctx)]
                                                        :when (seq query)]
                                                    query)} :alias_is_required_by_sql_but_not_needed_here]]
-                             :order-by [(order-clause (:search-string search-ctx))]}
+                             :order-by [((fnil order-clause "") (:search-string search-ctx))]}
           _                 (log/tracef "Searching with query:\n%s" (u/pprint-to-str search-query))
           reducible-results (db/reducible-query search-query :max-rows search-config/db-max-results)
           xf                (comp
@@ -354,8 +354,6 @@
   [q archived]
   {q        (s/maybe su/NonBlankString)
    archived (s/maybe su/BooleanString)}
-  (if q
-    (search (search-context q archived))
-    []))
+  (search (search-context q archived)))
 
 (api/define-routes)

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -163,10 +163,13 @@
 
 (defn- text-score-with-match
   [raw-search-string result]
-  (when (seq raw-search-string)
+  (if (seq raw-search-string)
     (text-score-with match-based-scorers
                      (tokenize (normalize raw-search-string))
-                     result)))
+                     result)
+    {:text-score          0
+     :match               ""
+     :result              result}))
 
 (defn- pinned-score
   [{:keys [model collection_position]}]
@@ -213,7 +216,8 @@
                                  (nil? display_name))
                            name
                            display_name)
-         :context        (when-not (search-config/displayed-columns column)
+         :context        (when (and (not (search-config/displayed-columns column))
+                                    match-context-thunk)
                            (match-context-thunk))
          :collection     {:id   collection_id
                           :name collection_name}

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -165,11 +165,6 @@
     (with-search-items-in-root-collection "test"
       (is (= (default-search-results)
              (search-request :crowberto :q "test")))))
-
-  (testing (str "Search with no search string should yield no results.")
-    (with-search-items-in-root-collection "test"
-      (is (empty? (search-request :crowberto)))))
-
   (testing "Basic search should only return substring matches"
     (with-search-items-in-root-collection "test"
       (with-search-items-in-root-collection "something different"
@@ -346,12 +341,22 @@
   (testing "Should return archived results when specified"
     (with-search-items-in-root-collection "test2"
       (mt/with-temp* [Card       [_ (archived {:name "card test card"})]
+                      Card       [_ (archived {:name "card that will not appear in results"})]
                       Dashboard  [_ (archived {:name "dashboard test dashboard"})]
                       Collection [_ (archived {:name "collection test collection"})]
                       Metric     [_ (archived {:name "metric test metric"})]
                       Segment    [_ (archived {:name "segment test segment"})]]
         (is (= (default-archived-results)
-               (search-request :crowberto :q "test", :archived "true")))))))
+               (search-request :crowberto :q "test", :archived "true"))))))
+  (testing "Should return archived results when specified without a search query"
+    (with-search-items-in-root-collection "test2"
+      (mt/with-temp* [Card       [_ (archived {:name "card test card"})]
+                      Dashboard  [_ (archived {:name "dashboard test dashboard"})]
+                      Collection [_ (archived {:name "collection test collection"})]
+                      Metric     [_ (archived {:name "metric test metric"})]
+                      Segment    [_ (archived {:name "segment test segment"})]]
+        (is (= (default-archived-results)
+               (search-request :crowberto :archived "true")))))))
 
 (deftest alerts-test
   (testing "Search should not return alerts"


### PR DESCRIPTION
Fixes #15080.

I opted for the "least moving parts" approach since the release is nigh.

This will break in 40 due to #15518 (the archived page will show _all_ databases since databases don't have an `archived` column). For 40, I think the real fix is to have separate endpoints for searching and archiving. There's (now) a lot of complexity when searching that the simple "show me everything that's archived" handler shouldn't have to deal with.