### PR TITLE
fix inability to filter by a field of a joined table

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -767,7 +767,11 @@ export class FieldDimension extends Dimension {
     if (field && field.isDate()) {
       return this.withTemporalUnit(field.getDefaultDateTimeUnit());
     }
-    return super.defaultDimension(dimensionTypes);
+
+    const dimension = super.defaultDimension(dimensionTypes);
+    const joinAlias = this.joinAlias();
+
+    return joinAlias ? dimension.withJoinAlias(joinAlias) : dimension;
   }
 
   _dimensionForOption(option): FieldDimension {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -620,7 +620,7 @@ describe("scenarios > question > notebook", () => {
         .isVisibleInPopover();
     });
 
-    it.skip("should add numeric filter on joined table (metabase#15570)", () => {
+    it("should add numeric filter on joined table (metabase#15570)", () => {
       cy.createQuestion({
         name: "15570",
         query: {


### PR DESCRIPTION
### Description

Filtering by fields of joined tables did not work because `join-alias` of the dimension that was used for filtering had been missing.

After:
<img width="812" alt="Screen Shot 2021-04-14 at 00 30 40" src="https://user-images.githubusercontent.com/14301985/114624877-0e23a800-9cba-11eb-87f0-ff16fe7e2550.png">

Fixes https://github.com/metabase/metabase/issues/15570