### PR TITLE
Fix login history emails

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -189,10 +189,8 @@
   login history infomation as returned by `metabase.models.login-history/human-friendly-infos`."
   [{user-id :user_id, :keys [timestamp timezone], :as login-history}]
   (let [user-info    (db/select-one ['User [:first_name :first-name] :email :locale] :id user-id)
-        timestamp    (cond-> timestamp
-                       timezone (u.date/with-time-zone-same-instant (t/zone-id timezone))
-                       true     (u.date/format-human-readable (or (:locale user-info)
-                                                                  (i18n/site-locale))))
+        user-locale  (or (:locale user-info) (i18n/site-locale))
+        timestamp    (u.date/format-human-readable timestamp user-locale)
         context      (merge (common-context)
                             {:first-name (:first-name user-info)
                              :device     (:device_description login-history)

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -187,7 +187,7 @@
 (defn send-login-from-new-device-email!
   "Format and send an email informing the user that this is the first time we've seen a login from this device. Expects
   login history infomation as returned by `metabase.models.login-history/human-friendly-infos`."
-  [{user-id :user_id, :keys [timestamp timezone], :as login-history}]
+  [{user-id :user_id, :keys [timestamp], :as login-history}]
   (let [user-info    (db/select-one ['User [:first_name :first-name] :email :locale] :id user-id)
         user-locale  (or (:locale user-info) (i18n/site-locale))
         timestamp    (u.date/format-human-readable timestamp user-locale)

--- a/src/metabase/models/login_history.clj
+++ b/src/metabase/models/login_history.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.login-history
   (:require [clojure.tools.logging :as log]
+            [java-time :as t]
             [metabase.email.messages :as email.messages]
             [metabase.models.setting :refer [defsetting]]
             [metabase.server.request.util :as request.u]
@@ -30,7 +31,7 @@
                  :timezone (timezone-display-name timezone))
           (update :timestamp (fn [timestamp]
                                (if (and timestamp timezone)
-                                 (u.date/with-time-zone-same-instant timestamp timezone)
+                                 (t/zoned-date-time (u.date/with-time-zone-same-instant timestamp timezone) timezone)
                                  timestamp)))
           (update :device_description request.u/describe-user-agent)))))
 

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -13,7 +13,7 @@
             [schema.core :as s])
   (:import [java.time DayOfWeek Duration Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime Period
             ZonedDateTime]
-           [java.time.format DateTimeFormatter DateTimeFormatterBuilder FormatStyle]
+           [java.time.format DateTimeFormatter DateTimeFormatterBuilder FormatStyle TextStyle]
            [java.time.temporal Temporal TemporalAdjuster WeekFields]
            org.threeten.extra.PeriodDuration))
 
@@ -106,13 +106,22 @@
                     (.toFormatter builder))
    OffsetTime     (let [builder (doto (DateTimeFormatterBuilder.)
                                   (.append (DateTimeFormatter/ofLocalizedTime FormatStyle/MEDIUM))
-                                  (.appendPattern " (OOOO)"))]
+                                  (.appendLiteral " (")
+                                  (.appendLocalizedOffset TextStyle/FULL)
+                                  (.appendLiteral ")"))]
                     (.toFormatter builder))
    OffsetDateTime (let [builder (doto (DateTimeFormatterBuilder.)
                                   (.appendLocalized FormatStyle/LONG FormatStyle/MEDIUM)
-                                  (.appendPattern " (OOOO)"))]
+                                  (.appendLiteral " (")
+                                  (.appendLocalizedOffset TextStyle/FULL)
+                                  (.appendLiteral ")"))]
                     (.toFormatter builder))
-   ZonedDateTime  (DateTimeFormatter/ofLocalizedDateTime FormatStyle/LONG)})
+   ZonedDateTime  (let [builder (doto (DateTimeFormatterBuilder.)
+                                  (.appendLocalized FormatStyle/LONG FormatStyle/MEDIUM)
+                                  (.appendLiteral " (")
+                                  (.appendZoneText TextStyle/FULL)
+                                  (.appendLiteral ")"))]
+                    (.toFormatter builder))})
 
 (defn format-human-readable
   "Format a temporal value `t` in a human-friendly way for `locale` (by default, the current User's locale).

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -8,6 +8,7 @@
             [metabase.models.setting.cache :as setting.cache]
             [metabase.server.request.util :as request.u]
             [metabase.test :as mt]
+            [metabase.util.date-2 :as u.date]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -68,7 +69,8 @@
                       (doseq [expected-str ["We've noticed a new login on your Metabase account."
                                             "We noticed a login on your Metabase account from a new device."
                                             "Browser (Chrome/Windows) - San Francisco, California, United States"
-                                            "April 2, 2021 3:52:00 PM (Pacific Daylight Time)"]]
+                                            ;; `format-human-readable` has slightly different output on different JVMs
+                                            (u.date/format-human-readable #t "2021-04-02T15:52:00-07:00[US/Pacific]")]]
                         (is (str/includes? message expected-str))))))
 
                 (testing "don't send email on subsequent login from same device"

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -158,11 +158,11 @@
   ;; strings are localized slightly differently on different JVMs. For places where there are multiple possible
   ;; correct results, we'll use a set with all the possibilities below and check membership
   (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]" ; ZonedDateTime
-                        {:en-US #{"April 2, 2021 2:42:09 PM PDT"
-                                  "April 2, 2021 at 2:42:09 PM PDT"}
-                         :es-MX #{"2 de abril de 2021 02:42:09 PM PDT"
-                                  "2 de abril de 2021, 14:42:09 PDT"
-                                  "2 de abril de 2021 a las 14:42:09 PDT"}}
+                        {:en-US #{"April 2, 2021 2:42:09 PM (Pacific Daylight Time)"
+                                  "April 2, 2021 at 2:42:09 PM (Pacific Daylight Time)"}
+                         :es-MX #{"2 de abril de 2021 02:42:09 PM (Hora de verano del Pacífico)"
+                                  "2 de abril de 2021, 14:42:09 (Hora de verano del Pacífico)"
+                                  "2 de abril de 2021 a las 14:42:09 (Hora de verano del Pacífico)"}}
 
                         #t "2021-04-02T14:42:09.524392-07:00" ; OffsetDateTime
                         {:en-US #{"April 2, 2021 2:42:09 PM (GMT-07:00)"

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -159,10 +159,11 @@
   ;; correct results, we'll use a set with all the possibilities below and check membership
   (doseq [[t expected] {#t "2021-04-02T14:42:09.524392-07:00[US/Pacific]" ; ZonedDateTime
                         {:en-US #{"April 2, 2021 2:42:09 PM (Pacific Daylight Time)"
-                                  "April 2, 2021 at 2:42:09 PM (Pacific Daylight Time)"}
+                                  "April 2, 2021, 2:42:09 PM (Pacific Daylight Time)"}
                          :es-MX #{"2 de abril de 2021 02:42:09 PM (Hora de verano del Pacífico)"
-                                  "2 de abril de 2021, 14:42:09 (Hora de verano del Pacífico)"
-                                  "2 de abril de 2021 a las 14:42:09 (Hora de verano del Pacífico)"}}
+                                  "2 de abril de 2021 14:42:09 (Hora de verano del Pacífico)"
+                                  "2 de abril de 2021 14:42:09 (hora de verano del Pacífico)"
+                                  "2 de abril de 2021, 14:42:09 (Hora de verano del Pacífico)"}}
 
                         #t "2021-04-02T14:42:09.524392-07:00" ; OffsetDateTime
                         {:en-US #{"April 2, 2021 2:42:09 PM (GMT-07:00)"


### PR DESCRIPTION
Fixes #15603

The issue was we were converting the timezone we got as a result of geocoding the IP address to a human-friendly abbreviation string, e.g. `PT` (for Pacific Time); the email logic then attempted to convert this string back to a `ZoneId`, which failed, at least for `PT` -- the Java libs apparently don't know what zone `PT` refers to. The purpose of doing this in the first place was so we could coerce the login timestamp to the time zone for the associated location; this step was actually unneeded because, we were already doing this (using the original `ZoneId`) in `metabase.models.login-history` itself -- so all I had to do was remove that code from `metabase.email.messages`.

I also made some unrelated improvements to `metabase.util.date-2/format-human-friendly` so ZonedDateTimes come back like

`April 2, 2021 2:42:09 PM (Pacific Daylight Time)` instead of `April 2, 2021 2:42:09 PM PDT` -- not specifically related to this fix, but it was something I noticed while working on it and I think it looks a bit nicer.
